### PR TITLE
feat(ingest): add language-specific import extraction for 13 languages

### DIFF
--- a/docs/superpowers/plans/2026-06-18-import-extraction-13-langs.md
+++ b/docs/superpowers/plans/2026-06-18-import-extraction-13-langs.md
@@ -1,0 +1,1313 @@
+# Import Extraction for 13 Languages — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add language-specific import extraction for Go, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Scala, Haskell, Lua, and Elixir so that `:depends-on` edges are written during git ingestion for all supported languages.
+
+**Architecture:** Add 9 missing tree-sitter grammar packages to `install.py`; extend `_LANG_NODE_TYPES` in `mcp_server.py` with 12 new entries; add helper functions for complex languages (C/C++, C#, Ruby, Lua, Elixir) following the existing `_rust_use_root()` pattern; add inline branches for simple languages (Go, Java, Kotlin, Swift, Scala, Haskell, PHP) inside `_extract_import_name()`.
+
+**Tech Stack:** Python 3.10+, tree-sitter 0.22+, individual `tree-sitter-<lang>` packages, pytest.
+
+---
+
+## File Map
+
+| File | Changes |
+|---|---|
+| `install.py` | Add 9 packages to the individual-install fallback list (line 132–136) |
+| `mcp_server.py` | Extend `_LANG_NODE_TYPES` (line 163); add 5 helper functions after `_rust_use_root`; add 13 `elif` branches in `_extract_import_name` |
+| `tests/test_mcp_server.py` | Add `_find_node` helper and `TestExtractImportName` class at end of file |
+
+---
+
+## Task 1: Install 9 Missing Tree-Sitter Grammar Packages
+
+**Files:**
+- Modify: `install.py:131-136`
+
+- [ ] **Step 1: Update install.py to include the 9 missing packages**
+
+In `install.py`, replace the `individual` list (lines 131–136):
+
+```python
+    individual = [
+        "tree-sitter>=0.22.0",
+        "tree-sitter-rust", "tree-sitter-python", "tree-sitter-javascript",
+        "tree-sitter-typescript", "tree-sitter-go", "tree-sitter-java",
+        "tree-sitter-c", "tree-sitter-cpp",
+        "tree-sitter-c-sharp", "tree-sitter-ruby", "tree-sitter-php",
+        "tree-sitter-kotlin", "tree-sitter-swift", "tree-sitter-scala",
+        "tree-sitter-haskell", "tree-sitter-lua", "tree-sitter-elixir",
+    ]
+```
+
+- [ ] **Step 2: Install the 9 new packages into the venv**
+
+```bash
+.venv/bin/pip install \
+  tree-sitter-c-sharp tree-sitter-ruby tree-sitter-php \
+  tree-sitter-kotlin tree-sitter-swift tree-sitter-scala \
+  tree-sitter-haskell tree-sitter-lua tree-sitter-elixir
+```
+
+Expected: each package installs successfully and lists `Successfully installed`.
+
+- [ ] **Step 3: Verify all 9 packages are importable**
+
+```bash
+.venv/bin/python -c "
+import tree_sitter_c_sharp, tree_sitter_ruby, tree_sitter_php
+import tree_sitter_kotlin, tree_sitter_swift, tree_sitter_scala
+import tree_sitter_haskell, tree_sitter_lua, tree_sitter_elixir
+print('all ok')
+"
+```
+
+Expected: `all ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add install.py
+git commit -m "feat(install): add 9 missing tree-sitter grammar packages for full language coverage"
+```
+
+---
+
+## Task 2: Go Import Extraction
+
+Go already has a `_LANG_NODE_TYPES` entry. This task only adds the extraction branch.
+
+**Files:**
+- Modify: `mcp_server.py:226-251` (`_extract_import_name`)
+- Test: `tests/test_mcp_server.py` (append `TestExtractImportName` class)
+
+- [ ] **Step 1: Add the test helper and Go test to test_mcp_server.py**
+
+Append to the end of `tests/test_mcp_server.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Helpers for TestExtractImportName
+# ---------------------------------------------------------------------------
+
+def _find_node(root, node_type: str):
+    """DFS search for the first node matching node_type."""
+    if root.type == node_type:
+        return root
+    for child in root.children:
+        found = _find_node(child, node_type)
+        if found:
+            return found
+    return None
+
+
+def _parse_import_node(lang_name: str, source: bytes, node_type: str, tmp_path):
+    """Parse source for lang_name, return first node of node_type or skip."""
+    import mcp_server
+    ext = {
+        "go": ".go", "java": ".java", "c": ".c", "cpp": ".cpp",
+        "c_sharp": ".cs", "ruby": ".rb", "php": ".php", "kotlin": ".kt",
+        "swift": ".swift", "scala": ".scala", "haskell": ".hs",
+        "lua": ".lua", "elixir": ".ex",
+    }[lang_name]
+    tmp_file = tmp_path / f"test{ext}"
+    tmp_file.write_bytes(source)
+    parser = mcp_server._get_parser(str(tmp_file))
+    if parser is None:
+        pytest.skip(f"No tree-sitter parser available for {lang_name}")
+    tree = parser.parse(source)
+    node = _find_node(tree.root_node, node_type)
+    if node is None:
+        pytest.fail(
+            f"No {node_type!r} node found in AST.\n"
+            f"Full AST sexp:\n{tree.root_node.sexp()}"
+        )
+    return node
+
+
+class TestExtractImportName:
+    """Unit tests for _extract_import_name — one per language, using real parsers."""
+
+    def test_go_single_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_go")
+        import mcp_server
+        source = b'package main\nimport "fmt"'
+        node = _parse_import_node("go", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "go")
+        assert result == ["fmt"]
+
+    def test_go_grouped_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_go")
+        import mcp_server
+        source = b'package main\nimport (\n\t"os"\n\t"github.com/user/pkg"\n)'
+        node = _parse_import_node("go", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "go")
+        assert "os" in result
+        assert "pkg" in result
+```
+
+- [ ] **Step 2: Run the Go tests to confirm they fail**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_go_single_import tests/test_mcp_server.py::TestExtractImportName::test_go_grouped_import -v
+```
+
+Expected: FAIL — `_extract_import_name` returns `[]` for `lang_name == "go"`.
+
+- [ ] **Step 3: Add the Go branch to `_extract_import_name`**
+
+In `mcp_server.py`, inside `_extract_import_name`, after the `elif lang_name == "rust":` block (after line 250, before `return names`):
+
+```python
+    elif lang_name == "go":
+        def _go_spec(spec_node):
+            path = spec_node.child_by_field_name("path")
+            if path:
+                val = path.text.decode("utf-8").strip('"')
+                names.append(val.split("/")[-1])
+
+        for child in node.named_children:
+            if child.type == "import_spec":
+                _go_spec(child)
+            elif child.type == "import_spec_list":
+                for spec in child.named_children:
+                    if spec.type == "import_spec":
+                        _go_spec(spec)
+```
+
+- [ ] **Step 4: Run Go tests to confirm they pass**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_go_single_import tests/test_mcp_server.py::TestExtractImportName::test_go_grouped_import -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add Go import extraction with tests"
+```
+
+---
+
+## Task 3: Java Import Extraction
+
+**Files:**
+- Modify: `mcp_server.py:132-163` (`_LANG_NODE_TYPES`), `mcp_server.py:226-251` (`_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing Java test**
+
+Append to `class TestExtractImportName` in `tests/test_mcp_server.py`:
+
+```python
+    def test_java_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_java")
+        import mcp_server
+        source = b'import java.util.List;'
+        node = _parse_import_node("java", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "java")
+        assert result == ["java"]
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_java_import -v
+```
+
+Expected: FAIL — no `"java"` entry in `_LANG_NODE_TYPES`, so `_walk_ast` never reaches this node, and the branch is missing.
+
+- [ ] **Step 3: Add Java to `_LANG_NODE_TYPES`**
+
+In `mcp_server.py`, add after the `"go": {...}` block (line 162, before the closing `}`):
+
+```python
+    "java": {
+        "functions": {"method_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"import_declaration"},
+        "calls": {"method_invocation"},
+    },
+```
+
+- [ ] **Step 4: Add the Java branch to `_extract_import_name`**
+
+After the Go branch added in Task 2:
+
+```python
+    elif lang_name == "java":
+        def _java_leftmost(n) -> Optional[str]:
+            if n.type == "identifier":
+                return n.text.decode("utf-8")
+            for c in n.named_children:
+                result = _java_leftmost(c)
+                if result:
+                    return result
+            return None
+
+        result = _java_leftmost(node)
+        if result:
+            names.append(result)
+```
+
+- [ ] **Step 5: Run Java test to confirm it passes**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_java_import -v
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add Java import extraction with tests"
+```
+
+---
+
+## Task 4: C and C++ Import Extraction
+
+C and C++ share a helper `_c_include_name()` and the same node type `preproc_include`.
+
+**Files:**
+- Modify: `mcp_server.py:132-163` (`_LANG_NODE_TYPES`), `mcp_server.py:166` (new helpers), `mcp_server.py:226+` (`_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing C and C++ tests**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_c_system_include(self, tmp_path):
+        pytest.importorskip("tree_sitter_c")
+        import mcp_server
+        source = b'#include <stdio.h>'
+        node = _parse_import_node("c", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "c")
+        assert result == ["stdio"]
+
+    def test_c_local_include(self, tmp_path):
+        pytest.importorskip("tree_sitter_c")
+        import mcp_server
+        source = b'#include "myheader.h"'
+        node = _parse_import_node("c", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "c")
+        assert result == ["myheader"]
+
+    def test_cpp_include(self, tmp_path):
+        pytest.importorskip("tree_sitter_cpp")
+        import mcp_server
+        source = b'#include <iostream>'
+        node = _parse_import_node("cpp", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "cpp")
+        assert result == ["iostream"]
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_c_system_include tests/test_mcp_server.py::TestExtractImportName::test_c_local_include tests/test_mcp_server.py::TestExtractImportName::test_cpp_include -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add C and C++ to `_LANG_NODE_TYPES`**
+
+In `mcp_server.py`, add after the Java entry:
+
+```python
+    "c": {
+        "functions": {"function_definition"},
+        "classes": {"struct_specifier"},
+        "imports": {"preproc_include"},
+        "calls": {"call_expression"},
+    },
+    "cpp": {
+        "functions": {"function_definition"},
+        "classes": {"class_specifier", "struct_specifier"},
+        "imports": {"preproc_include"},
+        "calls": {"call_expression"},
+    },
+```
+
+- [ ] **Step 4: Add `_c_include_name` helper**
+
+In `mcp_server.py`, add the helper immediately after `_rust_use_root` (before `_extract_import_name`, around line 225):
+
+```python
+def _c_include_name(node) -> Optional[str]:
+    """Return the header name (no path, no extension) from a C/C++ preproc_include node.
+
+    Handles both:
+      #include <stdio.h>   → system_lib_string → "stdio"
+      #include "myheader.h" → string_literal    → "myheader"
+    """
+    import os
+    for child in node.children:
+        if child.type in ("system_lib_string", "string_literal"):
+            raw = child.text.decode("utf-8").strip("<>\"'")
+            return os.path.splitext(os.path.basename(raw))[0]
+    return None
+```
+
+- [ ] **Step 5: Add C/C++ branches to `_extract_import_name`**
+
+After the Java branch:
+
+```python
+    elif lang_name in ("c", "cpp"):
+        name = _c_include_name(node)
+        if name:
+            names.append(name)
+```
+
+- [ ] **Step 6: Run C/C++ tests to confirm they pass**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_c_system_include tests/test_mcp_server.py::TestExtractImportName::test_c_local_include tests/test_mcp_server.py::TestExtractImportName::test_cpp_include -v
+```
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add C/C++ import extraction via _c_include_name helper"
+```
+
+---
+
+## Task 5: C# Import Extraction
+
+**Files:**
+- Modify: `mcp_server.py` (`_LANG_NODE_TYPES`, new helper, `_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing C# test**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_csharp_using_simple(self, tmp_path):
+        pytest.importorskip("tree_sitter_c_sharp")
+        import mcp_server
+        source = b'using System;'
+        node = _parse_import_node("c_sharp", source, "using_directive", tmp_path)
+        result = mcp_server._extract_import_name(node, "c_sharp")
+        assert result == ["System"]
+
+    def test_csharp_using_dotted(self, tmp_path):
+        pytest.importorskip("tree_sitter_c_sharp")
+        import mcp_server
+        source = b'using System.Collections.Generic;'
+        node = _parse_import_node("c_sharp", source, "using_directive", tmp_path)
+        result = mcp_server._extract_import_name(node, "c_sharp")
+        assert result == ["System"]
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_csharp_using_simple tests/test_mcp_server.py::TestExtractImportName::test_csharp_using_dotted -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add C# to `_LANG_NODE_TYPES`**
+
+```python
+    "c_sharp": {
+        "functions": {"method_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"using_directive"},
+        "calls": {"invocation_expression"},
+    },
+```
+
+- [ ] **Step 4: Add `_csharp_using_name` helper**
+
+Add after `_c_include_name`:
+
+```python
+def _csharp_using_name(node) -> Optional[str]:
+    """Return the root namespace from a C# using_directive node.
+
+    using System;                    → "System"
+    using System.Collections.Generic → "System"
+    """
+    def _first_ident(n) -> Optional[str]:
+        if n.type == "identifier":
+            return n.text.decode("utf-8")
+        for c in n.named_children:
+            result = _first_ident(c)
+            if result:
+                return result
+        return None
+
+    return _first_ident(node)
+```
+
+- [ ] **Step 5: Add C# branch to `_extract_import_name`**
+
+```python
+    elif lang_name == "c_sharp":
+        name = _csharp_using_name(node)
+        if name:
+            names.append(name)
+```
+
+- [ ] **Step 6: Run C# tests to confirm they pass**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_csharp_using_simple tests/test_mcp_server.py::TestExtractImportName::test_csharp_using_dotted -v
+```
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add C# using-directive import extraction"
+```
+
+---
+
+## Task 6: Ruby Import Extraction
+
+Ruby uses `call` nodes for `require`/`require_relative`. `_LANG_NODE_TYPES` puts `call` in `imports` (not `calls`) so all `call` nodes pass through `_extract_import_name`; the helper filters on method name.
+
+**Files:**
+- Modify: `mcp_server.py` (`_LANG_NODE_TYPES`, new helper, `_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing Ruby tests**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_ruby_require(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"require 'rails'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == ["rails"]
+
+    def test_ruby_require_relative(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"require_relative 'my_module'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == ["my_module"]
+
+    def test_ruby_non_require_call_ignored(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"puts 'hello'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == []
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_ruby_require tests/test_mcp_server.py::TestExtractImportName::test_ruby_require_relative tests/test_mcp_server.py::TestExtractImportName::test_ruby_non_require_call_ignored -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add Ruby to `_LANG_NODE_TYPES`**
+
+```python
+    "ruby": {
+        "functions": {"method"},
+        "classes": {"class"},
+        "imports": {"call"},
+        "calls": set(),
+    },
+```
+
+Note: `calls` is empty — Ruby regular calls are sacrificed to keep the `elif` logic clean. Ruby call-extraction is out of scope for this issue.
+
+- [ ] **Step 4: Add `_ruby_require_name` helper**
+
+Add after `_csharp_using_name`:
+
+```python
+def _ruby_require_name(node) -> Optional[str]:
+    """Return the required module name from a Ruby call node.
+
+    Handles:
+      require 'rails'             → "rails"
+      require_relative 'my_mod'  → "my_mod"
+    Returns None for non-require calls.
+    """
+    import os
+    method = node.child_by_field_name("method")
+    if method is None:
+        # Some grammars use the first identifier child instead of a named field
+        for child in node.named_children:
+            if child.type == "identifier":
+                method = child
+                break
+    if method is None or method.text.decode("utf-8") not in ("require", "require_relative"):
+        return None
+    args = node.child_by_field_name("arguments")
+    if args is None:
+        for child in node.named_children:
+            if child.type == "argument_list":
+                args = child
+                break
+    if args is None:
+        return None
+    for child in args.named_children:
+        if child.type in ("string", "simple_string", "string_literal"):
+            # Try to get the string content node (strips the quote characters)
+            content_node = next(
+                (c for c in child.named_children if c.type in ("string_content", "string_value")),
+                None,
+            )
+            if content_node:
+                val = content_node.text.decode("utf-8")
+            else:
+                val = child.text.decode("utf-8").strip("'\"")
+            return os.path.splitext(os.path.basename(val))[0]
+    return None
+```
+
+- [ ] **Step 5: Add Ruby branch to `_extract_import_name`**
+
+```python
+    elif lang_name == "ruby":
+        name = _ruby_require_name(node)
+        if name:
+            names.append(name)
+```
+
+- [ ] **Step 6: Run Ruby tests to confirm they pass**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_ruby_require tests/test_mcp_server.py::TestExtractImportName::test_ruby_require_relative tests/test_mcp_server.py::TestExtractImportName::test_ruby_non_require_call_ignored -v
+```
+
+Expected: PASS. If any test fails with unexpected node structure, inspect the AST:
+```bash
+.venv/bin/python -c "
+import tree_sitter_ruby, tree_sitter
+lang = tree_sitter.Language(tree_sitter_ruby.language())
+p = tree_sitter.Parser(lang)
+t = p.parse(b\"require 'rails'\")
+print(t.root_node.sexp())
+"
+```
+Then adjust field names in `_ruby_require_name` accordingly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add Ruby require/require_relative import extraction"
+```
+
+---
+
+## Task 7: PHP Import Extraction
+
+**Files:**
+- Modify: `mcp_server.py` (`_LANG_NODE_TYPES`, `_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing PHP tests**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_php_require(self, tmp_path):
+        pytest.importorskip("tree_sitter_php")
+        import mcp_server
+        source = b"<?php\nrequire 'config.php';"
+        node = _parse_import_node("php", source, "require_expression", tmp_path)
+        result = mcp_server._extract_import_name(node, "php")
+        assert result == ["config"]
+
+    def test_php_include(self, tmp_path):
+        pytest.importorskip("tree_sitter_php")
+        import mcp_server
+        source = b"<?php\ninclude 'header.php';"
+        node = _parse_import_node("php", source, "include_expression", tmp_path)
+        result = mcp_server._extract_import_name(node, "php")
+        assert result == ["header"]
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_php_require tests/test_mcp_server.py::TestExtractImportName::test_php_include -v
+```
+
+Expected: FAIL. If the test fails with `No 'require_expression' node found`, inspect the AST:
+```bash
+.venv/bin/python -c "
+import tree_sitter_php, tree_sitter
+lang = tree_sitter.Language(tree_sitter_php.language_php())
+p = tree_sitter.Parser(lang)
+t = p.parse(b\"<?php\nrequire 'config.php';\")
+print(t.root_node.sexp())
+"
+```
+Note: `tree_sitter_php` exposes `language_php()` not `language()`. Adjust the `_get_parser` fallback if needed (see step 3 note).
+
+- [ ] **Step 3: Add PHP to `_LANG_NODE_TYPES`**
+
+```python
+    "php": {
+        "functions": {"function_definition", "method_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"require_expression", "include_expression",
+                    "require_once_expression", "include_once_expression"},
+        "calls": {"function_call_expression"},
+    },
+```
+
+Note: PHP's tree-sitter package uses `language_php()` instead of `language()`. If `_get_parser` fails for `.php` files because `__import__("tree_sitter_php").language()` doesn't exist, add a special-case import in `_get_parser`:
+
+```python
+    # Attempt 2: individual tree-sitter-<lang> packages
+    if parser is None:
+        try:
+            mod = __import__(f"tree_sitter_{lang_name}", fromlist=["language"])
+            from tree_sitter import Language, Parser
+            # PHP exposes language_php() instead of language()
+            lang_fn = getattr(mod, f"language_{lang_name}", None) or mod.language
+            lang_obj = Language(lang_fn())
+            parser = Parser(lang_obj)
+        except Exception:
+            pass
+```
+
+- [ ] **Step 4: Add PHP branch to `_extract_import_name`**
+
+```python
+    elif lang_name == "php":
+        import os
+        for child in node.children:
+            if child.type in ("string", "encapsed_string", "string_literal"):
+                val = child.text.decode("utf-8").strip("'\"")
+                names.append(os.path.splitext(os.path.basename(val))[0])
+                break
+```
+
+- [ ] **Step 5: Run PHP tests to confirm they pass**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_php_require tests/test_mcp_server.py::TestExtractImportName::test_php_include -v
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add PHP include/require import extraction"
+```
+
+---
+
+## Task 8: Kotlin Import Extraction
+
+**Files:**
+- Modify: `mcp_server.py` (`_LANG_NODE_TYPES`, `_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing Kotlin test**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_kotlin_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_kotlin")
+        import mcp_server
+        source = b'import kotlin.collections.List'
+        node = _parse_import_node("kotlin", source, "import_header", tmp_path)
+        result = mcp_server._extract_import_name(node, "kotlin")
+        assert result == ["kotlin"]
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_kotlin_import -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add Kotlin to `_LANG_NODE_TYPES`**
+
+```python
+    "kotlin": {
+        "functions": {"function_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"import_header"},
+        "calls": {"call_expression"},
+    },
+```
+
+- [ ] **Step 4: Add Kotlin branch to `_extract_import_name`**
+
+```python
+    elif lang_name == "kotlin":
+        # import_header contains a dotted identifier path
+        # Walk to leftmost simple_identifier or identifier child
+        def _kotlin_first_seg(n) -> Optional[str]:
+            if n.type in ("simple_identifier", "identifier"):
+                return n.text.decode("utf-8")
+            for c in n.named_children:
+                result = _kotlin_first_seg(c)
+                if result:
+                    return result
+            return None
+
+        result = _kotlin_first_seg(node)
+        if result:
+            names.append(result)
+```
+
+- [ ] **Step 5: Run Kotlin test to confirm it passes**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_kotlin_import -v
+```
+
+Expected: PASS. If it fails with wrong result, inspect:
+```bash
+.venv/bin/python -c "
+import tree_sitter_kotlin, tree_sitter
+lang = tree_sitter.Language(tree_sitter_kotlin.language())
+p = tree_sitter.Parser(lang)
+t = p.parse(b'import kotlin.collections.List')
+print(t.root_node.sexp())
+"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add Kotlin import_header extraction"
+```
+
+---
+
+## Task 9: Swift Import Extraction
+
+**Files:**
+- Modify: `mcp_server.py` (`_LANG_NODE_TYPES`, `_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing Swift test**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_swift_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_swift")
+        import mcp_server
+        source = b'import Foundation'
+        node = _parse_import_node("swift", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "swift")
+        assert result == ["Foundation"]
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_swift_import -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add Swift to `_LANG_NODE_TYPES`**
+
+```python
+    "swift": {
+        "functions": {"function_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"import_declaration"},
+        "calls": {"call_expression"},
+    },
+```
+
+- [ ] **Step 4: Add Swift branch to `_extract_import_name`**
+
+```python
+    elif lang_name == "swift":
+        # import_declaration → identifier child is the module name
+        for child in node.named_children:
+            if child.type in ("identifier", "simple_identifier"):
+                names.append(child.text.decode("utf-8"))
+                break
+```
+
+- [ ] **Step 5: Run Swift test to confirm it passes**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_swift_import -v
+```
+
+Expected: PASS. If it fails, inspect:
+```bash
+.venv/bin/python -c "
+import tree_sitter_swift, tree_sitter
+lang = tree_sitter.Language(tree_sitter_swift.language())
+p = tree_sitter.Parser(lang)
+t = p.parse(b'import Foundation')
+print(t.root_node.sexp())
+"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add Swift import_declaration extraction"
+```
+
+---
+
+## Task 10: Scala Import Extraction
+
+**Files:**
+- Modify: `mcp_server.py` (`_LANG_NODE_TYPES`, `_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing Scala test**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_scala_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_scala")
+        import mcp_server
+        source = b'import scala.collection.mutable'
+        node = _parse_import_node("scala", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "scala")
+        assert result == ["scala"]
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_scala_import -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add Scala to `_LANG_NODE_TYPES`**
+
+```python
+    "scala": {
+        "functions": {"function_definition"},
+        "classes": {"class_definition"},
+        "imports": {"import_declaration"},
+        "calls": {"call_expression"},
+    },
+```
+
+- [ ] **Step 4: Add Scala branch to `_extract_import_name`**
+
+```python
+    elif lang_name == "scala":
+        # import_declaration contains a path; take the first dotted segment
+        for child in node.named_children:
+            txt = child.text.decode("utf-8")
+            names.append(txt.split(".")[0])
+            break
+```
+
+- [ ] **Step 5: Run Scala test to confirm it passes**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_scala_import -v
+```
+
+Expected: PASS. If it fails, inspect:
+```bash
+.venv/bin/python -c "
+import tree_sitter_scala, tree_sitter
+lang = tree_sitter.Language(tree_sitter_scala.language())
+p = tree_sitter.Parser(lang)
+t = p.parse(b'import scala.collection.mutable')
+print(t.root_node.sexp())
+"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add Scala import_declaration extraction"
+```
+
+---
+
+## Task 11: Haskell Import Extraction
+
+**Files:**
+- Modify: `mcp_server.py` (`_LANG_NODE_TYPES`, `_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing Haskell test**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_haskell_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_haskell")
+        import mcp_server
+        source = b'import Data.List'
+        node = _parse_import_node("haskell", source, "import", tmp_path)
+        result = mcp_server._extract_import_name(node, "haskell")
+        assert result == ["Data"]
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_haskell_import -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add Haskell to `_LANG_NODE_TYPES`**
+
+```python
+    "haskell": {
+        "functions": {"function"},
+        "classes": {"data_type"},
+        "imports": {"import"},
+        "calls": {"apply"},
+    },
+```
+
+- [ ] **Step 4: Add Haskell branch to `_extract_import_name`**
+
+```python
+    elif lang_name == "haskell":
+        # import node contains the module name; find a module or constructor child
+        for child in node.named_children:
+            if child.type in ("module", "qualified_module", "constructor"):
+                txt = child.text.decode("utf-8")
+                names.append(txt.split(".")[0])
+                break
+```
+
+- [ ] **Step 5: Run Haskell test to confirm it passes**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_haskell_import -v
+```
+
+Expected: PASS. If it fails, inspect:
+```bash
+.venv/bin/python -c "
+import tree_sitter_haskell, tree_sitter
+lang = tree_sitter.Language(tree_sitter_haskell.language())
+p = tree_sitter.Parser(lang)
+t = p.parse(b'import Data.List')
+print(t.root_node.sexp())
+"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add Haskell import extraction"
+```
+
+---
+
+## Task 12: Lua Import Extraction
+
+Lua uses `function_call` nodes for `require(...)`. Like Ruby, `function_call` goes in `imports` to filter via helper.
+
+**Files:**
+- Modify: `mcp_server.py` (`_LANG_NODE_TYPES`, new helper, `_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing Lua tests**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_lua_require(self, tmp_path):
+        pytest.importorskip("tree_sitter_lua")
+        import mcp_server
+        source = b'require("socket")'
+        node = _parse_import_node("lua", source, "function_call", tmp_path)
+        result = mcp_server._extract_import_name(node, "lua")
+        assert result == ["socket"]
+
+    def test_lua_non_require_ignored(self, tmp_path):
+        pytest.importorskip("tree_sitter_lua")
+        import mcp_server
+        source = b'print("hello")'
+        node = _parse_import_node("lua", source, "function_call", tmp_path)
+        result = mcp_server._extract_import_name(node, "lua")
+        assert result == []
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_lua_require tests/test_mcp_server.py::TestExtractImportName::test_lua_non_require_ignored -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add Lua to `_LANG_NODE_TYPES`**
+
+```python
+    "lua": {
+        "functions": {"function_definition"},
+        "classes": set(),
+        "imports": {"function_call"},
+        "calls": set(),
+    },
+```
+
+- [ ] **Step 4: Add `_lua_require_name` helper**
+
+Add after `_ruby_require_name`:
+
+```python
+def _lua_require_name(node) -> Optional[str]:
+    """Return the module name from a Lua function_call to require().
+
+    require("socket")  → "socket"
+    require "lfs"      → "lfs"
+    Returns None for non-require calls.
+    """
+    # The function name is usually the first child (identifier or prefix_expression)
+    fn_node = None
+    for child in node.children:
+        if child.type in ("identifier", "name"):
+            fn_node = child
+            break
+    if fn_node is None or fn_node.text.decode("utf-8") != "require":
+        return None
+    # Arguments: args node contains the string
+    for child in node.named_children:
+        if child.type in ("args", "argument_list"):
+            for arg in child.named_children:
+                if arg.type == "string":
+                    return arg.text.decode("utf-8").strip("'\"()")
+            # fallback: the arg itself is a string
+            if child.type == "string":
+                return child.text.decode("utf-8").strip("'\"")
+    return None
+```
+
+- [ ] **Step 5: Add Lua branch to `_extract_import_name`**
+
+```python
+    elif lang_name == "lua":
+        name = _lua_require_name(node)
+        if name:
+            names.append(name)
+```
+
+- [ ] **Step 6: Run Lua tests to confirm they pass**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_lua_require tests/test_mcp_server.py::TestExtractImportName::test_lua_non_require_ignored -v
+```
+
+Expected: PASS. If it fails, inspect:
+```bash
+.venv/bin/python -c "
+import tree_sitter_lua, tree_sitter
+lang = tree_sitter.Language(tree_sitter_lua.language())
+p = tree_sitter.Parser(lang)
+t = p.parse(b'require(\"socket\")')
+print(t.root_node.sexp())
+"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add Lua require() import extraction"
+```
+
+---
+
+## Task 13: Elixir Import Extraction
+
+Elixir uses `call` nodes for `alias`, `import`, and `use`.
+
+**Files:**
+- Modify: `mcp_server.py` (`_LANG_NODE_TYPES`, new helper, `_extract_import_name`)
+- Test: `tests/test_mcp_server.py`
+
+- [ ] **Step 1: Write the failing Elixir tests**
+
+Append to `class TestExtractImportName`:
+
+```python
+    def test_elixir_alias(self, tmp_path):
+        pytest.importorskip("tree_sitter_elixir")
+        import mcp_server
+        source = b'alias MyApp.Router'
+        node = _parse_import_node("elixir", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "elixir")
+        assert result == ["MyApp"]
+
+    def test_elixir_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_elixir")
+        import mcp_server
+        source = b'import Ecto.Query'
+        node = _parse_import_node("elixir", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "elixir")
+        assert result == ["Ecto"]
+
+    def test_elixir_non_module_call_ignored(self, tmp_path):
+        pytest.importorskip("tree_sitter_elixir")
+        import mcp_server
+        source = b'IO.puts("hello")'
+        # IO.puts is a dot_call or qualified_call, not a plain call — skip if no call node
+        try:
+            node = _parse_import_node("elixir", source, "call", tmp_path)
+        except pytest.fail.Exception:
+            return  # no call node at all — that's fine
+        result = mcp_server._extract_import_name(node, "elixir")
+        assert result == []
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_elixir_alias tests/test_mcp_server.py::TestExtractImportName::test_elixir_import tests/test_mcp_server.py::TestExtractImportName::test_elixir_non_module_call_ignored -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Add Elixir to `_LANG_NODE_TYPES`**
+
+```python
+    "elixir": {
+        "functions": {"def", "defp"},
+        "classes": {"defmodule"},
+        "imports": {"call"},
+        "calls": set(),
+    },
+```
+
+- [ ] **Step 4: Add `_elixir_module_name` helper**
+
+Add after `_lua_require_name`:
+
+```python
+def _elixir_module_name(node) -> Optional[str]:
+    """Return the root module name from an Elixir alias/import/use call node.
+
+    alias MyApp.Router     → "MyApp"
+    import Ecto.Query      → "Ecto"
+    use Phoenix.Controller → "Phoenix"
+    Returns None for non-module calls.
+    """
+    _ELIXIR_MODULE_CALLS = {"alias", "import", "use", "require"}
+    # The call target (function name) is usually the first named child
+    target = node.child_by_field_name("target")
+    if target is None:
+        for child in node.named_children:
+            if child.type in ("identifier", "atom"):
+                target = child
+                break
+    if target is None or target.text.decode("utf-8") not in _ELIXIR_MODULE_CALLS:
+        return None
+    # Arguments contain the module name
+    args = node.child_by_field_name("arguments")
+    if args is None:
+        for child in node.named_children:
+            if child.type in ("arguments", "argument_list"):
+                args = child
+                break
+    if args is None:
+        return None
+    for child in args.named_children:
+        txt = child.text.decode("utf-8")
+        return txt.split(".")[0]
+    return None
+```
+
+- [ ] **Step 5: Add Elixir branch to `_extract_import_name`**
+
+```python
+    elif lang_name == "elixir":
+        name = _elixir_module_name(node)
+        if name:
+            names.append(name)
+```
+
+- [ ] **Step 6: Run Elixir tests to confirm they pass**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName::test_elixir_alias tests/test_mcp_server.py::TestExtractImportName::test_elixir_import tests/test_mcp_server.py::TestExtractImportName::test_elixir_non_module_call_ignored -v
+```
+
+Expected: PASS. If it fails, inspect:
+```bash
+.venv/bin/python -c "
+import tree_sitter_elixir, tree_sitter
+lang = tree_sitter.Language(tree_sitter_elixir.language())
+p = tree_sitter.Parser(lang)
+t = p.parse(b'alias MyApp.Router')
+print(t.root_node.sexp())
+"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat(ingest): add Elixir alias/import/use extraction"
+```
+
+---
+
+## Task 14: Full Test Run and Final Commit
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py -v 2>&1 | tail -30
+```
+
+Expected: all `TestExtractImportName` tests pass; no regressions in existing tests.
+
+- [ ] **Step 2: Run only the new extraction tests as a final check**
+
+```bash
+.venv/bin/pytest tests/test_mcp_server.py::TestExtractImportName -v
+```
+
+Expected: all 20+ tests pass (or skip with `SKIP` reason if parser unavailable in CI).
+
+- [ ] **Step 3: Close the issue**
+
+```bash
+gh issue close 76 --comment "All 13 languages implemented with tests. See commits in this branch."
+```

--- a/docs/superpowers/specs/2026-06-18-import-extraction-design.md
+++ b/docs/superpowers/specs/2026-06-18-import-extraction-design.md
@@ -1,0 +1,135 @@
+# Import Extraction for 13 Languages — Design Spec
+
+**Issue:** #76
+**Date:** 2026-06-18
+
+## Background
+
+`_extract_import_name()` in `mcp_server.py` currently handles Python, JavaScript/TypeScript, and Rust. All other languages in `_EXT_TO_LANG` have their extensions mapped but produce no `:depends-on` edges because (a) `_LANG_NODE_TYPES` is missing their entries and (b) `_extract_import_name` has no branch for them.
+
+The 13 languages to add: Go, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Scala, Haskell, Lua, Elixir.
+
+## Section 1: Package Installation
+
+Add 9 missing tree-sitter grammar packages to the fallback install list in `install.py`'s `check_tree_sitter_languages_package()`:
+
+```
+tree-sitter-c-sharp
+tree-sitter-ruby
+tree-sitter-php
+tree-sitter-kotlin
+tree-sitter-swift
+tree-sitter-scala
+tree-sitter-haskell
+tree-sitter-lua
+tree-sitter-elixir
+```
+
+These are installed at the same time as the existing individual packages (Go, Java, C, C++ etc.) in the Python 3.13+ fallback branch. No change to `pyproject.toml` — the project's dependency management for tree-sitter continues to be handled by `install.py`.
+
+## Section 2: `_LANG_NODE_TYPES` Additions
+
+Add entries for 12 new languages (Go already has an entry):
+
+| Language key | `imports` node type(s) |
+|---|---|
+| `java` | `import_declaration` |
+| `c` | `preproc_include` |
+| `cpp` | `preproc_include` |
+| `c_sharp` | `using_directive` |
+| `ruby` | `call` |
+| `php` | `include_expression`, `require_expression` |
+| `kotlin` | `import_header` |
+| `swift` | `import_declaration` |
+| `scala` | `import_declaration` |
+| `haskell` | `import` |
+| `lua` | `function_call` |
+| `elixir` | `call` |
+
+Note: Ruby, Lua, and Elixir use general-purpose call/function-call nodes. `_walk_ast` passes all matching nodes to `_extract_import_name`, which filters on the callee name (`require`, `alias`, `import`, `use`).
+
+## Section 3: `_extract_import_name` Branches and Helpers
+
+### Approach: Option B — helpers for complex cases, inline for simple ones
+
+Following the `_rust_use_root()` precedent, languages whose extraction requires more than a field lookup get dedicated top-level helper functions.
+
+### Helper functions (new)
+
+**`_c_include_name(node) -> Optional[str]`** — shared by C and C++
+- Reads `system_lib_string` child (for `<stdio.h>`) or `string_literal` child (for `"myheader.h"`)
+- Strips angle brackets or quotes, drops directory prefix, drops file extension
+- Returns e.g. `"stdio"`, `"myheader"`
+
+**`_csharp_using_name(node) -> Optional[str]`** — for C# `using_directive`
+- Walks the qualified name child, extracts the first `.`-separated segment
+- Returns e.g. `"System"` from `using System.Collections.Generic`
+
+**`_ruby_require_name(node) -> Optional[str]`** — for Ruby `call` nodes
+- Guards: method name must be `require` or `require_relative`
+- Reads the string argument, strips quotes, returns `basename` without extension
+- Returns e.g. `"rails"`, `"my_module"`
+
+**`_lua_require_name(node) -> Optional[str]`** — for Lua `function_call` nodes
+- Guards: function name must be `require`
+- Reads string argument, returns it stripped of quotes
+- Returns e.g. `"socket"`, `"mymodule"`
+
+**`_elixir_module_name(node) -> Optional[str]`** — for Elixir `call` nodes
+- Guards: call target must be `alias`, `import`, or `use`
+- Reads first argument, returns first `.`-separated segment
+- Returns e.g. `"MyApp"` from `alias MyApp.Router`
+
+### Inline branches in `_extract_import_name`
+
+**Go** — `import_declaration`:
+- Walk named children; if child is `import_spec`, read its `path` field (strip quotes, take last `/`-segment)
+- If child is `import_spec_list`, recurse into its `import_spec` children the same way
+- Handles both `import "fmt"` and `import ("fmt"; "os")`
+
+**Java** — `import_declaration`:
+- Find `scoped_identifier` or `identifier` child, walk to the leftmost dotted segment
+- Returns e.g. `"java"` from `import java.util.List`
+
+**C / C++** — delegates to `_c_include_name(node)`
+
+**C#** — delegates to `_csharp_using_name(node)`
+
+**Ruby** — delegates to `_ruby_require_name(node)`
+
+**PHP** — `include_expression` / `require_expression`:
+- Read the string child, strip quotes, return basename without extension
+
+**Kotlin** — `import_header`:
+- Walk the identifier path (dotted), return first segment
+- Returns e.g. `"kotlin"` from `import kotlin.collections.List`
+
+**Swift** — `import_declaration`:
+- Find `identifier` child directly, return its text
+- Returns e.g. `"Foundation"`
+
+**Scala** — `import_declaration`:
+- Walk `stable_identifier` child, return first dotted segment
+- Returns e.g. `"scala"` from `import scala.collection.mutable`
+
+**Haskell** — `import`:
+- Find `module` child, return first dotted segment
+- Returns e.g. `"Data"` from `import Data.List`
+
+**Lua** — delegates to `_lua_require_name(node)`
+
+**Elixir** — delegates to `_elixir_module_name(node)`
+
+## Section 4: Testing
+
+Add `class TestExtractImportName` in `tests/test_mcp_server.py`.
+
+One test per language:
+1. Parse a minimal snippet using the real tree-sitter parser (no mocking)
+2. Find the import node by its expected type
+3. Call `_extract_import_name(node, lang_name)` directly
+4. Assert the returned list contains the expected module name
+
+Each test is guarded with `pytest.mark.skipif` checking that the grammar package is importable, so CI doesn't break on environments where optional grammars are absent.
+
+The existing integration tests in `TestRunIngestionBitemporalDeps` remain unchanged — they continue to validate the full pipeline end-to-end for Python.

--- a/install.py
+++ b/install.py
@@ -133,6 +133,9 @@ def check_tree_sitter_languages_package():
         "tree-sitter-rust", "tree-sitter-python", "tree-sitter-javascript",
         "tree-sitter-typescript", "tree-sitter-go", "tree-sitter-java",
         "tree-sitter-c", "tree-sitter-cpp",
+        "tree-sitter-c-sharp", "tree-sitter-ruby", "tree-sitter-php",
+        "tree-sitter-kotlin", "tree-sitter-swift", "tree-sitter-scala",
+        "tree-sitter-haskell", "tree-sitter-lua", "tree-sitter-elixir",
     ]
     if _venv_pip_install(*individual):
         print("✓ Individual tree-sitter language packages installed")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -199,6 +199,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
                     "require_once_expression", "include_once_expression"},
         "calls": {"function_call_expression"},
     },
+    "kotlin": {
+        "functions": {"function_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"import"},
+        "calls": {"call_expression"},
+    },
 }
 
 
@@ -395,6 +401,19 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
                 val = child.text.decode("utf-8").strip("'\"")
                 names.append(os.path.splitext(os.path.basename(val))[0])
                 break
+    elif lang_name == "kotlin":
+        def _kotlin_first_seg(n) -> Optional[str]:
+            if n.type in ("simple_identifier", "identifier"):
+                return n.text.decode("utf-8")
+            for c in n.named_children:
+                result = _kotlin_first_seg(c)
+                if result:
+                    return result
+            return None
+
+        result = _kotlin_first_seg(node)
+        if result:
+            names.append(result)
     return names
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -217,6 +217,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "imports": {"import_declaration"},
         "calls": {"call_expression"},
     },
+    "haskell": {
+        "functions": {"function"},
+        "classes": {"data_type"},
+        "imports": {"import"},
+        "calls": {"apply"},
+    },
 }
 
 
@@ -436,6 +442,12 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
             txt = child.text.decode("utf-8")
             names.append(txt.split(".")[0])
             break
+    elif lang_name == "haskell":
+        for child in node.named_children:
+            if child.type in ("module", "qualified_module", "constructor"):
+                txt = child.text.decode("utf-8")
+                names.append(txt.split(".")[0])
+                break
     return names
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -117,7 +117,9 @@ def _get_parser(file_path: str) -> Optional[Any]:
         try:
             mod = __import__(f"tree_sitter_{lang_name}", fromlist=["language"])
             from tree_sitter import Language, Parser  # type: ignore
-            lang_obj = Language(mod.language())
+            # PHP exposes language_php() instead of language()
+            lang_fn = getattr(mod, f"language_{lang_name}", None) or mod.language
+            lang_obj = Language(lang_fn())
             parser = Parser(lang_obj)
         except Exception:
             pass
@@ -189,6 +191,13 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "classes": {"class"},
         "imports": {"call"},
         "calls": set(),
+    },
+    "php": {
+        "functions": {"function_definition", "method_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"require_expression", "include_expression",
+                    "require_once_expression", "include_once_expression"},
+        "calls": {"function_call_expression"},
     },
 }
 
@@ -379,6 +388,13 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
         name = _ruby_require_name(node)
         if name:
             names.append(name)
+    elif lang_name == "php":
+        import os
+        for child in node.children:
+            if child.type in ("string", "encapsed_string", "string_literal"):
+                val = child.text.decode("utf-8").strip("'\"")
+                names.append(os.path.splitext(os.path.basename(val))[0])
+                break
     return names
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -205,6 +205,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "imports": {"import"},
         "calls": {"call_expression"},
     },
+    "swift": {
+        "functions": {"function_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"import_declaration"},
+        "calls": {"call_expression"},
+    },
 }
 
 
@@ -414,6 +420,11 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
         result = _kotlin_first_seg(node)
         if result:
             names.append(result)
+    elif lang_name == "swift":
+        for child in node.named_children:
+            if child.type in ("identifier", "simple_identifier"):
+                names.append(child.text.decode("utf-8"))
+                break
     return names
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -166,6 +166,18 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "imports": {"import_declaration"},
         "calls": {"method_invocation"},
     },
+    "c": {
+        "functions": {"function_definition"},
+        "classes": {"struct_specifier"},
+        "imports": {"preproc_include"},
+        "calls": {"call_expression"},
+    },
+    "cpp": {
+        "functions": {"function_definition"},
+        "classes": {"class_specifier", "struct_specifier"},
+        "imports": {"preproc_include"},
+        "calls": {"call_expression"},
+    },
 }
 
 
@@ -229,6 +241,21 @@ def _rust_use_root(node) -> Optional[str]:
     return None
 
 
+def _c_include_name(node) -> Optional[str]:
+    """Return the header name (no path, no extension) from a C/C++ preproc_include node.
+
+    Handles both:
+      #include <stdio.h>    → system_lib_string → "stdio"
+      #include "myheader.h" → string_literal    → "myheader"
+    """
+    import os
+    for child in node.children:
+        if child.type in ("system_lib_string", "string_literal"):
+            raw = child.text.decode("utf-8").strip("<>\"'")
+            return os.path.splitext(os.path.basename(raw))[0]
+    return None
+
+
 def _extract_import_name(node, lang_name: str) -> List[str]:
     """Extract top-level module names from an import node (may return multiple)."""
     names: List[str] = []
@@ -281,6 +308,10 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
         result = _java_leftmost(node)
         if result:
             names.append(result)
+    elif lang_name in ("c", "cpp"):
+        name = _c_include_name(node)
+        if name:
+            names.append(name)
     return names
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -160,6 +160,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "imports": {"import_declaration"},
         "calls": {"call_expression"},
     },
+    "java": {
+        "functions": {"method_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"import_declaration"},
+        "calls": {"method_invocation"},
+    },
 }
 
 
@@ -262,6 +268,19 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
                 for spec in child.named_children:
                     if spec.type == "import_spec":
                         _go_spec(spec)
+    elif lang_name == "java":
+        def _java_leftmost(n) -> Optional[str]:
+            if n.type == "identifier":
+                return n.text.decode("utf-8")
+            for c in n.named_children:
+                result = _java_leftmost(c)
+                if result:
+                    return result
+            return None
+
+        result = _java_leftmost(node)
+        if result:
+            names.append(result)
     return names
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -223,6 +223,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "imports": {"import"},
         "calls": {"apply"},
     },
+    "lua": {
+        "functions": {"function_definition"},
+        "classes": set(),
+        "imports": {"function_call"},
+        "calls": set(),
+    },
 }
 
 
@@ -348,6 +354,35 @@ def _ruby_require_name(node) -> Optional[str]:
     return None
 
 
+def _lua_require_name(node) -> Optional[str]:
+    """Return the module name from a Lua function_call to require().
+
+    require("socket")  → "socket"
+    Returns None for non-require calls.
+
+    AST shape:
+      function_call
+        identifier  b'require'
+        arguments
+          (  b'('
+          string  b'"socket"'
+          )  b')'
+    """
+    fn_node = None
+    for child in node.children:
+        if child.type == "identifier":
+            fn_node = child
+            break
+    if fn_node is None or fn_node.text.decode("utf-8") != "require":
+        return None
+    for child in node.children:
+        if child.type == "arguments":
+            for arg in child.children:
+                if arg.type == "string":
+                    return arg.text.decode("utf-8").strip("'\"")
+    return None
+
+
 def _extract_import_name(node, lang_name: str) -> List[str]:
     """Extract top-level module names from an import node (may return multiple)."""
     names: List[str] = []
@@ -448,6 +483,10 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
                 txt = child.text.decode("utf-8")
                 names.append(txt.split(".")[0])
                 break
+    elif lang_name == "lua":
+        name = _lua_require_name(node)
+        if name:
+            names.append(name)
     return names
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -211,6 +211,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "imports": {"import_declaration"},
         "calls": {"call_expression"},
     },
+    "scala": {
+        "functions": {"function_definition"},
+        "classes": {"class_definition"},
+        "imports": {"import_declaration"},
+        "calls": {"call_expression"},
+    },
 }
 
 
@@ -425,6 +431,11 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
             if child.type in ("identifier", "simple_identifier"):
                 names.append(child.text.decode("utf-8"))
                 break
+    elif lang_name == "scala":
+        for child in node.named_children:
+            txt = child.text.decode("utf-8")
+            names.append(txt.split(".")[0])
+            break
     return names
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -184,6 +184,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "imports": {"using_directive"},
         "calls": {"invocation_expression"},
     },
+    "ruby": {
+        "functions": {"method"},
+        "classes": {"class"},
+        "imports": {"call"},
+        "calls": set(),
+    },
 }
 
 
@@ -280,6 +286,35 @@ def _csharp_using_name(node) -> Optional[str]:
     return _first_ident(node)
 
 
+def _ruby_require_name(node) -> Optional[str]:
+    """Return the required module name from a Ruby call node.
+
+    Handles:
+      require 'rails'            → "rails"
+      require_relative 'my_mod' → "my_mod"
+    Returns None for non-require calls.
+    """
+    import os
+    method = node.child_by_field_name("method")
+    if method is None or method.text.decode("utf-8") not in ("require", "require_relative"):
+        return None
+    args = node.child_by_field_name("arguments")
+    if args is None:
+        return None
+    for child in args.named_children:
+        if child.type == "string":
+            content_node = next(
+                (c for c in child.named_children if c.type == "string_content"),
+                None,
+            )
+            if content_node:
+                val = content_node.text.decode("utf-8")
+            else:
+                val = child.text.decode("utf-8").strip("'\"")
+            return os.path.splitext(os.path.basename(val))[0]
+    return None
+
+
 def _extract_import_name(node, lang_name: str) -> List[str]:
     """Extract top-level module names from an import node (may return multiple)."""
     names: List[str] = []
@@ -338,6 +373,10 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
             names.append(name)
     elif lang_name == "c_sharp":
         name = _csharp_using_name(node)
+        if name:
+            names.append(name)
+    elif lang_name == "ruby":
+        name = _ruby_require_name(node)
         if name:
             names.append(name)
     return names

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -178,6 +178,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "imports": {"preproc_include"},
         "calls": {"call_expression"},
     },
+    "c_sharp": {
+        "functions": {"method_declaration"},
+        "classes": {"class_declaration"},
+        "imports": {"using_directive"},
+        "calls": {"invocation_expression"},
+    },
 }
 
 
@@ -256,6 +262,24 @@ def _c_include_name(node) -> Optional[str]:
     return None
 
 
+def _csharp_using_name(node) -> Optional[str]:
+    """Return the root namespace from a C# using_directive node.
+
+    using System;                     → "System"
+    using System.Collections.Generic; → "System"
+    """
+    def _first_ident(n) -> Optional[str]:
+        if n.type == "identifier":
+            return n.text.decode("utf-8")
+        for c in n.named_children:
+            result = _first_ident(c)
+            if result:
+                return result
+        return None
+
+    return _first_ident(node)
+
+
 def _extract_import_name(node, lang_name: str) -> List[str]:
     """Extract top-level module names from an import node (may return multiple)."""
     names: List[str] = []
@@ -310,6 +334,10 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
             names.append(result)
     elif lang_name in ("c", "cpp"):
         name = _c_include_name(node)
+        if name:
+            names.append(name)
+    elif lang_name == "c_sharp":
+        name = _csharp_using_name(node)
         if name:
             names.append(name)
     return names

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -229,6 +229,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "imports": {"function_call"},
         "calls": set(),
     },
+    "elixir": {
+        "functions": {"def", "defp"},
+        "classes": {"defmodule"},
+        "imports": {"call"},
+        "calls": set(),
+    },
 }
 
 
@@ -383,6 +389,34 @@ def _lua_require_name(node) -> Optional[str]:
     return None
 
 
+def _elixir_module_name(node) -> Optional[str]:
+    """Return the root module name from an Elixir alias/import/use/require call.
+
+    alias MyApp.Router     → "MyApp"
+    import Ecto.Query      → "Ecto"
+    use Phoenix.Controller → "Phoenix"
+    require Logger         → "Logger"
+    Returns None for non-module calls (e.g. IO.puts/1 where target is a dot node).
+    """
+    _ELIXIR_MODULE_CALLS = {"alias", "import", "use", "require"}
+    # The call target is the field named "target" — an identifier for alias/import/use/require,
+    # or a dot node for things like IO.puts/1.
+    target = node.child_by_field_name("target")
+    if target is None or target.type != "identifier":
+        return None
+    if target.text.decode("utf-8") not in _ELIXIR_MODULE_CALLS:
+        return None
+    # The module argument is in an "arguments" child (unnamed field).
+    # It contains an "alias" node whose text is the full dotted module name.
+    for child in node.children:
+        if child.type == "arguments":
+            for arg in child.children:
+                if arg.type == "alias":
+                    txt = arg.text.decode("utf-8")
+                    return txt.split(".")[0]
+    return None
+
+
 def _extract_import_name(node, lang_name: str) -> List[str]:
     """Extract top-level module names from an import node (may return multiple)."""
     names: List[str] = []
@@ -485,6 +519,10 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
                 break
     elif lang_name == "lua":
         name = _lua_require_name(node)
+        if name:
+            names.append(name)
+    elif lang_name == "elixir":
+        name = _elixir_module_name(node)
         if name:
             names.append(name)
     return names

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -248,6 +248,20 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
         name = _rust_use_root(node)
         if name:
             names.append(name)
+    elif lang_name == "go":
+        def _go_spec(spec_node):
+            path = spec_node.child_by_field_name("path")
+            if path:
+                val = path.text.decode("utf-8").strip('"')
+                names.append(val.split("/")[-1])
+
+        for child in node.named_children:
+            if child.type == "import_spec":
+                _go_spec(child)
+            elif child.type == "import_spec_list":
+                for spec in child.named_children:
+                    if spec.type == "import_spec":
+                        _go_spec(spec)
     return names
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2455,3 +2455,11 @@ class TestExtractImportName:
         result = mcp_server._extract_import_name(node, "go")
         assert "os" in result
         assert "pkg" in result
+
+    def test_java_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_java")
+        import mcp_server
+        source = b'import java.util.List;'
+        node = _parse_import_node("java", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "java")
+        assert result == ["java"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2591,3 +2591,32 @@ class TestExtractImportName:
         node = _parse_import_node("lua", source, "function_call", tmp_path)
         result = mcp_server._extract_import_name(node, "lua")
         assert result == []
+
+    def test_elixir_alias(self, tmp_path):
+        pytest.importorskip("tree_sitter_elixir")
+        import mcp_server
+        source = b'alias MyApp.Router'
+        node = _parse_import_node("elixir", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "elixir")
+        assert result == ["MyApp"]
+
+    def test_elixir_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_elixir")
+        import mcp_server
+        source = b'import Ecto.Query'
+        node = _parse_import_node("elixir", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "elixir")
+        assert result == ["Ecto"]
+
+    def test_elixir_non_module_call_ignored(self, tmp_path):
+        pytest.importorskip("tree_sitter_elixir")
+        import mcp_server
+        # A plain expression that's not alias/import/use
+        source = b'IO.puts("hello")'
+        # If this produces no "call" node, the test should just pass with []
+        try:
+            node = _parse_import_node("elixir", source, "call", tmp_path)
+        except Exception:
+            return  # no call node found — that's fine
+        result = mcp_server._extract_import_name(node, "elixir")
+        assert result == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2575,3 +2575,19 @@ class TestExtractImportName:
         node = _parse_import_node("haskell", source, "import", tmp_path)
         result = mcp_server._extract_import_name(node, "haskell")
         assert result == ["Data"]
+
+    def test_lua_require(self, tmp_path):
+        pytest.importorskip("tree_sitter_lua")
+        import mcp_server
+        source = b'require("socket")'
+        node = _parse_import_node("lua", source, "function_call", tmp_path)
+        result = mcp_server._extract_import_name(node, "lua")
+        assert result == ["socket"]
+
+    def test_lua_non_require_ignored(self, tmp_path):
+        pytest.importorskip("tree_sitter_lua")
+        import mcp_server
+        source = b'print("hello")'
+        node = _parse_import_node("lua", source, "function_call", tmp_path)
+        result = mcp_server._extract_import_name(node, "lua")
+        assert result == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2503,3 +2503,27 @@ class TestExtractImportName:
         node = _parse_import_node("c_sharp", source, "using_directive", tmp_path)
         result = mcp_server._extract_import_name(node, "c_sharp")
         assert result == ["System"]
+
+    def test_ruby_require(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"require 'rails'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == ["rails"]
+
+    def test_ruby_require_relative(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"require_relative 'my_module'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == ["my_module"]
+
+    def test_ruby_non_require_call_ignored(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"puts 'hello'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2463,3 +2463,27 @@ class TestExtractImportName:
         node = _parse_import_node("java", source, "import_declaration", tmp_path)
         result = mcp_server._extract_import_name(node, "java")
         assert result == ["java"]
+
+    def test_c_system_include(self, tmp_path):
+        pytest.importorskip("tree_sitter_c")
+        import mcp_server
+        source = b'#include <stdio.h>'
+        node = _parse_import_node("c", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "c")
+        assert result == ["stdio"]
+
+    def test_c_local_include(self, tmp_path):
+        pytest.importorskip("tree_sitter_c")
+        import mcp_server
+        source = b'#include "myheader.h"'
+        node = _parse_import_node("c", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "c")
+        assert result == ["myheader"]
+
+    def test_cpp_include(self, tmp_path):
+        pytest.importorskip("tree_sitter_cpp")
+        import mcp_server
+        source = b'#include <iostream>'
+        node = _parse_import_node("cpp", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "cpp")
+        assert result == ["iostream"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2559,3 +2559,11 @@ class TestExtractImportName:
         node = _parse_import_node("swift", source, "import_declaration", tmp_path)
         result = mcp_server._extract_import_name(node, "swift")
         assert result == ["Foundation"]
+
+    def test_scala_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_scala")
+        import mcp_server
+        source = b'import scala.collection.mutable'
+        node = _parse_import_node("scala", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "scala")
+        assert result == ["scala"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2487,3 +2487,19 @@ class TestExtractImportName:
         node = _parse_import_node("cpp", source, "preproc_include", tmp_path)
         result = mcp_server._extract_import_name(node, "cpp")
         assert result == ["iostream"]
+
+    def test_csharp_using_simple(self, tmp_path):
+        pytest.importorskip("tree_sitter_c_sharp")
+        import mcp_server
+        source = b'using System;'
+        node = _parse_import_node("c_sharp", source, "using_directive", tmp_path)
+        result = mcp_server._extract_import_name(node, "c_sharp")
+        assert result == ["System"]
+
+    def test_csharp_using_dotted(self, tmp_path):
+        pytest.importorskip("tree_sitter_c_sharp")
+        import mcp_server
+        source = b'using System.Collections.Generic;'
+        node = _parse_import_node("c_sharp", source, "using_directive", tmp_path)
+        result = mcp_server._extract_import_name(node, "c_sharp")
+        assert result == ["System"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2396,3 +2396,62 @@ class TestRunIngestionBitemporalDeps:
             f"Expected _ingest_close to be called with '{dep_triple}' when import removed, "
             f"got: {close_triples_seen}"
         )
+
+# ---------------------------------------------------------------------------
+# Helpers for TestExtractImportName
+# ---------------------------------------------------------------------------
+
+def _find_node(root, node_type: str):
+    """DFS search for the first node matching node_type."""
+    if root.type == node_type:
+        return root
+    for child in root.children:
+        found = _find_node(child, node_type)
+        if found:
+            return found
+    return None
+
+
+def _parse_import_node(lang_name: str, source: bytes, node_type: str, tmp_path):
+    """Parse source for lang_name, return first node of node_type or skip."""
+    import mcp_server
+    ext = {
+        "go": ".go", "java": ".java", "c": ".c", "cpp": ".cpp",
+        "c_sharp": ".cs", "ruby": ".rb", "php": ".php", "kotlin": ".kt",
+        "swift": ".swift", "scala": ".scala", "haskell": ".hs",
+        "lua": ".lua", "elixir": ".ex",
+    }[lang_name]
+    tmp_file = tmp_path / f"test{ext}"
+    tmp_file.write_bytes(source)
+    parser = mcp_server._get_parser(str(tmp_file))
+    if parser is None:
+        pytest.skip(f"No tree-sitter parser available for {lang_name}")
+    tree = parser.parse(source)
+    node = _find_node(tree.root_node, node_type)
+    if node is None:
+        pytest.fail(
+            f"No {node_type!r} node found in AST.\n"
+            f"Full AST sexp:\n{tree.root_node.sexp()}"
+        )
+    return node
+
+
+class TestExtractImportName:
+    """Unit tests for _extract_import_name — one per language, using real parsers."""
+
+    def test_go_single_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_go")
+        import mcp_server
+        source = b'package main\nimport "fmt"'
+        node = _parse_import_node("go", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "go")
+        assert result == ["fmt"]
+
+    def test_go_grouped_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_go")
+        import mcp_server
+        source = b'package main\nimport (\n\t"os"\n\t"github.com/user/pkg"\n)'
+        node = _parse_import_node("go", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "go")
+        assert "os" in result
+        assert "pkg" in result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2543,3 +2543,11 @@ class TestExtractImportName:
         node = _parse_import_node("php", source, "include_expression", tmp_path)
         result = mcp_server._extract_import_name(node, "php")
         assert result == ["header"]
+
+    def test_kotlin_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_kotlin")
+        import mcp_server
+        source = b'import kotlin.collections.List'
+        node = _parse_import_node("kotlin", source, "import", tmp_path)
+        result = mcp_server._extract_import_name(node, "kotlin")
+        assert result == ["kotlin"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2527,3 +2527,19 @@ class TestExtractImportName:
         node = _parse_import_node("ruby", source, "call", tmp_path)
         result = mcp_server._extract_import_name(node, "ruby")
         assert result == []
+
+    def test_php_require(self, tmp_path):
+        pytest.importorskip("tree_sitter_php")
+        import mcp_server
+        source = b"<?php\nrequire 'config.php';"
+        node = _parse_import_node("php", source, "require_expression", tmp_path)
+        result = mcp_server._extract_import_name(node, "php")
+        assert result == ["config"]
+
+    def test_php_include(self, tmp_path):
+        pytest.importorskip("tree_sitter_php")
+        import mcp_server
+        source = b"<?php\ninclude 'header.php';"
+        node = _parse_import_node("php", source, "include_expression", tmp_path)
+        result = mcp_server._extract_import_name(node, "php")
+        assert result == ["header"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2567,3 +2567,11 @@ class TestExtractImportName:
         node = _parse_import_node("scala", source, "import_declaration", tmp_path)
         result = mcp_server._extract_import_name(node, "scala")
         assert result == ["scala"]
+
+    def test_haskell_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_haskell")
+        import mcp_server
+        source = b'import Data.List'
+        node = _parse_import_node("haskell", source, "import", tmp_path)
+        result = mcp_server._extract_import_name(node, "haskell")
+        assert result == ["Data"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2551,3 +2551,11 @@ class TestExtractImportName:
         node = _parse_import_node("kotlin", source, "import", tmp_path)
         result = mcp_server._extract_import_name(node, "kotlin")
         assert result == ["kotlin"]
+
+    def test_swift_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_swift")
+        import mcp_server
+        source = b'import Foundation'
+        node = _parse_import_node("swift", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "swift")
+        assert result == ["Foundation"]


### PR DESCRIPTION
Closes #76

## Summary

- Installs 9 missing tree-sitter grammar packages (`tree-sitter-c-sharp`, `tree-sitter-ruby`, `tree-sitter-php`, `tree-sitter-kotlin`, `tree-sitter-swift`, `tree-sitter-scala`, `tree-sitter-haskell`, `tree-sitter-lua`, `tree-sitter-elixir`) and adds them to `install.py`'s fallback list
- Extends `_LANG_NODE_TYPES` with 12 new language entries (Go already had one); fixes PHP parser loading via `language_php()` in `_get_parser`
- Adds 5 helper functions (`_c_include_name`, `_csharp_using_name`, `_ruby_require_name`, `_lua_require_name`, `_elixir_module_name`) and 13 `elif` branches in `_extract_import_name` so all languages now write `:depends-on` edges during ingestion

## Languages added

Go · Java · C · C++ · C# · Ruby · PHP · Kotlin · Swift · Scala · Haskell · Lua · Elixir

## Test Plan

- [ ] `pytest tests/test_mcp_server.py::TestExtractImportName -v` — 20+ new unit tests (one per language), skip gracefully if grammar not installed
- [ ] `pytest tests/test_mcp_server.py -q` — full suite, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)