### PR TITLE
feat(mcp): add ancestor rule to SESSION_RULES for commit graph traversal

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -28,6 +28,11 @@ SESSION_RULES = [
     "(rule [(reachable ?a ?b) [?a :calls ?b]])",
     "(rule [(linked ?a ?b) [?a :contains ?b]])",
     "(rule [(reachable ?a ?b) [?a :contains ?b]])",
+    # Commit-graph traversal: (ancestor ?child ?anc) holds when ?anc is a
+    # (possibly transitive) git ancestor of ?child via :parent edges.
+    # Only evaluated when a query explicitly calls (ancestor ...).
+    "(rule [(ancestor ?child ?anc) [?child :parent ?anc]])",
+    "(rule [(ancestor ?child ?anc) [?child :parent ?mid] (ancestor ?mid ?anc)])",
 ]
 
 # User-registered rules — persisted across DB reopens (unlike SESSION_RULES,


### PR DESCRIPTION
## Summary

- Adds base and recursive `ancestor` Datalog rules to `SESSION_RULES` so they are registered on every DB open, without requiring a separate `vulcan_rule` call
- `(ancestor ?child ?anc)` is true when `?anc` is a transitive git ancestor of `?child` via `:parent` edges ingested during `vulcan_ingest_git`
- Rules are only evaluated when a query explicitly calls `(ancestor ...)` — no performance impact on other queries

## Context

During investigation of commit-graph queries (answering "which release introduced file format v7?"), we found that `ancestor` rules registered via `vulcan_rule` were silently lost after each tool call (fixed in #79). The rule is useful enough for commit provenance queries that it belongs in `SESSION_RULES` permanently.

**Known limitation**: full transitive closure on repos with >1k commits may hit Minigraf's `max_derived_facts_per_iteration` limit (100,000). Tracked upstream in project-minigraf/minigraf#288. Workarounds: bounded multi-hop queries or date-based filtering.

## Test plan

- [ ] Register `ancestor` rules via SESSION_RULES on server start
- [ ] Query `[:find ?child :where (ancestor ?child :commit/<hash>)]` returns descendants of a given commit (on small repos)
- [ ] Queries that don't use `ancestor` are unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)