### PR TITLE
fix: eliminate TOCTOU race in get_db() between None-check and return

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -956,10 +956,18 @@ def get_db() -> MiniGrafDb:
     _open_db_at_with_retry) — safe here only because event-loop call sites
     (call_tool, _run_ingestion) always await _ensure_db_async() first, so _db
     is already populated by the time they reach this function.
+
+    Reads the module-level _db global into a local exactly once. IndexCache's
+    background rebuild thread also calls this function, concurrently with
+    call_tool()'s finally block resetting _db to None — reading the global a
+    second time for the return would let that reset race in between the
+    None-check and the return, yielding None even though _db was live at call
+    time (issue #122).
     """
-    if _db is None:
-        _open_db_at_with_retry(_graph_path or _get_graph_path())
-    return _db
+    db = _db
+    if db is None:
+        db = _open_db_at_with_retry(_graph_path or _get_graph_path())
+    return db
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -207,6 +207,71 @@ class TestGetDbLockRetry:
         assert mock_class.open.call_count == 2 * mcp_server._LOCK_RETRY_MAX
 
 
+class TestGetDbConcurrentResetRace:
+    """Regression test for #122: IndexCache._rebuild calls get_db() from a
+    background thread. get_db() used to read the module-level _db global
+    twice -- once in `if _db is None`, once again in `return _db` -- so if
+    call_tool()'s finally block reset _db to None in the window between
+    those two reads, get_db() returned None even though a live db existed
+    when it was called, producing "'NoneType' object has no attribute
+    'execute'" in _rebuild."""
+
+    def test_returns_live_db_despite_concurrent_reset_before_return(self):
+        import inspect
+        import sys as _sys
+        import threading
+        import mcp_server
+
+        class FakeDb:
+            def execute(self, datalog):
+                return json.dumps({"results": []})
+
+        fake_db = FakeDb()
+        mcp_server._db = fake_db
+
+        target_code = mcp_server.get_db.__code__
+        src_lines, start_line = inspect.getsourcelines(mcp_server.get_db)
+        return_line = start_line + len(src_lines) - 1
+
+        paused = threading.Event()
+        resume = threading.Event()
+        outcome = {}
+
+        def local_trace(frame, event, arg):
+            if event == "line" and frame.f_lineno == return_line:
+                paused.set()
+                resume.wait(timeout=2)
+            return local_trace
+
+        def global_trace(frame, event, arg):
+            if event == "call" and frame.f_code is target_code:
+                return local_trace
+            return None
+
+        def rebuild_worker():
+            _sys.settrace(global_trace)
+            try:
+                outcome["db"] = mcp_server.get_db()
+            finally:
+                _sys.settrace(None)
+
+        t = threading.Thread(target=rebuild_worker)
+        t.start()
+        try:
+            assert paused.wait(timeout=2), "tracer never reached get_db's return line"
+            # Simulate call_tool's finally block racing in between get_db()'s
+            # None-check and its return.
+            mcp_server._db = None
+            resume.set()
+        finally:
+            t.join(timeout=2)
+
+        assert outcome.get("db") is fake_db, (
+            "get_db() returned a stale/None value after a concurrent reset "
+            "of the global between its None-check and its return (#122)"
+        )
+
+
 class TestOpenDbAtWithExtendedRetry:
     """Unit tests for _open_db_at_with_extended_retry — the longer,
     time-budgeted backoff used only for ingestion startup lock acquisition,


### PR DESCRIPTION
## Summary
- `IndexCache._rebuild` calls `get_db()` from a background daemon thread while `call_tool()`'s `finally` block resets the module-level `_db` global to `None` after every tool call.
- `get_db()` read that global twice — once in `if _db is None`, once again in `return _db` — so a reset landing between those two reads made it return `None` even though a live db existed at call time, producing `'NoneType' object has no attribute 'execute'` in `_rebuild`.
- Fix: capture `_db` into a local once and return that local, removing the second read and closing the race window.

## Test plan
- [x] Added `TestGetDbConcurrentResetRace` (`tests/test_mcp_server.py`), using `sys.settrace` to deterministically pause the background thread exactly at `get_db`'s return line and flip the global from the main thread — reproduces the race without relying on timing luck. Confirmed red on pre-fix code, green after.
- [x] Full suite: 326 passed, 38 skipped, 0 regressions.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYLgnPb8M3nVDZro7ikcuY