### PR TITLE
fix: run git-ingestion extraction in a process pool, not threads (#116)

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -11,6 +11,7 @@ import configparser
 import contextlib
 import datetime
 import json
+import multiprocessing
 import os
 import re
 import signal
@@ -151,9 +152,9 @@ def _build_parser(lang_name: str) -> Any:
     Also used by _thread_parser to build a private-to-this-thread instance
     once _get_parser has already proven the grammar loads; an unexpected
     failure there is left to propagate to the caller (Task 3's
-    _extract_commit, running in a worker thread) rather than being
-    swallowed, consistent with how any other producer-task exception is
-    handled.
+    _extract_commit, running in a worker process — see #116) rather than
+    being swallowed, consistent with how any other producer-task exception
+    is handled.
     """
     module_name = _LANG_MODULE_OVERRIDES.get(lang_name, f"tree_sitter_{lang_name}")
     mod = __import__(module_name, fromlist=["language"])
@@ -3048,8 +3049,11 @@ def _extract_commit(
     _precompute_file_triples), unlike the incrementally-mutated file_entities/
     entity_valid_from state only the serial main thread maintains.
 
-    Runs in a worker thread via the ThreadPoolExecutor in _run_ingestion. Touches no
-    shared mutable state and no DB. Returns (file_results, gitlink_changes, gitmodules_map):
+    Runs in a worker process via the ProcessPoolExecutor in _run_ingestion (#116 —
+    a thread pool here let tree-sitter's GIL-holding C parse starve the event
+    loop). Touches no shared mutable state and no DB — a hard requirement now
+    that this crosses a process boundary, not just a nice property. Returns
+    (file_results, gitlink_changes, gitmodules_map):
 
       file_results: one entry per changed file that has a supported parser, as
         (status, file_path, extracted, precomputed). A/M files whose content fetch
@@ -3112,12 +3116,23 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 
     Extraction (git show + tree-sitter parse) for upcoming commits runs
-    ahead of time on a thread pool via a bounded sliding-window pipeline;
-    all DB-writing bookkeeping below stays strictly sequential, one commit
-    at a time, exactly as before this pipeline was introduced — the actual
-    db.execute()/checkpoint() calls just run on a dedicated single-worker
-    executor (write_executor) instead of inline on the event-loop thread, so
-    each fsync no longer blocks concurrent call_tool() requests.
+    ahead of time on a process pool (#116) via a bounded sliding-window
+    pipeline; all DB-writing bookkeeping below stays strictly sequential,
+    one commit at a time, exactly as before this pipeline was introduced —
+    the actual db.execute()/checkpoint() calls just run on a dedicated
+    single-worker thread executor (write_executor) instead of inline on the
+    event-loop thread, so each fsync no longer blocks concurrent
+    call_tool() requests. write_executor also runs the extraction process
+    pool's own (blocking) shutdown for the same reason — see its
+    construction below.
+
+    Note on failure isolation: a worker process crashing outright (OOM
+    kill, native segfault in tree-sitter) raises BrokenProcessPool for
+    every pending future in the sliding window, not just the commit that
+    triggered it — a strictly worse blast radius than the old thread pool,
+    where a crash would have taken down this whole server process anyway.
+    Ordinary exceptions (bad git ref, unreadable blob, unsupported syntax)
+    are unaffected and still fail only the one commit as before.
     """
     global _db, _ingest_progress
     # Safe to clear unconditionally: handle_minigraf_ingest_git refuses to start a
@@ -3156,7 +3171,16 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
         last_hash = watermark or ""
 
         env_workers = os.environ.get("MINIGRAF_INGEST_WORKERS")
-        max_workers = int(env_workers) if env_workers else min(32, (os.cpu_count() or 1) + 4)
+        # CPU-bound-appropriate default: one worker per core, not the
+        # I/O-bound ThreadPoolExecutor heuristic (cpu_count() + 4) this used
+        # before #116 — extra worker *processes* beyond the core count only
+        # add context-switch overhead for a pool that's actually saturating
+        # the CPU (see #116, "needs a process pool"). Still capped at 32:
+        # each worker is now a spawned OS process that re-imports this whole
+        # module (plus whichever tree-sitter grammars it touches), far
+        # pricier per-worker than a thread, so an uncapped cpu_count() on a
+        # very high-core host would spawn an excessive number of them.
+        max_workers = int(env_workers) if env_workers else min(32, (os.cpu_count() or 1))
         pipeline_depth = max_workers * 2
 
         completed_all = True
@@ -3168,11 +3192,35 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
         # concurrent call_tool() requests while a write's fsync is in flight,
         # instead of blocking the whole loop for that call. A single worker keeps
         # writes strictly one-at-a-time, matching the existing invariant that only
-        # one commit's write section ever holds _db/db at once.
+        # one commit's write section ever holds _db/db at once. Also reused below
+        # (#116) to run the extraction ProcessPoolExecutor's blocking shutdown()
+        # off the event-loop thread — that reuse is only safe because this pool
+        # isn't shut down itself until the outer `finally` further down, after
+        # the extraction pool's own shutdown has already been submitted to it.
         write_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
         try:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # Extraction (git show + tree-sitter parse + triple construction) runs
+            # in real OS processes, not threads (#116): tree-sitter's C parse holds
+            # the GIL for its whole duration (confirmed empirically — a single
+            # busy thread stalls a concurrent event loop's asyncio.sleep(0) ticks
+            # by tens of ms per tick vs sub-millisecond baseline), so a thread pool
+            # here would starve the event loop for as long as a heavy commit takes
+            # to parse, exactly the symptom #116 reports. An explicit "spawn"
+            # context is used rather than the platform default ("fork" on Linux)
+            # because worker processes are created lazily as commits are submitted
+            # below, by which point write_executor's thread and IndexCache's
+            # background rebuild thread (see #122) may already be alive in this
+            # process — forking with other threads running risks inheriting a
+            # lock one of them held at the instant of fork, which would deadlock
+            # forever in the child. spawn starts each worker from a clean
+            # interpreter instead, at the one-time cost of re-importing this
+            # module per worker process (not per commit).
+            mp_context = multiprocessing.get_context("spawn")
+            executor = concurrent.futures.ProcessPoolExecutor(
+                max_workers=max_workers, mp_context=mp_context
+            )
+            try:
                 commits_iter = iter(commits)
                 pending: Any = deque()
 
@@ -3392,6 +3440,16 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
 
                     _ingest_progress["processed"] += 1
                     await asyncio.sleep(0)  # yield to event loop
+            finally:
+                # ProcessPoolExecutor.shutdown(wait=True) blocks joining the
+                # worker OS processes — measured ~90ms even for a pool that
+                # never did any real work, entirely from process-exit
+                # teardown, not GIL contention. That's a plain blocking call:
+                # running it inline here would stall the event loop for that
+                # whole span, undoing this fix's own purpose in its teardown.
+                # Routing it through write_executor keeps the wait off the
+                # event-loop thread, same as every other blocking call above.
+                await loop.run_in_executor(write_executor, executor.shutdown)
 
             if completed_all:
                 now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2713,18 +2713,22 @@ class TestIngestionWrites:
         assert "1017" in call_args
         assert ":valid-from" not in call_args
 
-    def test_run_ingestion_writes_last_run_on_completion(self, mock_minigraf_db, tmp_path, monkeypatch):
+    def test_run_ingestion_writes_last_run_on_completion(self, mock_minigraf_db, git_repo, monkeypatch):
+        """Uses the real git_repo fixture (2 real commits) rather than
+        faking a commit list + empty _git_diff_tree_raw: _extract_commit
+        runs in a spawned worker process (#116), which re-imports
+        mcp_server fresh and never sees _git_diff_tree_raw patched on this
+        (parent) process's module object — a fabricated commit hash against
+        a non-git tmp_path would just make the real git call fail in the
+        worker. _last_run_write itself still runs on write_executor, an
+        in-process thread, so patching it here still works as before.
+        """
         mock_class, db_instance = mock_minigraf_db
         import mcp_server
-        mcp_server.open_db(str(tmp_path / "t.graph"))
+        mcp_server.open_db(str(git_repo / "t.graph"))
 
-        monkeypatch.setattr(mcp_server, "_watermark_query", lambda db: None)
-        monkeypatch.setattr(
-            mcp_server, "_git_commits",
-            lambda repo, watermark, branch: [("abc123", "2025-01-01T00:00:00Z", "author", "msg")]
-        )
-        monkeypatch.setattr(mcp_server, "_git_diff_tree_raw", lambda repo, commit: [])
-        monkeypatch.setattr(mcp_server, "_watermark_update", lambda db, h, ts, r: None)
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        last_hash = commits[-1][0]
 
         last_run_calls = []
         monkeypatch.setattr(
@@ -2732,12 +2736,12 @@ class TestIngestionWrites:
             lambda db, h, t, n: last_run_calls.append((h, t, n))
         )
 
-        asyncio.run(mcp_server._run_ingestion(str(tmp_path), "HEAD"))
+        asyncio.run(mcp_server._run_ingestion(str(git_repo), "HEAD"))
 
         assert len(last_run_calls) == 1
-        assert last_run_calls[0][0] == "abc123"
+        assert last_run_calls[0][0] == last_hash
         assert last_run_calls[0][1].endswith("Z")
-        assert last_run_calls[0][2] == 1  # 1 commit processed
+        assert last_run_calls[0][2] == 2  # 2 commits processed
 
     def test_run_ingestion_writes_last_run_when_no_commits(self, mock_minigraf_db, tmp_path, monkeypatch):
         mock_class, db_instance = mock_minigraf_db
@@ -3413,8 +3417,15 @@ class TestRunIngestionConcurrency:
 
     @pytest.mark.asyncio
     async def test_one_commits_file_failure_does_not_affect_other_commits(
-        self, mock_minigraf_db, git_repo, monkeypatch
+        self, mock_minigraf_db, git_repo
     ):
+        """A file-content fetch failure must be induced for real, not via
+        monkeypatch: _extract_commit runs in a spawned worker process
+        (#116), which re-imports mcp_server fresh and never sees a patch
+        applied to this (parent) process's module object. Corrupting the
+        actual loose git blob object for auth.py makes `git show
+        <hash>:auth.py` genuinely fail inside the worker, exercising the
+        same try/except continue path the old monkeypatch used to reach."""
         mock_class, db_instance = mock_minigraf_db
         db_instance.execute.return_value = json.dumps({"results": []})
         import mcp_server
@@ -3426,20 +3437,93 @@ class TestRunIngestionConcurrency:
 
         commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
         failing_hash = commits[0][0]
-        real_content = mcp_server._git_file_content
 
-        def flaky(repo, commit, path):
-            if commit == failing_hash:
-                raise mcp_server.MiniGrafError("simulated failure for one commit's file")
-            return real_content(repo, commit, path)
+        blob_sha = _subprocess.run(
+            ["git", "rev-parse", f"{failing_hash}:auth.py"],
+            cwd=git_repo, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        object_path = git_repo / ".git" / "objects" / blob_sha[:2] / blob_sha[2:]
+        assert object_path.is_file(), "expected a loose object for a freshly committed blob"
+        object_path.chmod(0o644)  # git writes loose objects read-only
+        object_path.write_bytes(b"not a valid git object")
 
-        monkeypatch.setattr(mcp_server, "_git_file_content", flaky)
         await mcp_server._run_ingestion(str(git_repo), "HEAD")
 
         # Both commits still get counted as processed even though the first
         # commit's only changed file failed to fetch.
         assert mcp_server._ingest_progress["status"] == "complete"
         assert mcp_server._ingest_progress["processed"] == 2
+
+
+class TestRunIngestionEventLoopResponsiveness:
+    @pytest.mark.asyncio
+    async def test_event_loop_stays_responsive_during_heavy_extraction(
+        self, mock_minigraf_db, tmp_path
+    ):
+        """#116: tree-sitter's C parse holds the GIL for its whole duration
+        (confirmed empirically — a single hammering thread stalls a
+        concurrent event loop's asyncio.sleep(0) ticks by tens of ms per
+        tick vs sub-millisecond baseline). Extraction must therefore run in
+        real OS processes, not GIL-sharing threads, so a heavy commit's
+        parse work cannot starve the MCP server's event loop.
+
+        Uses one giant function body (30k trivial statements) rather than
+        many small functions: parse time scales with statement count
+        (~500ms here) while the *extracted* output stays a single
+        function entity (~1KB pickled) — this isolates "the parse itself
+        holds the GIL for the whole commit" (the bug) from "deserializing
+        a large extracted result briefly holds the GIL" (an unavoidable,
+        output-sized, sub-commit-duration cost of any cross-process
+        handoff). A thread pool would freeze the loop for close to the
+        full ~500ms parse; a process pool's residual cost is bounded by
+        the tiny output, not the parse time.
+        """
+        db_instance = mock_minigraf_db[1]
+        db_instance.execute.return_value = json.dumps({"results": []})
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+        big_body = "".join(f"    x{i} = {i} + a * {i}\n" for i in range(30000))
+        big_source = "def one_big_function(a):\n" + big_body + "    return x0\n"
+        (repo / "big.py").write_text(big_source)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add big file"], cwd=repo, check=True, capture_output=True)
+
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0,
+            "current_commit": "", "error": None,
+        }
+
+        gaps = []
+
+        async def heartbeat():
+            last = time.monotonic()
+            while True:
+                await asyncio.sleep(0)
+                now = time.monotonic()
+                gaps.append(now - last)
+                last = now
+
+        hb_task = asyncio.ensure_future(heartbeat())
+        try:
+            await mcp_server._run_ingestion(str(repo), "HEAD")
+        finally:
+            hb_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await hb_task
+
+        assert mcp_server._ingest_progress["status"] == "complete"
+        max_gap = max(gaps) if gaps else 0.0
+        assert max_gap < 0.2, (
+            f"event loop tick blocked for {max_gap * 1000:.1f}ms during extraction "
+            "(a GIL-bound thread pool would block for close to the full ~1s parse here)"
+        )
 
 
 class TestRunIngestionShutdown:


### PR DESCRIPTION
## Summary

- #116: tree-sitter's C parse holds the GIL for its whole duration (confirmed empirically — a single busy thread stalls a concurrent event loop's `asyncio.sleep(0)` ticks by tens of ms per tick vs sub-millisecond baseline), so the `ThreadPoolExecutor` used for per-commit extraction let a heavy commit's parse work freeze the MCP server's event loop for as long as the parse took.
- Extraction now runs in a `ProcessPoolExecutor` with an explicit `spawn` context (avoids fork+threads deadlock risk from `write_executor`'s thread / `IndexCache`'s background rebuild thread possibly being alive when workers are lazily created).
- `ProcessPoolExecutor.shutdown()` itself blocks joining worker processes (~90ms observed even for trivial work) — routed through `write_executor` instead of a bare `with` block so that wait doesn't itself stall the event loop.
- Worker-count default switched from the I/O-bound `cpu_count()+4` heuristic to a CPU-bound one, still capped at 32 since each worker is now a heavier spawned process.
- Two tests that monkeypatched functions inside `_extract_commit`'s call chain no longer worked as written (spawn re-imports `mcp_server` fresh in the child, never seeing a patch on the parent's module object) — reworked to induce genuine failures (a corrupted git blob object, a real multi-commit repo) instead of monkeypatching.
- Added a regression test that races a heartbeat coroutine against ingestion of a commit with a deliberately heavy parse (a single function with 30k statements): red (~330ms stall) on the old thread pool, green (<200ms) on the process pool.

Fixes #116

## Test plan

- [x] `pytest tests/` — 367 passed, 0 failed
- [x] New regression test verified red against the old `ThreadPoolExecutor` code, green against the fix
- [x] Ran a 5-agent code review (medium effort) against the diff; addressed the worker-cap regression, documented the `write_executor`/pool-teardown coupling and `BrokenProcessPool` blast-radius trade-off, shrank an oversized test fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYLgnPb8M3nVDZro7ikcuY