### PR TITLE
fix: flip ingest status to "starting" the instant the background task exists (#109)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -260,7 +260,7 @@ Returns `{"ok": true, "rule": "..."}` on success, or `{"ok": false, "error": "..
 
 Start background ingestion of code structure from git history into the bi-temporal graph. Returns immediately — ingestion runs as an asyncio background task.
 
-**Always call `minigraf_ingest_status` first.** Only call `minigraf_ingest_git` if status shows `idle`. If status is `running` or `complete`, do not start a new ingestion — report the current status to the user instead.
+**Always call `minigraf_ingest_status` first.** Only call `minigraf_ingest_git` if status shows `idle`. If status is `starting`, `running`, or `complete`, do not start a new ingestion — report the current status to the user instead.
 
 ```python
 # Step 1: check status
@@ -294,7 +294,12 @@ minigraf_ingest_status()
 #    "total": 47, "current_commit": "a3f2bc...", "error": null}
 ```
 
-`status` is one of: `idle`, `running`, `complete`, `error`, `stopped`, `skipped`.
+`status` is one of: `idle`, `starting`, `running`, `complete`, `error`, `stopped`, `skipped`.
+`starting` means a background ingestion task has been created (auto-started at
+server boot, or via `minigraf_ingest_git`) but hasn't finished its preload phase
+(re-scanning already-known entities/dependencies) yet, so `processed`/`total`
+aren't populated — a subsequent `minigraf_ingest_git` call will still be
+rejected with "already in progress" during this window, same as `running`.
 `stopped` means a graceful shutdown (session end) paused ingestion between commits —
 not a failure; the next `minigraf_ingest_git` call (or server auto-start)
 resumes from the watermark automatically. `skipped` means another live process

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3395,7 +3395,7 @@ async def handle_minigraf_ingest_git(
             "error": f"Not a git repository (or git not found): {repo}",
         }
     _ingest_progress = {
-        "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+        "status": "starting", "processed": 0, "total": 0, "prior_ingested": 0,
         "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
     }
     _ingest_task = asyncio.create_task(_run_ingestion(repo, branch))
@@ -3791,6 +3791,7 @@ async def main() -> None:
             _ingest_progress["status"] = "skipped"
             _ingest_progress["owner_pid"] = holder_pid
         else:
+            _ingest_progress["status"] = "starting"
             _ingest_task = asyncio.create_task(_run_ingestion(str(Path.cwd()), "HEAD"))
 
     loop = asyncio.get_running_loop()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3083,6 +3083,30 @@ class TestRunIngestion:
         assert mcp_server._ingest_task is not None
 
     @pytest.mark.asyncio
+    async def test_status_not_idle_immediately_after_ingest_git_starts(
+        self, mock_minigraf_db, git_repo, monkeypatch
+    ):
+        """Regression test for #109: handle_minigraf_ingest_git creates
+        _ingest_task and returns before _run_ingestion's preload phase has
+        had a chance to run, so _ingest_progress must already reflect
+        "in progress" the instant it returns. Leaving it at "idle" reproduces
+        the reported contradiction, where a caller sees status "idle" but
+        a subsequent minigraf_ingest_git call is rejected with "already in
+        progress" because the task-existence check is accurate immediately."""
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        monkeypatch.setattr(mcp_server, "_live_lock_holder_pid", lambda path: None)
+        mcp_server._ingest_task = None
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+            "current_commit": "", "error": None, "owner_pid": None,
+        }
+        result = await mcp_server.handle_minigraf_ingest_git(repo_path=str(git_repo))
+        assert result["ok"] is True
+        assert mcp_server._ingest_progress["status"] == "starting"
+
+    @pytest.mark.asyncio
     async def test_processed_seeded_from_prior_ingested(self, mock_minigraf_db, git_repo, monkeypatch):
         """processed starts at the true persisted commit count and increments
         cumulatively — regression test for #85 (seeding must not rely on the
@@ -3472,6 +3496,61 @@ class TestMainAutoIngestLockCheck:
 
         assert mcp_server._ingest_task is not None
         assert mcp_server._ingest_progress["status"] != "skipped"
+
+        mcp_server._shutdown_requested.set()
+        await asyncio.wait_for(main_task, timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_status_not_idle_immediately_after_auto_start(self, monkeypatch, tmp_path):
+        """Regression test for #109: main() creates _ingest_task for the
+        auto-started ingestion, then _run_ingestion's preload phase (a full
+        re-scan that can take minutes on a large repo) runs before status
+        ever leaves "idle" — so a caller polling minigraf_ingest_status
+        right after startup sees "idle" while minigraf_ingest_git already
+        rejects a start attempt with "already in progress", an actionable
+        -but-confusing contradiction. _ingest_progress must reflect
+        "in progress" the instant the task exists, not just once preload
+        completes."""
+        import mcp_server
+
+        monkeypatch.setenv("MINIGRAF_GRAPH_PATH", str(tmp_path / "t.graph"))
+        monkeypatch.setattr(mcp_server, "_live_lock_holder_pid", lambda path: None)
+
+        async def fake_run_ingestion(repo_path, branch):
+            # Never touches _ingest_progress — isolates what main() itself
+            # sets before/at task creation from what _run_ingestion would
+            # later set once its preload phase completes.
+            await asyncio.wait(
+                {
+                    asyncio.create_task(mcp_server._shutdown_requested.wait()),
+                    asyncio.create_task(asyncio.Event().wait()),
+                },
+                return_when=asyncio.FIRST_COMPLETED
+            )
+
+        monkeypatch.setattr(mcp_server, "_run_ingestion", fake_run_ingestion)
+        mcp_server._shutdown_requested = asyncio.Event()
+        mcp_server._ingest_task = None
+
+        @contextlib.asynccontextmanager
+        async def fake_stdio_server():
+            yield (object(), object())
+
+        monkeypatch.setattr(mcp_server, "stdio_server", fake_stdio_server)
+
+        run_started = asyncio.Event()
+
+        async def fake_run(read_stream, write_stream, init_opts):
+            run_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(mcp_server.server, "run", fake_run)
+
+        main_task = asyncio.create_task(mcp_server.main())
+        await run_started.wait()
+
+        assert mcp_server._ingest_task is not None
+        assert mcp_server._ingest_progress["status"] == "starting"
 
         mcp_server._shutdown_requested.set()
         await asyncio.wait_for(main_task, timeout=2)


### PR DESCRIPTION
_run_ingestion only set _ingest_progress["status"] to "running" after its
preload phase (a full re-scan of known entities/deps) completed, so status
stayed "idle" for minutes on large repos even though the task already
existed and minigraf_ingest_git's task-existence check correctly reported
"already in progress" — a caller polling minigraf_ingest_status had no way
to distinguish genuinely idle from already-starting. Both call sites that
create the task (main()'s auto-start and handle_minigraf_ingest_git) now set
status to "starting" synchronously before scheduling the task.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYLgnPb8M3nVDZro7ikcuY