### PR TITLE
feat: support path-ignore config for git ingestion (#115)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ skills/
 # Git worktrees
 .worktrees/
 
+# Subagent-driven-development scratch (progress ledger, task briefs/reports)
+.superpowers/
+
 #IDEs
 .idea
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -282,6 +282,8 @@ Once started, inform the user that ingestion is running in the background and mo
 
 Auto-started at MCP server startup — the server creates a background asyncio task that calls `_run_ingestion(cwd, "HEAD")` immediately. Set `MINIGRAF_NO_AUTO_INGEST=1` to suppress this (useful in eval sandboxes). Incremental: reads the `:ingestion/watermark` entity to determine the last ingested commit, then only processes new commits.
 
+Vendored/third-party/generated paths are skipped for AST extraction by default (`3rdParty/`, `third_party/`, `vendor/`, `node_modules/`, `dist/`, `build/`, `*.min.js`, `*.map`) — no per-file entities are created for them, and any in-repo import resolving into an ignored path is tagged `:type/external-dependency` instead of an internal module dependency. Extend the ignore list with `MINIGRAF_INGEST_IGNORE` (comma-separated globs/prefixes, e.g. `MINIGRAF_INGEST_IGNORE=generated/,*.pb.go`) and/or a repo-local `.temporalignore` file (one pattern per line, `#` comments allowed) — both add to the defaults, they don't replace them. Ignore config is resolved once when ingestion starts and applies uniformly across all historical commits; it does not retroactively remove entities from a graph that was already ingested before the ignore list was added.
+
 Do not write to `:ingestion/watermark` or any `:ingestion/` entity directly.
 
 ### minigraf_ingest_status

--- a/docs/superpowers/plans/2026-07-14-git-ingestion-path-ignore.md
+++ b/docs/superpowers/plans/2026-07-14-git-ingestion-path-ignore.md
@@ -1,0 +1,762 @@
+# Git Ingestion Path-Ignore Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let git ingestion skip vendored/third-party/generated paths entirely (no tree-sitter parse, no per-file entities), while in-repo files that import from a now-excluded path still resolve to a single `:type/external-dependency` entity via the existing unresolved-import fallback — the same treatment already given to real external packages and gitlink submodules.
+
+**Architecture:** A pure glob/prefix matcher (`_is_ignored_path`) and a config loader (`_load_ignore_patterns`, merging built-in defaults + `MINIGRAF_INGEST_IGNORE` env var + an optional `.temporalignore` file) plug into two existing chokepoints — `_known_files_at_commit` (excludes ignored paths from the known-files set used for import resolution) and `_extract_commit`'s per-file loop (skips ignored files before `_thread_parser`/tree-sitter run). `_run_ingestion` resolves the pattern list once and threads it through the `ProcessPoolExecutor` submission call. No new entity type or write-path code.
+
+**Tech Stack:** Python stdlib only (`fnmatch`, `pathlib`) — no new dependency.
+
+## Global Constraints
+
+- No new PyPI dependency (rejected `pathspec` in the design — see spec's "Matching" section).
+- `MINIGRAF_INGEST_IGNORE` env var naming follows the existing `MINIGRAF_INGEST_WORKERS` convention (mcp_server.py:3173).
+- Ignore config is resolved once per ingestion run from the current working tree, not re-read per historical commit.
+- Forward-only: no retroactive purge/backfill of already-ingested vendored entities.
+- New `ignore_patterns` parameters on `_known_files_at_commit`/`_extract_commit` must default to `()` so none of the 10 existing call sites in `tests/test_mcp_server.py` (lines 2261, 2270, 2287, 2294, 2392, 2410, 2422, 2436, 2468, 2493) need to change.
+
+---
+
+### Task 1: `_is_ignored_path` matcher
+
+**Files:**
+- Modify: `mcp_server.py` (add `import fnmatch` near line 16; add `Sequence` to the `typing` import at line 24; add new function immediately before `_known_files_at_commit` at line 1585)
+- Test: `tests/test_mcp_server.py` (new `TestIsIgnoredPath` class, placed immediately before `TestKnownFilesAtCommit` at line 2256)
+
+**Interfaces:**
+- Produces: `_is_ignored_path(file_path: str, patterns: Sequence[str]) -> bool` — pure function, no I/O. Used by Task 3 and Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_mcp_server.py` immediately before `class TestKnownFilesAtCommit:` (line 2256):
+
+```python
+class TestIsIgnoredPath:
+    def test_directory_pattern_matches_nested_path(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("src/vendor/foo.js", ["vendor/"]) is True
+
+    def test_directory_pattern_matches_top_level_path(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("vendor/bar.js", ["vendor/"]) is True
+
+    def test_directory_pattern_does_not_match_substring(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("vendored_thing.js", ["vendor/"]) is False
+
+    def test_glob_pattern_matches_basename(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("dist/app.min.js", ["*.min.js"]) is True
+
+    def test_glob_pattern_no_match_on_unrelated_file(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("dist/app.js", ["*.min.js"]) is False
+
+    def test_map_glob_pattern_matches(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("dist/app.js.map", ["*.map"]) is True
+
+    def test_exact_segment_match(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("a/node_modules/pkg/index.js", ["node_modules"]) is True
+
+    def test_exact_basename_match(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("some/path/README.md", ["README.md"]) is True
+
+    def test_no_patterns_never_matches(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("src/main.py", []) is False
+
+    def test_no_matching_pattern_returns_false(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("src/main.py", ["vendor/", "*.min.js"]) is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestIsIgnoredPath -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_is_ignored_path'`
+
+- [ ] **Step 3: Implement**
+
+In `mcp_server.py`, change the import line at line 16 from:
+
+```python
+import re
+```
+
+to:
+
+```python
+import fnmatch
+import re
+```
+
+(alphabetical order — `fnmatch` sorts before `re`, but after `datetime`/`json`/`multiprocessing`/`os`; insert it right after `datetime` at line 12 to keep the existing alphabetical ordering: `asyncio, concurrent.futures, configparser, contextlib, datetime, fnmatch, json, multiprocessing, os, re, signal, ...`)
+
+So the full corrected import block (lines 8-24) becomes:
+
+```python
+import asyncio
+import concurrent.futures
+import configparser
+import contextlib
+import datetime
+import fnmatch
+import json
+import multiprocessing
+import os
+import re
+import signal
+import subprocess as _subprocess
+import sys
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+```
+
+Then, immediately before `def _known_files_at_commit(...)` at line 1585, add:
+
+```python
+def _is_ignored_path(file_path: str, patterns: Sequence[str]) -> bool:
+    """Simplified .gitignore-style match: no negation, no ** anchoring, no new
+    dependency (see 2026-07-14 path-ignore design doc's "Matching" section for
+    why full gitignore semantics via pathspec were rejected).
+
+    - Pattern ending in "/": matches if that name is any path segment
+      (directory-anywhere-in-path semantics — "vendor/" matches both
+      "src/vendor/foo.js" and "vendor/bar.js", but never a bare substring
+      like "vendored_thing.js").
+    - Pattern containing a glob char (*, ?, [): fnmatch against the
+      basename, then the full path.
+    - Otherwise: exact match against any path segment or the basename.
+    """
+    segments = Path(file_path).parts
+    basename = segments[-1] if segments else file_path
+    for pattern in patterns:
+        if pattern.endswith("/"):
+            if pattern.rstrip("/") in segments:
+                return True
+        elif any(ch in pattern for ch in "*?["):
+            if fnmatch.fnmatch(basename, pattern) or fnmatch.fnmatch(file_path, pattern):
+                return True
+        elif pattern in segments or pattern == basename:
+            return True
+    return False
+
+
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestIsIgnoredPath -v`
+Expected: PASS (10 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add _is_ignored_path glob/prefix matcher for git ingestion (#115)"
+```
+
+---
+
+### Task 2: `_load_ignore_patterns` config loader
+
+**Files:**
+- Modify: `mcp_server.py` (add function immediately after `_is_ignored_path`, before `_known_files_at_commit`)
+- Test: `tests/test_mcp_server.py` (new `TestLoadIgnorePatterns` class, placed immediately after `TestIsIgnoredPath`)
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent pure/IO function).
+- Produces: `_load_ignore_patterns(repo_path: str) -> List[str]`. Used by Task 5 (`_run_ingestion`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_mcp_server.py` immediately after the `TestIsIgnoredPath` class body (before `class TestKnownFilesAtCommit:`):
+
+```python
+class TestLoadIgnorePatterns:
+    def test_defaults_present_with_no_env_or_file(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.delenv("MINIGRAF_INGEST_IGNORE", raising=False)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert "vendor/" in patterns
+        assert "third_party/" in patterns
+        assert "3rdParty/" in patterns
+        assert "node_modules/" in patterns
+        assert "dist/" in patterns
+        assert "build/" in patterns
+        assert "*.min.js" in patterns
+        assert "*.map" in patterns
+
+    def test_env_var_patterns_are_appended(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.setenv("MINIGRAF_INGEST_IGNORE", "generated/,*.pb.go")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert "generated/" in patterns
+        assert "*.pb.go" in patterns
+        assert "vendor/" in patterns  # defaults still present
+
+    def test_temporalignore_file_patterns_are_merged(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.delenv("MINIGRAF_INGEST_IGNORE", raising=False)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".temporalignore").write_text(
+            "# comment line\n\nlegacy/\n*.generated.ts\n"
+        )
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert "legacy/" in patterns
+        assert "*.generated.ts" in patterns
+        assert "vendor/" in patterns  # defaults still present
+        assert "# comment line" not in patterns
+
+    def test_missing_temporalignore_file_is_not_an_error(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.delenv("MINIGRAF_INGEST_IGNORE", raising=False)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert isinstance(patterns, list)
+        assert len(patterns) > 0
+
+    def test_all_three_sources_merge_together(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.setenv("MINIGRAF_INGEST_IGNORE", "from_env/")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".temporalignore").write_text("from_file/\n")
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert "vendor/" in patterns       # default
+        assert "from_env/" in patterns     # env var
+        assert "from_file/" in patterns    # .temporalignore
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestLoadIgnorePatterns -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_load_ignore_patterns'`
+
+- [ ] **Step 3: Implement**
+
+Add immediately after `_is_ignored_path` (before `_known_files_at_commit`):
+
+```python
+_DEFAULT_IGNORE_PATTERNS: Tuple[str, ...] = (
+    "3rdParty/", "third_party/", "vendor/", "node_modules/",
+    "dist/", "build/", "*.min.js", "*.map",
+)
+
+
+def _load_ignore_patterns(repo_path: str) -> List[str]:
+    """Resolve the effective ignore-pattern list for one ingestion run.
+
+    Merges, in order: built-in defaults, MINIGRAF_INGEST_IGNORE (comma-separated),
+    and an optional .temporalignore file (one pattern per line, blank lines and
+    "#"-prefixed comments skipped) read once from repo_path's current working
+    tree — not re-read per historical commit, since ignore config describes how
+    this run should behave, not something that varies commit-to-commit.
+    """
+    patterns: List[str] = list(_DEFAULT_IGNORE_PATTERNS)
+
+    env_patterns = os.environ.get("MINIGRAF_INGEST_IGNORE")
+    if env_patterns:
+        patterns.extend(p.strip() for p in env_patterns.split(",") if p.strip())
+
+    ignore_file = Path(repo_path) / ".temporalignore"
+    if ignore_file.is_file():
+        for line in ignore_file.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                patterns.append(line)
+
+    return patterns
+
+
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestLoadIgnorePatterns -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add _load_ignore_patterns config loader for git ingestion (#115)"
+```
+
+---
+
+### Task 3: Wire into `_known_files_at_commit`
+
+**Files:**
+- Modify: `mcp_server.py:1585` (`_known_files_at_commit` signature + body)
+- Test: `tests/test_mcp_server.py` (add tests to existing `TestKnownFilesAtCommit` class)
+
+**Interfaces:**
+- Consumes: `_is_ignored_path` (Task 1).
+- Produces: `_known_files_at_commit(repo_path: str, commit_hash: str, ignore_patterns: Sequence[str] = ()) -> Dict[str, List[str]]` — new optional third parameter, default `()` (empty — matches current behavior when omitted, so all 4 existing call sites at lines 2261/2270/2287/2294 keep passing unchanged). Consumed by Task 5 (`_extract_commit`'s internal call to this function).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `TestKnownFilesAtCommit` class in `tests/test_mcp_server.py` (after `test_returned_dict_shape_matches_file_entities`, before `class TestGitlinkChanges:`):
+
+```python
+    def test_ignored_path_excluded_even_with_supported_extension(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "main.py").write_text("def f(): pass\n")
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "lib.py").write_text("def g(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        known = mcp_server._known_files_at_commit(str(repo), commits[0][0], ["vendor/"])
+        assert "main.py" in known
+        assert "vendor/lib.py" not in known
+
+    def test_no_ignore_patterns_keeps_default_behavior(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        known = mcp_server._known_files_at_commit(str(git_repo), commits[0][0])
+        assert "auth.py" in known
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestKnownFilesAtCommit -v`
+Expected: `test_ignored_path_excluded_even_with_supported_extension` FAILs with `TypeError: _known_files_at_commit() takes 2 positional arguments but 3 were given`; the other new test passes already (no signature change yet).
+
+- [ ] **Step 3: Implement**
+
+In `mcp_server.py`, change the `_known_files_at_commit` signature and body (line 1585 onward):
+
+```python
+def _known_files_at_commit(
+    repo_path: str, commit_hash: str, ignore_patterns: Sequence[str] = ()
+) -> Dict[str, List[str]]:
+    """Return {file_path: []} for every file tracked at commit_hash whose extension
+    has a supported tree-sitter grammar (_EXT_TO_LANG) and that doesn't match
+    ignore_patterns (see _is_ignored_path) — excluding a vendored path here means
+    any import resolving against it falls through to the external-dependency
+    fallback in _resolve_module_import instead of matching internally (#115).
+
+    A pure function of commit_hash via `git ls-tree -r --name-only`, independent of
+    ingestion progress — unlike the incrementally-mutated file_entities dict, this
+    reflects the repo's actual state at that specific historical commit, so it can
+    run inside _extract_commit on the worker pool instead of waiting for the serial
+    main thread to catch up. Shaped like file_entities (dict keyed on path, values
+    unused) so it can be passed straight into _resolve_module_import, which only
+    ever reads the dict's keys.
+    """
+    result = _subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", commit_hash],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    known: Dict[str, List[str]] = {}
+    for path in result.stdout.strip().splitlines():
+        if Path(path).suffix.lower() in _EXT_TO_LANG and not _is_ignored_path(path, ignore_patterns):
+            known[path] = []
+    return known
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestKnownFilesAtCommit -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Run the full existing test file to check for regressions**
+
+Run: `python -m pytest tests/test_mcp_server.py -k "KnownFiles or ExtractCommit" -v`
+Expected: PASS (all existing `_known_files_at_commit`/`_extract_commit` call sites still work since the new param defaults to `()`)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: exclude ignored paths from _known_files_at_commit (#115)"
+```
+
+---
+
+### Task 4: Wire into `_extract_commit`
+
+**Files:**
+- Modify: `mcp_server.py:3043` (`_extract_commit` signature + per-file loop, and its internal call to `_known_files_at_commit`)
+- Test: `tests/test_mcp_server.py` (add tests to existing `TestExtractCommit` class)
+
+**Interfaces:**
+- Consumes: `_is_ignored_path` (Task 1), `_known_files_at_commit(..., ignore_patterns=...)` (Task 3).
+- Produces: `_extract_commit(repo_path: str, commit_hash: str, ignore_patterns: Sequence[str] = ()) -> Tuple[List[tuple], List[tuple], Dict[str, Dict[str, str]]]` — new optional third parameter, default `()` (all 6 existing call sites at lines 2392/2410/2422/2436/2468/2493 keep passing unchanged). Consumed by Task 5 (`_run_ingestion`'s submission call).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `TestExtractCommit` class in `tests/test_mcp_server.py` (find the class's last test method and add these directly after it, before the next `class` definition):
+
+```python
+    def test_ignored_file_produces_no_results_entry(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "lib.py").write_text("def vendored_fn(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add vendored lib"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(
+            str(repo), commits[0][0], ["vendor/"]
+        )
+        assert results == []
+
+    def test_no_ignore_patterns_keeps_default_behavior(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        first_hash = commits[0][0]
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), first_hash)
+        assert len(results) == 1
+        assert results[0][1] == "auth.py"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestExtractCommit -v`
+Expected: `test_ignored_file_produces_no_results_entry` FAILs with `TypeError: _extract_commit() takes 2 positional arguments but 3 were given`; the other new test passes already.
+
+- [ ] **Step 3: Implement**
+
+In `mcp_server.py`, change the `_extract_commit` signature (line 3043) and its per-file loop (lines 3087-3105):
+
+```python
+def _extract_commit(
+    repo_path: str, commit_hash: str, ignore_patterns: Sequence[str] = ()
+) -> Tuple[List[tuple], List[tuple], Dict[str, Dict[str, str]]]:
+```
+
+(docstring unchanged except adding one sentence — see below), and inside the function body, change:
+
+```python
+    for status, old_mode, new_mode, old_sha, new_sha, file_path in raw_entries:
+        parser = _thread_parser(file_path)
+        if parser is None:
+            continue
+        if status == "D":
+            results.append((status, file_path, None, None))
+            continue
+        try:
+            content = _git_file_content(repo_path, commit_hash, file_path)
+        except Exception:
+            continue
+        extracted = _extract_from_source(content, parser, file_path)
+        if known_files is None:
+            known_files = _known_files_at_commit(repo_path, commit_hash)
+            segment_index = _SegmentSuffixIndex(known_files)
+```
+
+to:
+
+```python
+    for status, old_mode, new_mode, old_sha, new_sha, file_path in raw_entries:
+        if _is_ignored_path(file_path, ignore_patterns):
+            continue
+        parser = _thread_parser(file_path)
+        if parser is None:
+            continue
+        if status == "D":
+            results.append((status, file_path, None, None))
+            continue
+        try:
+            content = _git_file_content(repo_path, commit_hash, file_path)
+        except Exception:
+            continue
+        extracted = _extract_from_source(content, parser, file_path)
+        if known_files is None:
+            known_files = _known_files_at_commit(repo_path, commit_hash, ignore_patterns)
+            segment_index = _SegmentSuffixIndex(known_files)
+```
+
+Also add one paragraph to the docstring, inserted right after the first paragraph
+(`"""Read-only, stateless per-commit extraction: ...` through `...unlike the
+incrementally-mutated file_entities/entity_valid_from state only the serial main
+thread maintains."""`'s first paragraph) and before the `"Runs in a worker process..."`
+paragraph:
+
+```
+    ignore_patterns (see _is_ignored_path/_load_ignore_patterns) are checked first,
+    before _thread_parser even runs — an ignored file costs zero parse time and is
+    also excluded from known_files, so anything importing it falls through to the
+    external-dependency fallback instead of resolving internally (#115).
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestExtractCommit -v`
+Expected: PASS (all tests in the class, including the two new ones)
+
+- [ ] **Step 5: Run the full existing test file to check for regressions**
+
+Run: `python -m pytest tests/test_mcp_server.py -v 2>&1 | tail -30`
+Expected: same pass/skip counts as before this task (no regressions) — this is the last task that touches `_extract_commit`/`_known_files_at_commit` in isolation, so it's the right point to confirm nothing else broke before wiring `_run_ingestion` in Task 5.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: skip ignored files in _extract_commit before parsing (#115)"
+```
+
+---
+
+### Task 5: Wire `_run_ingestion` end-to-end + regression tests
+
+**Files:**
+- Modify: `mcp_server.py:3115` (`_run_ingestion` — resolve ignore patterns once, pass through the `ProcessPoolExecutor` submission call)
+- Test: `tests/test_mcp_server.py` (new `TestGitIngestionPathIgnore` class, placed immediately after `TestUnresolvedImportTagging` at line 4608, i.e. right before `class TestResolveModuleImportTieredMatcher:`)
+
+**Interfaces:**
+- Consumes: `_load_ignore_patterns` (Task 2), `_extract_commit(..., ignore_patterns=...)` (Task 4).
+- Produces: nothing new consumed by later tasks — this is the final wiring task.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_mcp_server.py` immediately after the `TestUnresolvedImportTagging` class (before `class TestResolveModuleImportTieredMatcher:`):
+
+```python
+class TestGitIngestionPathIgnore:
+    def _make_progress(self):
+        return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
+
+    @pytest.mark.asyncio
+    async def test_default_ignored_directory_produces_no_code_entities(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """A file under a default-ignored directory (vendor/) must not produce
+        any :type/module, :type/function, or :type/class triples."""
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "lib.py").write_text("def vendored_fn(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add vendored lib"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        vendored_module_ident = mcp_server._code_ident("module", "vendor/lib.py")
+        assert not any(vendored_module_ident in t for t in transact_calls)
+        assert not any(":entity-type :type/function" in t for t in transact_calls)
+        assert not any(":entity-type :type/class" in t for t in transact_calls)
+
+    @pytest.mark.asyncio
+    async def test_import_into_ignored_path_becomes_external_dependency(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """Before this feature, vendor/foo.py would resolve as a normal in-tree
+        module (see _resolve_module_import's segment-suffix matcher) and
+        main.py's import of it would create an internal :depends-on edge, not
+        an external-dependency entity. Excluding vendor/ from known_files must
+        make it fall through to the same fallback used for real external
+        packages (see TestUnresolvedImportTagging)."""
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "foo.py").write_text("def helper(): pass\n")
+        (repo / "main.py").write_text("import vendor.foo\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add vendor and main"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        external_ident = mcp_server._canonical_ident("module", "vendor.foo")
+        assert any(
+            f"[{external_ident} :entity-type :type/external-dependency]" in t for t in transact_calls
+        )
+
+    @pytest.mark.asyncio
+    async def test_env_var_ignore_pattern_excludes_custom_directory(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """MINIGRAF_INGEST_IGNORE must add to the default ignore list, not
+        replace it — a custom pattern not in the built-in defaults must still
+        be honored."""
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "generated").mkdir()
+        (repo / "generated" / "codegen.py").write_text("def generated_fn(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add generated file"], cwd=repo, check=True, capture_output=True)
+
+        monkeypatch.setenv("MINIGRAF_INGEST_IGNORE", "generated/")
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        generated_module_ident = mcp_server._code_ident("module", "generated/codegen.py")
+        assert not any(generated_module_ident in t for t in transact_calls)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestGitIngestionPathIgnore -v`
+Expected: FAIL — `test_default_ignored_directory_produces_no_code_entities` and
+`test_env_var_ignore_pattern_excludes_custom_directory` fail because `_run_ingestion`
+doesn't yet resolve/pass ignore patterns (vendor/lib.py and generated/codegen.py still
+get ingested as normal modules); `test_import_into_ignored_path_becomes_external_dependency`
+fails because `vendor.foo` still resolves internally instead of becoming an
+external-dependency.
+
+- [ ] **Step 3: Implement**
+
+In `mcp_server.py`, inside `_run_ingestion` (starting at line 3115), add the ignore-pattern
+resolution right after `commits = _git_commits(...)` (line 3160) and before the
+`repo_total_result` computation:
+
+```python
+        commits = _git_commits(repo_path, watermark, branch)
+        ignore_patterns = _load_ignore_patterns(repo_path)
+        repo_total_result = _subprocess.run(
+```
+
+Then change the extraction submission call inside `submit_next` (line 3232) from:
+
+```python
+                    fut = loop.run_in_executor(executor, _extract_commit, repo_path, commit[0])
+```
+
+to:
+
+```python
+                    fut = loop.run_in_executor(
+                        executor, _extract_commit, repo_path, commit[0], ignore_patterns
+                    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestGitIngestionPathIgnore -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Run the full test suite to check for regressions**
+
+Run: `python -m pytest tests/ -v 2>&1 | tail -40`
+Expected: same pass/skip counts as the pre-existing baseline plus the new tests from
+Tasks 1-5 (10 + 5 + 2 + 2 + 3 = 22 new tests), 0 regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: resolve and apply ignore patterns in _run_ingestion (#115)"
+```
+
+---
+
+### Task 6: Docs — SKILL.md
+
+**Files:**
+- Modify: `SKILL.md` (insert new paragraph in the `### minigraf_ingest_git` section, immediately after the "Auto-started..." paragraph at line 283)
+
+**Interfaces:**
+- Consumes: nothing (docs only).
+- Produces: nothing (terminal task).
+
+- [ ] **Step 1: Add the documentation paragraph**
+
+In `SKILL.md`, immediately after this existing line (283):
+
+```
+Auto-started at MCP server startup — the server creates a background asyncio task that calls `_run_ingestion(cwd, "HEAD")` immediately. Set `MINIGRAF_NO_AUTO_INGEST=1` to suppress this (useful in eval sandboxes). Incremental: reads the `:ingestion/watermark` entity to determine the last ingested commit, then only processes new commits.
+```
+
+insert:
+
+```
+Vendored/third-party/generated paths are skipped for AST extraction by default (`3rdParty/`, `third_party/`, `vendor/`, `node_modules/`, `dist/`, `build/`, `*.min.js`, `*.map`) — no per-file entities are created for them, and any in-repo import resolving into an ignored path is tagged `:type/external-dependency` instead of an internal module dependency. Extend the ignore list with `MINIGRAF_INGEST_IGNORE` (comma-separated globs/prefixes, e.g. `MINIGRAF_INGEST_IGNORE=generated/,*.pb.go`) and/or a repo-local `.temporalignore` file (one pattern per line, `#` comments allowed) — both add to the defaults, they don't replace them. Ignore config is resolved once when ingestion starts and applies uniformly across all historical commits; it does not retroactively remove entities from a graph that was already ingested before the ignore list was added.
+```
+
+- [ ] **Step 2: Verify the doc renders sensibly**
+
+Run: `grep -n "MINIGRAF_INGEST_IGNORE" SKILL.md`
+Expected: one match, in the new paragraph.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add SKILL.md
+git commit -m "docs: document MINIGRAF_INGEST_IGNORE and .temporalignore (#115)"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run the complete test suite one more time: `python -m pytest tests/ -v 2>&1 | tail -20` — expect 0 failures, 0 regressions vs. the pre-Task-1 baseline.
+- [ ] `git log --oneline -6` shows the 6 commits from Tasks 1-6 in order.
+- [ ] Open a PR with `Fixes #115` in the body (per this repo's established pattern — see [[project_issue_sequence_2026_07]] memory for why the closing keyword must be in the PR body up front).

--- a/docs/superpowers/specs/2026-07-14-git-ingestion-path-ignore-design.md
+++ b/docs/superpowers/specs/2026-07-14-git-ingestion-path-ignore-design.md
@@ -1,0 +1,193 @@
+# Git Ingestion Path-Ignore Config — Design
+
+**Date:** 2026-07-14
+**Issue:** #115
+
+## Problem
+
+Git ingestion walks every changed file in every historical commit through tree-sitter to
+extract function/class entities, with no way to exclude vendored/third-party/generated
+directories. On a real-world repo (ArangoDB, ~53k commits) this stalls for hours at commits
+that vendor V8/ICU wholesale — one commit alone (`8e858bc9`, "Upgrade V8 to 4.2.77") touches
+23,051 files, ~4,954 of them AST-parseable C++. Because extraction now runs in a
+`ProcessPoolExecutor` (#116), a mega-commit like this pins every worker on CPU for as long as
+the parse takes; the graph also gets bloated with thousands of vendored-code entities that
+every structural query then has to contend with.
+
+## Goal
+
+Let ingestion skip vendored/generated paths entirely — no tree-sitter parse, no per-file
+`:type/module`/function/class entities — while keeping in-repo files that legitimately
+depend on that vendored code resolvable to *something*, not silently dangling.
+
+## Design
+
+### Treatment: same as external code, not a new entity type
+
+The codebase already has a fallback for imports it can't resolve to an in-tree file: it
+creates a single `:type/external-dependency` entity (mcp_server.py:3320-3331), the same
+mechanism used for real npm/cargo/etc. packages and (as a distinct code path) for gitlink
+submodules (mcp_server.py:3350-3389).
+
+`_resolve_module_import`'s generic segment-suffix matcher currently treats vendored in-tree
+code as fully internal, matching it against `known_files` like first-party source — that's
+exactly why vendored code today produces full per-function/per-class entities instead of
+falling through to the external-dependency fallback.
+
+The fix requires no new entity-creation code: exclude ignored paths from `known_files`
+(mcp_server.py:1585, `_known_files_at_commit`), and any in-repo import pointing at
+now-excluded vendored code can no longer match the internal segment-suffix tiers, so it falls
+through to the existing unresolved-import fallback automatically — one
+`:type/external-dependency` entity for the whole ident, not one entity per vendored function.
+
+### Ignore pattern resolution — once, at ingestion start
+
+New function `_load_ignore_patterns(repo_path: str) -> List[str]`, called once in
+`_run_ingestion` before the commit loop (near where `max_workers`/`pipeline_depth` are
+computed, mcp_server.py:3173-3184). Merges three sources into one list, in this order:
+
+1. Built-in defaults:
+   ```python
+   _DEFAULT_IGNORE_PATTERNS = (
+       "3rdParty/", "third_party/", "vendor/", "node_modules/",
+       "dist/", "build/", "*.min.js", "*.map",
+   )
+   ```
+2. `MINIGRAF_INGEST_IGNORE` env var — comma-separated extra patterns, following the existing
+   `MINIGRAF_INGEST_WORKERS`-style naming convention (mcp_server.py:3173).
+3. An optional `.temporalignore` file at `repo_path`'s root — one pattern per line, blank
+   lines and `#`-prefixed comment lines skipped. Read once via a plain file read against the
+   current working tree (not `git show` against a historical commit) — the ignore config is
+   a property of *how this ingestion run should behave*, not something that should vary
+   commit-to-commit; re-reading it per commit would also mean early history ingests under an
+   inconsistent (often absent) file.
+
+Resolved once, so it's a plain `List[str]`, cheap to pass as an explicit argument across the
+process-pool boundary (workers can't share module-level state set after `_run_ingestion`
+starts — see #116's `spawn` context).
+
+### Matching — simple glob/prefix, no new dependency
+
+New pure function, placed near `_known_files_at_commit`:
+
+```python
+def _is_ignored_path(file_path: str, patterns: Sequence[str]) -> bool:
+    """Simplified .gitignore-style match: no negation, no new dependency.
+
+    - Pattern ending in "/": matches if that name is any path segment
+      (directory-anywhere-in-path semantics, e.g. "vendor/" matches
+      "src/vendor/foo.js" and "vendor/bar.js").
+    - Pattern containing a glob char (*, ?, [): fnmatch against the
+      basename, then the full path (covers "*.min.js" and prefix-style
+      globs like "generated/**" alike without needing real ** support).
+    - Otherwise: exact match against any path segment or the basename.
+    """
+    segments = Path(file_path).parts
+    basename = segments[-1] if segments else file_path
+    for pattern in patterns:
+        if pattern.endswith("/"):
+            if pattern.rstrip("/") in segments:
+                return True
+        elif any(ch in pattern for ch in "*?["):
+            if fnmatch.fnmatch(basename, pattern) or fnmatch.fnmatch(file_path, pattern):
+                return True
+        elif pattern in segments or pattern == basename:
+            return True
+    return False
+```
+
+`fnmatch` is already stdlib — no new dependency, matching the recommended approach (full
+`.gitignore` semantics via `pathspec` was considered and rejected: this project currently
+has zero dependencies beyond `minigraf`/`mcp`, and the issue's own proposal only asks for
+"glob/prefix exclusion list", not negation or `**` anchoring).
+
+### Plumbing through the process-pool boundary
+
+`_extract_commit`'s signature (mcp_server.py:3043) gains `ignore_patterns: Sequence[str]`:
+
+```python
+def _extract_commit(
+    repo_path: str, commit_hash: str, ignore_patterns: Sequence[str]
+) -> Tuple[List[tuple], List[tuple], Dict[str, Dict[str, str]]]:
+```
+
+Inside its per-file loop (mcp_server.py:3087-3105), ignored files are skipped *before*
+`_thread_parser` runs — zero parse cost, matching the issue's actual complaint:
+
+```python
+for status, old_mode, new_mode, old_sha, new_sha, file_path in raw_entries:
+    if _is_ignored_path(file_path, ignore_patterns):
+        continue
+    parser = _thread_parser(file_path)
+    ...
+```
+
+`_known_files_at_commit` (mcp_server.py:1585) gains the same parameter and excludes matches:
+
+```python
+def _known_files_at_commit(
+    repo_path: str, commit_hash: str, ignore_patterns: Sequence[str]
+) -> Dict[str, List[str]]:
+    ...
+    for path in result.stdout.strip().splitlines():
+        if Path(path).suffix.lower() in _EXT_TO_LANG and not _is_ignored_path(path, ignore_patterns):
+            known[path] = []
+```
+
+`_run_ingestion`'s submission call (mcp_server.py:3232) passes the resolved list through:
+
+```python
+fut = loop.run_in_executor(executor, _extract_commit, repo_path, commit[0], ignore_patterns)
+```
+
+Gitlink/submodule handling (mcp_server.py:3344-3389) is untouched — gitlink paths are
+extensionless and already produce a single opaque `:type/external-dependency` entity; the
+ignore list only concerns AST-parseable in-tree files.
+
+### Scope: forward-only
+
+Ignored paths are skipped for any commit processed after this ships — new commits appended
+to an already-ingested repo, or a from-scratch re-ingestion. A repo that was already fully
+ingested before this feature existed keeps whatever vendored entities it already has; no
+retroactive purge/backfill worker is in scope here (analogous to how #114's backfill for
+#111/#112/#113 is its own separate, explicitly-scoped follow-up).
+
+## Affected functions
+
+| Function | Change |
+|---|---|
+| `_is_ignored_path` | New — pure glob/prefix/segment matcher |
+| `_load_ignore_patterns` | New — merges defaults + env var + `.temporalignore` once at ingestion start |
+| `_known_files_at_commit` | Gains `ignore_patterns` param; excludes matches from the known-files set |
+| `_extract_commit` | Gains `ignore_patterns` param; skips ignored files before `_thread_parser` |
+| `_run_ingestion` | Resolves ignore patterns once; passes them through the process-pool submission call |
+
+## Testing
+
+- `_is_ignored_path`: directory-anywhere match (`"vendor/"` vs `"src/vendor/foo.js"`,
+  `"vendor/bar.js"`, and a non-match like `"vendored_thing.js"` — must not match on a bare
+  substring); glob match (`"*.min.js"`, `"*.map"`); exact-segment/basename match; a path with
+  no match returns `False`.
+- `_load_ignore_patterns`: defaults present with no env var/file; env var patterns appended;
+  `.temporalignore` lines parsed with comments/blanks skipped; all three merge together.
+- `_known_files_at_commit`: an ignored path present in `git ls-tree` output is excluded from
+  the returned dict even though its extension is in `_EXT_TO_LANG`.
+- Ingestion-level regression: a commit adding a file under a default-ignored directory (e.g.
+  `third_party/foo.cpp`) produces zero `:type/module`/function/class triples for that file;
+  a separate in-repo file whose import resolves to that now-excluded path gets a single
+  `:type/external-dependency` entity instead of an internally-resolved module dependency edge
+  (mirrors the existing `TestExternalDependencyLabeling`-style test, per the 2026-07-04
+  external-dependency design doc).
+
+## Docs
+
+- `SKILL.md`: document `MINIGRAF_INGEST_IGNORE` and `.temporalignore` alongside the other
+  `MINIGRAF_*` ingestion env vars, including the built-in default pattern list.
+
+## Non-goals
+
+- No retroactive purge/backfill of vendored entities already ingested before this ships.
+- No full `.gitignore` semantics (no negation, no `**` anchoring) — simple glob/prefix only.
+- No per-commit re-reading of `.temporalignore` from historical tree state — resolved once
+  from the current working tree at ingestion start.
+- No change to gitlink/submodule handling — already minimal/opaque.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1610,6 +1610,37 @@ def _is_ignored_path(file_path: str, patterns: Sequence[str]) -> bool:
     return False
 
 
+_DEFAULT_IGNORE_PATTERNS: Tuple[str, ...] = (
+    "3rdParty/", "third_party/", "vendor/", "node_modules/",
+    "dist/", "build/", "*.min.js", "*.map",
+)
+
+
+def _load_ignore_patterns(repo_path: str) -> List[str]:
+    """Resolve the effective ignore-pattern list for one ingestion run.
+
+    Merges, in order: built-in defaults, MINIGRAF_INGEST_IGNORE (comma-separated),
+    and an optional .temporalignore file (one pattern per line, blank lines and
+    "#"-prefixed comments skipped) read once from repo_path's current working
+    tree — not re-read per historical commit, since ignore config describes how
+    this run should behave, not something that varies commit-to-commit.
+    """
+    patterns: List[str] = list(_DEFAULT_IGNORE_PATTERNS)
+
+    env_patterns = os.environ.get("MINIGRAF_INGEST_IGNORE")
+    if env_patterns:
+        patterns.extend(p.strip() for p in env_patterns.split(",") if p.strip())
+
+    ignore_file = Path(repo_path) / ".temporalignore"
+    if ignore_file.is_file():
+        for line in ignore_file.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                patterns.append(line)
+
+    return patterns
+
+
 def _known_files_at_commit(repo_path: str, commit_hash: str) -> Dict[str, List[str]]:
     """Return {file_path: []} for every file tracked at commit_hash whose extension
     has a supported tree-sitter grammar (_EXT_TO_LANG).

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3229,6 +3229,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
         _db = None  # release file lock while enumerating commits
 
         commits = _git_commits(repo_path, watermark, branch)
+        ignore_patterns = _load_ignore_patterns(repo_path)
         repo_total_result = _subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
             cwd=repo_path, capture_output=True, text=True,
@@ -3300,7 +3301,9 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                         commit = next(commits_iter)
                     except StopIteration:
                         return False
-                    fut = loop.run_in_executor(executor, _extract_commit, repo_path, commit[0])
+                    fut = loop.run_in_executor(
+                        executor, _extract_commit, repo_path, commit[0], ignore_patterns
+                    )
                     pending.append((commit, fut))
                     return True
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1624,6 +1624,10 @@ def _load_ignore_patterns(repo_path: str) -> List[str]:
     "#"-prefixed comments skipped) read once from repo_path's current working
     tree — not re-read per historical commit, since ignore config describes how
     this run should behave, not something that varies commit-to-commit.
+
+    Fails closed: an unreadable or undecodable .temporalignore file contributes
+    zero extra patterns (defaults + env var still apply), matching best-effort
+    conventions used elsewhere in this file (e.g. _parse_gitmodules).
     """
     patterns: List[str] = list(_DEFAULT_IGNORE_PATTERNS)
 
@@ -1633,7 +1637,11 @@ def _load_ignore_patterns(repo_path: str) -> List[str]:
 
     ignore_file = Path(repo_path) / ".temporalignore"
     if ignore_file.is_file():
-        for line in ignore_file.read_text().splitlines():
+        try:
+            lines = ignore_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        except Exception:
+            lines = []
+        for line in lines:
             line = line.strip()
             if line and not line.startswith("#"):
                 patterns.append(line)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -10,6 +10,7 @@ import concurrent.futures
 import configparser
 import contextlib
 import datetime
+import fnmatch
 import json
 import multiprocessing
 import os
@@ -21,7 +22,7 @@ import threading
 import time
 from collections import deque
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -1580,6 +1581,33 @@ def _git_file_content(repo_path: str, commit_hash: str, file_path: str) -> bytes
         cwd=repo_path, capture_output=True, check=True,
     )
     return result.stdout
+
+
+def _is_ignored_path(file_path: str, patterns: Sequence[str]) -> bool:
+    """Simplified .gitignore-style match: no negation, no ** anchoring, no new
+    dependency (see 2026-07-14 path-ignore design doc's "Matching" section for
+    why full gitignore semantics via pathspec were rejected).
+
+    - Pattern ending in "/": matches if that name is any path segment
+      (directory-anywhere-in-path semantics — "vendor/" matches both
+      "src/vendor/foo.js" and "vendor/bar.js", but never a bare substring
+      like "vendored_thing.js").
+    - Pattern containing a glob char (*, ?, [): fnmatch against the
+      basename, then the full path.
+    - Otherwise: exact match against any path segment or the basename.
+    """
+    segments = Path(file_path).parts
+    basename = segments[-1] if segments else file_path
+    for pattern in patterns:
+        if pattern.endswith("/"):
+            if pattern.rstrip("/") in segments:
+                return True
+        elif any(ch in pattern for ch in "*?["):
+            if fnmatch.fnmatch(basename, pattern) or fnmatch.fnmatch(file_path, pattern):
+                return True
+        elif pattern in segments or pattern == basename:
+            return True
+    return False
 
 
 def _known_files_at_commit(repo_path: str, commit_hash: str) -> Dict[str, List[str]]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3105,13 +3105,18 @@ def _ingest_tags(db: Any, repo_path: str, run_ts_iso: str) -> None:
 
 
 def _extract_commit(
-    repo_path: str, commit_hash: str
+    repo_path: str, commit_hash: str, ignore_patterns: Sequence[str] = ()
 ) -> Tuple[List[tuple], List[tuple], Dict[str, Dict[str, str]]]:
     """Read-only, stateless per-commit extraction: diff-tree + git-show + tree-sitter parse,
     plus import resolution and "if this turns out to be new" triple precomputation —
     both pure functions of this commit alone (see _known_files_at_commit and
     _precompute_file_triples), unlike the incrementally-mutated file_entities/
     entity_valid_from state only the serial main thread maintains.
+
+    ignore_patterns (see _is_ignored_path/_load_ignore_patterns) are checked first,
+    before _thread_parser even runs — an ignored file costs zero parse time and is
+    also excluded from known_files, so anything importing it falls through to the
+    external-dependency fallback instead of resolving internally (#115).
 
     Runs in a worker process via the ProcessPoolExecutor in _run_ingestion (#116 —
     a thread pool here let tree-sitter's GIL-holding C parse starve the event
@@ -3149,6 +3154,8 @@ def _extract_commit(
     segment_index: Optional[_SegmentSuffixIndex] = None
 
     for status, old_mode, new_mode, old_sha, new_sha, file_path in raw_entries:
+        if _is_ignored_path(file_path, ignore_patterns):
+            continue
         parser = _thread_parser(file_path)
         if parser is None:
             continue
@@ -3161,7 +3168,7 @@ def _extract_commit(
             continue
         extracted = _extract_from_source(content, parser, file_path)
         if known_files is None:
-            known_files = _known_files_at_commit(repo_path, commit_hash)
+            known_files = _known_files_at_commit(repo_path, commit_hash, ignore_patterns)
             segment_index = _SegmentSuffixIndex(known_files)
         precomputed = _precompute_file_triples(
             file_path, extracted, commit_ident, known_files, segment_index=segment_index,

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1641,9 +1641,14 @@ def _load_ignore_patterns(repo_path: str) -> List[str]:
     return patterns
 
 
-def _known_files_at_commit(repo_path: str, commit_hash: str) -> Dict[str, List[str]]:
+def _known_files_at_commit(
+    repo_path: str, commit_hash: str, ignore_patterns: Sequence[str] = ()
+) -> Dict[str, List[str]]:
     """Return {file_path: []} for every file tracked at commit_hash whose extension
-    has a supported tree-sitter grammar (_EXT_TO_LANG).
+    has a supported tree-sitter grammar (_EXT_TO_LANG) and that doesn't match
+    ignore_patterns (see _is_ignored_path) — excluding a vendored path here means
+    any import resolving against it falls through to the external-dependency
+    fallback in _resolve_module_import instead of matching internally (#115).
 
     A pure function of commit_hash via `git ls-tree -r --name-only`, independent of
     ingestion progress — unlike the incrementally-mutated file_entities dict, this
@@ -1659,7 +1664,7 @@ def _known_files_at_commit(repo_path: str, commit_hash: str) -> Dict[str, List[s
     )
     known: Dict[str, List[str]] = {}
     for path in result.stdout.strip().splitlines():
-        if Path(path).suffix.lower() in _EXT_TO_LANG:
+        if Path(path).suffix.lower() in _EXT_TO_LANG and not _is_ignored_path(path, ignore_patterns):
             known[path] = []
     return known
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2397,6 +2397,30 @@ class TestKnownFilesAtCommit:
         known = mcp_server._known_files_at_commit(str(git_repo), commits[0][0])
         assert known["auth.py"] == []
 
+    def test_ignored_path_excluded_even_with_supported_extension(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "main.py").write_text("def f(): pass\n")
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "lib.py").write_text("def g(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        known = mcp_server._known_files_at_commit(str(repo), commits[0][0], ["vendor/"])
+        assert "main.py" in known
+        assert "vendor/lib.py" not in known
+
+    def test_no_ignore_patterns_keeps_default_behavior(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        known = mcp_server._known_files_at_commit(str(git_repo), commits[0][0])
+        assert "auth.py" in known
+
 
 class TestGitlinkChanges:
     def test_non_gitlink_rows_are_ignored(self):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2295,6 +2295,67 @@ class TestIsIgnoredPath:
         assert mcp_server._is_ignored_path("src/main.py", ["vendor/", "*.min.js"]) is False
 
 
+class TestLoadIgnorePatterns:
+    def test_defaults_present_with_no_env_or_file(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.delenv("MINIGRAF_INGEST_IGNORE", raising=False)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert "vendor/" in patterns
+        assert "third_party/" in patterns
+        assert "3rdParty/" in patterns
+        assert "node_modules/" in patterns
+        assert "dist/" in patterns
+        assert "build/" in patterns
+        assert "*.min.js" in patterns
+        assert "*.map" in patterns
+
+    def test_env_var_patterns_are_appended(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.setenv("MINIGRAF_INGEST_IGNORE", "generated/,*.pb.go")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert "generated/" in patterns
+        assert "*.pb.go" in patterns
+        assert "vendor/" in patterns  # defaults still present
+
+    def test_temporalignore_file_patterns_are_merged(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.delenv("MINIGRAF_INGEST_IGNORE", raising=False)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".temporalignore").write_text(
+            "# comment line\n\nlegacy/\n*.generated.ts\n"
+        )
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert "legacy/" in patterns
+        assert "*.generated.ts" in patterns
+        assert "vendor/" in patterns  # defaults still present
+        assert "# comment line" not in patterns
+
+    def test_missing_temporalignore_file_is_not_an_error(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.delenv("MINIGRAF_INGEST_IGNORE", raising=False)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert isinstance(patterns, list)
+        assert len(patterns) > 0
+
+    def test_all_three_sources_merge_together(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.setenv("MINIGRAF_INGEST_IGNORE", "from_env/")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".temporalignore").write_text("from_file/\n")
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert "vendor/" in patterns       # default
+        assert "from_env/" in patterns     # env var
+        assert "from_file/" in patterns    # .temporalignore
+
+
 class TestKnownFilesAtCommit:
     def test_returns_files_present_at_that_commit(self, git_repo):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2622,6 +2622,32 @@ class TestExtractCommit:
         assert len(results) == 2  # mod_a.py (imports mod_b) and mod_b.py both added here
         assert build_count == 1
 
+    def test_ignored_file_produces_no_results_entry(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "lib.py").write_text("def vendored_fn(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add vendored lib"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(
+            str(repo), commits[0][0], ["vendor/"]
+        )
+        assert results == []
+
+    def test_no_ignore_patterns_keeps_default_behavior(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        first_hash = commits[0][0]
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), first_hash)
+        assert len(results) == 1
+        assert results[0][1] == "auth.py"
+
 
 class TestIngestionWrites:
     def test_ingest_transact_uses_valid_from(self, mock_minigraf_db, tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2253,6 +2253,48 @@ class TestGitDiffTreeRaw:
         assert path == "vendor/lib"
 
 
+class TestIsIgnoredPath:
+    def test_directory_pattern_matches_nested_path(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("src/vendor/foo.js", ["vendor/"]) is True
+
+    def test_directory_pattern_matches_top_level_path(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("vendor/bar.js", ["vendor/"]) is True
+
+    def test_directory_pattern_does_not_match_substring(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("vendored_thing.js", ["vendor/"]) is False
+
+    def test_glob_pattern_matches_basename(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("dist/app.min.js", ["*.min.js"]) is True
+
+    def test_glob_pattern_no_match_on_unrelated_file(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("dist/app.js", ["*.min.js"]) is False
+
+    def test_map_glob_pattern_matches(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("dist/app.js.map", ["*.map"]) is True
+
+    def test_exact_segment_match(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("a/node_modules/pkg/index.js", ["node_modules"]) is True
+
+    def test_exact_basename_match(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("some/path/README.md", ["README.md"]) is True
+
+    def test_no_patterns_never_matches(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("src/main.py", []) is False
+
+    def test_no_matching_pattern_returns_false(self):
+        import mcp_server
+        assert mcp_server._is_ignored_path("src/main.py", ["vendor/", "*.min.js"]) is False
+
+
 class TestKnownFilesAtCommit:
     def test_returns_files_present_at_that_commit(self, git_repo):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2355,6 +2355,32 @@ class TestLoadIgnorePatterns:
         assert "from_env/" in patterns     # env var
         assert "from_file/" in patterns    # .temporalignore
 
+    def test_unreadable_temporalignore_fails_closed(self, tmp_path, monkeypatch):
+        """Unreadable .temporalignore should not abort ingestion; defaults + env patterns still apply."""
+        import mcp_server
+        from pathlib import Path
+
+        monkeypatch.delenv("MINIGRAF_INGEST_IGNORE", raising=False)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".temporalignore").write_text("from_file/\n")
+
+        # Monkeypatch Path.read_text to raise OSError for our .temporalignore file
+        original_read_text = Path.read_text
+
+        def mock_read_text(self, encoding=None, errors=None):
+            if ".temporalignore" in str(self):
+                raise OSError("Permission denied")
+            return original_read_text(self, encoding=encoding, errors=errors)
+
+        monkeypatch.setattr(Path, "read_text", mock_read_text)
+
+        # Should not raise; should return defaults at minimum
+        patterns = mcp_server._load_ignore_patterns(str(repo))
+        assert isinstance(patterns, list)
+        assert "vendor/" in patterns  # default should still be present
+        assert len(patterns) > 0
+
 
 class TestKnownFilesAtCommit:
     def test_returns_files_present_at_that_commit(self, git_repo):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4759,6 +4759,127 @@ class TestUnresolvedImportTagging:
         )
 
 
+class TestGitIngestionPathIgnore:
+    def _make_progress(self):
+        return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
+
+    @pytest.mark.asyncio
+    async def test_default_ignored_directory_produces_no_code_entities(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """A file under a default-ignored directory (vendor/) must not produce
+        any :type/module, :type/function, or :type/class triples."""
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "lib.py").write_text("def vendored_fn(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add vendored lib"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        vendored_module_ident = mcp_server._code_ident("module", "vendor/lib.py")
+        assert not any(vendored_module_ident in t for t in transact_calls)
+        assert not any(":entity-type :type/function" in t for t in transact_calls)
+        assert not any(":entity-type :type/class" in t for t in transact_calls)
+
+    @pytest.mark.asyncio
+    async def test_import_into_ignored_path_becomes_external_dependency(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """Before this feature, vendor/foo.py would resolve as a normal in-tree
+        module (see _resolve_module_import's segment-suffix matcher) and
+        main.py's import of it would create an internal :depends-on edge, not
+        an external-dependency entity. Excluding vendor/ from known_files must
+        make it fall through to the same fallback used for real external
+        packages (see TestUnresolvedImportTagging)."""
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "foo.py").write_text("def helper(): pass\n")
+        (repo / "main.py").write_text("import vendor.foo\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add vendor and main"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        external_ident = mcp_server._canonical_ident("module", "vendor.foo")
+        assert any(
+            f"[{external_ident} :entity-type :type/external-dependency]" in t for t in transact_calls
+        )
+
+    @pytest.mark.asyncio
+    async def test_env_var_ignore_pattern_excludes_custom_directory(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """MINIGRAF_INGEST_IGNORE must add to the default ignore list, not
+        replace it — a custom pattern not in the built-in defaults must still
+        be honored."""
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "generated").mkdir()
+        (repo / "generated" / "codegen.py").write_text("def generated_fn(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add generated file"], cwd=repo, check=True, capture_output=True)
+
+        monkeypatch.setenv("MINIGRAF_INGEST_IGNORE", "generated/")
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        transact_calls: list = []
+        real_ingest_transact = mcp_server._ingest_transact
+
+        def capture_transact(db, triples, ts_iso, reason=""):
+            transact_calls.extend(triples)
+            return real_ingest_transact(db, triples, ts_iso, reason)
+
+        monkeypatch.setattr(mcp_server, "_ingest_transact", capture_transact)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        generated_module_ident = mcp_server._code_ident("module", "generated/codegen.py")
+        assert not any(generated_module_ident in t for t in transact_calls)
+
+
 class TestResolveModuleImportTieredMatcher:
     def test_exact_file_match_java_package(self):
         import mcp_server


### PR DESCRIPTION
## Summary

- Add `_is_ignored_path`, a pure glob/prefix matcher (no new dependency) — a trailing `/` matches a directory name anywhere in the path, `*`/`?`/`[` patterns glob against the basename or full path, anything else matches an exact path segment or basename.
- Add `_load_ignore_patterns`, which merges built-in defaults (`3rdParty/`, `third_party/`, `vendor/`, `node_modules/`, `dist/`, `build/`, `*.min.js`, `*.map`) + the `MINIGRAF_INGEST_IGNORE` env var (comma-separated) + an optional repo-local `.temporalignore` file, resolved once per ingestion run (not re-read per historical commit). Fails closed on an unreadable/undecodable `.temporalignore`, matching this file's existing `_parse_gitmodules` convention.
- `_known_files_at_commit` and `_extract_commit` both gain an `ignore_patterns: Sequence[str] = ()` parameter (default preserves all 10 pre-existing call sites unchanged) that excludes/skips matching paths — `_extract_commit` skips ignored files *before* `_thread_parser` runs, so they cost zero tree-sitter parse time.
- `_run_ingestion` resolves the pattern list once and threads it through the `ProcessPoolExecutor` submission call to `_extract_commit` as a plain picklable list (required since #116's spawn-context workers don't share parent-process state).

**Key architectural decision:** excluding a vendored path from `_known_files_at_commit`'s known-files set means an in-repo import into that path can no longer resolve via `_resolve_module_import`'s internal segment-suffix matcher, so it automatically falls through to the *pre-existing, unmodified* unresolved-import fallback that tags a `:type/external-dependency` entity — the same mechanism already used for real external packages and gitlink submodules. No new entity-creation code was added anywhere.

Scope is forward-only: no retroactive purge/backfill of vendored entities already ingested before this feature existed.

Design spec: `docs/superpowers/specs/2026-07-14-git-ingestion-path-ignore-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-14-git-ingestion-path-ignore.md`

Fixes #115

## Test plan

- [x] 23 new tests across matcher, config loader, `_known_files_at_commit`, `_extract_commit`, and end-to-end `_run_ingestion` scenarios (default-ignored directory produces zero code entities, import into an ignored path becomes `:type/external-dependency`, `MINIGRAF_INGEST_IGNORE` env var honored)
- [x] Full suite: 352 passed, 38 skipped, 0 regressions vs. a 329-passed/38-skipped pre-feature baseline
- [x] Task-by-task subagent review (6 tasks, all approved) + final whole-branch review (Ready to merge: Yes, 0 Critical/Important — one Minor fail-closed hardening applied, two other Minor items are explicitly by-design per the spec's forward-only/no-negation non-goals)
- [x] `SKILL.md` updated to document `MINIGRAF_INGEST_IGNORE` and `.temporalignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYLgnPb8M3nVDZro7ikcuY