### PR TITLE
fix: reuse already-open db handle instead of racing a redundant open (#107)

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -731,10 +731,24 @@ def _get_graph_path() -> str:
     return os.environ.get("MINIGRAF_GRAPH_PATH", str(Path.cwd() / "memory.graph"))
 
 
-def _open_db_at(path: str) -> MiniGrafDb:
-    """Open MiniGrafDb at path, register session rules, update mtime tracking."""
+def _open_db_at(path: str, *, force: bool = True) -> MiniGrafDb:
+    """Open MiniGrafDb at path, register session rules, update mtime tracking.
+
+    force=False reuses an already-open _db instead of opening a second handle,
+    checked atomically under _db_native_lock. Without this, two threads that
+    both observe _db as None (e.g. the ingestion preload thread and an
+    _ensure_db_async() caller racing during the "starting" phase, before
+    _run_ingestion flips status to "running") each call MiniGrafDb.open() on
+    the same path from this same process. The second open collides with the
+    first handle's still-held lock file and surfaces as "Database is locked
+    by another process", with the lock file's own PID equal to *our* PID
+    (#107). force=True (the default) is for callers that need a genuine
+    reopen regardless of any existing handle, e.g. _refresh_if_stale().
+    """
     global _db, _graph_path, _db_mtime
     with _db_native_lock:
+        if not force and _db is not None:
+            return _db
         _db = MiniGrafDb.open(path)
     for rule in SESSION_RULES:
         _db_execute(_db, rule)
@@ -854,19 +868,22 @@ def _try_open_with_self_heal(path: str) -> MiniGrafDb:
     running) by removing it and retrying once, instead of surfacing a
     permanent error.
 
+    Reuses an already-open _db instead of opening a redundant second handle
+    (force=False) — see _open_db_at's docstring (#107).
+
     Raises the lock-contention exception if the lock is still held by a live
     process (caller decides whether to back off and retry); raises any
     non-lock exception immediately.
     """
     try:
-        return _open_db_at(path)
+        return _open_db_at(path, force=False)
     except Exception as e:
         if not _is_lock_error(e):
             raise
         holder_pid = _stale_lock_holder_pid(e)
         if holder_pid is not None and _clear_stale_lock(path, holder_pid):
             try:
-                return _open_db_at(path)
+                return _open_db_at(path, force=False)
             except Exception as e2:
                 if not _is_lock_error(e2):
                     raise

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -207,6 +207,65 @@ class TestGetDbLockRetry:
         assert mock_class.open.call_count == 2 * mcp_server._LOCK_RETRY_MAX
 
 
+class TestTryOpenWithSelfHealReuse:
+    """Regression test for #107: minigraf_ingest_status incorrectly reported
+    "Database is locked by another process" while minigraf_ingest_git was
+    actively running. Root cause: _try_open_with_self_heal always called
+    _open_db_at(path) unconditionally, even when another thread had already
+    opened the db and populated _db in the window between this thread's
+    None-check and its own open attempt (e.g. the ingestion preload thread,
+    which opens its own handle on a worker thread, racing against an
+    _ensure_db_async() caller like minigraf_ingest_status during the
+    "starting" phase, before _run_ingestion flips status to "running").
+    That produced a second, redundant MiniGrafDb.open() from this same
+    process, which collides with the first handle's still-live lock file and
+    surfaces as "locked by another process" with the lock file's own PID
+    equal to our own."""
+
+    def test_concurrent_open_attempts_only_open_db_once(self, mock_minigraf_db, tmp_path, monkeypatch):
+        mock_class, db_instance = mock_minigraf_db
+        import mcp_server
+        import threading
+        import time as _time
+
+        path = str(tmp_path / "race.graph")
+        mcp_server._db = None
+        mcp_server._graph_path = ""
+
+        open_call_count = {"n": 0}
+        open_lock = threading.Lock()
+
+        def slow_open(p):
+            with open_lock:
+                open_call_count["n"] += 1
+            _time.sleep(0.05)  # widen the race window so racers overlap
+            return db_instance
+
+        mock_class.open.side_effect = slow_open
+
+        results = []
+        results_lock = threading.Lock()
+
+        def worker():
+            db = mcp_server._try_open_with_self_heal(path)
+            with results_lock:
+                results.append(db)
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert open_call_count["n"] == 1, (
+            f"MiniGrafDb.open() called {open_call_count['n']} times for concurrent "
+            "open attempts racing on the same None _db -- _try_open_with_self_heal "
+            "must recheck _db under _db_native_lock before opening a second handle (#107)"
+        )
+        assert len(results) == 5
+        assert all(r is db_instance for r in results)
+
+
 class TestGetDbConcurrentResetRace:
     """Regression test for #122: IndexCache._rebuild calls get_db() from a
     background thread. get_db() used to read the module-level _db global


### PR DESCRIPTION
## Summary

Fixes #107 — `minigraf_ingest_status` incorrectly reported "Database is locked by another process" while `minigraf_ingest_git` was actively running in the background, even though `handle_minigraf_ingest_status()` never touches the DB while `status == "running"`.

**Root cause:** the redundant-open window is during the **"starting"** phase, before `_run_ingestion` flips status to `"running"` (after preload completes). `_run_ingestion`'s preload phase (`_load_ingestion_preload_state`) opens its own `MiniGrafDb` handle on a worker thread. Meanwhile, `call_tool`'s dispatch for `minigraf_ingest_status` only skips touching the DB when status `== "running"` — while status is `"starting"`, it still calls `_ensure_db_async()`, which has a check-then-open race: it checks `if _db is not None: return _db`, then — if that races against the preload thread's in-flight open — falls through to `_try_open_with_self_heal()` → `_open_db_at()`, which called `MiniGrafDb.open(path)` **unconditionally**, without rechecking `_db` immediately before opening.

A second `open()` on the same path from the *same process* collides with the still-open first handle's lock file. Since the lock file records this process's own PID, the resulting error reads "Database is locked by another process, holder PID: `<own pid>`" — exactly the reported symptom. This is a distinct bug from #110 (which serializes native calls into an *already-shared* handle to prevent torn reads/checksum mismatches) — #110 didn't touch `_ensure_db_async`, `_load_ingestion_preload_state`, or any status-gating logic, and doesn't stop a second, redundant `open()` call from happening.

**Fix:** `_open_db_at` gains a `force=False` mode that rechecks `_db is not None` atomically under the existing `_db_native_lock`, before calling `MiniGrafDb.open()`, and reuses the already-open handle instead of opening a second one. `_try_open_with_self_heal` — the common chokepoint for `_ensure_db_async`, `_open_db_at_with_retry`, and `_open_db_at_with_extended_retry` — now opens with `force=False`. `open_db()` (startup) and `_refresh_if_stale()` (explicit reopen on external modification) keep the `force=True` default since they need a genuine reopen regardless of any existing handle.

## Test plan

- [x] Added `TestTryOpenWithSelfHealReuse` — 5 threads race `_try_open_with_self_heal` against a slow mocked `MiniGrafDb.open` with `_db` initially `None`; verified it fails (`MiniGrafDb.open()` called 5 times) against pre-fix code and passes (called once, all callers get the same instance) with the fix.
- [x] Full suite: `python3 -m pytest tests/` → 328 passed, 38 skipped, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01VYLgnPb8M3nVDZro7ikcuY