### PR TITLE
Label git submodules and unresolved imports as external dependencies

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -362,6 +362,20 @@ Ident: `:tag/<slugified-tag-name>`
 | `:date` | tag creation date (if available) |
 | `:tagged-commit` (keyword ref) | the commit this tag points to |
 
+#### `:type/external-dependency` — real git submodules and genuinely-unresolved imports
+Ident: `:module/<slugified-path-or-import-name>` (shares the module ident namespace — only `:entity-type` distinguishes internal from external)
+
+| Attribute | Notes |
+|---|---|
+| `:description` | submodule's declared name from `.gitmodules` if resolvable, else raw path (submodules); raw import specifier (unresolved imports) |
+| `:path` | submodule's repo path (submodules only; absent for unresolved-import placeholders — they have no path) |
+| `:pinned-commit` | pinned commit SHA the submodule currently points to (submodules only); bi-temporally closed and reopened on every bump — point-in-time queries see the SHA pinned at that time |
+| `:submodule-name` / `:submodule-url` | from `.gitmodules`, when parseable (submodules only) |
+| `:introduced-by` (keyword ref) | commit that first introduced this dependency |
+| `:modified-in` (keyword ref) | one edge per commit that bumped a submodule's pinned commit |
+
+Vendored-in-tree code checked in as regular files (not a git submodule) is parsed as ordinary `:type/module`/`:function`/`:class` entities like any first-party code — only real gitlinks (mode `160000`) and genuinely-unresolved imports get the external marker.
+
 **Supported languages for AST extraction:** Python, JavaScript, TypeScript (+ TSX/JSX), Rust, Go, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Scala, Haskell, Lua, Elixir. Files in other languages are tracked as modules (with `:introduced-by`/`:modified-in`) but yield no function or class entities.
 
 **Pre-registered SESSION_RULES** — these are always available; no `minigraf_rule` call needed:

--- a/docs/superpowers/plans/2026-07-04-external-dependency-labeling.md
+++ b/docs/superpowers/plans/2026-07-04-external-dependency-labeling.md
@@ -626,9 +626,11 @@ class TestExtractCommit:
         commits = mcp_server._git_commits(str(repo), watermark_hash=None)
         results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(repo), commits[0][0])
 
-        # The gitlink path itself never has a resolvable extension, so it
-        # contributes nothing to the regular per-file results — only .gitmodules does.
-        assert [r[1] for r in results] == [".gitmodules"]
+        # Neither the gitlink path nor .gitmodules itself has a resolvable
+        # extension (Path(".gitmodules").suffix == "" per pathlib — a
+        # leading-dot-only filename has no extension), so both are omitted
+        # from the regular per-file results just like any unsupported file.
+        assert results == []
         assert gitlink_changes == [("add", sub_hash, "vendor/lib")]
         assert gitmodules_map == {"vendor/lib": {"name": "lib", "url": "https://example.com/lib.git"}}
 ```

--- a/docs/superpowers/plans/2026-07-04-external-dependency-labeling.md
+++ b/docs/superpowers/plans/2026-07-04-external-dependency-labeling.md
@@ -1,0 +1,2440 @@
+# External Dependency Labeling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Label real git submodules and genuinely-unresolved imports as `:type/external-dependency` instead of silently dropping them or leaving unmarked placeholders, while fixing the import-resolution gaps (Rust-only heuristic, per-language truncation, no relative-import support) that would otherwise make that labeling mislabel vendored in-tree code — plus an unrelated `.tsx` ingestion bug found during design.
+
+**Architecture:** All changes live in `mcp_server.py` (the codebase's existing single-file convention for ingestion logic) and `tests/test_mcp_server.py`. No new modules. Four independently-testable slices, each ending in a green test suite: (1) `.tsx` parser-loading fix, (2) submodule schema + bi-temporal detection, (3) unresolved-import tagging using today's resolver, (4) generalized import resolution + relative imports, which also upgrades the tagging from (3) to stop mislabeling vendored code.
+
+**Tech Stack:** Python 3.10+, tree-sitter grammars, minigraf (bi-temporal Datalog store), pytest + pytest-asyncio.
+
+## Global Constraints
+
+- Every new/changed function needs a docstring in the file's existing style (see `_build_close_triples`, `_preload_known_deps` for the pattern: state *why*, not what).
+- No new exception-handling patterns — route through the existing `_ingest_close`/`_ingest_transact` helpers and match the file's `except Exception: pass` best-effort convention for git/parse failures.
+- `os`, `re`, `Path`, `Tuple`, `Dict`, `List`, `Optional` are already imported at module level in `mcp_server.py` (lines 13, 14, 21, 22) — do not add local `import os`/`import re` inside functions (some existing functions do this redundantly; don't copy that pattern in new code).
+- Run the full suite (`pytest tests/ -x -q`) at the end of every task, not just the new test — several tasks change a shared function's contract and must not silently break unrelated tests.
+
+---
+
+## File Structure
+
+Only two files change in this plan:
+
+- `mcp_server.py` — all production code changes (new helpers + modifications to `_build_parser`, `_LANG_NODE_TYPES`, `_extract_import_name`, `_c_include_name`, `_ruby_require_name`, `_resolve_module_import`, `_extract_commit`, `_preload_known_entities`, `_run_ingestion`).
+- `tests/test_mcp_server.py` — new test classes plus updates to existing tests whose assertions encode the *old* (buggy) behavior this plan intentionally changes.
+
+Also touched at the very end: `SKILL.md` (schema docs), for the new `:type/external-dependency` entity type.
+
+---
+
+## Task 1: Fix `.tsx` parser loading
+
+**Files:**
+- Modify: `mcp_server.py:103-121` (`_build_parser`)
+- Test: `tests/test_mcp_server.py` (new test in a new `TestTsxParserLoading` class, placed after the existing `TestExtractFromSourceCFamily` class around line 1560)
+
+**Interfaces:**
+- Produces: `_build_parser(lang_name)` now succeeds for `lang_name == "tsx"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestTsxParserLoading:
+    """Regression test for the .tsx module-name bug: _build_parser assumed
+    the importable module is always tree_sitter_{lang_name}, but tsx's grammar
+    ships inside the tree_sitter_typescript package under language_tsx()."""
+
+    def test_tsx_parser_builds_successfully(self):
+        pytest.importorskip("tree_sitter_typescript")
+        import mcp_server
+        mcp_server._grammar_cache.clear()
+        parser = mcp_server._get_parser("component.tsx")
+        assert parser is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_mcp_server.py::TestTsxParserLoading -v`
+Expected: FAIL — `assert parser is not None` fails because `_get_parser` catches the `ModuleNotFoundError` for `tree_sitter_tsx` and caches `None`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `_build_parser` at `mcp_server.py:103-121`:
+
+```python
+# Maps lang_name to the actual importable module, for the (currently only)
+# case where a single package ships multiple grammar variants. tsx and
+# typescript are both exposed by the tree_sitter_typescript package via
+# separate language_tsx()/language_typescript() functions — there is no
+# separate tree_sitter_tsx module, unlike every other language here.
+_LANG_MODULE_OVERRIDES: Dict[str, str] = {
+    "tsx": "tree_sitter_typescript",
+}
+
+
+def _build_parser(lang_name: str) -> Any:
+    """Construct a fresh tree_sitter.Parser for lang_name. Raises on failure
+    (missing grammar package, incompatible tree-sitter version, etc).
+
+    No caching, no warning side effects — those stay in _get_parser, the
+    only caller that needs to turn a failure into a one-time stderr warning.
+    Also used by _thread_parser to build a private-to-this-thread instance
+    once _get_parser has already proven the grammar loads; an unexpected
+    failure there is left to propagate to the caller (Task 3's
+    _extract_commit, running in a worker thread) rather than being
+    swallowed, consistent with how any other producer-task exception is
+    handled.
+    """
+    module_name = _LANG_MODULE_OVERRIDES.get(lang_name, f"tree_sitter_{lang_name}")
+    mod = __import__(module_name, fromlist=["language"])
+    from tree_sitter import Language, Parser  # type: ignore
+    # PHP exposes language_php() instead of language(); tsx exposes
+    # language_tsx() from within the tree_sitter_typescript module.
+    lang_fn = getattr(mod, f"language_{lang_name}", None) or mod.language
+    lang_obj = Language(lang_fn())
+    return Parser(lang_obj)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_mcp_server.py::TestTsxParserLoading -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "fix: resolve tree_sitter_typescript module for tsx grammar (#97)"
+```
+
+---
+
+## Task 2: Alias `tsx` to `typescript` for node-type dispatch
+
+**Files:**
+- Modify: `mcp_server.py:617-621` (`_walk_ast`) and `mcp_server.py:478-481` (`_extract_import_name`)
+- Test: `tests/test_mcp_server.py`, same `TestTsxParserLoading` class from Task 1
+
+**Interfaces:**
+- Consumes: `_LANG_MODULE_OVERRIDES` is unrelated; this task only touches the two lookup sites.
+- Produces: `.tsx` files now yield functions/classes/imports identical to `.ts` in shape.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+    def test_tsx_extracts_functions_classes_imports(self):
+        pytest.importorskip("tree_sitter_typescript")
+        import mcp_server
+        mcp_server._grammar_cache.clear()
+        source = (
+            b"import React from 'react';\n"
+            b"class Widget extends React.Component {\n"
+            b"  render() { return null; }\n"
+            b"}\n"
+            b"function useThing() { return 1; }\n"
+        )
+        parser = mcp_server._get_parser("component.tsx")
+        result = mcp_server._extract_from_source(source, parser, "component.tsx")
+        assert "Widget" in result["classes"]
+        assert "useThing" in result["functions"] or "render" in result["functions"]
+        assert "react" in result["imports"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_mcp_server.py::TestTsxParserLoading::test_tsx_extracts_functions_classes_imports -v`
+Expected: FAIL — `result["classes"]`, `result["functions"]`, `result["imports"]` are all empty lists because `_walk_ast` returns immediately (`_LANG_NODE_TYPES.get("tsx")` is `None`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `_walk_ast` (`mcp_server.py:617-621`), change:
+
+```python
+def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
+    """Recursively extract code entities from a tree-sitter AST node."""
+    node_types = _LANG_NODE_TYPES.get(lang_name)
+    if node_types is None:
+        return
+```
+
+to:
+
+```python
+def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
+    """Recursively extract code entities from a tree-sitter AST node.
+
+    tsx is treated as an alias of typescript here (and in _extract_import_name)
+    rather than duplicating every _LANG_NODE_TYPES entry — the TSX grammar is
+    a strict superset of TypeScript's node types for the constructs this
+    module cares about (functions, classes, imports, calls).
+    """
+    node_types = _LANG_NODE_TYPES.get("typescript" if lang_name == "tsx" else lang_name)
+    if node_types is None:
+        return
+```
+
+In `_extract_import_name` (`mcp_server.py:478-495`), change the dispatch condition:
+
+```python
+    elif lang_name in ("javascript", "typescript"):
+```
+
+to:
+
+```python
+    elif lang_name in ("javascript", "typescript", "tsx"):
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_mcp_server.py::TestTsxParserLoading -v`
+Expected: PASS (both tests in the class)
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pytest tests/ -x -q`
+Expected: PASS, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "fix: alias tsx to typescript in node-type and import dispatch (#97)"
+```
+
+---
+
+## Task 3: Add `_git_diff_tree_raw` (single-call raw diff-tree helper)
+
+**Files:**
+- Modify: `mcp_server.py:1140-1154` (add new function immediately before `_git_changed_files`)
+- Test: `tests/test_mcp_server.py`, new `TestGitDiffTreeRaw` class placed directly after the existing `TestGitHelpers` class (ends around line 1751)
+
+**Interfaces:**
+- Produces: `_git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[Tuple[str, str, str, str, str, str]]` — `(status_char, old_mode, new_mode, old_sha, new_sha, path)` for every changed path in a commit.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestGitDiffTreeRaw:
+    def test_regular_file_add(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(git_repo), commits[0][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path = entries[0]
+        assert status == "A"
+        assert old_mode == "000000"
+        assert new_mode == "100644"
+        assert path == "auth.py"
+
+    def test_gitlink_add_reports_mode_160000(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        _subprocess.run(["git", "init"], cwd=sub, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "--allow-empty", "-m", "e"], cwd=sub, check=True, capture_output=True)
+        sub_hash = _subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=sub, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        _subprocess.run(
+            ["git", "update-index", "--add", "--cacheinfo", f"160000,{sub_hash},vendor/lib"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(["git", "commit", "-m", "add submodule"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(repo), commits[0][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path = entries[0]
+        assert status == "A"
+        assert new_mode == "160000"
+        assert new_sha == sub_hash
+        assert path == "vendor/lib"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_mcp_server.py::TestGitDiffTreeRaw -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_git_diff_tree_raw'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert immediately before `_git_changed_files` at `mcp_server.py:1140`:
+
+```python
+def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
+    """Return (status_char, old_mode, new_mode, old_sha, new_sha, path) for
+    every changed path in a commit, via a single `git diff-tree --raw` call.
+
+    Supersedes running diff-tree a second time just to detect gitlinks:
+    --raw already carries file mode (needed to spot submodule paths, mode
+    160000) in the same subprocess invocation _extract_commit already makes.
+    """
+    result = _subprocess.run(
+        ["git", "diff-tree", "--no-commit-id", "-r", "--raw", "--root", commit_hash],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    entries = []
+    for line in result.stdout.strip().splitlines():
+        if not line.startswith(":"):
+            continue
+        meta, sep, path = line.partition("\t")
+        if not sep:
+            continue
+        fields = meta[1:].split(" ")
+        if len(fields) < 5:
+            continue
+        old_mode, new_mode, old_sha, new_sha, status = fields[0], fields[1], fields[2], fields[3], fields[4]
+        entries.append((status[0], old_mode, new_mode, old_sha, new_sha, path))
+    return entries
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_mcp_server.py::TestGitDiffTreeRaw -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add _git_diff_tree_raw for mode-aware diff-tree parsing (#97)"
+```
+
+---
+
+## Task 4: Add `_gitlink_changes` (pure filter over raw entries)
+
+**Files:**
+- Modify: `mcp_server.py` (add new function + `_GITLINK_MODE` constant directly after `_git_diff_tree_raw`)
+- Test: `tests/test_mcp_server.py`, new `TestGitlinkChanges` class placed directly after `TestGitDiffTreeRaw`
+
+**Interfaces:**
+- Consumes: same tuple shape as `_git_diff_tree_raw`'s return.
+- Produces: `_gitlink_changes(raw_entries: List[tuple]) -> List[Tuple[str, str, str]]` — `(change_kind, sha, path)`, `change_kind` in `{"add", "bump", "remove"}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestGitlinkChanges:
+    def test_non_gitlink_rows_are_ignored(self):
+        import mcp_server
+        raw = [("A", "000000", "100644", "0" * 40, "a" * 40, "auth.py")]
+        assert mcp_server._gitlink_changes(raw) == []
+
+    def test_add_when_new_mode_is_gitlink(self):
+        import mcp_server
+        raw = [("A", "000000", "160000", "0" * 40, "b" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("add", "b" * 40, "vendor/lib")]
+
+    def test_bump_when_both_modes_are_gitlink(self):
+        import mcp_server
+        raw = [("M", "160000", "160000", "b" * 40, "c" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("bump", "c" * 40, "vendor/lib")]
+
+    def test_remove_when_old_mode_is_gitlink(self):
+        import mcp_server
+        raw = [("D", "160000", "000000", "c" * 40, "0" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("remove", "c" * 40, "vendor/lib")]
+
+    def test_type_change_into_internal_reported_as_remove(self):
+        import mcp_server
+        raw = [("T", "160000", "100644", "c" * 40, "d" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("remove", "c" * 40, "vendor/lib")]
+
+    def test_type_change_into_external_reported_as_add(self):
+        import mcp_server
+        raw = [("T", "100644", "160000", "d" * 40, "e" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("add", "e" * 40, "vendor/lib")]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_mcp_server.py::TestGitlinkChanges -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_gitlink_changes'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+_GITLINK_MODE = "160000"
+
+
+def _gitlink_changes(raw_entries: List[tuple]) -> List[tuple]:
+    """Filter _git_diff_tree_raw's output down to gitlink-involving rows,
+    collapsed into three cases by mode pair rather than by the raw status
+    letter (which varies: A/D/M/T can all represent a gitlink change
+    depending on what else happened to the same path):
+
+      "add"    — new_mode is a gitlink, old_mode is not. Covers a plain
+                 submodule addition (status A) and a same-path flip from a
+                 regular blob into a gitlink (status T).
+      "bump"   — both modes are gitlinks (status M): the pinned commit changed.
+      "remove" — old_mode is a gitlink, new_mode is not. Covers a plain
+                 submodule removal (status D) and a same-path flip from a
+                 gitlink back into a regular blob (status T).
+
+    sha is the new pinned commit for "add"/"bump", or the last-known pinned
+    commit for "remove" (needed by the caller to close the right fact).
+    """
+    changes = []
+    for status, old_mode, new_mode, old_sha, new_sha, path in raw_entries:
+        old_is_link = old_mode == _GITLINK_MODE
+        new_is_link = new_mode == _GITLINK_MODE
+        if not old_is_link and not new_is_link:
+            continue
+        if new_is_link and not old_is_link:
+            changes.append(("add", new_sha, path))
+        elif old_is_link and new_is_link:
+            changes.append(("bump", new_sha, path))
+        else:
+            changes.append(("remove", old_sha, path))
+    return changes
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_mcp_server.py::TestGitlinkChanges -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add _gitlink_changes filter over raw diff-tree entries (#97)"
+```
+
+---
+
+## Task 5: Add `.gitmodules` parsing (`_parse_gitmodules`, `_git_gitmodules_at`)
+
+**Files:**
+- Modify: `mcp_server.py` (add both functions directly after `_git_file_content`, i.e. after line 1168)
+- Test: `tests/test_mcp_server.py`, new `TestParseGitmodules` class placed after `TestGitlinkChanges`
+
+**Interfaces:**
+- Consumes: `_git_file_content(repo_path, commit_hash, file_path) -> bytes` (existing, unchanged).
+- Produces: `_parse_gitmodules(content: bytes) -> Dict[str, Dict[str, str]]` (path → `{"name", "url"}`); `_git_gitmodules_at(repo_path, commit_hash) -> Dict[str, Dict[str, str]]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestParseGitmodules:
+    def test_parses_single_submodule(self):
+        import mcp_server
+        content = (
+            b'[submodule "abseil-cpp"]\n'
+            b'\tpath = 3rdParty/abseil-cpp\n'
+            b'\turl = https://github.com/abseil/abseil-cpp.git\n'
+        )
+        result = mcp_server._parse_gitmodules(content)
+        assert result == {
+            "3rdParty/abseil-cpp": {
+                "name": "abseil-cpp",
+                "url": "https://github.com/abseil/abseil-cpp.git",
+            }
+        }
+
+    def test_parses_multiple_submodules(self):
+        import mcp_server
+        content = (
+            b'[submodule "a"]\n\tpath = vendor/a\n\turl = https://x/a.git\n'
+            b'[submodule "b"]\n\tpath = vendor/b\n\turl = https://x/b.git\n'
+        )
+        result = mcp_server._parse_gitmodules(content)
+        assert set(result.keys()) == {"vendor/a", "vendor/b"}
+
+    def test_malformed_content_returns_empty_dict(self):
+        import mcp_server
+        result = mcp_server._parse_gitmodules(b"not a valid [ini file")
+        assert result == {}
+
+    def test_empty_content_returns_empty_dict(self):
+        import mcp_server
+        assert mcp_server._parse_gitmodules(b"") == {}
+
+    def test_git_gitmodules_at_missing_file_returns_empty(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        result = mcp_server._git_gitmodules_at(str(git_repo), commits[0][0])
+        assert result == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_mcp_server.py::TestParseGitmodules -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_parse_gitmodules'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def _parse_gitmodules(content: bytes) -> Dict[str, Dict[str, str]]:
+    """Parse .gitmodules content into {path: {"name": ..., "url": ...}}.
+
+    Best-effort: git config's `[section "subsection"]` syntax is a strict
+    superset of what configparser expects for ordinary cases, so malformed
+    or unusual .gitmodules content fails closed to an empty dict rather
+    than raising — matches this file's existing best-effort git/parse
+    conventions (see _extract_from_source's bare except).
+    """
+    import configparser
+
+    result: Dict[str, Dict[str, str]] = {}
+    parser = configparser.ConfigParser()
+    try:
+        parser.read_string(content.decode("utf-8", errors="replace"))
+    except configparser.Error:
+        return result
+    for section in parser.sections():
+        m = re.match(r'submodule\s+"(.+)"', section)
+        if not m:
+            continue
+        path = parser.get(section, "path", fallback=None)
+        url = parser.get(section, "url", fallback=None)
+        if path:
+            result[path] = {"name": m.group(1), "url": url or ""}
+    return result
+
+
+def _git_gitmodules_at(repo_path: str, commit_hash: str) -> Dict[str, Dict[str, str]]:
+    """Fetch and parse .gitmodules as it exists at commit_hash.
+
+    Empty dict if missing or unparseable — most repos never have a
+    .gitmodules file at all, which is the normal case, not an error.
+    """
+    try:
+        content = _git_file_content(repo_path, commit_hash, ".gitmodules")
+    except Exception:
+        return {}
+    return _parse_gitmodules(content)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_mcp_server.py::TestParseGitmodules -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add .gitmodules parsing for submodule name/url (#97)"
+```
+
+---
+
+## Task 6: Extend `_extract_commit` to return gitlink changes and `.gitmodules` map
+
+**Files:**
+- Modify: `mcp_server.py:2425-2450` (`_extract_commit`)
+- Modify: `tests/test_mcp_server.py:1753-1799` (4 existing tests in `TestExtractCommit` that unpack `_extract_commit`'s return or monkeypatch its git call)
+- Test: same file, new tests appended to `TestExtractCommit`
+
+**Interfaces:**
+- Consumes: `_git_diff_tree_raw` (Task 3), `_gitlink_changes` (Task 4), `_git_gitmodules_at` (Task 5).
+- Produces: `_extract_commit(repo_path, commit_hash) -> Tuple[List[Tuple[str,str,Optional[Dict]]], List[Tuple[str,str,str]], Dict[str,Dict[str,str]]]` — `(file_results, gitlink_changes, gitmodules_map)`. **This changes the existing return shape from a bare list to a 3-tuple — every caller must be updated in this task.**
+
+- [ ] **Step 1: Update the 4 existing tests that call `_extract_commit` directly**
+
+In `tests/test_mcp_server.py`, replace the `TestExtractCommit` class body (currently lines 1753-1799) with:
+
+```python
+class TestExtractCommit:
+    def test_added_file_returns_extracted_dict(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        first_hash = commits[0][0]
+
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), first_hash)
+
+        assert len(results) == 1
+        status, file_path, extracted = results[0]
+        assert status == "A"
+        assert file_path == "auth.py"
+        assert "login" in extracted["functions"]
+        assert gitlink_changes == []
+        assert gitmodules_map == {}
+
+    def test_deleted_file_has_none_extracted(self, git_repo_with_deletion):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo_with_deletion), watermark_hash=None)
+        delete_hash = commits[-1][0]
+
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo_with_deletion), delete_hash)
+
+        d_entries = [r for r in results if r[0] == "D"]
+        assert len(d_entries) == 1
+        assert d_entries[0][2] is None
+
+    def test_unsupported_extension_is_omitted(self, git_repo, monkeypatch):
+        import mcp_server
+        monkeypatch.setattr(
+            mcp_server, "_git_diff_tree_raw",
+            lambda repo, commit: [("A", "000000", "100644", "0" * 40, "a" * 40, "notes.txt")],
+        )
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), "deadbeef")
+        assert results == []
+
+    def test_content_fetch_failure_is_omitted_not_raised(self, git_repo, monkeypatch):
+        import mcp_server
+        monkeypatch.setattr(
+            mcp_server, "_git_diff_tree_raw",
+            lambda repo, commit: [("A", "000000", "100644", "0" * 40, "a" * 40, "auth.py")],
+        )
+
+        def boom(repo, commit, path):
+            raise mcp_server.MiniGrafError("simulated git-show failure")
+
+        monkeypatch.setattr(mcp_server, "_git_file_content", boom)
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), "deadbeef")
+        assert results == []
+
+    def test_gitlink_add_is_reported_separately_from_file_results(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        _subprocess.run(["git", "init"], cwd=sub, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "--allow-empty", "-m", "e"], cwd=sub, check=True, capture_output=True)
+        sub_hash = _subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=sub, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        (repo / ".gitmodules").write_text(
+            '[submodule "lib"]\n\tpath = vendor/lib\n\turl = https://example.com/lib.git\n'
+        )
+        _subprocess.run(
+            ["git", "update-index", "--add", "--cacheinfo", f"160000,{sub_hash},vendor/lib"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(["git", "add", ".gitmodules"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add submodule"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(repo), commits[0][0])
+
+        # The gitlink path itself never has a resolvable extension, so it
+        # contributes nothing to the regular per-file results — only .gitmodules does.
+        assert [r[1] for r in results] == [".gitmodules"]
+        assert gitlink_changes == [("add", sub_hash, "vendor/lib")]
+        assert gitmodules_map == {"vendor/lib": {"name": "lib", "url": "https://example.com/lib.git"}}
+```
+
+- [ ] **Step 2: Run the updated/new tests to verify they fail**
+
+Run: `pytest tests/test_mcp_server.py::TestExtractCommit -v`
+Expected: FAIL — `ValueError: too many values to unpack` on the first 4 tests (old `_extract_commit` still returns a bare list), and `AttributeError` on `_git_diff_tree_raw` monkeypatch targets not existing yet in that role, plus the new gitlink test failing since gitlink info isn't returned at all yet.
+
+- [ ] **Step 3: Update `_extract_commit`**
+
+Replace `mcp_server.py:2425-2450`:
+
+```python
+def _extract_commit(
+    repo_path: str, commit_hash: str
+) -> Tuple[List[Tuple[str, str, Optional[Dict[str, List[str]]]]], List[tuple], Dict[str, Dict[str, str]]]:
+    """Read-only, stateless per-commit extraction: diff-tree + git-show + tree-sitter parse.
+
+    Runs in a worker thread via the ThreadPoolExecutor in _run_ingestion.
+    Touches no shared mutable state and no DB. Returns (file_results,
+    gitlink_changes, gitmodules_map):
+
+      file_results: one entry per changed file that has a supported parser;
+        A/M files whose content fetch fails are omitted entirely, mirroring
+        the previous inline `continue` — same as before this pipeline existed.
+      gitlink_changes: _gitlink_changes' output — gitlink-involving rows,
+        never fed through the tree-sitter parser (gitlink paths never have
+        a resolvable extension).
+      gitmodules_map: path -> {"name", "url"}, populated only when this
+        commit has at least one gitlink "add" — avoids a wasted git-show
+        call on the (overwhelmingly common) case of a commit that touches
+        no submodules at all.
+
+    Sources both file_results and gitlink_changes from a single
+    `git diff-tree --raw` call (via _git_diff_tree_raw) rather than the
+    former --name-status call, which discarded file mode entirely.
+    """
+    raw_entries = _git_diff_tree_raw(repo_path, commit_hash)
+    results: List[Tuple[str, str, Optional[Dict[str, List[str]]]]] = []
+    for status, old_mode, new_mode, old_sha, new_sha, file_path in raw_entries:
+        parser = _thread_parser(file_path)
+        if parser is None:
+            continue
+        if status == "D":
+            results.append((status, file_path, None))
+            continue
+        try:
+            content = _git_file_content(repo_path, commit_hash, file_path)
+        except Exception:
+            continue
+        extracted = _extract_from_source(content, parser, file_path)
+        results.append((status, file_path, extracted))
+
+    gitlink_changes = _gitlink_changes(raw_entries)
+    gitmodules_map: Dict[str, Dict[str, str]] = {}
+    if any(kind == "add" for kind, _, _ in gitlink_changes):
+        gitmodules_map = _git_gitmodules_at(repo_path, commit_hash)
+
+    return results, gitlink_changes, gitmodules_map
+```
+
+- [ ] **Step 4: Update the one production call site in `_run_ingestion`**
+
+At `mcp_server.py:2524` (inside the `while pending:` loop), change:
+
+```python
+                (commit_hash, commit_ts_iso, author, subject), fut = pending.popleft()
+                extracted_files = await fut
+                submit_next()
+```
+
+to:
+
+```python
+                (commit_hash, commit_ts_iso, author, subject), fut = pending.popleft()
+                extracted_files, gitlink_changes, gitmodules_map = await fut
+                submit_next()
+```
+
+(`gitlink_changes`/`gitmodules_map` are unused until Task 8 wires them in — that's fine, they're just local variables for now.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_server.py::TestExtractCommit -v && pytest tests/ -x -q`
+Expected: PASS, full suite green (in particular `TestRunIngestionBitemporalDeps` and the async ingestion tests, which go through `_run_ingestion`'s unpacking).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extend _extract_commit to report gitlink changes and .gitmodules (#97)"
+```
+
+---
+
+## Task 7: Broaden entity preload + add `_preload_pinned_commits`
+
+**Files:**
+- Modify: `mcp_server.py:2279-2329` (`_preload_known_entities`)
+- Modify: `mcp_server.py` (add `_preload_pinned_commits` directly after `_preload_known_deps`, i.e. after line 2391)
+- Test: `tests/test_mcp_server.py`, new `TestPreloadExternalDependencies` class placed directly after the existing `TestPreloadKnownDeps` class (ends around line 2119)
+
+**Interfaces:**
+- Consumes: `_VALID_TIME_FOREVER_MS` (existing constant, `mcp_server.py:2332`).
+- Produces: `_preload_known_entities` now also loads `:type/external-dependency` idents into the same `entity_valid_from`/`entity_descriptions`/`file_entities` dicts. New `_preload_pinned_commits(db) -> Dict[str, Tuple[str, str]]` — `{ident: (sha, valid_from_iso)}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+This follows the exact fixture idiom already used by `TestPreloadKnownDeps` at `tests/test_mcp_server.py:2057-2075`: `mock_minigraf_db` patches the `MiniGrafDb` constructor, so tests call `mcp_server.open_db(...)` then `mcp_server.get_db()` to obtain the (mocked) handle — they never construct `MiniGrafDb` directly.
+
+```python
+class TestPreloadExternalDependencies:
+    def test_preload_known_entities_includes_external_dependency(self, mock_minigraf_db, tmp_path):
+        mock_class, db_instance = mock_minigraf_db
+        import mcp_server
+        # _preload_known_entities' query shape is [?ident ?path ?desc ?date] per entity_type
+        db_instance.execute.return_value = json.dumps({
+            "results": [[":module/vendor-lib", "vendor/lib", "lib", "2026-01-01T00:00:00Z"]]
+        })
+        mcp_server.open_db(str(tmp_path / "memory.graph"))
+        db = mcp_server.get_db()
+
+        entity_valid_from, entity_descriptions, file_entities = mcp_server._preload_known_entities(db, str(tmp_path))
+
+        assert ":module/vendor-lib" in entity_valid_from
+        assert entity_descriptions[":module/vendor-lib"] == "lib"
+        assert "vendor/lib" in file_entities
+
+    def test_preload_pinned_commits_reloads_current_sha(self, mock_minigraf_db, tmp_path):
+        mock_class, db_instance = mock_minigraf_db
+        import mcp_server
+        # _preload_pinned_commits' query shape is [?e ?sha ?vf] with :any-valid-time
+        db_instance.execute.return_value = json.dumps({
+            "results": [[":module/vendor-lib", "abc123", 1735689600000]]
+        })
+        mcp_server.open_db(str(tmp_path / "memory.graph"))
+        db = mcp_server.get_db()
+
+        pinned = mcp_server._preload_pinned_commits(db)
+
+        assert pinned[":module/vendor-lib"][0] == "abc123"
+        assert pinned[":module/vendor-lib"][1].endswith("Z")
+
+    def test_preload_pinned_commits_returns_empty_on_query_failure(self, mock_minigraf_db, tmp_path):
+        mock_class, db_instance = mock_minigraf_db
+        import mcp_server
+        from minigraf import MiniGrafError
+        mcp_server.open_db(str(tmp_path / "memory.graph"))
+        db = mcp_server.get_db()
+        db_instance.execute.side_effect = MiniGrafError("boom")
+
+        assert mcp_server._preload_pinned_commits(db) == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_server.py::TestPreloadExternalDependencies -v`
+Expected: FAIL — `_preload_known_entities` doesn't query `:type/external-dependency` yet, and `_preload_pinned_commits` doesn't exist.
+
+- [ ] **Step 3: Broaden `_preload_known_entities`**
+
+At `mcp_server.py:2307-2308`, change:
+
+```python
+    for entity_type in ("module", "function", "class"):
+        path_attr = "path" if entity_type == "module" else "file"
+```
+
+to:
+
+```python
+    for entity_type in ("module", "function", "class", "external-dependency"):
+        path_attr = "path" if entity_type in ("module", "external-dependency") else "file"
+```
+
+Update the function's docstring (`mcp_server.py:2279-2289`) to mention external-dependency:
+
+```python
+def _preload_known_entities(db: Any, repo_path: str) -> tuple:
+    """Load all existing module/function/class/external-dependency idents from
+    the DB, and pre-seed file_entities with all currently tracked files in the
+    repo.
+
+    external-dependency entities share the module ident namespace and use the
+    same "path" attribute as modules, so folding them into this same query
+    means the existing close/reopen machinery (entity_valid_from,
+    entity_descriptions) just works for submodules without new parallel state.
+    Unresolved-import placeholders (no :path) are not reloaded by this query —
+    nothing in this codebase ever closes one, so the gap is harmless; see the
+    design spec's Section 2.
+
+    Pre-seeding from `git ls-files` ensures that _resolve_module_import can
+    find any module file even when processing early commits — before those files
+    have been introduced in the chronological commit walk.
+
+    Returns (entity_valid_from, entity_descriptions, file_entities).
+    entity_valid_from maps ident → git commit timestamp of first introduction.
+    entity_descriptions maps ident → human-readable name (function/class/file).
+    """
+```
+
+- [ ] **Step 4: Add `_preload_pinned_commits`**
+
+Insert directly after `_preload_known_deps` (after `mcp_server.py:2391`):
+
+```python
+def _preload_pinned_commits(db: Any) -> Dict[str, tuple]:
+    """Reload each external-dependency entity's current :pinned-commit value
+    and the timestamp it was set at, mirroring _preload_known_deps's per-fact
+    :any-valid-time pattern for :depends-on.
+
+    Needed because :pinned-commit is bi-temporally closed and reopened on
+    every bump (see _run_ingestion's gitlink handling) — without this, the
+    server would lose track of the prior SHA and valid-from across a restart,
+    corrupting the close on the next bump or removal exactly the way
+    _preload_known_deps' docstring describes for :depends-on.
+
+    Returns {ident: (sha, valid_from_iso)}.
+    """
+    pinned: Dict[str, tuple] = {}
+    try:
+        raw = db.execute(
+            "(query [:find ?e ?sha ?vf "
+            ":any-valid-time "
+            ":where [?e :pinned-commit ?sha] "
+            "[?e :db/valid-from ?vf] "
+            "[?e :db/valid-to ?vt] "
+            f"[(= ?vt {_VALID_TIME_FOREVER_MS})]])"
+        )
+        rows = json.loads(raw).get("results", [])
+    except Exception:
+        return pinned
+    for ident, sha, vf_ms in rows:
+        vf_iso = (
+            datetime.datetime.fromtimestamp(vf_ms / 1000, datetime.timezone.utc)
+            .strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+        )
+        pinned[ident] = (sha, vf_iso)
+    return pinned
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_server.py::TestPreloadExternalDependencies -v && pytest tests/ -x -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: preload external-dependency entities and pinned-commit history (#97)"
+```
+
+---
+
+## Task 8: Wire gitlink handling into `_run_ingestion`'s commit loop
+
+**Files:**
+- Modify: `mcp_server.py:2453-2492` (preload section at the top of `_run_ingestion`)
+- Modify: `mcp_server.py:2523-2626` (per-commit body)
+- Test: `tests/test_mcp_server.py`, new `TestRunIngestionGitlinks` class placed after `TestRunIngestionBitemporalDeps` (after line 3240)
+
+**Interfaces:**
+- Consumes: `_preload_pinned_commits` (Task 7), `_gitlink_changes`/`gitmodules_map` now returned by `_extract_commit` (Task 6), `_build_close_triples`, `_ingest_transact`, `_ingest_close`, `_edn_escape` (all existing).
+- Produces: `:type/external-dependency` entities in the DB for submodule add/bump/remove/flip.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestRunIngestionGitlinks:
+    """End-to-end tests for submodule add/bump/remove/flip via _run_ingestion."""
+
+    def _make_progress(self):
+        return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
+
+    def _add_submodule_commit(self, repo, path="vendor/lib", name="lib", url="https://example.com/lib.git"):
+        sub = repo.parent / f"{repo.name}-sub"
+        _subprocess.run(["git", "init", "-q", str(sub)], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "config", "user.email", "t@t.com"], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "config", "user.name", "T"], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "commit", "--allow-empty", "-m", "e"], check=True, capture_output=True)
+        sub_hash = _subprocess.run(
+            ["git", "-C", str(sub), "rev-parse", "HEAD"], check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        (repo / ".gitmodules").write_text(f'[submodule "{name}"]\n\tpath = {path}\n\turl = {url}\n')
+        _subprocess.run(
+            ["git", "update-index", "--add", "--cacheinfo", f"160000,{sub_hash},{path}"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(["git", "add", ".gitmodules"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add submodule"], cwd=repo, check=True, capture_output=True)
+        return sub_hash
+
+    @pytest.mark.asyncio
+    async def test_submodule_add_creates_external_dependency_entity(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        sub_hash = self._add_submodule_commit(repo)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        ident = mcp_server._code_ident("module", "vendor/lib")
+        assert any(f"[{ident} :entity-type :type/external-dependency]" in t for t in transact_calls)
+        assert any(f'[{ident} :pinned-commit "{sub_hash}"]' in t for t in transact_calls)
+        assert any(f'[{ident} :submodule-name "lib"]' in t for t in transact_calls)
+        assert any(f'[{ident} :submodule-url "https://example.com/lib.git"]' in t for t in transact_calls)
+
+    @pytest.mark.asyncio
+    async def test_submodule_bump_closes_old_pinned_commit(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        first_sha = self._add_submodule_commit(repo)
+
+        sub_dir = tmp_path / f"{repo.name}-sub"
+        _subprocess.run(["git", "-C", str(sub_dir), "commit", "--allow-empty", "-m", "bump"], check=True, capture_output=True)
+        second_sha = _subprocess.run(
+            ["git", "-C", str(sub_dir), "rev-parse", "HEAD"], check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        _subprocess.run(
+            ["git", "update-index", "--cacheinfo", f"160000,{second_sha},vendor/lib"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(["git", "commit", "-m", "bump submodule"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen: list = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        ident = mcp_server._code_ident("module", "vendor/lib")
+        assert any(f'[{ident} :pinned-commit "{first_sha}"]' in t for t in close_triples_seen)
+
+    @pytest.mark.asyncio
+    async def test_submodule_removal_closes_entity(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        self._add_submodule_commit(repo)
+
+        _subprocess.run(["git", "rm", "-f", "vendor/lib"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "remove submodule"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen: list = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        ident = mcp_server._code_ident("module", "vendor/lib")
+        assert any(f'[{ident} :ident "{ident}"]' in t for t in close_triples_seen)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_server.py::TestRunIngestionGitlinks -v`
+Expected: FAIL — none of the assertions find matching triples since gitlink changes aren't wired into the commit loop yet.
+
+- [ ] **Step 3: Add `pinned_commit_state` to the preload section**
+
+At `mcp_server.py:2472-2473`, change:
+
+```python
+        entity_valid_from, entity_descriptions, file_entities = _preload_known_entities(db, repo_path)
+        file_deps, dep_valid_from = _preload_known_deps(db, file_entities)
+```
+
+to:
+
+```python
+        entity_valid_from, entity_descriptions, file_entities = _preload_known_entities(db, repo_path)
+        file_deps, dep_valid_from = _preload_known_deps(db, file_entities)
+        pinned_commit_state = _preload_pinned_commits(db)
+```
+
+- [ ] **Step 4: Insert gitlink handling into the per-commit body**
+
+At `mcp_server.py:2549`, immediately after the existing per-file `for status, file_path, extracted in extracted_files:` loop closes and before the `# Split :contains triples out before batching.` comment (`mcp_server.py:2611`), insert:
+
+```python
+                    for kind, sha, path in gitlink_changes:
+                        ext_ident = _code_ident("module", path)
+                        if kind == "add":
+                            info = gitmodules_map.get(path, {})
+                            name = info.get("name", "")
+                            url = info.get("url", "")
+                            description = name or path
+                            ext_triples = [
+                                f"[{ext_ident} :entity-type :type/external-dependency]",
+                                f'[{ext_ident} :ident "{_edn_escape(ext_ident)}"]',
+                                f'[{ext_ident} :description "{_edn_escape(description)}"]',
+                                f'[{ext_ident} :path "{_edn_escape(path)}"]',
+                                f'[{ext_ident} :pinned-commit "{_edn_escape(sha)}"]',
+                                f"[{ext_ident} :introduced-by {commit_ident}]",
+                            ]
+                            if name:
+                                ext_triples.append(f'[{ext_ident} :submodule-name "{_edn_escape(name)}"]')
+                            if url:
+                                ext_triples.append(f'[{ext_ident} :submodule-url "{_edn_escape(url)}"]')
+                            add_triples.extend(ext_triples)
+                            entity_valid_from[ext_ident] = commit_ts_iso
+                            entity_descriptions[ext_ident] = description
+                            pinned_commit_state[ext_ident] = (sha, commit_ts_iso)
+                        elif kind == "bump":
+                            old_sha, orig_ts = pinned_commit_state.get(ext_ident, (None, commit_ts_iso))
+                            if old_sha is not None:
+                                close_items.append(
+                                    ([f'[{ext_ident} :pinned-commit "{_edn_escape(old_sha)}"]'], orig_ts)
+                                )
+                            add_triples.append(f'[{ext_ident} :pinned-commit "{_edn_escape(sha)}"]')
+                            add_triples.append(f"[{ext_ident} :modified-in {commit_ident}]")
+                            pinned_commit_state[ext_ident] = (sha, commit_ts_iso)
+                        else:  # "remove"
+                            orig_ts = entity_valid_from.get(ext_ident, commit_ts_iso)
+                            desc = entity_descriptions.get(ext_ident, "")
+                            close_items.append(
+                                (_build_close_triples(ext_ident, desc, ext_ident), orig_ts)
+                            )
+                            old_sha, pin_orig_ts = pinned_commit_state.pop(ext_ident, (None, commit_ts_iso))
+                            if old_sha is not None:
+                                close_items.append(
+                                    ([f'[{ext_ident} :pinned-commit "{_edn_escape(old_sha)}"]'], pin_orig_ts)
+                                )
+
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_server.py::TestRunIngestionGitlinks -v && pytest tests/ -x -q`
+Expected: PASS, full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: label real git submodules as :type/external-dependency (#97)"
+```
+
+---
+
+## Task 9: Tag unresolved imports as external, using today's (Rust-only) resolver
+
+**Files:**
+- Modify: `mcp_server.py:1062-1090` (`_resolve_module_import`)
+- Modify: `mcp_server.py:2593-2609` (the dependency-diffing block inside `_run_ingestion`'s per-file loop)
+- Test: `tests/test_mcp_server.py`, new `TestUnresolvedImportTagging` class placed after `TestRunIngestionBitemporalDeps`
+
+**Interfaces:**
+- Produces: `_resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]) -> Tuple[str, bool]` — the bool is `True` when it resolved to a known file, `False` when it fell through to the bare-ident guess. **Return type change — the one call site in `_run_ingestion` must be updated in this same task.**
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestUnresolvedImportTagging:
+    def _make_progress(self):
+        return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
+
+    def test_resolve_module_import_returns_bool_flag(self):
+        import mcp_server
+        file_entities = {"src/storage.rs": []}
+        ident, is_resolved = mcp_server._resolve_module_import("storage", file_entities)
+        assert is_resolved is True
+        ident, is_resolved = mcp_server._resolve_module_import("totally_unknown_crate", file_entities)
+        assert is_resolved is False
+
+    @pytest.mark.asyncio
+    async def test_unresolved_import_gets_tagged_external_dependency(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "main.rs").write_text('use tokio;\nfn main() {}\n')
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add main"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        tokio_ident = mcp_server._canonical_ident("module", "tokio")
+        assert any(f"[{tokio_ident} :entity-type :type/external-dependency]" in t for t in transact_calls)
+        assert any(f'[{tokio_ident} :description "tokio"]' in t for t in transact_calls)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_server.py::TestUnresolvedImportTagging -v`
+Expected: FAIL — `_resolve_module_import` still returns a bare string (unpacking into `ident, is_resolved` raises `ValueError`), and the tagging isn't wired in.
+
+- [ ] **Step 3: Update `_resolve_module_import`'s return type**
+
+Replace `mcp_server.py:1062-1090`:
+
+```python
+def _resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]) -> Tuple[str, bool]:
+    """Resolve an import name to a module ident that joins with stored module entities.
+
+    For a name like "storage", tries standard Rust source-root locations first
+    (src/storage.rs, src/storage/mod.rs) before falling back to a broader name
+    search. The ordered-priority approach prevents e.g. src/graph/storage.rs
+    from matching a top-level `use crate::storage` import.
+
+    Returns (ident, is_resolved). is_resolved is True when import_name matched
+    a real file in file_entities, False when it fell through to the bare
+    _canonical_ident guess — the caller uses this to tag genuinely unresolved
+    imports as :type/external-dependency without also tagging real (if not
+    yet visited) internal modules.
+    """
+    # Priority 1: canonical Rust module root paths under common source roots
+    for src_root in ("src", "lib", ""):
+        prefix = f"{src_root}/" if src_root else ""
+        candidate_file = f"{prefix}{import_name}.rs"
+        candidate_mod = f"{prefix}{import_name}/mod.rs"
+        if candidate_file in file_entities:
+            return _code_ident("module", candidate_file), True
+        if candidate_mod in file_entities:
+            return _code_ident("module", candidate_mod), True
+
+    # Priority 2: broader search — only match files directly under a src root
+    # (parent.parent is the source root, not a nested subdir)
+    for file_path in file_entities:
+        p = Path(file_path)
+        if p.stem == "mod" and p.parent.name == import_name:
+            return _code_ident("module", file_path), True
+
+    return _canonical_ident("module", import_name), False
+```
+
+- [ ] **Step 4: Update the call site to tag first-seen unresolved idents**
+
+At `mcp_server.py:2593-2601`, change:
+
+```python
+                            # Compute dep edges for this file and diff against previous
+                            module_ident = _code_ident("module", file_path)
+                            current_deps: set = set()
+                            for import_name in set(extracted.get("imports", [])):
+                                dep_ident = _resolve_module_import(import_name, file_entities)
+                                if dep_ident != module_ident:
+                                    current_deps.add(dep_ident)
+```
+
+to:
+
+```python
+                            # Compute dep edges for this file and diff against previous
+                            module_ident = _code_ident("module", file_path)
+                            current_deps: set = set()
+                            for import_name in set(extracted.get("imports", [])):
+                                dep_ident, is_resolved = _resolve_module_import(import_name, file_entities)
+                                if dep_ident != module_ident:
+                                    current_deps.add(dep_ident)
+                                    if not is_resolved and dep_ident not in entity_valid_from:
+                                        add_triples.extend([
+                                            f"[{dep_ident} :entity-type :type/external-dependency]",
+                                            f'[{dep_ident} :ident "{_edn_escape(dep_ident)}"]',
+                                            f'[{dep_ident} :description "{_edn_escape(import_name)}"]',
+                                        ])
+                                        entity_valid_from[dep_ident] = commit_ts_iso
+                                        entity_descriptions[dep_ident] = import_name
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_server.py::TestUnresolvedImportTagging -v && pytest tests/ -x -q`
+Expected: PASS. (`TestRunIngestionBitemporalDeps`'s two existing tests still pass unchanged at this point — Python's `mod_b` import still falls through to the same Rust-only fallback ident, now additionally tagged external, which those tests don't check for and so don't break on.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: tag genuinely-unresolved imports as :type/external-dependency (#97)"
+```
+
+---
+
+## Task 10: Preserve full paths in C/C++, Ruby, PHP, Go import extraction
+
+**Files:**
+- Modify: `mcp_server.py:359-371` (`_c_include_name`)
+- Modify: `mcp_server.py:392-418` (`_ruby_require_name`)
+- Modify: `mcp_server.py:503-516` (Go branch of `_extract_import_name`)
+- Modify: `mcp_server.py:542-548` (PHP branch of `_extract_import_name`)
+- Modify (existing tests whose assertions encode the old truncated behavior): `tests/test_mcp_server.py` — `test_ruby_require_relative` (~3356-3362), `test_go_grouped_import` (~3291-3298)
+- Test: `tests/test_mcp_server.py`, new tests appended to `TestExtractImportName`
+
+**Interfaces:**
+- Produces: these four extractors now preserve directory structure (extension stripped, basename-only truncation removed).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `TestExtractImportName`:
+
+```python
+    def test_c_local_include_preserves_subdirectory(self, tmp_path):
+        pytest.importorskip("tree_sitter_c")
+        import mcp_server
+        source = b'#include "unicode/uloc.h"'
+        node = _parse_import_node("c", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "c")
+        assert result == ["unicode/uloc"]
+
+    def test_c_angle_include_preserves_subdirectory(self, tmp_path):
+        pytest.importorskip("tree_sitter_c")
+        import mcp_server
+        source = b'#include <sys/socket.h>'
+        node = _parse_import_node("c", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "c")
+        assert result == ["sys/socket"]
+
+    def test_ruby_require_preserves_subdirectory(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"require 'active_support/core_ext/string'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == ["active_support/core_ext/string"]
+
+    def test_ruby_require_relative_gets_dot_slash_marker(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"require_relative 'my_module'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == ["./my_module"]
+
+    def test_php_require_preserves_subdirectory(self, tmp_path):
+        pytest.importorskip("tree_sitter_php")
+        import mcp_server
+        source = b"<?php\nrequire 'app/config/database.php';"
+        node = _parse_import_node("php", source, "require_expression", tmp_path)
+        result = mcp_server._extract_import_name(node, "php")
+        assert result == ["app/config/database"]
+
+    def test_go_grouped_import_preserves_full_path(self, tmp_path):
+        pytest.importorskip("tree_sitter_go")
+        import mcp_server
+        source = b'package main\nimport (\n\t"os"\n\t"github.com/user/pkg"\n)'
+        node = _parse_import_node("go", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "go")
+        assert "os" in result
+        assert "github.com/user/pkg" in result
+```
+
+Also update the two now-outdated existing tests:
+
+`test_ruby_require_relative` (currently ~3356-3362):
+
+```python
+    def test_ruby_require_relative(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"require_relative 'my_module'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == ["./my_module"]
+```
+
+`test_go_grouped_import` (currently ~3291-3298):
+
+```python
+    def test_go_grouped_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_go")
+        import mcp_server
+        source = b'package main\nimport (\n\t"os"\n\t"github.com/user/pkg"\n)'
+        node = _parse_import_node("go", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "go")
+        assert "os" in result
+        assert "github.com/user/pkg" in result
+```
+
+(`test_go_single_import`, `test_c_system_include`, `test_cpp_include`, `test_php_require`, `test_php_include`, `test_ruby_require` need no changes — none of their fixtures include a subdirectory, so basename == full path for those and the assertions already hold either way.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_server.py::TestExtractImportName -v`
+Expected: FAIL on all the new/updated subdirectory-preserving assertions.
+
+- [ ] **Step 3: Update `_c_include_name`**
+
+Replace `mcp_server.py:359-371`:
+
+```python
+def _c_include_name(node) -> Optional[str]:
+    """Return the include target (path preserved, extension stripped) from a
+    C/C++ preproc_include node.
+
+    Handles both:
+      #include <stdio.h>          → system_lib_string → "stdio"
+      #include <unicode/uloc.h>   → system_lib_string → "unicode/uloc"
+      #include "sub/myheader.h"   → string_literal    → "sub/myheader"
+
+    Path structure is preserved (not reduced to a bare basename) so
+    _resolve_module_import can match vendored in-tree headers precisely —
+    both angle-bracket and quoted forms commonly carry a real subdirectory
+    (<sys/socket.h>, <unicode/uloc.h>, "app/config.h"), not just stdlib-style
+    bare names like <vector>.
+    """
+    for child in node.children:
+        if child.type in ("system_lib_string", "string_literal"):
+            raw = child.text.decode("utf-8").strip("<>\"'")
+            return os.path.splitext(raw)[0]
+    return None
+```
+
+- [ ] **Step 4: Update `_ruby_require_name`**
+
+Replace `mcp_server.py:392-418`:
+
+```python
+def _ruby_require_name(node) -> Optional[str]:
+    """Return the required path from a Ruby call node (path preserved,
+    extension stripped). A require_relative target is prefixed with "./" so
+    it reuses the same relative-import detection _resolve_module_import
+    already needs for JS/TS-style "./foo" specifiers, rather than plumbing a
+    separate is-relative flag through the whole imports pipeline.
+
+    Handles:
+      require 'rails'                            → "rails"
+      require 'active_support/core_ext/string'    → "active_support/core_ext/string"
+      require_relative 'my_mod'                   → "./my_mod"
+    Returns None for non-require calls.
+    """
+    method = node.child_by_field_name("method")
+    if method is None or method.text.decode("utf-8") not in ("require", "require_relative"):
+        return None
+    is_relative = method.text.decode("utf-8") == "require_relative"
+    args = node.child_by_field_name("arguments")
+    if args is None:
+        return None
+    for child in args.named_children:
+        if child.type == "string":
+            content_node = next(
+                (c for c in child.named_children if c.type == "string_content"),
+                None,
+            )
+            if content_node:
+                val = content_node.text.decode("utf-8")
+            else:
+                val = child.text.decode("utf-8").strip("'\"")
+            path = os.path.splitext(val)[0]
+            return f"./{path}" if is_relative else path
+    return None
+```
+
+- [ ] **Step 5: Update the Go branch of `_extract_import_name`**
+
+At `mcp_server.py:503-516`, change:
+
+```python
+    elif lang_name == "go":
+        def _go_spec(spec_node):
+            path = spec_node.child_by_field_name("path")
+            if path:
+                val = path.text.decode("utf-8").strip('"')
+                names.append(val.split("/")[-1])
+
+        for child in node.named_children:
+            if child.type == "import_spec":
+                _go_spec(child)
+            elif child.type == "import_spec_list":
+                for spec in child.named_children:
+                    if spec.type == "import_spec":
+                        _go_spec(spec)
+```
+
+to:
+
+```python
+    elif lang_name == "go":
+        def _go_spec(spec_node):
+            path = spec_node.child_by_field_name("path")
+            if path:
+                names.append(path.text.decode("utf-8").strip('"'))
+
+        for child in node.named_children:
+            if child.type == "import_spec":
+                _go_spec(child)
+            elif child.type == "import_spec_list":
+                for spec in child.named_children:
+                    if spec.type == "import_spec":
+                        _go_spec(spec)
+```
+
+- [ ] **Step 6: Update the PHP branch of `_extract_import_name`**
+
+At `mcp_server.py:542-548`, change:
+
+```python
+    elif lang_name == "php":
+        import os
+        for child in node.children:
+            if child.type in ("string", "encapsed_string", "string_literal"):
+                val = child.text.decode("utf-8").strip("'\"")
+                names.append(os.path.splitext(os.path.basename(val))[0])
+                break
+```
+
+to:
+
+```python
+    elif lang_name == "php":
+        for child in node.children:
+            if child.type in ("string", "encapsed_string", "string_literal"):
+                val = child.text.decode("utf-8").strip("'\"")
+                names.append(os.path.splitext(val)[0])
+                break
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_server.py::TestExtractImportName -v && pytest tests/ -x -q`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "fix: preserve directory structure in C/C++, Ruby, PHP, Go import extraction (#97)"
+```
+
+---
+
+## Task 11: Full-name capture for namespace languages
+
+**Files:**
+- Modify: `mcp_server.py:481-494` (Python branch of `_extract_import_name`)
+- Modify: `mcp_server.py:517-529` (Java branch)
+- Modify: `mcp_server.py:534-537` (`_csharp_using_name` call site — modify the helper itself, `mcp_server.py:374-389`)
+- Modify: `mcp_server.py:549-561` (Kotlin branch)
+- Modify: `mcp_server.py:562-566` (Swift branch)
+- Modify: `mcp_server.py:567-571` (Scala branch)
+- Modify: `mcp_server.py:572-577` (Haskell branch)
+- Modify: `mcp_server.py:450-475` (`_elixir_module_name`)
+- Modify existing tests: `test_java_import`, `test_csharp_using_dotted`, `test_kotlin_import`, `test_scala_import`, `test_haskell_import`, `test_elixir_alias`, `test_elixir_import` (all in `TestExtractImportName`, lines ~3300-3450)
+- Test: `tests/test_mcp_server.py`, new tests for Python and Swift (whose existing tests use single-segment fixtures that don't exercise the truncation bug)
+
+**Interfaces:**
+- Produces: these branches now capture the full dotted/qualified name instead of the first segment.
+
+- [ ] **Step 1: Update the existing tests that assert first-segment truncation**
+
+```python
+    def test_java_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_java")
+        import mcp_server
+        source = b'import java.util.List;'
+        node = _parse_import_node("java", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "java")
+        assert result == ["java.util.List"]
+
+    def test_csharp_using_dotted(self, tmp_path):
+        pytest.importorskip("tree_sitter_c_sharp")
+        import mcp_server
+        source = b'using System.Collections.Generic;'
+        node = _parse_import_node("c_sharp", source, "using_directive", tmp_path)
+        result = mcp_server._extract_import_name(node, "c_sharp")
+        assert result == ["System.Collections.Generic"]
+
+    def test_kotlin_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_kotlin")
+        import mcp_server
+        source = b'import kotlin.collections.List'
+        node = _parse_import_node("kotlin", source, "import", tmp_path)
+        result = mcp_server._extract_import_name(node, "kotlin")
+        assert result == ["kotlin.collections.List"]
+
+    def test_scala_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_scala")
+        import mcp_server
+        source = b'import scala.collection.mutable'
+        node = _parse_import_node("scala", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "scala")
+        assert result == ["scala.collection.mutable"]
+
+    def test_haskell_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_haskell")
+        import mcp_server
+        source = b'import Data.List'
+        node = _parse_import_node("haskell", source, "import", tmp_path)
+        result = mcp_server._extract_import_name(node, "haskell")
+        assert result == ["Data.List"]
+
+    def test_elixir_alias(self, tmp_path):
+        pytest.importorskip("tree_sitter_elixir")
+        import mcp_server
+        source = b'alias MyApp.Router'
+        node = _parse_import_node("elixir", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "elixir")
+        assert result == ["MyApp.Router"]
+
+    def test_elixir_import(self, tmp_path):
+        pytest.importorskip("tree_sitter_elixir")
+        import mcp_server
+        source = b'import Ecto.Query'
+        node = _parse_import_node("elixir", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "elixir")
+        assert result == ["Ecto.Query"]
+```
+
+Add two new tests (existing Python/Swift fixtures are single-segment and don't exercise the bug):
+
+```python
+    def test_python_import_from_preserves_full_dotted_name(self):
+        import mcp_server
+        source = b"from pathlib import Path\n"
+        result = mcp_server._extract_from_source(
+            source, TestExtractFromSource()._python_parser(), "foo.py"
+        )
+        assert "pathlib" in result["imports"]
+
+    def test_python_dotted_import_preserves_full_name(self):
+        import mcp_server
+        source = b"import os.path\n"
+        result = mcp_server._extract_from_source(
+            source, TestExtractFromSource()._python_parser(), "foo.py"
+        )
+        assert "os.path" in result["imports"]
+
+    def test_swift_submodule_import_preserves_full_name(self, tmp_path):
+        pytest.importorskip("tree_sitter_swift")
+        import mcp_server
+        source = b'import Foundation.NSString'
+        node = _parse_import_node("swift", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "swift")
+        assert result == ["Foundation.NSString"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_server.py::TestExtractImportName -v`
+Expected: FAIL on every updated/new assertion above.
+
+- [ ] **Step 3: Update the Python branch**
+
+At `mcp_server.py:481-494`, change:
+
+```python
+    if lang_name == "python":
+        if node.type == "import_from_statement":
+            m = node.child_by_field_name("module_name")
+            if m:
+                names.append(m.text.decode("utf-8").split(".")[0])
+        else:
+            # import_statement: collect all top-level module names
+            for child in node.named_children:
+                if child.type == "aliased_import":
+                    n = child.child_by_field_name("name")
+                    if n:
+                        names.append(n.text.decode("utf-8").split(".")[0])
+                elif child.type == "dotted_name":
+                    names.append(child.text.decode("utf-8").split(".")[0])
+```
+
+to:
+
+```python
+    if lang_name == "python":
+        if node.type == "import_from_statement":
+            m = node.child_by_field_name("module_name")
+            if m:
+                # m.text is the raw specifier as written, including relative
+                # forms: "pathlib", ".sub", "..pkg" — see _resolve_module_import
+                # for how leading dots get resolved against the importing file.
+                names.append(m.text.decode("utf-8"))
+        else:
+            # import_statement: collect all full dotted module names
+            for child in node.named_children:
+                if child.type == "aliased_import":
+                    n = child.child_by_field_name("name")
+                    if n:
+                        names.append(n.text.decode("utf-8"))
+                elif child.type == "dotted_name":
+                    names.append(child.text.decode("utf-8"))
+```
+
+- [ ] **Step 4: Update the Java branch**
+
+At `mcp_server.py:517-529`, change:
+
+```python
+    elif lang_name == "java":
+        def _java_leftmost(n) -> Optional[str]:
+            if n.type == "identifier":
+                return n.text.decode("utf-8")
+            for c in n.named_children:
+                result = _java_leftmost(c)
+                if result:
+                    return result
+            return None
+
+        result = _java_leftmost(node)
+        if result:
+            names.append(result)
+```
+
+to:
+
+```python
+    elif lang_name == "java":
+        # import_declaration's dotted path is one named child, already the
+        # full text (e.g. "java.util.List") — scoped_identifier for
+        # multi-segment paths, plain identifier for single-segment ones.
+        for child in node.named_children:
+            if child.type in ("scoped_identifier", "identifier"):
+                names.append(child.text.decode("utf-8"))
+                break
+```
+
+- [ ] **Step 5: Update `_csharp_using_name`**
+
+Replace `mcp_server.py:374-389`:
+
+```python
+def _csharp_using_name(node) -> Optional[str]:
+    """Return the full dotted namespace from a C# using_directive node.
+
+    using System;                     → "System"
+    using System.Collections.Generic; → "System.Collections.Generic"
+
+    The dotted path is one named child (qualified_name for multi-segment
+    paths, identifier for single-segment ones) whose own .text is already
+    the full joined name.
+    """
+    for child in node.named_children:
+        if child.type in ("qualified_name", "identifier"):
+            return child.text.decode("utf-8")
+    return None
+```
+
+- [ ] **Step 6: Update the Kotlin branch**
+
+At `mcp_server.py:549-561`, change:
+
+```python
+    elif lang_name == "kotlin":
+        def _kotlin_first_seg(n) -> Optional[str]:
+            if n.type in ("simple_identifier", "identifier"):
+                return n.text.decode("utf-8")
+            for c in n.named_children:
+                result = _kotlin_first_seg(c)
+                if result:
+                    return result
+            return None
+
+        result = _kotlin_first_seg(node)
+        if result:
+            names.append(result)
+```
+
+to:
+
+```python
+    elif lang_name == "kotlin":
+        # import node's dotted path is one named child (qualified_identifier
+        # for multi-segment, identifier for single-segment) whose .text is
+        # already the full joined name.
+        for child in node.named_children:
+            if child.type in ("qualified_identifier", "identifier"):
+                names.append(child.text.decode("utf-8"))
+                break
+```
+
+- [ ] **Step 7: Update the Swift branch**
+
+At `mcp_server.py:562-566`, change:
+
+```python
+    elif lang_name == "swift":
+        for child in node.named_children:
+            if child.type in ("identifier", "simple_identifier"):
+                names.append(child.text.decode("utf-8"))
+                break
+```
+
+to:
+
+```python
+    elif lang_name == "swift":
+        # import_declaration's single "identifier" named child already
+        # holds the full dotted text (e.g. "Foundation.NSString") directly —
+        # no recursion needed.
+        for child in node.named_children:
+            if child.type in ("identifier", "simple_identifier"):
+                names.append(child.text.decode("utf-8"))
+                break
+```
+
+(No functional change here beyond the comment — the existing code already captured the full node text since it never recursed into `simple_identifier` children for a top-level `identifier` node. Verified against the real tree-sitter-swift grammar: `import_declaration`'s child is type `identifier` whose whole text is `"Foundation.NSString"`, matched by the first branch of the `in` check before ever considering `simple_identifier`.)
+
+- [ ] **Step 8: Update the Scala branch**
+
+At `mcp_server.py:567-571`, change:
+
+```python
+    elif lang_name == "scala":
+        for child in node.named_children:
+            txt = child.text.decode("utf-8")
+            names.append(txt.split(".")[0])
+            break
+```
+
+to:
+
+```python
+    elif lang_name == "scala":
+        # import_declaration's path is flattened into individual "identifier"
+        # named children (no wrapping scoped node), so join the leading run
+        # of identifiers rather than taking the first one's text alone.
+        segments = []
+        for child in node.named_children:
+            if child.type != "identifier":
+                break
+            segments.append(child.text.decode("utf-8"))
+        if segments:
+            names.append(".".join(segments))
+```
+
+- [ ] **Step 9: Update the Haskell branch**
+
+At `mcp_server.py:572-577`, change:
+
+```python
+    elif lang_name == "haskell":
+        for child in node.named_children:
+            if child.type in ("module", "qualified_module", "constructor"):
+                txt = child.text.decode("utf-8")
+                names.append(txt.split(".")[0])
+                break
+```
+
+to:
+
+```python
+    elif lang_name == "haskell":
+        for child in node.named_children:
+            if child.type in ("module", "qualified_module", "constructor"):
+                names.append(child.text.decode("utf-8"))
+                break
+```
+
+- [ ] **Step 10: Update `_elixir_module_name`**
+
+At `mcp_server.py:450-475`, in the final loop, change:
+
+```python
+    for child in node.children:
+        if child.type == "arguments":
+            for arg in child.children:
+                if arg.type == "alias":
+                    txt = arg.text.decode("utf-8")
+                    return txt.split(".")[0]
+    return None
+```
+
+to:
+
+```python
+    for child in node.children:
+        if child.type == "arguments":
+            for arg in child.children:
+                if arg.type == "alias":
+                    return arg.text.decode("utf-8")
+    return None
+```
+
+Update the docstring's example lines too (`mcp_server.py:453-456`):
+
+```python
+    alias MyApp.Router     → "MyApp.Router"
+    import Ecto.Query      → "Ecto.Query"
+    use Phoenix.Controller → "Phoenix.Controller"
+    require Logger         → "Logger"
+```
+
+- [ ] **Step 11: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_server.py::TestExtractImportName -v && pytest tests/ -x -q`
+Expected: PASS
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "fix: capture full qualified names for namespace-language imports (#97)"
+```
+
+---
+
+## Task 12: Generic tiered matcher in `_resolve_module_import`
+
+**Files:**
+- Modify: `mcp_server.py:1062-1090` (`_resolve_module_import`, as last touched in Task 9)
+- Test: `tests/test_mcp_server.py`, new `TestResolveModuleImportTieredMatcher` class placed after `TestUnresolvedImportTagging`
+
+**Interfaces:**
+- Consumes: `file_entities: Dict[str, List[str]]` (existing, keys are repo-relative file paths).
+- Produces: two new small helpers, `_path_segments(path_str) -> List[str]` and `_segments_end_with(full_segments, candidate_segments) -> bool`. `_resolve_module_import` now resolves namespace/path-like imports against `file_entities` via two segment-based suffix-match tiers (file match, parent-directory match) before falling through to the external tag. Rust's existing exact conventions are checked first and are unaffected.
+
+**Design note on why this isn't a naive dot-to-slash replace:** Go import paths routinely contain literal dots that are *not* hierarchy separators (`github.com/user/pkg` — `github.com` is one path segment). Blanket-replacing `.` with `/` before matching would corrupt these into `github/com/user/pkg`. The fix: split on `/` when the specifier already contains one (Go, C/C++, Ruby, PHP — already segment-separated by `/`), otherwise split on `.` (Java, C#, Python, Scala, Kotlin, Swift, Haskell, Elixir — genuinely dot-separated, no literal dots expected within a single segment). Matching is then a **suffix comparison over whole path segments** (not a raw substring) against each candidate file's own path — this uniformly handles an exact match, a vendored path with extra prefix segments (`3rdParty/somelib/com/google/gson/Gson.java` still matches `com.google.gson.Gson`), and a bare single-segment name (degenerates to a basename check) with one algorithm, rather than three separate ad hoc tiers.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestResolveModuleImportTieredMatcher:
+    def test_exact_file_match_java_package(self):
+        import mcp_server
+        file_entities = {"com/google/gson/Gson.java": []}
+        ident, is_resolved = mcp_server._resolve_module_import("com.google.gson.Gson", file_entities)
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "com/google/gson/Gson.java")
+
+    def test_parent_directory_match_java_wildcard_style(self):
+        import mcp_server
+        # "com.google.gson" (no trailing class name) is a package-level
+        # reference — it matches via the file's *parent directory*, not the
+        # file's own path, since there's no specific file named exactly that.
+        file_entities = {"com/google/gson/JsonElement.java": []}
+        ident, is_resolved = mcp_server._resolve_module_import("com.google.gson", file_entities)
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "com/google/gson/JsonElement.java")
+
+    def test_genuinely_external_java_package_not_resolved(self):
+        import mcp_server
+        file_entities = {"com/mycompany/App.java": []}
+        # com.fasterxml.jackson.Foo shares no path with the project's own "com" tree
+        ident, is_resolved = mcp_server._resolve_module_import("com.fasterxml.jackson.Foo", file_entities)
+        assert is_resolved is False
+
+    def test_exact_file_match_go_full_path(self):
+        import mcp_server
+        # Vendored Go deps live under a vendor/ prefix that never appears in
+        # the import string itself — this must match as a segment suffix,
+        # not exact path equality, and "github.com" must survive as one path
+        # segment rather than being split on its literal dot.
+        file_entities = {"vendor/github.com/user/pkg/pkg.go": []}
+        ident, is_resolved = mcp_server._resolve_module_import("github.com/user/pkg/pkg", file_entities)
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "vendor/github.com/user/pkg/pkg.go")
+
+    def test_basename_match_vendored_c_header(self):
+        import mcp_server
+        file_entities = {"3rdParty/icu/include/unicode/uloc.h": []}
+        ident, is_resolved = mcp_server._resolve_module_import("unicode/uloc", file_entities)
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "3rdParty/icu/include/unicode/uloc.h")
+
+    def test_genuinely_external_c_stdlib_header_not_resolved(self):
+        import mcp_server
+        file_entities = {"src/main.cpp": []}
+        ident, is_resolved = mcp_server._resolve_module_import("vector", file_entities)
+        assert is_resolved is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_server.py::TestResolveModuleImportTieredMatcher -v`
+Expected: FAIL — the generic tiers don't exist yet, so anything beyond Rust's exact conventions falls straight to `is_resolved is False`, including the cases that should now resolve.
+
+- [ ] **Step 3: Add the tiered matcher**
+
+Replace `mcp_server.py:1062-1090` (as it stands after Task 9) with:
+
+```python
+def _path_segments(path_str: str) -> List[str]:
+    """Split a path into non-empty segments, normalizing os.sep to '/'."""
+    return [seg for seg in path_str.replace(os.sep, "/").split("/") if seg]
+
+
+def _segments_end_with(full_segments: List[str], candidate_segments: List[str]) -> bool:
+    """True if full_segments' trailing slice equals candidate_segments exactly.
+
+    A whole-segment suffix comparison, not a raw string suffix — comparing
+    strings directly would let e.g. "xyzcom/google" wrongly match a
+    candidate of "com/google" (the substring is present but not as its own
+    path segment).
+    """
+    if not candidate_segments or len(candidate_segments) > len(full_segments):
+        return False
+    return full_segments[-len(candidate_segments):] == candidate_segments
+
+
+def _resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]) -> Tuple[str, bool]:
+    """Resolve an import name to a module ident that joins with stored module entities.
+
+    Tries Rust's exact source-root conventions first (src/storage.rs,
+    src/storage/mod.rs), then a generic, language-agnostic segment-suffix
+    matcher used by every other language. This exists because every other
+    language's import extraction already reduces to a bare or dotted/slashed
+    specifier (see _extract_import_name) that would otherwise always fall
+    through to the external-dependency fallback — including for real in-tree
+    vendored code, which must stay internal per the design spec's Non-goals.
+
+    The specifier is split into segments on "/" if present (Go, C/C++, Ruby,
+    PHP already use "/" natively — note Go paths like "github.com/user/pkg"
+    contain literal dots inside a segment that must NOT be treated as
+    separators), otherwise on "." (Java, C#, Python, Scala, Kotlin, Swift,
+    Haskell, Elixir — genuinely dot-separated). Matching a whole-segment
+    suffix (not a raw substring) against either a file's own path or its
+    parent directory uniformly covers: an exact match, a vendored path with
+    extra prefix segments, a package-only/wildcard-style import (matches via
+    the parent-directory tier), and a bare single-segment name (degenerates
+    to a basename check) — one algorithm instead of separate ad hoc tiers.
+
+    Returns (ident, is_resolved). is_resolved is True when import_name
+    matched a real file in file_entities, False when it fell through to the
+    bare _canonical_ident guess.
+    """
+    # Priority 1: canonical Rust module root paths under common source roots
+    for src_root in ("src", "lib", ""):
+        prefix = f"{src_root}/" if src_root else ""
+        candidate_file = f"{prefix}{import_name}.rs"
+        candidate_mod = f"{prefix}{import_name}/mod.rs"
+        if candidate_file in file_entities:
+            return _code_ident("module", candidate_file), True
+        if candidate_mod in file_entities:
+            return _code_ident("module", candidate_mod), True
+
+    # Priority 2: broader search — only match files directly under a src root
+    # (parent.parent is the source root, not a nested subdir)
+    for file_path in file_entities:
+        p = Path(file_path)
+        if p.stem == "mod" and p.parent.name == import_name:
+            return _code_ident("module", file_path), True
+
+    # Priority 3: generic segment-suffix matcher for every other language.
+    candidate_segments = import_name.split("/") if "/" in import_name else import_name.split(".")
+
+    # 3a. file match (exact, or a vendored path with extra prefix segments), extension stripped
+    for file_path in file_entities:
+        file_segments = _path_segments(str(Path(file_path).with_suffix("")))
+        if _segments_end_with(file_segments, candidate_segments):
+            return _code_ident("module", file_path), True
+
+    # 3b. parent-directory match (package-only/wildcard-style imports, e.g.
+    # a Java "import com.google.gson.*;" or a bare "com.google.gson" reference
+    # with no specific trailing class name)
+    for file_path in file_entities:
+        parent_segments = _path_segments(str(Path(file_path).parent))
+        if _segments_end_with(parent_segments, candidate_segments):
+            return _code_ident("module", file_path), True
+
+    return _canonical_ident("module", import_name), False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_server.py::TestResolveModuleImportTieredMatcher -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full suite — expect two known, intentional failures**
+
+Run: `pytest tests/ -x -q`
+Expected: `TestRunIngestionBitemporalDeps::test_new_import_writes_depends_on_via_ingest_transact` and `::test_removed_import_closes_depends_on_edge` now FAIL. This is expected and fixed in Task 14 — `mod_a.py`'s `import mod_b` now correctly resolves to the real `mod_b.py` module (via the 3a segment-suffix tier, since a single-segment candidate against `mod_b.py`'s single-segment stem degenerates to a basename match) instead of the old external fallback ident, since `mod_b.py` genuinely exists in `file_entities`. Do not treat this as a regression to revert; do not skip Task 14.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add generic tiered import resolution across all languages (#97)"
+```
+
+---
+
+## Task 13: Relative-import resolution
+
+**Files:**
+- Modify: `mcp_server.py:1062-1108` (`_resolve_module_import`, as it stands after Task 12) — add `importing_file` parameter
+- Modify: `mcp_server.py:2596` (call site inside `_run_ingestion`, updated in Task 9's Step 4) — pass `importing_file=file_path`
+- Test: `tests/test_mcp_server.py`, new `TestResolveModuleImportRelative` class placed after `TestResolveModuleImportTieredMatcher`
+
+**Interfaces:**
+- Produces: `_resolve_module_import(import_name, file_entities, importing_file: Optional[str] = None) -> Tuple[str, bool]`. When `import_name` starts with `.` and `importing_file` is given, resolves relative to the importing file's directory before running the tiered matcher; an unresolved relative import is never tagged external (handled by the caller already only tagging on `is_resolved is False` for the generic external label, which the spec's Section 3 says to skip for relative specifiers — see Step 4's caller note).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestResolveModuleImportRelative:
+    def test_js_relative_import_resolves_against_importing_file(self):
+        import mcp_server
+        file_entities = {"src/utils/foo.ts": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "./utils/foo", file_entities, importing_file="src/main.ts",
+        )
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "src/utils/foo.ts")
+
+    def test_js_parent_relative_import_resolves(self):
+        import mcp_server
+        file_entities = {"lib.ts": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "../lib", file_entities, importing_file="src/main.ts",
+        )
+        assert is_resolved is True
+
+    def test_python_single_dot_relative_import_resolves(self):
+        import mcp_server
+        file_entities = {"pkg/sibling.py": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            ".sibling", file_entities, importing_file="pkg/main.py",
+        )
+        assert is_resolved is True
+
+    def test_python_double_dot_relative_import_resolves(self):
+        import mcp_server
+        # For a file at a/b/c/main.py, the containing package is a.b.c: one
+        # leading dot means "this package" (a/b/c), two dots means "the
+        # parent package" (a/b) — so "..sibling" resolves to a/b/sibling.py,
+        # not a top-level sibling.py.
+        file_entities = {"a/b/sibling.py": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "..sibling", file_entities, importing_file="a/b/c/main.py",
+        )
+        assert is_resolved is True
+
+    def test_ruby_require_relative_marker_resolves(self):
+        import mcp_server
+        file_entities = {"lib/helper.rb": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "./helper", file_entities, importing_file="lib/main.rb",
+        )
+        assert is_resolved is True
+
+    def test_unresolved_relative_import_is_not_tagged_external(self):
+        import mcp_server
+        file_entities: dict = {}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "./missing", file_entities, importing_file="src/main.ts",
+        )
+        assert is_resolved is False
+        # Caller-side contract (see _run_ingestion): a relative import is only
+        # ever tagged external if the generic (non-relative) tiers would also
+        # tag it — this test documents that resolution itself still reports
+        # is_resolved=False for a genuinely missing relative target, same as
+        # any other unresolved import; the "don't mislabel" guarantee lives in
+        # the caller, verified by Task 13's Step 5 integration test below.
+```
+
+Add one integration test in `TestUnresolvedImportTagging` (or a new small class) verifying the caller-side contract:
+
+```python
+    @pytest.mark.asyncio
+    async def test_unresolved_relative_import_not_tagged_external_end_to_end(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "main.ts").write_text("import { thing } from './missing';\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add main"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        missing_ident = mcp_server._canonical_ident("module", "./missing")
+        assert not any(
+            f"[{missing_ident} :entity-type :type/external-dependency]" in t for t in transact_calls
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_server.py::TestResolveModuleImportRelative -v`
+Expected: FAIL — `_resolve_module_import` doesn't accept `importing_file` yet (`TypeError: unexpected keyword argument`).
+
+- [ ] **Step 3: Add relative-import resolution**
+
+Replace the entire `_resolve_module_import` function (as it stands after Task 12) with this complete version — the only change is the new relative-import branch inserted before Priority 1, plus the new `importing_file` parameter; Priorities 1, 2, and 3 are otherwise identical to Task 12:
+
+```python
+def _resolve_module_import(
+    import_name: str,
+    file_entities: Dict[str, List[str]],
+    importing_file: Optional[str] = None,
+) -> Tuple[str, bool]:
+    """Resolve an import name to a module ident that joins with stored module entities.
+
+    Tries a relative-import resolution first (see below), then Rust's exact
+    source-root conventions (src/storage.rs, src/storage/mod.rs), then a
+    generic, language-agnostic segment-suffix matcher used by every other
+    language. This exists because every other language's import extraction
+    already reduces to a bare or dotted/slashed specifier (see
+    _extract_import_name) that would otherwise always fall through to the
+    external-dependency fallback — including for real in-tree vendored code,
+    which must stay internal per the design spec's Non-goals.
+
+    When import_name is relative (starts with ".") and importing_file is
+    given, resolves against the importing file's own directory before any
+    other tier runs. Covers three conventions: JS/TS/Ruby-style "./foo" and
+    "../foo/bar" (plain relative filesystem paths — Ruby's require_relative
+    results already carry this "./" prefix, added by _ruby_require_name),
+    and Python-style leading dots with no slash ("." = same package, each
+    extra dot = one directory further up) followed by an optional dotted
+    module path.
+
+    The generic matcher splits the specifier into segments on "/" if present
+    (Go, C/C++, Ruby, PHP already use "/" natively — note Go paths like
+    "github.com/user/pkg" contain literal dots inside a segment that must
+    NOT be treated as separators), otherwise on "." (Java, C#, Python, Scala,
+    Kotlin, Swift, Haskell, Elixir — genuinely dot-separated). Matching a
+    whole-segment suffix (not a raw substring) against either a file's own
+    path or its parent directory uniformly covers: an exact match, a
+    vendored path with extra prefix segments, a package-only/wildcard-style
+    import (via the parent-directory tier), and a bare single-segment name
+    (degenerates to a basename check).
+
+    Returns (ident, is_resolved). is_resolved is True when import_name
+    matched a real file in file_entities, False when it fell through to the
+    bare _canonical_ident guess.
+    """
+    if importing_file and import_name.startswith("."):
+        base_dir = Path(importing_file).parent
+        if import_name.startswith("./") or import_name.startswith("../"):
+            target = os.path.normpath(str(base_dir / import_name))
+        else:
+            stripped = import_name.lstrip(".")
+            levels_up = len(import_name) - len(stripped) - 1
+            target_dir = base_dir
+            for _ in range(levels_up):
+                target_dir = target_dir.parent
+            target = str(target_dir / stripped.replace(".", "/")) if stripped else str(target_dir)
+            target = os.path.normpath(target)
+        target = target.replace(os.sep, "/")
+        for file_path in file_entities:
+            if str(Path(file_path).with_suffix("")).replace(os.sep, "/") == target:
+                return _code_ident("module", file_path), True
+        return _canonical_ident("module", import_name), False
+
+    # Priority 1: canonical Rust module root paths under common source roots
+    for src_root in ("src", "lib", ""):
+        prefix = f"{src_root}/" if src_root else ""
+        candidate_file = f"{prefix}{import_name}.rs"
+        candidate_mod = f"{prefix}{import_name}/mod.rs"
+        if candidate_file in file_entities:
+            return _code_ident("module", candidate_file), True
+        if candidate_mod in file_entities:
+            return _code_ident("module", candidate_mod), True
+
+    # Priority 2: broader search — only match files directly under a src root
+    # (parent.parent is the source root, not a nested subdir)
+    for file_path in file_entities:
+        p = Path(file_path)
+        if p.stem == "mod" and p.parent.name == import_name:
+            return _code_ident("module", file_path), True
+
+    # Priority 3: generic segment-suffix matcher for every other language.
+    candidate_segments = import_name.split("/") if "/" in import_name else import_name.split(".")
+
+    # 3a. file match (exact, or a vendored path with extra prefix segments), extension stripped
+    for file_path in file_entities:
+        file_segments = _path_segments(str(Path(file_path).with_suffix("")))
+        if _segments_end_with(file_segments, candidate_segments):
+            return _code_ident("module", file_path), True
+
+    # 3b. parent-directory match (package-only/wildcard-style imports)
+    for file_path in file_entities:
+        parent_segments = _path_segments(str(Path(file_path).parent))
+        if _segments_end_with(parent_segments, candidate_segments):
+            return _code_ident("module", file_path), True
+
+    return _canonical_ident("module", import_name), False
+```
+
+- [ ] **Step 4: Update the call site to pass `importing_file`**
+
+At `mcp_server.py:2596` (as it stands after Task 9's Step 4), change:
+
+```python
+                                dep_ident, is_resolved = _resolve_module_import(import_name, file_entities)
+```
+
+to:
+
+```python
+                                dep_ident, is_resolved = _resolve_module_import(
+                                    import_name, file_entities, importing_file=file_path,
+                                )
+```
+
+The existing `if not is_resolved and dep_ident not in entity_valid_from:` tagging guard already does the right thing for relative imports with no further change: an unresolved relative specifier still reports `is_resolved=False` and would, by that guard, get tagged external. Add the guard the spec requires — a relative specifier is never tagged external, resolved or not:
+
+```python
+                                if dep_ident != module_ident:
+                                    current_deps.add(dep_ident)
+                                    is_relative = import_name.startswith(".")
+                                    if not is_resolved and not is_relative and dep_ident not in entity_valid_from:
+                                        add_triples.extend([
+                                            f"[{dep_ident} :entity-type :type/external-dependency]",
+                                            f'[{dep_ident} :ident "{_edn_escape(dep_ident)}"]',
+                                            f'[{dep_ident} :description "{_edn_escape(import_name)}"]',
+                                        ])
+                                        entity_valid_from[dep_ident] = commit_ts_iso
+                                        entity_descriptions[dep_ident] = import_name
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_server.py::TestResolveModuleImportRelative -v tests/test_mcp_server.py::TestUnresolvedImportTagging -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: resolve relative imports against the importing file's path (#97)"
+```
+
+---
+
+## Task 14: Update the two pre-existing dependency tests for the new correct resolution
+
+**Files:**
+- Modify: `tests/test_mcp_server.py:3181-3239` (`TestRunIngestionBitemporalDeps`, the two tests flagged as expected-to-fail at the end of Task 12)
+
+**Interfaces:**
+- Consumes: nothing new — this task only updates test expectations to match the now-correct behavior from Tasks 12-13.
+
+- [ ] **Step 1: Update the two tests**
+
+```python
+    @pytest.mark.asyncio
+    async def test_new_import_writes_depends_on_via_ingest_transact(
+        self, mock_minigraf_db, git_repo_with_deps, monkeypatch
+    ):
+        """Adding a file with an import must call _ingest_transact with a :depends-on triple
+        using the git commit timestamp."""
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(git_repo_with_deps / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+
+        await mcp_server._run_ingestion(str(git_repo_with_deps), "HEAD")
+
+        mod_a_ident = mcp_server._code_ident("module", "mod_a.py")
+        # mod_b.py genuinely exists in file_entities, so the generalized
+        # tiered matcher (Task 12) now resolves "mod_b" to the real internal
+        # module via the basename tier, instead of the old Rust-only fallback.
+        mod_b_resolved = mcp_server._code_ident("module", "mod_b.py")
+        dep_triple = f"{mod_a_ident} :depends-on {mod_b_resolved}"
+        assert any(dep_triple in t for t in transact_calls), (
+            f"Expected _ingest_transact to be called with '{dep_triple}' during commit loop, "
+            f"got: {transact_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_removed_import_closes_depends_on_edge(
+        self, mock_minigraf_db, git_repo_with_dep_removal, monkeypatch
+    ):
+        """Removing an import in a modified file must call _ingest_close with the
+        :depends-on triple so the edge gets a :valid-to bound."""
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(git_repo_with_dep_removal / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen: list = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(git_repo_with_dep_removal), "HEAD")
+
+        mod_a_ident = mcp_server._code_ident("module", "mod_a.py")
+        mod_b_resolved = mcp_server._code_ident("module", "mod_b.py")
+        dep_triple = f"{mod_a_ident} :depends-on {mod_b_resolved}"
+        assert any(dep_triple in t for t in close_triples_seen), (
+            f"Expected _ingest_close to be called with '{dep_triple}' when import removed, "
+            f"got: {close_triples_seen}"
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_server.py::TestRunIngestionBitemporalDeps -v`
+Expected: PASS
+
+- [ ] **Step 3: Run the entire suite**
+
+Run: `pytest tests/ -q`
+Expected: PASS, zero failures, zero unexpected skips (importorskip-guarded tests skip only if a grammar package is genuinely absent).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_mcp_server.py
+git commit -m "test: update dependency-edge tests for the now-correct mod_b resolution (#97)"
+```
+
+---
+
+## Task 15: Document `:type/external-dependency` in SKILL.md
+
+**Files:**
+- Modify: `SKILL.md` (insert a new subsection into "Git-Ingested Data Schema", after the existing `:type/tag` subsection at line ~363, before "**Supported languages...**" at line 365)
+
+**Interfaces:** none — documentation only.
+
+- [ ] **Step 1: Add the new schema subsection**
+
+Insert after `SKILL.md:363` (the `:tagged-commit` row of the `:type/tag` table) and before line 365 (`**Supported languages for AST extraction:**`):
+
+```markdown
+
+#### `:type/external-dependency` — real git submodules and genuinely-unresolved imports
+Ident: `:module/<slugified-path-or-import-name>` (shares the module ident namespace — only `:entity-type` distinguishes internal from external)
+
+| Attribute | Notes |
+|---|---|
+| `:description` | submodule's declared name from `.gitmodules` if resolvable, else raw path (submodules); raw import specifier (unresolved imports) |
+| `:path` | submodule's repo path (submodules only; absent for unresolved-import placeholders — they have no path) |
+| `:pinned-commit` | pinned commit SHA the submodule currently points to (submodules only); bi-temporally closed and reopened on every bump — point-in-time queries see the SHA pinned at that time |
+| `:submodule-name` / `:submodule-url` | from `.gitmodules`, when parseable (submodules only) |
+| `:introduced-by` (keyword ref) | commit that first introduced this dependency |
+| `:modified-in` (keyword ref) | one edge per commit that bumped a submodule's pinned commit |
+
+Vendored-in-tree code checked in as regular files (not a git submodule) is parsed as ordinary `:type/module`/`:function`/`:class` entities like any first-party code — only real gitlinks (mode `160000`) and genuinely-unresolved imports get the external marker.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add SKILL.md
+git commit -m "docs: document :type/external-dependency schema (#97)"
+```
+
+---
+
+## Final Self-Review Checklist (for whoever executes this plan)
+
+- [ ] Every task's tests pass in isolation and the full suite (`pytest tests/ -q`) is green after Task 14.
+- [ ] `git log --oneline` shows one commit per task (15 commits), each independently revertable.
+- [ ] Confirm no task left a `TODO`/placeholder in `mcp_server.py` — grep for `TODO` and `FIXME` before closing out.
+- [ ] Spec coverage: Section 1 (schema) → Tasks 8, 15. Section 2 (detection/control flow) → Tasks 3-9. Section 3 (generalized resolution + relative imports) → Tasks 10-14. Section 4 (TSX fix) → Tasks 1-2.

--- a/docs/superpowers/specs/2026-07-04-external-dependency-labeling-design.md
+++ b/docs/superpowers/specs/2026-07-04-external-dependency-labeling-design.md
@@ -1,0 +1,108 @@
+# External Dependency Labeling (Submodules, Unresolved Imports, Import Resolution) — Design Spec
+
+**Issue:** #97
+**Date:** 2026-07-04
+
+## Background
+
+Ingestion has no concept of "external" vs "in-source" code, confirmed against the arangodb repo:
+
+1. **Real git submodules are invisible.** A gitlink path (mode `160000`, e.g. `3rdParty/abseil-cpp`) has no file extension `_get_parser` recognizes, and even if it did, `git show <hash>:<path>` fails on a gitlink (no blob content). The bare `except Exception: continue` in `_extract_commit` silently drops it — a submodule bump commit gets a `:type/commit` entity but contributes zero structure facts.
+2. **Unresolved imports become unmarked placeholders.** `_resolve_module_import` falls back to `_canonical_ident("module", import_name)` for anything it can't match, minting a `:depends-on` edge target with no `:entity-type`, `:description`, or `:path` — indistinguishable from a real module that just hasn't been visited yet.
+3. **While investigating #2, a deeper pre-existing gap surfaced:** `_resolve_module_import`'s matching logic is Rust-only (`src/{name}.rs`, `{name}/mod.rs` conventions). Every other supported language's import extraction already truncates to a bare top-level segment (first segment for Java/C#/Python/Scala/Kotlin/Swift/Haskell/Elixir, last segment for Go, basename for C/C++/Ruby/PHP) and *always* falls through to the external fallback today — meaning shipping "tag unresolved as external" as originally scoped would mislabel real in-tree vendored dependencies (e.g. arangodb's `3rdParty/icu`, `3rdParty/v8`) as external, contradicting the explicit requirement that vendored-in-tree code stays internal.
+4. **Unrelated bug found during the same audit:** `.tsx` files are completely unsupported despite `_EXT_TO_LANG` listing them and SKILL.md claiming TSX support. `_build_parser` assumes the importable module name is always `tree_sitter_{lang_name}`; for `tsx` the actual (and only) module is `tree_sitter_typescript`, which exposes both `language_typescript()` and `language_tsx()`. The import throws, `_get_parser` caches `None`, and every `.tsx` file is silently skipped — same failure shape as the submodule problem, different root cause. Folded into this design as an additional fix.
+
+## Goals
+
+- Real submodules become queryable entities instead of silently vanishing.
+- Genuinely unresolved imports are distinguishable from "not yet visited" internal modules.
+- Vendored-in-tree code (regular files, not gitlinks) keeps today's internal treatment — never mislabeled external.
+- Import resolution works consistently across all 17 supported languages, not just Rust.
+- A path that flips between vendored-regular-file and submodule at the exact same location transitions bi-temporally: point-in-time queries before/after the flip see the correct designation.
+- `.tsx` ingestion actually works.
+
+## Non-goals
+
+- Renamed/copied gitlink paths (`R`/`C` diff-tree status) — rare enough in practice to leave as a documented limitation, matching the existing (also incomplete) rename handling for regular files.
+- Retroactive backfill of `:depends-on` edge granularity for already-ingested history in namespace languages — only files touched in commits after this ships get the new fuller-granularity edges; existing historical edges remain valid for their original time window.
+
+## Section 1: Schema — `:type/external-dependency`
+
+New entity type. Ident reuses the existing slug scheme (`:module/<slugified-path-or-name>`) so `:depends-on`/`:contains` edges naturally reference it the same way they reference `:type/module` — only `:entity-type` distinguishes internal from external.
+
+| Attribute | Notes |
+|---|---|
+| `:description` | submodule's declared name from `.gitmodules` if resolvable, else raw path (submodules); raw import name (unresolved imports) |
+| `:path` | submodule's repo path (submodules only; absent for unresolved-import placeholders) |
+| `:pinned-commit` | pinned SHA the submodule currently points to (submodules only); bi-temporally closed/reopened on every bump |
+| `:submodule-name` / `:submodule-url` | from `.gitmodules`, when parseable (submodules only) |
+| `:introduced-by` / `:modified-in` (keyword refs) | same convention as `:type/module` |
+
+Verified empirically (scratch repo): a submodule **add** is a plain `A` on the gitlink path; a **pinned-commit bump** is `M` with old/new mode both `160000`; a genuine same-path flip between a regular blob and a gitlink is `T` (type-change) — and only occurs when the path was a single file (not a directory) on both sides. "Vendored directory of files → submodule at the directory's path" is an ordinary `D`+`A` pair on two different literal paths, requiring no special-casing.
+
+## Section 2: Detection & control flow
+
+`_extract_commit` sources both file-level changes and gitlink-mode info from a single `git diff-tree --raw` call per commit (replacing the current `--name-status` call, which discards mode entirely — no added subprocess overhead). From the raw rows:
+
+- the existing `(status, path)` list still feeds the unchanged tree-sitter extraction loop.
+- gitlink-relevant rows (`old_mode == 160000` or `new_mode == 160000`) collapse into three cases based on the mode pair, regardless of the raw status letter:
+  - **becoming external** (`new_mode==160000`, `old_mode!=160000`): fetch `.gitmodules` *at this commit* (current content, not diffed; best-effort `configparser` parse, `{}` on failure) to look up name/url for this path, then open a new `:type/external-dependency` entity.
+  - **still external, pinned commit changed** (`old_mode==new_mode==160000`): close the old `:pinned-commit` fact, reopen with the new SHA, add a `:modified-in` edge.
+  - **becoming internal or removed** (`old_mode==160000`, `new_mode!=160000`): close the external-dependency entity (same `:ident`/`:description`/`:path`/`:pinned-commit` close pattern used elsewhere). If the path is now a real blob with a supported extension, the existing, untouched tree-sitter loop creates the new internal module in the same commit automatically.
+
+**State reuse, not new parallel structures:** `_preload_known_entities`'s query is broadened to also load `:type/external-dependency` idents into the same `entity_valid_from`/`entity_descriptions` dicts already used for close/reopen of modules — idents share one namespace, so this "just works." A new small preload, `_preload_pinned_commits`, modeled directly on the existing `_preload_known_deps` per-fact `:any-valid-time` pattern, tracks each external entity's current pinned SHA + its valid-from for correct closing on the next bump or removal.
+
+**Unresolved imports:** `_resolve_module_import`'s return type changes from `str` to `(str, bool)` — the bool says whether it resolved to a known file or fell through to a bare-ident guess. The call site checks that flag: the first time a given fallback ident is seen (not already in `entity_valid_from`, which now also contains previously-tagged externals), it emits `:entity-type :type/external-dependency` + `:description <bare import name>` alongside the `:depends-on` edge already being written. No `:path` is set. If a same-named local module appears in a later commit, it resolves to a *different* ident (full-path-based vs bare-name-based), so the existing `:depends-on` add/remove diffing naturally retargets the edge — the stale external entity remains as accurate history for the period it was genuinely unresolved.
+
+## Section 3: Generalized import resolution
+
+This replaces the Rust-only heuristic so the labeling in Section 2 doesn't systematically mislabel vendored dependencies in every other language.
+
+**Extraction changes** — capture the fullest identifying string per language instead of today's truncation:
+
+| Language(s) | Today | Change |
+|---|---|---|
+| Java, C#, Python, Scala, Kotlin, Swift, Haskell, Elixir | first dotted segment only (`com.google.Gson` → `com`) | keep full dotted name |
+| Go | last slash segment only (`github.com/foo/bar` → `bar`) | keep full path |
+| JS/TS, Ruby | already carries enough of the raw string | unchanged |
+| C/C++ quoted (`#include "unicode/uloc.h"`) | basename only (`uloc`) — `_c_include_name` currently applies `os.path.basename` to both quoted and angle-bracket forms alike | keep the full quoted path (`unicode/uloc.h`); quoted includes are relative-path-like almost by convention, so this materially improves resolution precision |
+| C/C++ angle-bracket (`#include <vector>`) | basename only | unchanged — no real path exists to preserve for `<vector>` |
+
+**Resolution changes** — one shared tiered matcher in `_resolve_module_import`, run after Rust's existing exact conventions (kept as-is, Rust unaffected):
+
+1. Normalize (`.` → `/`), then **exact file match**: does any `file_entities` path, extension stripped, equal the candidate? (resolves `com/google/gson/Gson` against `com/google/gson/Gson.java`)
+2. **Parent-directory match**: does the candidate minus its last segment equal some file's parent directory? (resolves package/wildcard-style imports)
+3. **Bare basename match**: last segment only, against any file's stem — broadest, final tier (resolves C/C++ vendored headers like `uloc` against `.../unicode/uloc.h`)
+4. Otherwise → genuinely unresolved → tag `:type/external-dependency` per Section 2.
+
+**Relative imports** (`./utils/foo`, Python `from . import x`, Ruby `require_relative`): `_resolve_module_import` gains the importing file's own path as a parameter and resolves the relative specifier against that file's directory before running the tiered matcher. A relative import that still fails to resolve (bug in the source, deleted target, etc.) is *not* tagged `:type/external-dependency` — that label is reserved for "no such reference could exist internally," and a relative specifier can only ever refer to something local. It's left as today's bare, untagged fallback ident (no `:entity-type`) — a known, narrow residual gap (the placeholder-vs-real-module ambiguity issue #97 raised still applies to this one case) rather than a regression.
+
+**Compatibility:** `:depends-on` edge granularity for the namespace/Go languages changes going forward. Existing coarse single-segment historical edges remain valid for their original time window (untouched); only files modified in commits after this ships get recomputed with the new fuller-granularity edges — consistent with the incremental ingester's existing behavior of only recomputing deps for files touched in the current run.
+
+## Section 4: TSX fix (unrelated root cause, folded in)
+
+- `_build_parser` gets an explicit `lang_name → module_name` override map (`{"tsx": "tree_sitter_typescript"}`) instead of assuming `tree_sitter_{lang_name}` always holds. `language_fn` lookup (`language_tsx` vs `language_typescript`) already works correctly once the right module is imported — no change needed there.
+- `_LANG_NODE_TYPES.get(lang_name)` and `_extract_import_name`'s dispatch both resolve `"tsx"` as an alias of `"typescript"` at the top of each function, rather than duplicating every table entry.
+
+## Error handling
+
+- `.gitmodules` fetch/parse failures (missing file, malformed INI) are best-effort — empty dict, matches the file's existing `except Exception: pass` conventions elsewhere.
+- Gitlink close/reopen triples use the same `_ingest_close`/`_ingest_transact` helpers already in place; retract-before-reopen failures are already tolerated (`except Exception: pass`) since a prior preload may have been incomplete.
+- No new exception-handling patterns introduced — everything routes through existing bi-temporal helpers.
+
+## Testing plan
+
+- Extend `git_repo`-style fixtures with a scratch repo that adds a gitlink, bumps its pinned commit, removes it, and (separately) performs a same-path blob↔gitlink flip — assert entity-type, `:pinned-commit` history, and close/reopen timestamps at each step.
+- Unresolved-import test: an import with no matching file gets tagged `:type/external-dependency` with `:description` set to the bare name, created exactly once across multiple commits/files referencing it.
+- Per-language resolution tests for the new tiered matcher: exact-file, parent-directory, and basename tiers, at least for Java (package match), Go (full-path match), and C/C++ (vendored header basename match).
+- Relative-import test: an unresolved `./utils/foo`-style import does not get tagged external.
+- `.tsx` regression test: a `.tsx` file with a function/class/import is ingested and yields non-empty `functions`/`classes`/`imports`, mirroring the existing `.ts` test.
+
+## Suggested implementation order
+
+Four independently testable slices, in dependency order (each buildable/reviewable on its own even though they land in one plan):
+
+1. TSX fix (Section 4) — fully independent, no dependency on anything else here.
+2. Schema + submodule detection/control flow (Sections 1-2, submodule half) — the `:type/external-dependency` type, gitlink add/bump/remove/flip handling.
+3. Unresolved-import tagging using today's existing (Rust-only) resolver (Section 2, import half) — proves out the tagging mechanism before the resolver itself changes underneath it.
+4. Generalized import resolution + relative imports (Section 3) — layers the tiered matcher and per-language extraction changes on top of the tagging mechanism from (3).

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -471,7 +471,7 @@ def _lua_require_name(node) -> Optional[str]:
 
 
 def _elixir_module_name(node) -> Optional[str]:
-    """Return the root module name from an Elixir alias/import/use/require call.
+    """Return the full dotted module name from an Elixir alias/import/use/require call.
 
     alias MyApp.Router     → "MyApp.Router"
     import Ecto.Query      → "Ecto.Query"

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -503,7 +503,7 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
                         names.append(n.text.decode("utf-8").split(".")[0])
                 elif child.type == "dotted_name":
                     names.append(child.text.decode("utf-8").split(".")[0])
-    elif lang_name in ("javascript", "typescript"):
+    elif lang_name in ("javascript", "typescript", "tsx"):
         src = node.child_by_field_name("source")
         if src:
             names.append(src.text.decode("utf-8").strip("'\""))
@@ -626,8 +626,14 @@ def _c_family_function_name(node) -> Optional[str]:
 
 
 def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
-    """Recursively extract code entities from a tree-sitter AST node."""
-    node_types = _LANG_NODE_TYPES.get(lang_name)
+    """Recursively extract code entities from a tree-sitter AST node.
+
+    tsx is treated as an alias of typescript here (and in _extract_import_name)
+    rather than duplicating every _LANG_NODE_TYPES entry — the TSX grammar is
+    a strict superset of TypeScript's node types for the constructs this
+    module cares about (functions, classes, imports, calls).
+    """
+    node_types = _LANG_NODE_TYPES.get("typescript" if lang_name == "tsx" else lang_name)
     if node_types is None:
         return
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -391,21 +391,19 @@ def _c_include_name(node) -> Optional[str]:
 
 
 def _csharp_using_name(node) -> Optional[str]:
-    """Return the root namespace from a C# using_directive node.
+    """Return the full dotted namespace from a C# using_directive node.
 
     using System;                     → "System"
-    using System.Collections.Generic; → "System"
-    """
-    def _first_ident(n) -> Optional[str]:
-        if n.type == "identifier":
-            return n.text.decode("utf-8")
-        for c in n.named_children:
-            result = _first_ident(c)
-            if result:
-                return result
-        return None
+    using System.Collections.Generic; → "System.Collections.Generic"
 
-    return _first_ident(node)
+    The dotted path is one named child (qualified_name for multi-segment
+    paths, identifier for single-segment ones) whose own .text is already
+    the full joined name.
+    """
+    for child in node.named_children:
+        if child.type in ("qualified_name", "identifier"):
+            return child.text.decode("utf-8")
+    return None
 
 
 def _ruby_require_name(node) -> Optional[str]:
@@ -475,9 +473,9 @@ def _lua_require_name(node) -> Optional[str]:
 def _elixir_module_name(node) -> Optional[str]:
     """Return the root module name from an Elixir alias/import/use/require call.
 
-    alias MyApp.Router     → "MyApp"
-    import Ecto.Query      → "Ecto"
-    use Phoenix.Controller → "Phoenix"
+    alias MyApp.Router     → "MyApp.Router"
+    import Ecto.Query      → "Ecto.Query"
+    use Phoenix.Controller → "Phoenix.Controller"
     require Logger         → "Logger"
     Returns None for non-module calls (e.g. IO.puts/1 where target is a dot node).
     """
@@ -495,8 +493,7 @@ def _elixir_module_name(node) -> Optional[str]:
         if child.type == "arguments":
             for arg in child.children:
                 if arg.type == "alias":
-                    txt = arg.text.decode("utf-8")
-                    return txt.split(".")[0]
+                    return arg.text.decode("utf-8")
     return None
 
 
@@ -507,16 +504,19 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
         if node.type == "import_from_statement":
             m = node.child_by_field_name("module_name")
             if m:
-                names.append(m.text.decode("utf-8").split(".")[0])
+                # m.text is the raw specifier as written, including relative
+                # forms: "pathlib", ".sub", "..pkg" — see _resolve_module_import
+                # for how leading dots get resolved against the importing file.
+                names.append(m.text.decode("utf-8"))
         else:
-            # import_statement: collect all top-level module names
+            # import_statement: collect all full dotted module names
             for child in node.named_children:
                 if child.type == "aliased_import":
                     n = child.child_by_field_name("name")
                     if n:
-                        names.append(n.text.decode("utf-8").split(".")[0])
+                        names.append(n.text.decode("utf-8"))
                 elif child.type == "dotted_name":
-                    names.append(child.text.decode("utf-8").split(".")[0])
+                    names.append(child.text.decode("utf-8"))
     elif lang_name in ("javascript", "typescript", "tsx"):
         src = node.child_by_field_name("source")
         if src:
@@ -539,18 +539,13 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
                     if spec.type == "import_spec":
                         _go_spec(spec)
     elif lang_name == "java":
-        def _java_leftmost(n) -> Optional[str]:
-            if n.type == "identifier":
-                return n.text.decode("utf-8")
-            for c in n.named_children:
-                result = _java_leftmost(c)
-                if result:
-                    return result
-            return None
-
-        result = _java_leftmost(node)
-        if result:
-            names.append(result)
+        # import_declaration's dotted path is one named child, already the
+        # full text (e.g. "java.util.List") — scoped_identifier for
+        # multi-segment paths, plain identifier for single-segment ones.
+        for child in node.named_children:
+            if child.type in ("scoped_identifier", "identifier"):
+                names.append(child.text.decode("utf-8"))
+                break
     elif lang_name in ("c", "cpp"):
         name = _c_include_name(node)
         if name:
@@ -570,33 +565,36 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
                 names.append(os.path.splitext(val)[0])
                 break
     elif lang_name == "kotlin":
-        def _kotlin_first_seg(n) -> Optional[str]:
-            if n.type in ("simple_identifier", "identifier"):
-                return n.text.decode("utf-8")
-            for c in n.named_children:
-                result = _kotlin_first_seg(c)
-                if result:
-                    return result
-            return None
-
-        result = _kotlin_first_seg(node)
-        if result:
-            names.append(result)
+        # import node's dotted path is one named child (qualified_identifier
+        # for multi-segment, identifier for single-segment) whose .text is
+        # already the full joined name.
+        for child in node.named_children:
+            if child.type in ("qualified_identifier", "identifier"):
+                names.append(child.text.decode("utf-8"))
+                break
     elif lang_name == "swift":
+        # import_declaration's single "identifier" named child already
+        # holds the full dotted text (e.g. "Foundation.NSString") directly —
+        # no recursion needed.
         for child in node.named_children:
             if child.type in ("identifier", "simple_identifier"):
                 names.append(child.text.decode("utf-8"))
                 break
     elif lang_name == "scala":
+        # import_declaration's path is flattened into individual "identifier"
+        # named children (no wrapping scoped node), so join the leading run
+        # of identifiers rather than taking the first one's text alone.
+        segments = []
         for child in node.named_children:
-            txt = child.text.decode("utf-8")
-            names.append(txt.split(".")[0])
-            break
+            if child.type != "identifier":
+                break
+            segments.append(child.text.decode("utf-8"))
+        if segments:
+            names.append(".".join(segments))
     elif lang_name == "haskell":
         for child in node.named_children:
             if child.type in ("module", "qualified_module", "constructor"):
-                txt = child.text.decode("utf-8")
-                names.append(txt.split(".")[0])
+                names.append(child.text.decode("utf-8"))
                 break
     elif lang_name == "lua":
         name = _lua_require_name(node)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1309,7 +1309,11 @@ def _gitlink_changes(raw_entries: List[tuple]) -> List[tuple]:
 
 
 def _git_changed_files(repo_path: str, commit_hash: str) -> List[tuple]:
-    """Return list of (status_char, path) for files changed in this commit."""
+    """Return list of (status_char, path) for files changed in this commit.
+
+    Not currently called by the ingestion pipeline (which uses _git_diff_tree_raw
+    instead, for mode-aware parsing) — retained as a general-purpose git helper.
+    """
     result = _subprocess.run(
         ["git", "diff-tree", "--no-commit-id", "-r", "--name-status", "--root", commit_hash],
         cwd=repo_path, capture_output=True, text=True, check=True,
@@ -2894,6 +2898,12 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                     )
                             file_deps[file_path] = current_deps
 
+                    # Process gitlink changes (submodule add/bump/remove).
+                    # The "remove" case's interaction with the ordinary per-file module-open
+                    # logic (elsewhere in this loop) is only sound because real submodule paths
+                    # are extensionless (no tree-sitter parser matches them, so no module is
+                    # ever opened for a bare gitlink path) — a gitlink path that happened to
+                    # carry a recognized source extension is an untested, unreachable-in-practice edge case.
                     for kind, sha, path in gitlink_changes:
                         ext_ident = _code_ident("module", path)
                         if kind == "add":

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2396,8 +2396,17 @@ def _build_code_triples(
 
 
 def _preload_known_entities(db: Any, repo_path: str) -> tuple:
-    """Load all existing module/function/class idents from the DB, and pre-seed
-    file_entities with all currently tracked files in the repo.
+    """Load all existing module/function/class/external-dependency idents from
+    the DB, and pre-seed file_entities with all currently tracked files in the
+    repo.
+
+    external-dependency entities share the module ident namespace and use the
+    same "path" attribute as modules, so folding them into this same query
+    means the existing close/reopen machinery (entity_valid_from,
+    entity_descriptions) just works for submodules without new parallel state.
+    Unresolved-import placeholders (no :path) are not reloaded by this query —
+    nothing in this codebase ever closes one, so the gap is harmless; see the
+    design spec's Section 2.
 
     Pre-seeding from `git ls-files` ensures that _resolve_module_import can
     find any module file even when processing early commits — before those files
@@ -2423,8 +2432,8 @@ def _preload_known_entities(db: Any, repo_path: str) -> tuple:
     except Exception:
         pass
 
-    for entity_type in ("module", "function", "class"):
-        path_attr = "path" if entity_type == "module" else "file"
+    for entity_type in ("module", "function", "class", "external-dependency"):
+        path_attr = "path" if entity_type in ("module", "external-dependency") else "file"
         try:
             raw = db.execute(
                 f'(query [:find ?ident ?path ?desc ?date '
@@ -2508,6 +2517,41 @@ def _preload_known_deps(
         dep_valid_from[(src_ident, dep_ident)] = vf_iso
 
     return file_deps, dep_valid_from
+
+
+def _preload_pinned_commits(db: Any) -> Dict[str, tuple]:
+    """Reload each external-dependency entity's current :pinned-commit value
+    and the timestamp it was set at, mirroring _preload_known_deps's per-fact
+    :any-valid-time pattern for :depends-on.
+
+    Needed because :pinned-commit is bi-temporally closed and reopened on
+    every bump (see _run_ingestion's gitlink handling) — without this, the
+    server would lose track of the prior SHA and valid-from across a restart,
+    corrupting the close on the next bump or removal exactly the way
+    _preload_known_deps' docstring describes for :depends-on.
+
+    Returns {ident: (sha, valid_from_iso)}.
+    """
+    pinned: Dict[str, tuple] = {}
+    try:
+        raw = db.execute(
+            "(query [:find ?e ?sha ?vf "
+            ":any-valid-time "
+            ":where [?e :pinned-commit ?sha] "
+            "[?e :db/valid-from ?vf] "
+            "[?e :db/valid-to ?vt] "
+            f"[(= ?vt {_VALID_TIME_FOREVER_MS})]])"
+        )
+        rows = json.loads(raw).get("results", [])
+    except Exception:
+        return pinned
+    for ident, sha, vf_ms in rows:
+        vf_iso = (
+            datetime.datetime.fromtimestamp(vf_ms / 1000, datetime.timezone.utc)
+            .strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+        )
+        pinned[ident] = (sha, vf_iso)
+    return pinned
 
 
 def _ingest_tags(db: Any, repo_path: str, run_ts_iso: str) -> None:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1181,6 +1181,41 @@ def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
     return entries
 
 
+_GITLINK_MODE = "160000"
+
+
+def _gitlink_changes(raw_entries: List[tuple]) -> List[tuple]:
+    """Filter _git_diff_tree_raw's output down to gitlink-involving rows,
+    collapsed into three cases by mode pair rather than by the raw status
+    letter (which varies: A/D/M/T can all represent a gitlink change
+    depending on what else happened to the same path):
+
+      "add"    — new_mode is a gitlink, old_mode is not. Covers a plain
+                 submodule addition (status A) and a same-path flip from a
+                 regular blob into a gitlink (status T).
+      "bump"   — both modes are gitlinks (status M): the pinned commit changed.
+      "remove" — old_mode is a gitlink, new_mode is not. Covers a plain
+                 submodule removal (status D) and a same-path flip from a
+                 gitlink back into a regular blob (status T).
+
+    sha is the new pinned commit for "add"/"bump", or the last-known pinned
+    commit for "remove" (needed by the caller to close the right fact).
+    """
+    changes = []
+    for status, old_mode, new_mode, old_sha, new_sha, path in raw_entries:
+        old_is_link = old_mode == _GITLINK_MODE
+        new_is_link = new_mode == _GITLINK_MODE
+        if not old_is_link and not new_is_link:
+            continue
+        if new_is_link and not old_is_link:
+            changes.append(("add", new_sha, path))
+        elif old_is_link and new_is_link:
+            changes.append(("bump", new_sha, path))
+        else:
+            changes.append(("remove", old_sha, path))
+    return changes
+
+
 def _git_changed_files(repo_path: str, commit_hash: str) -> List[tuple]:
     """Return list of (status_char, path) for files changed in this commit."""
     result = _subprocess.run(

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2654,6 +2654,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
         prior_ingested = _count_commit_entities(db)
         entity_valid_from, entity_descriptions, file_entities = _preload_known_entities(db, repo_path)
         file_deps, dep_valid_from = _preload_known_deps(db, file_entities)
+        pinned_commit_state = _preload_pinned_commits(db)
         # minigraf exposes no explicit close(): the file lock is only released once
         # every reference to the handle is gone, so the local `db` must be cleared
         # too, not just the global — otherwise this frame keeps it alive (and the
@@ -2790,6 +2791,50 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                         ([f"[{module_ident} :depends-on {dep_ident}]"], orig_ts)
                                     )
                             file_deps[file_path] = current_deps
+
+                    for kind, sha, path in gitlink_changes:
+                        ext_ident = _code_ident("module", path)
+                        if kind == "add":
+                            info = gitmodules_map.get(path, {})
+                            name = info.get("name", "")
+                            url = info.get("url", "")
+                            description = name or path
+                            ext_triples = [
+                                f"[{ext_ident} :entity-type :type/external-dependency]",
+                                f'[{ext_ident} :ident "{_edn_escape(ext_ident)}"]',
+                                f'[{ext_ident} :description "{_edn_escape(description)}"]',
+                                f'[{ext_ident} :path "{_edn_escape(path)}"]',
+                                f'[{ext_ident} :pinned-commit "{_edn_escape(sha)}"]',
+                                f"[{ext_ident} :introduced-by {commit_ident}]",
+                            ]
+                            if name:
+                                ext_triples.append(f'[{ext_ident} :submodule-name "{_edn_escape(name)}"]')
+                            if url:
+                                ext_triples.append(f'[{ext_ident} :submodule-url "{_edn_escape(url)}"]')
+                            add_triples.extend(ext_triples)
+                            entity_valid_from[ext_ident] = commit_ts_iso
+                            entity_descriptions[ext_ident] = description
+                            pinned_commit_state[ext_ident] = (sha, commit_ts_iso)
+                        elif kind == "bump":
+                            old_sha, orig_ts = pinned_commit_state.get(ext_ident, (None, commit_ts_iso))
+                            if old_sha is not None:
+                                close_items.append(
+                                    ([f'[{ext_ident} :pinned-commit "{_edn_escape(old_sha)}"]'], orig_ts)
+                                )
+                            add_triples.append(f'[{ext_ident} :pinned-commit "{_edn_escape(sha)}"]')
+                            add_triples.append(f"[{ext_ident} :modified-in {commit_ident}]")
+                            pinned_commit_state[ext_ident] = (sha, commit_ts_iso)
+                        else:  # "remove"
+                            orig_ts = entity_valid_from.get(ext_ident, commit_ts_iso)
+                            desc = entity_descriptions.get(ext_ident, "")
+                            close_items.append(
+                                (_build_close_triples(ext_ident, desc, ext_ident), orig_ts)
+                            )
+                            old_sha, pin_orig_ts = pinned_commit_state.pop(ext_ident, (None, commit_ts_iso))
+                            if old_sha is not None:
+                                close_items.append(
+                                    ([f'[{ext_ident} :pinned-commit "{_edn_escape(old_sha)}"]'], pin_orig_ts)
+                                )
 
                     # Split :contains triples out before batching.  Minigraf's EAVT
                     # pending index lacks value bytes in the key, so batching multiple

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -369,17 +369,24 @@ def _rust_use_root(node) -> Optional[str]:
 
 
 def _c_include_name(node) -> Optional[str]:
-    """Return the header name (no path, no extension) from a C/C++ preproc_include node.
+    """Return the include target (path preserved, extension stripped) from a
+    C/C++ preproc_include node.
 
     Handles both:
-      #include <stdio.h>    → system_lib_string → "stdio"
-      #include "myheader.h" → string_literal    → "myheader"
+      #include <stdio.h>          → system_lib_string → "stdio"
+      #include <unicode/uloc.h>   → system_lib_string → "unicode/uloc"
+      #include "sub/myheader.h"   → string_literal    → "sub/myheader"
+
+    Path structure is preserved (not reduced to a bare basename) so
+    _resolve_module_import can match vendored in-tree headers precisely —
+    both angle-bracket and quoted forms commonly carry a real subdirectory
+    (<sys/socket.h>, <unicode/uloc.h>, "app/config.h"), not just stdlib-style
+    bare names like <vector>.
     """
-    import os
     for child in node.children:
         if child.type in ("system_lib_string", "string_literal"):
             raw = child.text.decode("utf-8").strip("<>\"'")
-            return os.path.splitext(os.path.basename(raw))[0]
+            return os.path.splitext(raw)[0]
     return None
 
 
@@ -402,17 +409,22 @@ def _csharp_using_name(node) -> Optional[str]:
 
 
 def _ruby_require_name(node) -> Optional[str]:
-    """Return the required module name from a Ruby call node.
+    """Return the required path from a Ruby call node (path preserved,
+    extension stripped). A require_relative target is prefixed with "./" so
+    it reuses the same relative-import detection _resolve_module_import
+    already needs for JS/TS-style "./foo" specifiers, rather than plumbing a
+    separate is-relative flag through the whole imports pipeline.
 
     Handles:
-      require 'rails'            → "rails"
-      require_relative 'my_mod' → "my_mod"
+      require 'rails'                            → "rails"
+      require 'active_support/core_ext/string'    → "active_support/core_ext/string"
+      require_relative 'my_mod'                   → "./my_mod"
     Returns None for non-require calls.
     """
-    import os
     method = node.child_by_field_name("method")
     if method is None or method.text.decode("utf-8") not in ("require", "require_relative"):
         return None
+    is_relative = method.text.decode("utf-8") == "require_relative"
     args = node.child_by_field_name("arguments")
     if args is None:
         return None
@@ -426,7 +438,8 @@ def _ruby_require_name(node) -> Optional[str]:
                 val = content_node.text.decode("utf-8")
             else:
                 val = child.text.decode("utf-8").strip("'\"")
-            return os.path.splitext(os.path.basename(val))[0]
+            path = os.path.splitext(val)[0]
+            return f"./{path}" if is_relative else path
     return None
 
 
@@ -516,8 +529,7 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
         def _go_spec(spec_node):
             path = spec_node.child_by_field_name("path")
             if path:
-                val = path.text.decode("utf-8").strip('"')
-                names.append(val.split("/")[-1])
+                names.append(path.text.decode("utf-8").strip('"'))
 
         for child in node.named_children:
             if child.type == "import_spec":
@@ -552,11 +564,10 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
         if name:
             names.append(name)
     elif lang_name == "php":
-        import os
         for child in node.children:
             if child.type in ("string", "encapsed_string", "string_literal"):
                 val = child.text.decode("utf-8").strip("'\"")
-                names.append(os.path.splitext(os.path.basename(val))[0])
+                names.append(os.path.splitext(val)[0])
                 break
     elif lang_name == "kotlin":
         def _kotlin_first_seg(n) -> Optional[str]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1086,19 +1086,49 @@ def _canonical_ident(entity_type: str, value: str) -> str:
     return f":{entity_type}/{slug}"
 
 
+def _path_segments(path_str: str) -> List[str]:
+    """Split a path into non-empty segments, normalizing os.sep to '/'."""
+    return [seg for seg in path_str.replace(os.sep, "/").split("/") if seg]
+
+
+def _segments_end_with(full_segments: List[str], candidate_segments: List[str]) -> bool:
+    """True if full_segments' trailing slice equals candidate_segments exactly.
+
+    A whole-segment suffix comparison, not a raw string suffix — comparing
+    strings directly would let e.g. "xyzcom/google" wrongly match a
+    candidate of "com/google" (the substring is present but not as its own
+    path segment).
+    """
+    if not candidate_segments or len(candidate_segments) > len(full_segments):
+        return False
+    return full_segments[-len(candidate_segments):] == candidate_segments
+
+
 def _resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]) -> Tuple[str, bool]:
     """Resolve an import name to a module ident that joins with stored module entities.
 
-    For a name like "storage", tries standard Rust source-root locations first
-    (src/storage.rs, src/storage/mod.rs) before falling back to a broader name
-    search. The ordered-priority approach prevents e.g. src/graph/storage.rs
-    from matching a top-level `use crate::storage` import.
+    Tries Rust's exact source-root conventions first (src/storage.rs,
+    src/storage/mod.rs), then a generic, language-agnostic segment-suffix
+    matcher used by every other language. This exists because every other
+    language's import extraction already reduces to a bare or dotted/slashed
+    specifier (see _extract_import_name) that would otherwise always fall
+    through to the external-dependency fallback — including for real in-tree
+    vendored code, which must stay internal per the design spec's Non-goals.
 
-    Returns (ident, is_resolved). is_resolved is True when import_name matched
-    a real file in file_entities, False when it fell through to the bare
-    _canonical_ident guess — the caller uses this to tag genuinely unresolved
-    imports as :type/external-dependency without also tagging real (if not
-    yet visited) internal modules.
+    The specifier is split into segments on "/" if present (Go, C/C++, Ruby,
+    PHP already use "/" natively — note Go paths like "github.com/user/pkg"
+    contain literal dots inside a segment that must NOT be treated as
+    separators), otherwise on "." (Java, C#, Python, Scala, Kotlin, Swift,
+    Haskell, Elixir — genuinely dot-separated). Matching a whole-segment
+    suffix (not a raw substring) against either a file's own path or its
+    parent directory uniformly covers: an exact match, a vendored path with
+    extra prefix segments, a package-only/wildcard-style import (matches via
+    the parent-directory tier), and a bare single-segment name (degenerates
+    to a basename check) — one algorithm instead of separate ad hoc tiers.
+
+    Returns (ident, is_resolved). is_resolved is True when import_name
+    matched a real file in file_entities, False when it fell through to the
+    bare _canonical_ident guess.
     """
     # Priority 1: canonical Rust module root paths under common source roots
     for src_root in ("src", "lib", ""):
@@ -1115,6 +1145,23 @@ def _resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]
     for file_path in file_entities:
         p = Path(file_path)
         if p.stem == "mod" and p.parent.name == import_name:
+            return _code_ident("module", file_path), True
+
+    # Priority 3: generic segment-suffix matcher for every other language.
+    candidate_segments = import_name.split("/") if "/" in import_name else import_name.split(".")
+
+    # 3a. file match (exact, or a vendored path with extra prefix segments), extension stripped
+    for file_path in file_entities:
+        file_segments = _path_segments(str(Path(file_path).with_suffix("")))
+        if _segments_end_with(file_segments, candidate_segments):
+            return _code_ident("module", file_path), True
+
+    # 3b. parent-directory match (package-only/wildcard-style imports, e.g.
+    # a Java "import com.google.gson.*;" or a bare "com.google.gson" reference
+    # with no specific trailing class name)
+    for file_path in file_entities:
+        parent_segments = _path_segments(str(Path(file_path).parent))
+        if _segments_end_with(parent_segments, candidate_segments):
             return _code_ident("module", file_path), True
 
     return _canonical_ident("module", import_name), False

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7,6 +7,7 @@ Sole interface to the minigraf .graph file via the MiniGrafDb Python binding.
 """
 import asyncio
 import concurrent.futures
+import configparser
 import contextlib
 import datetime
 import json
@@ -1245,6 +1246,45 @@ def _git_file_content(repo_path: str, commit_hash: str, file_path: str) -> bytes
         cwd=repo_path, capture_output=True, check=True,
     )
     return result.stdout
+
+
+def _parse_gitmodules(content: bytes) -> Dict[str, Dict[str, str]]:
+    """Parse .gitmodules content into {path: {"name": ..., "url": ...}}.
+
+    Best-effort: git config's `[section "subsection"]` syntax is a strict
+    superset of what configparser expects for ordinary cases, so malformed
+    or unusual .gitmodules content fails closed to an empty dict rather
+    than raising — matches this file's existing best-effort git/parse
+    conventions (see _extract_from_source's bare except).
+    """
+    result: Dict[str, Dict[str, str]] = {}
+    parser = configparser.ConfigParser()
+    try:
+        parser.read_string(content.decode("utf-8", errors="replace"))
+    except configparser.Error:
+        return result
+    for section in parser.sections():
+        m = re.match(r'submodule\s+"(.+)"', section)
+        if not m:
+            continue
+        path = parser.get(section, "path", fallback=None)
+        url = parser.get(section, "url", fallback=None)
+        if path:
+            result[path] = {"name": m.group(1), "url": url or ""}
+    return result
+
+
+def _git_gitmodules_at(repo_path: str, commit_hash: str) -> Dict[str, Dict[str, str]]:
+    """Fetch and parse .gitmodules as it exists at commit_hash.
+
+    Empty dict if missing or unparseable — most repos never have a
+    .gitmodules file at all, which is the normal case, not an error.
+    """
+    try:
+        content = _git_file_content(repo_path, commit_hash, ".gitmodules")
+    except Exception:
+        return {}
+    return _parse_gitmodules(content)
 
 
 def _git_parent_hashes(repo_path: str, commit_hash: str) -> List[str]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -95,6 +95,15 @@ _EXT_TO_LANG: Dict[str, str] = {
     ".cc": "cpp", ".cxx": "cpp",
 }
 
+# Maps lang_name to the actual importable module, for the (currently only)
+# case where a single package ships multiple grammar variants. tsx and
+# typescript are both exposed by the tree_sitter_typescript package via
+# separate language_tsx()/language_typescript() functions — there is no
+# separate tree_sitter_tsx module, unlike every other language here.
+_LANG_MODULE_OVERRIDES: Dict[str, str] = {
+    "tsx": "tree_sitter_typescript",
+}
+
 _grammar_cache: Dict[str, Any] = {}  # lang_name → Parser or None
 
 _grammar_cache_lock = threading.Lock()
@@ -113,9 +122,11 @@ def _build_parser(lang_name: str) -> Any:
     swallowed, consistent with how any other producer-task exception is
     handled.
     """
-    mod = __import__(f"tree_sitter_{lang_name}", fromlist=["language"])
+    module_name = _LANG_MODULE_OVERRIDES.get(lang_name, f"tree_sitter_{lang_name}")
+    mod = __import__(module_name, fromlist=["language"])
     from tree_sitter import Language, Parser  # type: ignore
-    # PHP exposes language_php() instead of language()
+    # PHP exposes language_php() instead of language(); tsx exposes
+    # language_tsx() from within the tree_sitter_typescript module.
     lang_fn = getattr(mod, f"language_{lang_name}", None) or mod.language
     lang_obj = Language(lang_fn())
     return Parser(lang_obj)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1258,7 +1258,7 @@ def _parse_gitmodules(content: bytes) -> Dict[str, Dict[str, str]]:
     conventions (see _extract_from_source's bare except).
     """
     result: Dict[str, Dict[str, str]] = {}
-    parser = configparser.ConfigParser()
+    parser = configparser.ConfigParser(interpolation=None)
     try:
         parser.read_string(content.decode("utf-8", errors="replace"))
     except configparser.Error:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2543,17 +2543,31 @@ def _ingest_tags(db: Any, repo_path: str, run_ts_iso: str) -> None:
 
 def _extract_commit(
     repo_path: str, commit_hash: str
-) -> List[Tuple[str, str, Optional[Dict[str, List[str]]]]]:
+) -> Tuple[List[Tuple[str, str, Optional[Dict[str, List[str]]]]], List[tuple], Dict[str, Dict[str, str]]]:
     """Read-only, stateless per-commit extraction: diff-tree + git-show + tree-sitter parse.
 
     Runs in a worker thread via the ThreadPoolExecutor in _run_ingestion.
-    Touches no shared mutable state and no DB. Returns one entry per changed
-    file that has a supported parser; A/M files whose content fetch fails
-    are omitted entirely, mirroring the previous inline `continue` — the
-    file is simply skipped for this commit, same as today.
+    Touches no shared mutable state and no DB. Returns (file_results,
+    gitlink_changes, gitmodules_map):
+
+      file_results: one entry per changed file that has a supported parser;
+        A/M files whose content fetch fails are omitted entirely, mirroring
+        the previous inline `continue` — same as before this pipeline existed.
+      gitlink_changes: _gitlink_changes' output — gitlink-involving rows,
+        never fed through the tree-sitter parser (gitlink paths never have
+        a resolvable extension).
+      gitmodules_map: path -> {"name", "url"}, populated only when this
+        commit has at least one gitlink "add" — avoids a wasted git-show
+        call on the (overwhelmingly common) case of a commit that touches
+        no submodules at all.
+
+    Sources both file_results and gitlink_changes from a single
+    `git diff-tree --raw` call (via _git_diff_tree_raw) rather than the
+    former --name-status call, which discarded file mode entirely.
     """
+    raw_entries = _git_diff_tree_raw(repo_path, commit_hash)
     results: List[Tuple[str, str, Optional[Dict[str, List[str]]]]] = []
-    for status, file_path in _git_changed_files(repo_path, commit_hash):
+    for status, old_mode, new_mode, old_sha, new_sha, file_path in raw_entries:
         parser = _thread_parser(file_path)
         if parser is None:
             continue
@@ -2566,7 +2580,13 @@ def _extract_commit(
             continue
         extracted = _extract_from_source(content, parser, file_path)
         results.append((status, file_path, extracted))
-    return results
+
+    gitlink_changes = _gitlink_changes(raw_entries)
+    gitmodules_map: Dict[str, Dict[str, str]] = {}
+    if any(kind == "add" for kind, _, _ in gitlink_changes):
+        gitmodules_map = _git_gitmodules_at(repo_path, commit_hash)
+
+    return results, gitlink_changes, gitmodules_map
 
 
 async def _run_ingestion(repo_path: str, branch: str) -> None:
@@ -2640,7 +2660,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                     break
 
                 (commit_hash, commit_ts_iso, author, subject), fut = pending.popleft()
-                extracted_files = await fut
+                extracted_files, gitlink_changes, gitmodules_map = await fut
                 submit_next()
 
                 last_hash = commit_hash

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1154,6 +1154,33 @@ def _git_commits(
     return commits
 
 
+def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
+    """Return (status_char, old_mode, new_mode, old_sha, new_sha, path) for
+    every changed path in a commit, via a single `git diff-tree --raw` call.
+
+    Supersedes running diff-tree a second time just to detect gitlinks:
+    --raw already carries file mode (needed to spot submodule paths, mode
+    160000) in the same subprocess invocation _extract_commit already makes.
+    """
+    result = _subprocess.run(
+        ["git", "diff-tree", "--no-commit-id", "-r", "--raw", "--root", commit_hash],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    entries = []
+    for line in result.stdout.strip().splitlines():
+        if not line.startswith(":"):
+            continue
+        meta, sep, path = line.partition("\t")
+        if not sep:
+            continue
+        fields = meta[1:].split(" ")
+        if len(fields) < 5:
+            continue
+        old_mode, new_mode, old_sha, new_sha, status = fields[0], fields[1], fields[2], fields[3], fields[4]
+        entries.append((status[0], old_mode, new_mode, old_sha, new_sha, path))
+    return entries
+
+
 def _git_changed_files(repo_path: str, commit_hash: str) -> List[tuple]:
     """Return list of (status_char, path) for files changed in this commit."""
     result = _subprocess.run(

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1104,32 +1104,64 @@ def _segments_end_with(full_segments: List[str], candidate_segments: List[str]) 
     return full_segments[-len(candidate_segments):] == candidate_segments
 
 
-def _resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]) -> Tuple[str, bool]:
+def _resolve_module_import(
+    import_name: str,
+    file_entities: Dict[str, List[str]],
+    importing_file: Optional[str] = None,
+) -> Tuple[str, bool]:
     """Resolve an import name to a module ident that joins with stored module entities.
 
-    Tries Rust's exact source-root conventions first (src/storage.rs,
-    src/storage/mod.rs), then a generic, language-agnostic segment-suffix
-    matcher used by every other language. This exists because every other
-    language's import extraction already reduces to a bare or dotted/slashed
-    specifier (see _extract_import_name) that would otherwise always fall
-    through to the external-dependency fallback — including for real in-tree
-    vendored code, which must stay internal per the design spec's Non-goals.
+    Tries a relative-import resolution first (see below), then Rust's exact
+    source-root conventions (src/storage.rs, src/storage/mod.rs), then a
+    generic, language-agnostic segment-suffix matcher used by every other
+    language. This exists because every other language's import extraction
+    already reduces to a bare or dotted/slashed specifier (see
+    _extract_import_name) that would otherwise always fall through to the
+    external-dependency fallback — including for real in-tree vendored code,
+    which must stay internal per the design spec's Non-goals.
 
-    The specifier is split into segments on "/" if present (Go, C/C++, Ruby,
-    PHP already use "/" natively — note Go paths like "github.com/user/pkg"
-    contain literal dots inside a segment that must NOT be treated as
-    separators), otherwise on "." (Java, C#, Python, Scala, Kotlin, Swift,
-    Haskell, Elixir — genuinely dot-separated). Matching a whole-segment
-    suffix (not a raw substring) against either a file's own path or its
-    parent directory uniformly covers: an exact match, a vendored path with
-    extra prefix segments, a package-only/wildcard-style import (matches via
-    the parent-directory tier), and a bare single-segment name (degenerates
-    to a basename check) — one algorithm instead of separate ad hoc tiers.
+    When import_name is relative (starts with ".") and importing_file is
+    given, resolves against the importing file's own directory before any
+    other tier runs. Covers three conventions: JS/TS/Ruby-style "./foo" and
+    "../foo/bar" (plain relative filesystem paths — Ruby's require_relative
+    results already carry this "./" prefix, added by _ruby_require_name),
+    and Python-style leading dots with no slash ("." = same package, each
+    extra dot = one directory further up) followed by an optional dotted
+    module path.
+
+    The generic matcher splits the specifier into segments on "/" if present
+    (Go, C/C++, Ruby, PHP already use "/" natively — note Go paths like
+    "github.com/user/pkg" contain literal dots inside a segment that must
+    NOT be treated as separators), otherwise on "." (Java, C#, Python, Scala,
+    Kotlin, Swift, Haskell, Elixir — genuinely dot-separated). Matching a
+    whole-segment suffix (not a raw substring) against either a file's own
+    path or its parent directory uniformly covers: an exact match, a
+    vendored path with extra prefix segments, a package-only/wildcard-style
+    import (via the parent-directory tier), and a bare single-segment name
+    (degenerates to a basename check).
 
     Returns (ident, is_resolved). is_resolved is True when import_name
     matched a real file in file_entities, False when it fell through to the
     bare _canonical_ident guess.
     """
+    if importing_file and import_name.startswith("."):
+        base_dir = Path(importing_file).parent
+        if import_name.startswith("./") or import_name.startswith("../"):
+            target = os.path.normpath(str(base_dir / import_name))
+        else:
+            stripped = import_name.lstrip(".")
+            levels_up = len(import_name) - len(stripped) - 1
+            target_dir = base_dir
+            for _ in range(levels_up):
+                target_dir = target_dir.parent
+            target = str(target_dir / stripped.replace(".", "/")) if stripped else str(target_dir)
+            target = os.path.normpath(target)
+        target = target.replace(os.sep, "/")
+        for file_path in file_entities:
+            if str(Path(file_path).with_suffix("")).replace(os.sep, "/") == target:
+                return _code_ident("module", file_path), True
+        return _canonical_ident("module", import_name), False
+
     # Priority 1: canonical Rust module root paths under common source roots
     for src_root in ("src", "lib", ""):
         prefix = f"{src_root}/" if src_root else ""
@@ -2836,10 +2868,13 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                             module_ident = _code_ident("module", file_path)
                             current_deps: set = set()
                             for import_name in set(extracted.get("imports", [])):
-                                dep_ident, is_resolved = _resolve_module_import(import_name, file_entities)
+                                dep_ident, is_resolved = _resolve_module_import(
+                                    import_name, file_entities, importing_file=file_path,
+                                )
                                 if dep_ident != module_ident:
                                     current_deps.add(dep_ident)
-                                    if not is_resolved and dep_ident not in entity_valid_from:
+                                    is_relative = import_name.startswith(".")
+                                    if not is_resolved and not is_relative and dep_ident not in entity_valid_from:
                                         add_triples.extend([
                                             f"[{dep_ident} :entity-type :type/external-dependency]",
                                             f'[{dep_ident} :ident "{_edn_escape(dep_ident)}"]',

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1077,7 +1077,7 @@ def _canonical_ident(entity_type: str, value: str) -> str:
     return f":{entity_type}/{slug}"
 
 
-def _resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]) -> str:
+def _resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]) -> Tuple[str, bool]:
     """Resolve an import name to a module ident that joins with stored module entities.
 
     For a name like "storage", tries standard Rust source-root locations first
@@ -1085,8 +1085,11 @@ def _resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]
     search. The ordered-priority approach prevents e.g. src/graph/storage.rs
     from matching a top-level `use crate::storage` import.
 
-    Falls back to _canonical_ident for external crate names (std, tokio, …)
-    so they still get an edge even though they have no :path attribute.
+    Returns (ident, is_resolved). is_resolved is True when import_name matched
+    a real file in file_entities, False when it fell through to the bare
+    _canonical_ident guess — the caller uses this to tag genuinely unresolved
+    imports as :type/external-dependency without also tagging real (if not
+    yet visited) internal modules.
     """
     # Priority 1: canonical Rust module root paths under common source roots
     for src_root in ("src", "lib", ""):
@@ -1094,18 +1097,18 @@ def _resolve_module_import(import_name: str, file_entities: Dict[str, List[str]]
         candidate_file = f"{prefix}{import_name}.rs"
         candidate_mod = f"{prefix}{import_name}/mod.rs"
         if candidate_file in file_entities:
-            return _code_ident("module", candidate_file)
+            return _code_ident("module", candidate_file), True
         if candidate_mod in file_entities:
-            return _code_ident("module", candidate_mod)
+            return _code_ident("module", candidate_mod), True
 
     # Priority 2: broader search — only match files directly under a src root
     # (parent.parent is the source root, not a nested subdir)
     for file_path in file_entities:
         p = Path(file_path)
         if p.stem == "mod" and p.parent.name == import_name:
-            return _code_ident("module", file_path)
+            return _code_ident("module", file_path), True
 
-    return _canonical_ident("module", import_name)
+    return _canonical_ident("module", import_name), False
 
 
 def _code_ident(entity_type: str, file_path: str, name: Optional[str] = None) -> str:
@@ -2777,9 +2780,17 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                             module_ident = _code_ident("module", file_path)
                             current_deps: set = set()
                             for import_name in set(extracted.get("imports", [])):
-                                dep_ident = _resolve_module_import(import_name, file_entities)
+                                dep_ident, is_resolved = _resolve_module_import(import_name, file_entities)
                                 if dep_ident != module_ident:
                                     current_deps.add(dep_ident)
+                                    if not is_resolved and dep_ident not in entity_valid_from:
+                                        add_triples.extend([
+                                            f"[{dep_ident} :entity-type :type/external-dependency]",
+                                            f'[{dep_ident} :ident "{_edn_escape(dep_ident)}"]',
+                                            f'[{dep_ident} :description "{_edn_escape(import_name)}"]',
+                                        ])
+                                        entity_valid_from[dep_ident] = commit_ts_iso
+                                        entity_descriptions[dep_ident] = import_name
                             previous_deps = file_deps.get(file_path, set())
                             for dep_ident in current_deps - previous_deps:
                                 dep_add_triples.append(f"[{module_ident} :depends-on {dep_ident}]")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3483,6 +3483,50 @@ class TestRunIngestionBitemporalDeps:
         )
 
 
+class TestUnresolvedImportTagging:
+    def _make_progress(self):
+        return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
+
+    def test_resolve_module_import_returns_bool_flag(self):
+        import mcp_server
+        file_entities = {"src/storage.rs": []}
+        ident, is_resolved = mcp_server._resolve_module_import("storage", file_entities)
+        assert is_resolved is True
+        ident, is_resolved = mcp_server._resolve_module_import("totally_unknown_crate", file_entities)
+        assert is_resolved is False
+
+    @pytest.mark.asyncio
+    async def test_unresolved_import_gets_tagged_external_dependency(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "main.rs").write_text('use tokio;\nfn main() {}\n')
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add main"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        tokio_ident = mcp_server._canonical_ident("module", "tokio")
+        assert any(f"[{tokio_ident} :entity-type :type/external-dependency]" in t for t in transact_calls)
+        assert any(f'[{tokio_ident} :description "tokio"]' in t for t in transact_calls)
+
+
 class TestRunIngestionGitlinks:
     """End-to-end tests for submodule add/bump/remove/flip via _run_ingestion."""
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1559,6 +1559,19 @@ class TestExtractFromSourceCFamily:
         assert result["functions"] == ["square"]
 
 
+class TestTsxParserLoading:
+    """Regression test for the .tsx module-name bug: _build_parser assumed
+    the importable module is always tree_sitter_{lang_name}, but tsx's grammar
+    ships inside the tree_sitter_typescript package under language_tsx()."""
+
+    def test_tsx_parser_builds_successfully(self):
+        pytest.importorskip("tree_sitter_typescript")
+        import mcp_server
+        mcp_server._grammar_cache.clear()
+        parser = mcp_server._get_parser("component.tsx")
+        assert parser is not None
+
+
 class TestMinigrafIngestStatus:
     def test_returns_idle_before_ingestion(self, mock_minigraf_db, tmp_path):
         mock_class, db_instance = mock_minigraf_db

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3482,6 +3482,127 @@ class TestRunIngestionBitemporalDeps:
             f"got: {close_triples_seen}"
         )
 
+
+class TestRunIngestionGitlinks:
+    """End-to-end tests for submodule add/bump/remove/flip via _run_ingestion."""
+
+    def _make_progress(self):
+        return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
+
+    def _add_submodule_commit(self, repo, path="vendor/lib", name="lib", url="https://example.com/lib.git"):
+        sub = repo.parent / f"{repo.name}-sub"
+        _subprocess.run(["git", "init", "-q", str(sub)], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "config", "user.email", "t@t.com"], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "config", "user.name", "T"], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "commit", "--allow-empty", "-m", "e"], check=True, capture_output=True)
+        sub_hash = _subprocess.run(
+            ["git", "-C", str(sub), "rev-parse", "HEAD"], check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        (repo / ".gitmodules").write_text(f'[submodule "{name}"]\n\tpath = {path}\n\turl = {url}\n')
+        _subprocess.run(
+            ["git", "update-index", "--add", "--cacheinfo", f"160000,{sub_hash},{path}"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(["git", "add", ".gitmodules"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add submodule"], cwd=repo, check=True, capture_output=True)
+        return sub_hash
+
+    @pytest.mark.asyncio
+    async def test_submodule_add_creates_external_dependency_entity(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        sub_hash = self._add_submodule_commit(repo)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        ident = mcp_server._code_ident("module", "vendor/lib")
+        assert any(f"[{ident} :entity-type :type/external-dependency]" in t for t in transact_calls)
+        assert any(f'[{ident} :pinned-commit "{sub_hash}"]' in t for t in transact_calls)
+        assert any(f'[{ident} :submodule-name "lib"]' in t for t in transact_calls)
+        assert any(f'[{ident} :submodule-url "https://example.com/lib.git"]' in t for t in transact_calls)
+
+    @pytest.mark.asyncio
+    async def test_submodule_bump_closes_old_pinned_commit(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        first_sha = self._add_submodule_commit(repo)
+
+        sub_dir = tmp_path / f"{repo.name}-sub"
+        _subprocess.run(["git", "-C", str(sub_dir), "commit", "--allow-empty", "-m", "bump"], check=True, capture_output=True)
+        second_sha = _subprocess.run(
+            ["git", "-C", str(sub_dir), "rev-parse", "HEAD"], check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        _subprocess.run(
+            ["git", "update-index", "--cacheinfo", f"160000,{second_sha},vendor/lib"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(["git", "commit", "-m", "bump submodule"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen: list = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        ident = mcp_server._code_ident("module", "vendor/lib")
+        assert any(f'[{ident} :pinned-commit "{first_sha}"]' in t for t in close_triples_seen)
+
+    @pytest.mark.asyncio
+    async def test_submodule_removal_closes_entity(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        self._add_submodule_commit(repo)
+
+        _subprocess.run(["git", "rm", "-f", "vendor/lib"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "remove submodule"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen: list = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        ident = mcp_server._code_ident("module", "vendor/lib")
+        assert any(f'[{ident} :ident "{ident}"]' in t for t in close_triples_seen)
+
+
 # ---------------------------------------------------------------------------
 # Helpers for TestExtractImportName
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1803,6 +1803,8 @@ class TestGitDiffTreeRaw:
         sub = tmp_path / "sub"
         sub.mkdir()
         _subprocess.run(["git", "init"], cwd=sub, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=sub, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=sub, check=True, capture_output=True)
         _subprocess.run(["git", "commit", "--allow-empty", "-m", "e"], cwd=sub, check=True, capture_output=True)
         sub_hash = _subprocess.run(
             ["git", "rev-parse", "HEAD"], cwd=sub, check=True, capture_output=True, text=True,
@@ -1973,6 +1975,8 @@ class TestExtractCommit:
         sub = tmp_path / "sub"
         sub.mkdir()
         _subprocess.run(["git", "init"], cwd=sub, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=sub, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=sub, check=True, capture_output=True)
         _subprocess.run(["git", "commit", "--allow-empty", "-m", "e"], cwd=sub, check=True, capture_output=True)
         sub_hash = _subprocess.run(
             ["git", "rev-parse", "HEAD"], cwd=sub, check=True, capture_output=True, text=True,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3706,13 +3706,29 @@ class TestExtractImportName:
         assert "os" in result
         assert "github.com/user/pkg" in result
 
+    def test_python_import_from_preserves_full_dotted_name(self):
+        import mcp_server
+        source = b"from pathlib import Path\n"
+        result = mcp_server._extract_from_source(
+            source, TestExtractFromSource()._python_parser(), "foo.py"
+        )
+        assert "pathlib" in result["imports"]
+
+    def test_python_dotted_import_preserves_full_name(self):
+        import mcp_server
+        source = b"import os.path\n"
+        result = mcp_server._extract_from_source(
+            source, TestExtractFromSource()._python_parser(), "foo.py"
+        )
+        assert "os.path" in result["imports"]
+
     def test_java_import(self, tmp_path):
         pytest.importorskip("tree_sitter_java")
         import mcp_server
         source = b'import java.util.List;'
         node = _parse_import_node("java", source, "import_declaration", tmp_path)
         result = mcp_server._extract_import_name(node, "java")
-        assert result == ["java"]
+        assert result == ["java.util.List"]
 
     def test_c_system_include(self, tmp_path):
         pytest.importorskip("tree_sitter_c")
@@ -3752,7 +3768,7 @@ class TestExtractImportName:
         source = b'using System.Collections.Generic;'
         node = _parse_import_node("c_sharp", source, "using_directive", tmp_path)
         result = mcp_server._extract_import_name(node, "c_sharp")
-        assert result == ["System"]
+        assert result == ["System.Collections.Generic"]
 
     def test_ruby_require(self, tmp_path):
         pytest.importorskip("tree_sitter_ruby")
@@ -3800,7 +3816,7 @@ class TestExtractImportName:
         source = b'import kotlin.collections.List'
         node = _parse_import_node("kotlin", source, "import", tmp_path)
         result = mcp_server._extract_import_name(node, "kotlin")
-        assert result == ["kotlin"]
+        assert result == ["kotlin.collections.List"]
 
     def test_swift_import(self, tmp_path):
         pytest.importorskip("tree_sitter_swift")
@@ -3810,13 +3826,21 @@ class TestExtractImportName:
         result = mcp_server._extract_import_name(node, "swift")
         assert result == ["Foundation"]
 
+    def test_swift_submodule_import_preserves_full_name(self, tmp_path):
+        pytest.importorskip("tree_sitter_swift")
+        import mcp_server
+        source = b'import Foundation.NSString'
+        node = _parse_import_node("swift", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "swift")
+        assert result == ["Foundation.NSString"]
+
     def test_scala_import(self, tmp_path):
         pytest.importorskip("tree_sitter_scala")
         import mcp_server
         source = b'import scala.collection.mutable'
         node = _parse_import_node("scala", source, "import_declaration", tmp_path)
         result = mcp_server._extract_import_name(node, "scala")
-        assert result == ["scala"]
+        assert result == ["scala.collection.mutable"]
 
     def test_haskell_import(self, tmp_path):
         pytest.importorskip("tree_sitter_haskell")
@@ -3824,7 +3848,7 @@ class TestExtractImportName:
         source = b'import Data.List'
         node = _parse_import_node("haskell", source, "import", tmp_path)
         result = mcp_server._extract_import_name(node, "haskell")
-        assert result == ["Data"]
+        assert result == ["Data.List"]
 
     def test_lua_require(self, tmp_path):
         pytest.importorskip("tree_sitter_lua")
@@ -3848,7 +3872,7 @@ class TestExtractImportName:
         source = b'alias MyApp.Router'
         node = _parse_import_node("elixir", source, "call", tmp_path)
         result = mcp_server._extract_import_name(node, "elixir")
-        assert result == ["MyApp"]
+        assert result == ["MyApp.Router"]
 
     def test_elixir_import(self, tmp_path):
         pytest.importorskip("tree_sitter_elixir")
@@ -3856,7 +3880,7 @@ class TestExtractImportName:
         source = b'import Ecto.Query'
         node = _parse_import_node("elixir", source, "call", tmp_path)
         result = mcp_server._extract_import_name(node, "elixir")
-        assert result == ["Ecto"]
+        assert result == ["Ecto.Query"]
 
     def test_elixir_non_module_call_ignored(self, tmp_path):
         pytest.importorskip("tree_sitter_elixir")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1571,6 +1571,23 @@ class TestTsxParserLoading:
         parser = mcp_server._get_parser("component.tsx")
         assert parser is not None
 
+    def test_tsx_extracts_functions_classes_imports(self):
+        pytest.importorskip("tree_sitter_typescript")
+        import mcp_server
+        mcp_server._grammar_cache.clear()
+        source = (
+            b"import React from 'react';\n"
+            b"class Widget extends React.Component {\n"
+            b"  render() { return null; }\n"
+            b"}\n"
+            b"function useThing() { return 1; }\n"
+        )
+        parser = mcp_server._get_parser("component.tsx")
+        result = mcp_server._extract_from_source(source, parser, "component.tsx")
+        assert "Widget" in result["classes"]
+        assert "useThing" in result["functions"] or "render" in result["functions"]
+        assert "react" in result["imports"]
+
 
 class TestMinigrafIngestStatus:
     def test_returns_idle_before_ingestion(self, mock_minigraf_db, tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3445,9 +3445,10 @@ class TestRunIngestionBitemporalDeps:
         await mcp_server._run_ingestion(str(git_repo_with_deps), "HEAD")
 
         mod_a_ident = mcp_server._code_ident("module", "mod_a.py")
-        # _resolve_module_import is Rust-focused; for Python `import mod_b` it falls back
-        # to _canonical_ident("module", "mod_b") since mod_b.py != mod_b.rs
-        mod_b_resolved = mcp_server._canonical_ident("module", "mod_b")
+        # mod_b.py genuinely exists in file_entities, so the generalized
+        # tiered matcher (Task 12) now resolves "mod_b" to the real internal
+        # module via the basename tier, instead of the old Rust-only fallback.
+        mod_b_resolved = mcp_server._code_ident("module", "mod_b.py")
         dep_triple = f"{mod_a_ident} :depends-on {mod_b_resolved}"
         assert any(dep_triple in t for t in transact_calls), (
             f"Expected _ingest_transact to be called with '{dep_triple}' during commit loop, "
@@ -3475,7 +3476,7 @@ class TestRunIngestionBitemporalDeps:
         await mcp_server._run_ingestion(str(git_repo_with_dep_removal), "HEAD")
 
         mod_a_ident = mcp_server._code_ident("module", "mod_a.py")
-        mod_b_resolved = mcp_server._canonical_ident("module", "mod_b")
+        mod_b_resolved = mcp_server._code_ident("module", "mod_b.py")
         dep_triple = f"{mod_a_ident} :depends-on {mod_b_resolved}"
         assert any(dep_triple in t for t in close_triples_seen), (
             f"Expected _ingest_close to be called with '{dep_triple}' when import removed, "

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1890,6 +1890,21 @@ class TestParseGitmodules:
         import mcp_server
         assert mcp_server._parse_gitmodules(b"") == {}
 
+    def test_parses_url_containing_percent_sign(self):
+        import mcp_server
+        content = (
+            b'[submodule "weird"]\n'
+            b'\tpath = vendor/weird\n'
+            b'\turl = https://example.com/repo%2Fname.git\n'
+        )
+        result = mcp_server._parse_gitmodules(content)
+        assert result == {
+            "vendor/weird": {
+                "name": "weird",
+                "url": "https://example.com/repo%2Fname.git",
+            }
+        }
+
     def test_git_gitmodules_at_missing_file_returns_empty(self, git_repo):
         import mcp_server
         commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3708,11 +3708,11 @@ class TestExtractImportName:
 
     def test_python_import_from_preserves_full_dotted_name(self):
         import mcp_server
-        source = b"from pathlib import Path\n"
+        source = b"from os.path import join\n"
         result = mcp_server._extract_from_source(
             source, TestExtractFromSource()._python_parser(), "foo.py"
         )
-        assert "pathlib" in result["imports"]
+        assert "os.path" in result["imports"]
 
     def test_python_dotted_import_preserves_full_name(self):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1856,6 +1856,47 @@ class TestGitlinkChanges:
         assert mcp_server._gitlink_changes(raw) == [("add", "e" * 40, "vendor/lib")]
 
 
+class TestParseGitmodules:
+    def test_parses_single_submodule(self):
+        import mcp_server
+        content = (
+            b'[submodule "abseil-cpp"]\n'
+            b'\tpath = 3rdParty/abseil-cpp\n'
+            b'\turl = https://github.com/abseil/abseil-cpp.git\n'
+        )
+        result = mcp_server._parse_gitmodules(content)
+        assert result == {
+            "3rdParty/abseil-cpp": {
+                "name": "abseil-cpp",
+                "url": "https://github.com/abseil/abseil-cpp.git",
+            }
+        }
+
+    def test_parses_multiple_submodules(self):
+        import mcp_server
+        content = (
+            b'[submodule "a"]\n\tpath = vendor/a\n\turl = https://x/a.git\n'
+            b'[submodule "b"]\n\tpath = vendor/b\n\turl = https://x/b.git\n'
+        )
+        result = mcp_server._parse_gitmodules(content)
+        assert set(result.keys()) == {"vendor/a", "vendor/b"}
+
+    def test_malformed_content_returns_empty_dict(self):
+        import mcp_server
+        result = mcp_server._parse_gitmodules(b"not a valid [ini file")
+        assert result == {}
+
+    def test_empty_content_returns_empty_dict(self):
+        import mcp_server
+        assert mcp_server._parse_gitmodules(b"") == {}
+
+    def test_git_gitmodules_at_missing_file_returns_empty(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        result = mcp_server._git_gitmodules_at(str(git_repo), commits[0][0])
+        assert result == {}
+
+
 class TestExtractCommit:
     def test_added_file_returns_extracted_dict(self, git_repo):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3526,6 +3526,38 @@ class TestUnresolvedImportTagging:
         assert any(f"[{tokio_ident} :entity-type :type/external-dependency]" in t for t in transact_calls)
         assert any(f'[{tokio_ident} :description "tokio"]' in t for t in transact_calls)
 
+    @pytest.mark.asyncio
+    async def test_unresolved_relative_import_not_tagged_external_end_to_end(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "main.ts").write_text("import { thing } from './missing';\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add main"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        missing_ident = mcp_server._canonical_ident("module", "./missing")
+        assert not any(
+            f"[{missing_ident} :entity-type :type/external-dependency]" in t for t in transact_calls
+        )
+
 
 class TestResolveModuleImportTieredMatcher:
     def test_exact_file_match_java_package(self):
@@ -3575,6 +3607,67 @@ class TestResolveModuleImportTieredMatcher:
         file_entities = {"src/main.cpp": []}
         ident, is_resolved = mcp_server._resolve_module_import("vector", file_entities)
         assert is_resolved is False
+
+
+class TestResolveModuleImportRelative:
+    def test_js_relative_import_resolves_against_importing_file(self):
+        import mcp_server
+        file_entities = {"src/utils/foo.ts": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "./utils/foo", file_entities, importing_file="src/main.ts",
+        )
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "src/utils/foo.ts")
+
+    def test_js_parent_relative_import_resolves(self):
+        import mcp_server
+        file_entities = {"lib.ts": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "../lib", file_entities, importing_file="src/main.ts",
+        )
+        assert is_resolved is True
+
+    def test_python_single_dot_relative_import_resolves(self):
+        import mcp_server
+        file_entities = {"pkg/sibling.py": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            ".sibling", file_entities, importing_file="pkg/main.py",
+        )
+        assert is_resolved is True
+
+    def test_python_double_dot_relative_import_resolves(self):
+        import mcp_server
+        # For a file at a/b/c/main.py, the containing package is a.b.c: one
+        # leading dot means "this package" (a/b/c), two dots means "the
+        # parent package" (a/b) — so "..sibling" resolves to a/b/sibling.py,
+        # not a top-level sibling.py.
+        file_entities = {"a/b/sibling.py": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "..sibling", file_entities, importing_file="a/b/c/main.py",
+        )
+        assert is_resolved is True
+
+    def test_ruby_require_relative_marker_resolves(self):
+        import mcp_server
+        file_entities = {"lib/helper.rb": []}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "./helper", file_entities, importing_file="lib/main.rb",
+        )
+        assert is_resolved is True
+
+    def test_unresolved_relative_import_is_not_tagged_external(self):
+        import mcp_server
+        file_entities: dict = {}
+        ident, is_resolved = mcp_server._resolve_module_import(
+            "./missing", file_entities, importing_file="src/main.ts",
+        )
+        assert is_resolved is False
+        # Caller-side contract (see _run_ingestion): a relative import is only
+        # ever tagged external if the generic (non-relative) tiers would also
+        # tag it — this test documents that resolution itself still reports
+        # is_resolved=False for a genuinely missing relative target, same as
+        # any other unresolved import; the "don't mislabel" guarantee lives in
+        # the caller, verified by Task 13's Step 5 integration test below.
 
 
 class TestRunIngestionGitlinks:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1918,20 +1918,22 @@ class TestExtractCommit:
         commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
         first_hash = commits[0][0]
 
-        results = mcp_server._extract_commit(str(git_repo), first_hash)
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), first_hash)
 
         assert len(results) == 1
         status, file_path, extracted = results[0]
         assert status == "A"
         assert file_path == "auth.py"
         assert "login" in extracted["functions"]
+        assert gitlink_changes == []
+        assert gitmodules_map == {}
 
     def test_deleted_file_has_none_extracted(self, git_repo_with_deletion):
         import mcp_server
         commits = mcp_server._git_commits(str(git_repo_with_deletion), watermark_hash=None)
         delete_hash = commits[-1][0]
 
-        results = mcp_server._extract_commit(str(git_repo_with_deletion), delete_hash)
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo_with_deletion), delete_hash)
 
         d_entries = [r for r in results if r[0] == "D"]
         assert len(d_entries) == 1
@@ -1940,25 +1942,62 @@ class TestExtractCommit:
     def test_unsupported_extension_is_omitted(self, git_repo, monkeypatch):
         import mcp_server
         monkeypatch.setattr(
-            mcp_server, "_git_changed_files",
-            lambda repo, commit: [("A", "notes.txt")],
+            mcp_server, "_git_diff_tree_raw",
+            lambda repo, commit: [("A", "000000", "100644", "0" * 40, "a" * 40, "notes.txt")],
         )
-        results = mcp_server._extract_commit(str(git_repo), "deadbeef")
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), "deadbeef")
         assert results == []
 
     def test_content_fetch_failure_is_omitted_not_raised(self, git_repo, monkeypatch):
         import mcp_server
         monkeypatch.setattr(
-            mcp_server, "_git_changed_files",
-            lambda repo, commit: [("A", "auth.py")],
+            mcp_server, "_git_diff_tree_raw",
+            lambda repo, commit: [("A", "000000", "100644", "0" * 40, "a" * 40, "auth.py")],
         )
 
         def boom(repo, commit, path):
             raise mcp_server.MiniGrafError("simulated git-show failure")
 
         monkeypatch.setattr(mcp_server, "_git_file_content", boom)
-        results = mcp_server._extract_commit(str(git_repo), "deadbeef")
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), "deadbeef")
         assert results == []
+
+    def test_gitlink_add_is_reported_separately_from_file_results(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        _subprocess.run(["git", "init"], cwd=sub, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "--allow-empty", "-m", "e"], cwd=sub, check=True, capture_output=True)
+        sub_hash = _subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=sub, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        (repo / ".gitmodules").write_text(
+            '[submodule "lib"]\n\tpath = vendor/lib\n\turl = https://example.com/lib.git\n'
+        )
+        _subprocess.run(
+            ["git", "update-index", "--add", "--cacheinfo", f"160000,{sub_hash},vendor/lib"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(["git", "add", ".gitmodules"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add submodule"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(repo), commits[0][0])
+
+        # Neither the gitlink path (vendor/lib) nor .gitmodules itself has a
+        # resolvable extension (_EXT_TO_LANG has no entry for either), so
+        # file_results is empty for this commit — the submodule info is
+        # carried entirely by gitlink_changes/gitmodules_map instead.
+        assert results == []
+        assert gitlink_changes == [("add", sub_hash, "vendor/lib")]
+        assert gitmodules_map == {"vendor/lib": {"name": "lib", "url": "https://example.com/lib.git"}}
 
 
 class TestIngestionWrites:
@@ -2178,7 +2217,7 @@ class TestIngestionWrites:
             mcp_server, "_git_commits",
             lambda repo, watermark, branch: [("abc123", "2025-01-01T00:00:00Z", "author", "msg")]
         )
-        monkeypatch.setattr(mcp_server, "_git_changed_files", lambda repo, commit: [])
+        monkeypatch.setattr(mcp_server, "_git_diff_tree_raw", lambda repo, commit: [])
         monkeypatch.setattr(mcp_server, "_watermark_update", lambda db, h, ts, r: None)
 
         last_run_calls = []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1824,6 +1824,38 @@ class TestGitDiffTreeRaw:
         assert path == "vendor/lib"
 
 
+class TestGitlinkChanges:
+    def test_non_gitlink_rows_are_ignored(self):
+        import mcp_server
+        raw = [("A", "000000", "100644", "0" * 40, "a" * 40, "auth.py")]
+        assert mcp_server._gitlink_changes(raw) == []
+
+    def test_add_when_new_mode_is_gitlink(self):
+        import mcp_server
+        raw = [("A", "000000", "160000", "0" * 40, "b" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("add", "b" * 40, "vendor/lib")]
+
+    def test_bump_when_both_modes_are_gitlink(self):
+        import mcp_server
+        raw = [("M", "160000", "160000", "b" * 40, "c" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("bump", "c" * 40, "vendor/lib")]
+
+    def test_remove_when_old_mode_is_gitlink(self):
+        import mcp_server
+        raw = [("D", "160000", "000000", "c" * 40, "0" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("remove", "c" * 40, "vendor/lib")]
+
+    def test_type_change_into_internal_reported_as_remove(self):
+        import mcp_server
+        raw = [("T", "160000", "100644", "c" * 40, "d" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("remove", "c" * 40, "vendor/lib")]
+
+    def test_type_change_into_external_reported_as_add(self):
+        import mcp_server
+        raw = [("T", "100644", "160000", "d" * 40, "e" * 40, "vendor/lib")]
+        assert mcp_server._gitlink_changes(raw) == [("add", "e" * 40, "vendor/lib")]
+
+
 class TestExtractCommit:
     def test_added_file_returns_extracted_dict(self, git_repo):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2321,6 +2321,49 @@ class TestPreloadKnownDeps:
         assert dep_valid_from == {}
 
 
+class TestPreloadExternalDependencies:
+    def test_preload_known_entities_includes_external_dependency(self, mock_minigraf_db, tmp_path):
+        mock_class, db_instance = mock_minigraf_db
+        import mcp_server
+        # _preload_known_entities' query shape is [?ident ?path ?desc ?date] per entity_type
+        db_instance.execute.return_value = json.dumps({
+            "results": [[":module/vendor-lib", "vendor/lib", "lib", "2026-01-01T00:00:00Z"]]
+        })
+        mcp_server.open_db(str(tmp_path / "memory.graph"))
+        db = mcp_server.get_db()
+
+        entity_valid_from, entity_descriptions, file_entities = mcp_server._preload_known_entities(db, str(tmp_path))
+
+        assert ":module/vendor-lib" in entity_valid_from
+        assert entity_descriptions[":module/vendor-lib"] == "lib"
+        assert "vendor/lib" in file_entities
+
+    def test_preload_pinned_commits_reloads_current_sha(self, mock_minigraf_db, tmp_path):
+        mock_class, db_instance = mock_minigraf_db
+        import mcp_server
+        # _preload_pinned_commits' query shape is [?e ?sha ?vf] with :any-valid-time
+        db_instance.execute.return_value = json.dumps({
+            "results": [[":module/vendor-lib", "abc123", 1735689600000]]
+        })
+        mcp_server.open_db(str(tmp_path / "memory.graph"))
+        db = mcp_server.get_db()
+
+        pinned = mcp_server._preload_pinned_commits(db)
+
+        assert pinned[":module/vendor-lib"][0] == "abc123"
+        assert pinned[":module/vendor-lib"][1].endswith("Z")
+
+    def test_preload_pinned_commits_returns_empty_on_query_failure(self, mock_minigraf_db, tmp_path):
+        mock_class, db_instance = mock_minigraf_db
+        import mcp_server
+        from minigraf import MiniGrafError
+        mcp_server.open_db(str(tmp_path / "memory.graph"))
+        db = mcp_server.get_db()
+        db_instance.execute.side_effect = MiniGrafError("boom")
+
+        assert mcp_server._preload_pinned_commits(db) == {}
+
+
 class TestTotalIngestedQuery:
     def test_returns_zero_when_absent(self, mock_minigraf_db, tmp_path):
         mock_class, db_instance = mock_minigraf_db

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3527,6 +3527,56 @@ class TestUnresolvedImportTagging:
         assert any(f'[{tokio_ident} :description "tokio"]' in t for t in transact_calls)
 
 
+class TestResolveModuleImportTieredMatcher:
+    def test_exact_file_match_java_package(self):
+        import mcp_server
+        file_entities = {"com/google/gson/Gson.java": []}
+        ident, is_resolved = mcp_server._resolve_module_import("com.google.gson.Gson", file_entities)
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "com/google/gson/Gson.java")
+
+    def test_parent_directory_match_java_wildcard_style(self):
+        import mcp_server
+        # "com.google.gson" (no trailing class name) is a package-level
+        # reference — it matches via the file's *parent directory*, not the
+        # file's own path, since there's no specific file named exactly that.
+        file_entities = {"com/google/gson/JsonElement.java": []}
+        ident, is_resolved = mcp_server._resolve_module_import("com.google.gson", file_entities)
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "com/google/gson/JsonElement.java")
+
+    def test_genuinely_external_java_package_not_resolved(self):
+        import mcp_server
+        file_entities = {"com/mycompany/App.java": []}
+        # com.fasterxml.jackson.Foo shares no path with the project's own "com" tree
+        ident, is_resolved = mcp_server._resolve_module_import("com.fasterxml.jackson.Foo", file_entities)
+        assert is_resolved is False
+
+    def test_exact_file_match_go_full_path(self):
+        import mcp_server
+        # Vendored Go deps live under a vendor/ prefix that never appears in
+        # the import string itself — this must match as a segment suffix,
+        # not exact path equality, and "github.com" must survive as one path
+        # segment rather than being split on its literal dot.
+        file_entities = {"vendor/github.com/user/pkg/pkg.go": []}
+        ident, is_resolved = mcp_server._resolve_module_import("github.com/user/pkg/pkg", file_entities)
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "vendor/github.com/user/pkg/pkg.go")
+
+    def test_basename_match_vendored_c_header(self):
+        import mcp_server
+        file_entities = {"3rdParty/icu/include/unicode/uloc.h": []}
+        ident, is_resolved = mcp_server._resolve_module_import("unicode/uloc", file_entities)
+        assert is_resolved is True
+        assert ident == mcp_server._code_ident("module", "3rdParty/icu/include/unicode/uloc.h")
+
+    def test_genuinely_external_c_stdlib_header_not_resolved(self):
+        import mcp_server
+        file_entities = {"src/main.cpp": []}
+        ident, is_resolved = mcp_server._resolve_module_import("vector", file_entities)
+        assert is_resolved is False
+
+
 class TestRunIngestionGitlinks:
     """End-to-end tests for submodule add/bump/remove/flip via _run_ingestion."""
 
@@ -3943,3 +3993,4 @@ class TestExtractImportName:
         result = mcp_server._extract_import_name(node, "go")
         assert "os" in result
         assert "github.com/user/pkg" in result
+

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1780,6 +1780,50 @@ class TestGitHelpers:
         assert b"def login" in content
 
 
+class TestGitDiffTreeRaw:
+    def test_regular_file_add(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(git_repo), commits[0][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path = entries[0]
+        assert status == "A"
+        assert old_mode == "000000"
+        assert new_mode == "100644"
+        assert path == "auth.py"
+
+    def test_gitlink_add_reports_mode_160000(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        _subprocess.run(["git", "init"], cwd=sub, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "--allow-empty", "-m", "e"], cwd=sub, check=True, capture_output=True)
+        sub_hash = _subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=sub, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        _subprocess.run(
+            ["git", "update-index", "--add", "--cacheinfo", f"160000,{sub_hash},vendor/lib"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(["git", "commit", "-m", "add submodule"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(repo), commits[0][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path = entries[0]
+        assert status == "A"
+        assert new_mode == "160000"
+        assert new_sha == sub_hash
+        assert path == "vendor/lib"
+
+
 class TestExtractCommit:
     def test_added_file_returns_extracted_dict(self, git_repo):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3704,7 +3704,7 @@ class TestExtractImportName:
         node = _parse_import_node("go", source, "import_declaration", tmp_path)
         result = mcp_server._extract_import_name(node, "go")
         assert "os" in result
-        assert "pkg" in result
+        assert "github.com/user/pkg" in result
 
     def test_java_import(self, tmp_path):
         pytest.importorskip("tree_sitter_java")
@@ -3768,7 +3768,7 @@ class TestExtractImportName:
         source = b"require_relative 'my_module'"
         node = _parse_import_node("ruby", source, "call", tmp_path)
         result = mcp_server._extract_import_name(node, "ruby")
-        assert result == ["my_module"]
+        assert result == ["./my_module"]
 
     def test_ruby_non_require_call_ignored(self, tmp_path):
         pytest.importorskip("tree_sitter_ruby")
@@ -3870,3 +3870,52 @@ class TestExtractImportName:
             return  # no call node found — that's fine
         result = mcp_server._extract_import_name(node, "elixir")
         assert result == []
+
+    def test_c_local_include_preserves_subdirectory(self, tmp_path):
+        pytest.importorskip("tree_sitter_c")
+        import mcp_server
+        source = b'#include "unicode/uloc.h"'
+        node = _parse_import_node("c", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "c")
+        assert result == ["unicode/uloc"]
+
+    def test_c_angle_include_preserves_subdirectory(self, tmp_path):
+        pytest.importorskip("tree_sitter_c")
+        import mcp_server
+        source = b'#include <sys/socket.h>'
+        node = _parse_import_node("c", source, "preproc_include", tmp_path)
+        result = mcp_server._extract_import_name(node, "c")
+        assert result == ["sys/socket"]
+
+    def test_ruby_require_preserves_subdirectory(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"require 'active_support/core_ext/string'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == ["active_support/core_ext/string"]
+
+    def test_ruby_require_relative_gets_dot_slash_marker(self, tmp_path):
+        pytest.importorskip("tree_sitter_ruby")
+        import mcp_server
+        source = b"require_relative 'my_module'"
+        node = _parse_import_node("ruby", source, "call", tmp_path)
+        result = mcp_server._extract_import_name(node, "ruby")
+        assert result == ["./my_module"]
+
+    def test_php_require_preserves_subdirectory(self, tmp_path):
+        pytest.importorskip("tree_sitter_php")
+        import mcp_server
+        source = b"<?php\nrequire 'app/config/database.php';"
+        node = _parse_import_node("php", source, "require_expression", tmp_path)
+        result = mcp_server._extract_import_name(node, "php")
+        assert result == ["app/config/database"]
+
+    def test_go_grouped_import_preserves_full_path(self, tmp_path):
+        pytest.importorskip("tree_sitter_go")
+        import mcp_server
+        source = b'package main\nimport (\n\t"os"\n\t"github.com/user/pkg"\n)'
+        node = _parse_import_node("go", source, "import_declaration", tmp_path)
+        result = mcp_server._extract_import_name(node, "go")
+        assert "os" in result
+        assert "github.com/user/pkg" in result


### PR DESCRIPTION
## Summary

Closes #97.

- Real git submodules (gitlinks) are now labeled `:type/external-dependency` entities instead of silently vanishing from ingestion, with bi-temporal `:pinned-commit` tracking across add/bump/remove and a same-path blob↔gitlink flip.
- Genuinely-unresolved imports get tagged `:type/external-dependency` (name/path where known) instead of an unmarked `:depends-on` edge target indistinguishable from a not-yet-visited internal module.
- The import resolver (`_resolve_module_import`) was Rust-only, so shipping the above as originally scoped would have mislabeled vendored in-tree code in every other language. Replaced with a generic, language-agnostic segment-suffix matcher (exact match, parent-directory/package match) plus relative-import resolution (`./foo`, Python's leading-dot convention, Ruby's `require_relative`).
- Along the way: fixed an unrelated bug where `.tsx` files were completely unsupported (tree-sitter module-name mismatch in `_build_parser`).

## Process

Implemented via brainstorming → design spec → 15-task plan → subagent-driven execution, each task individually reviewed (one task required a fix round for a `configparser` interpolation bug on percent-signs in submodule URLs; another for weak test coverage), plus a final whole-branch review (verdict: ready to merge, only two Minor/cosmetic findings, both fixed).

- Design spec: `docs/superpowers/specs/2026-07-04-external-dependency-labeling-design.md`
- Implementation plan: `docs/superpowers/plans/2026-07-04-external-dependency-labeling.md`

## Test plan

- [x] Full suite passes locally: 313/313 (up from a 266 baseline before this branch)
- [x] Each of the 15 tasks individually TDD'd and reviewed for spec compliance + code quality
- [x] Final whole-branch review traced both bi-temporal lifecycles (submodule add/bump/remove; unresolved-import tagging across the tiered matcher + relative-import guard) end-to-end for cross-task correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbugdxu16ofrF5ckbXb5FC