### PR TITLE
Git ingestion rename/move tracking + global/field extraction (fixes #111, #113)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -421,7 +421,7 @@ Ident: `:module/<slugified-path-or-import-name>` (shares the module ident namesp
 
 Vendored-in-tree code checked in as regular files (not a git submodule) is parsed as ordinary `:type/module`/`:function`/`:class` entities like any first-party code — only real gitlinks (mode `160000`) and genuinely-unresolved imports get the external marker.
 
-**Supported languages for AST extraction:** Python, JavaScript, TypeScript (+ TSX/JSX), Rust, Go, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Scala, Haskell, Lua, Elixir. Files in other languages are tracked as modules (with `:introduced-by`/`:modified-in`) but yield no function or class entities.
+**Supported languages for AST extraction:** Python, JavaScript, TypeScript (+ TSX/JSX), Rust, Go, Java, C, C++, C#, Ruby, PHP, Kotlin, Swift, Scala, Haskell, Lua, Elixir. Files in other languages are tracked as modules (with `:introduced-by`/`:modified-in`) but yield no function, class, variable, or field entities.
 
 **Pre-registered SESSION_RULES** — these are always available; no `minigraf_rule` call needed:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -108,7 +108,7 @@ Only mint a new ident if the entity is genuinely new.
 
 Canonical ident form: lowercase, hyphens only — `:decision/redis` not `:decision/Redis_cache`.
 
-Allowed entity types: `:decision/`, `:preference/`, `:constraint/`, `:dependency/`, `:module/`, `:function/`, `:class/` (code structure — auto-ingested); `:commit/`, `:tag/`, `:ingestion/` are system-only (written by `minigraf_ingest_git`), do not write to them directly
+Allowed entity types: `:decision/`, `:preference/`, `:constraint/`, `:dependency/`, `:module/`, `:function/`, `:class/`, `:variable/`, `:field/` (code structure — auto-ingested); `:commit/`, `:tag/`, `:ingestion/` are system-only (written by `minigraf_ingest_git`), do not write to them directly
 Required attribute on all types: `:description`
 Optional attributes: `:rationale`, `:date`, `:alias`
 
@@ -346,8 +346,9 @@ Ident: `:module/<slugified-file-path>`
 | `:path` | file path |
 | `:introduced-by` (keyword ref) | commit that first added this file |
 | `:modified-in` (keyword ref) | one edge per subsequent modifying commit |
-| `:contains` (keyword ref) | functions and classes defined in this file |
+| `:contains` (keyword ref) | functions, classes, variables, and fields defined in this file |
 | `:depends-on` (keyword ref) | modules this file imports — tracked per-commit with full valid-time bounds: `:valid-from` = commit that introduced the import, `:valid-to` = commit that removed it (open-ended if still present) |
+| `:renamed-from` / `:renamed-to` (keyword ref) | rename/move continuity — see below |
 
 #### `:type/function` — one per top-level function or method
 Ident: `:function/<slugified-path-name>` (file path + `::` + function name, slugified together)
@@ -358,6 +359,7 @@ Ident: `:function/<slugified-path-name>` (file path + `::` + function name, slug
 | `:file` | source file path |
 | `:introduced-by` (keyword ref) | commit that first defined this function |
 | `:modified-in` (keyword ref) | one edge per subsequent modifying commit |
+| `:renamed-from` / `:renamed-to` (keyword ref) | rename/move continuity — see below |
 
 #### `:type/class` — one per class, struct, or type definition (same ident convention as function)
 
@@ -367,6 +369,33 @@ Ident: `:function/<slugified-path-name>` (file path + `::` + function name, slug
 | `:file` | source file path |
 | `:introduced-by` (keyword ref) | commit that first defined this class |
 | `:modified-in` (keyword ref) | one edge per subsequent modifying commit |
+| `:renamed-from` / `:renamed-to` (keyword ref) | rename/move continuity — see below |
+
+#### `:type/variable` — one per module-level global (same ident convention as function)
+
+| Attribute | Notes |
+|---|---|
+| `:description` | variable name |
+| `:file` | source file path |
+| `:introduced-by` (keyword ref) | commit that first defined this global |
+| `:modified-in` (keyword ref) | one edge per subsequent modifying commit |
+| `:renamed-from` / `:renamed-to` (keyword ref) | rename/move continuity — see below |
+
+#### `:type/field` — one per class/struct member, instance or static (ident convention: file path + `::` + `<ClassName>.<fieldName>`, slugified together)
+
+| Attribute | Notes |
+|---|---|
+| `:description` | `"<ClassName>.<fieldName>"` |
+| `:file` | source file path |
+| `:class` (keyword ref) | the owning class/struct entity |
+| `:static` | `true`/`false` — whether this is a static (class-level) field vs. an instance field |
+| `:introduced-by` (keyword ref) | commit that first defined this field |
+| `:modified-in` (keyword ref) | one edge per subsequent modifying commit |
+| `:renamed-from` / `:renamed-to` (keyword ref) | rename/move continuity — see below |
+
+**Rename/move continuity (`:renamed-from` / `:renamed-to`):** all five code entity types (module, function, class, variable, field) can carry these. When ingestion detects a rename — a file rename/move (via git's own `-M` similarity detection) or a function/class/global/field rename (via a custom AST-based matcher tolerant of local-variable renames) — the old entity is closed as usual but also gets `:renamed-to` pointing at the new entity's ident, and the new entity gets `:renamed-from` pointing back at the old one. This lets a query traverse continuous history across a rename that would otherwise look like an unrelated deletion followed by an unrelated creation.
+
+**Supported languages for `:type/variable`/`:type/field` extraction:** the same full language list as function/class extraction — see "Supported languages for AST extraction" below.
 
 #### `:type/tag` — one per git tag (system-only, not audited)
 Ident: `:tag/<slugified-tag-name>`

--- a/docs/superpowers/plans/2026-07-14-git-ingestion-rename-tracking.md
+++ b/docs/superpowers/plans/2026-07-14-git-ingestion-rename-tracking.md
@@ -1,0 +1,3449 @@
+# Git Ingestion Rename/Move Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make git ingestion track file/function/class/global/field renames and moves as continuous history instead of fracturing them into disconnected entities, and add global/field/static extraction (16 languages) as the entity types renames need to attach to.
+
+**Architecture:** Four components sharing a single `:renamed-from`/`:renamed-to` schema addition: (1) file-level rename detection via git's own `-M`, (2) a custom AST-lockstep matcher with local-variable bijection for function/class/global/field renames (below git's diff granularity), (3) new `:type/variable`/`:type/field` entity extraction across 16 languages via a new scope-aware traversal (not the existing naive full-tree walker), (4) rename tracking for the new entity types, reusing component 2's matcher.
+
+**Tech Stack:** Python 3.10+, tree-sitter (16 grammar packages, already installed in `.venv`), pytest/pytest-asyncio, minigraf (Rust-backed Datalog graph store via `mcp_server.py`'s `MiniGrafDb` wrapper).
+
+## Global Constraints
+
+- All new code lives in `mcp_server.py` — this codebase keeps everything in one file by established precedent (confirmed via the #115 path-ignore feature, which added its new functions directly into `mcp_server.py` rather than a new module). Do not create new files for source code.
+- Tests live in `tests/test_mcp_server.py` — same single-file precedent.
+- No new third-party dependencies. Everything here is buildable with the stdlib + already-installed `tree-sitter` + already-installed per-language grammar packages (`pyproject.toml`'s `git-ingestion` extra).
+- `minigraf`'s Datalog grammar has real boolean literals (`true`/`false`, unquoted) — confirmed via `minigraf/src/query/datalog/parser.rs:209-210,402-404`. `:static` must be declared `bool` in `MINIGRAF_SCHEMA` and written as a bare literal (e.g. `f"[{ident} :static {'true' if is_static else 'false'}]"`), matching the existing bare-int pattern already used for `:total-ingested` at `mcp_server.py:1886`. Do not quote it as a string.
+- `_extract_commit` (mcp_server.py:3115-3191) runs in a `ProcessPoolExecutor` worker (spawn context, see #116) — anything it returns must be plain, picklable data (strings, ints, bools, lists, dicts, tuples). Never return a `tree_sitter.Node`/`Tree` object across that boundary.
+- Every new git subprocess call must follow the existing pattern: `_subprocess.run([...], cwd=repo_path, capture_output=True, ...)`, matching every existing helper (`_git_commits`, `_git_diff_tree_raw`, `_git_file_content`, etc.).
+- Follow TDD: write the failing test first, run it, confirm the failure reason, then implement, then confirm green. Commit after each task.
+- Run the full suite (`pytest tests/test_mcp_server.py -q`) at the end of every phase (not just every task) to catch cross-task regressions early — the phases are listed in the task table below.
+
+## File structure
+
+Everything is additive or modifies existing functions/tests in-place:
+
+| File | Role |
+|---|---|
+| `mcp_server.py` | All new functions, schema entries, and modifications to existing pipeline functions |
+| `tests/test_mcp_server.py` | All new/modified tests |
+| `SKILL.md` | Docs for the new entity types and `:renamed-from`/`:renamed-to` attributes |
+
+## Task Overview (execute in this order — later tasks depend on earlier ones)
+
+| # | Task | Phase |
+|---|---|---|
+| 1 | Schema: `:renamed-from`/`:renamed-to` + `:type/variable`/`:type/field` | Foundations |
+| 2 | `_git_blob_content` helper | Foundations |
+| 3 | `-M` flag + raw-diff parser fix (7-tuple with `old_path`) | Component 1 |
+| 4 | `_extract_commit` R-status branch | Component 1 |
+| 5 | Module-level rename triples in `_run_ingestion` + flip existing test | Component 1 |
+| 6 | Capture function/class body text in extraction | Component 2 |
+| 7 | AST-lockstep bijective matcher (single-pair core) | Component 2 |
+| 8 | Round-based match orchestration | Component 2 |
+| 9 | Wire matcher into `_extract_commit` (fetch old blobs, build pools) | Component 2 |
+| 10 | Consume confirmed pairs in `_run_ingestion`, emit rename triples | Component 2 |
+| 11 | Generic `:type/variable`/`:type/field` plumbing (language-agnostic) | Component 3 |
+| 12 | Scope-aware traversal skeleton + per-language dispatch table | Component 3 |
+| 13 | Python globals/fields | Component 3 |
+| 14 | JavaScript + TypeScript globals/fields | Component 3 |
+| 15 | Rust + Go + C globals/fields | Component 3 |
+| 16 | Java + C# globals/fields | Component 3 |
+| 17 | C++ globals/fields | Component 3 |
+| 18 | Ruby globals/fields | Component 3 |
+| 19 | PHP globals/fields | Component 3 |
+| 20 | Kotlin globals/fields | Component 3 |
+| 21 | Swift globals/fields | Component 3 |
+| 22 | Scala globals/fields | Component 3 |
+| 23 | Haskell globals/fields | Component 3 |
+| 24 | Lua globals (no fields) | Component 3 |
+| 25 | Elixir fields (no globals) | Component 3 |
+| 26 | Extend matcher pools to globals/fields | Component 4 |
+| 27 | Wire global/field rename triples | Component 4 |
+| 28 | SKILL.md docs | Wrap-up |
+| 29 | Full suite regression + PR | Wrap-up |
+
+---
+
+## Task 1: Schema — `:renamed-from`/`:renamed-to` and new entity types
+
+**Files:**
+- Modify: `mcp_server.py:1894-1947` (`MINIGRAF_SCHEMA`)
+- Test: `tests/test_mcp_server.py` (new test near existing schema tests — search `MINIGRAF_SCHEMA` in the test file to find the right neighborhood)
+
+**Interfaces:**
+- Produces: `MINIGRAF_SCHEMA["variable"]`, `MINIGRAF_SCHEMA["field"]`, and `:renamed-from`/`:renamed-to` optional keys on `"module"`, `"function"`, `"class"`, `"variable"`, `"field"`. Every later task that writes a rename triple relies on these existing.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_schema_has_renamed_from_and_to_on_code_entities():
+    import mcp_server
+    for entity_type in ("module", "function", "class", "variable", "field"):
+        optional = mcp_server.MINIGRAF_SCHEMA[entity_type]["optional"]
+        assert optional[":renamed-from"] is str
+        assert optional[":renamed-to"] is str
+
+def test_schema_has_variable_and_field_types():
+    import mcp_server
+    assert mcp_server.MINIGRAF_SCHEMA["variable"]["required"][":description"] is str
+    field_optional = mcp_server.MINIGRAF_SCHEMA["field"]["optional"]
+    assert field_optional[":static"] is bool
+    assert field_optional[":class"] is str
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "schema_has_renamed_from or schema_has_variable_and_field" -v`
+Expected: FAIL with `KeyError: 'variable'` (or similar — the type doesn't exist yet).
+
+- [ ] **Step 3: Implement**
+
+Replace `mcp_server.py:1911-1934` (the `module`/`function`/`class` blocks) and insert two new blocks after `class`, before `ingestion`:
+
+```python
+    "module": {
+        "required": {":description": str},
+        "optional": {
+            ":path": str, ":alias": str,
+            # graph edges (keyword-valued, stored as strings)
+            ":contains": str, ":depends-on": str, ":calls": str,
+            # commit cross-references
+            ":introduced-by": str, ":modified-in": str,
+            # rename/move continuity (see 2026-07-14 rename-tracking design doc)
+            ":renamed-from": str, ":renamed-to": str,
+        },
+    },
+    "function": {
+        "required": {":description": str},
+        "optional": {
+            ":file": str, ":alias": str,
+            ":introduced-by": str, ":modified-in": str,
+            ":renamed-from": str, ":renamed-to": str,
+        },
+    },
+    "class": {
+        "required": {":description": str},
+        "optional": {
+            ":file": str, ":alias": str,
+            ":introduced-by": str, ":modified-in": str,
+            ":renamed-from": str, ":renamed-to": str,
+        },
+    },
+    "variable": {
+        "required": {":description": str},
+        "optional": {
+            ":file": str, ":alias": str,
+            ":introduced-by": str, ":modified-in": str,
+            ":renamed-from": str, ":renamed-to": str,
+        },
+    },
+    "field": {
+        "required": {":description": str},
+        "optional": {
+            ":file": str, ":alias": str, ":class": str, ":static": bool,
+            ":introduced-by": str, ":modified-in": str,
+            ":renamed-from": str, ":renamed-to": str,
+        },
+    },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "schema_has_renamed_from or schema_has_variable_and_field" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add :type/variable, :type/field, and rename-tracking schema attrs"
+```
+
+---
+
+## Task 2: `_git_blob_content` helper
+
+**Files:**
+- Modify: `mcp_server.py` (add near `_git_file_content`, line 1577-1583)
+- Test: `tests/test_mcp_server.py` (near existing `_git_file_content` tests — grep `_git_file_content` in the test file)
+
+**Interfaces:**
+- Produces: `_git_blob_content(repo_path: str, blob_sha: str) -> bytes`. Used by Task 9 to fetch a file's *old* content directly by blob SHA (already returned by `_git_diff_tree_raw` as `old_sha`), without needing to know the parent commit hash.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_git_blob_content_returns_raw_bytes(git_repo):
+    import mcp_server
+    commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+    entries = mcp_server._git_diff_tree_raw(str(git_repo), commits[0][0])
+    _, _, _, _, new_sha, _ = entries[0][:6]
+    content = mcp_server._git_blob_content(str(git_repo), new_sha)
+    assert b"def login" in content
+```
+
+(Reuses the existing `git_repo` fixture, defined earlier in the file — grep `def git_repo(` to confirm its exact contents; it's the repo with `auth.py` containing `def login()`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_git_blob_content_returns_raw_bytes -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_git_blob_content'`
+
+- [ ] **Step 3: Implement**
+
+Insert directly after `_git_file_content` (mcp_server.py:1577-1583):
+
+```python
+def _git_blob_content(repo_path: str, blob_sha: str) -> bytes:
+    """Return raw bytes of a blob by its own SHA, independent of any commit/path.
+
+    Used to fetch a file's *old* content directly from _git_diff_tree_raw's
+    old_sha field (a plain blob SHA) when comparing pre/post rename or
+    modification content — cheaper than resolving a parent commit hash and
+    re-deriving the old path, and correct even when the old path no longer
+    exists at any reachable commit-ish (e.g. mid-history rewrites).
+    """
+    result = _subprocess.run(
+        ["git", "cat-file", "blob", blob_sha],
+        cwd=repo_path, capture_output=True, check=True,
+    )
+    return result.stdout
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_git_blob_content_returns_raw_bytes -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add _git_blob_content helper for direct blob-SHA fetches"
+```
+
+---
+
+## Task 3: Enable `-M` and fix two-path raw-diff parsing
+
+**Files:**
+- Modify: `mcp_server.py:1489-1513` (`_git_diff_tree_raw`)
+- Modify: `mcp_server.py:1519-1548` (`_gitlink_changes` — unpack gains a 7th field)
+- Modify: `mcp_server.py:3164` (`_extract_commit`'s loop — unpack gains a 7th field; behavior change is Task 4)
+- Test: `tests/test_mcp_server.py:2210-2253` (`TestGitDiffTreeRaw` — existing 2 tests need the unpack updated; new rename tests added)
+
+**Interfaces:**
+- Produces: `_git_diff_tree_raw` now returns 7-tuples `(status, old_mode, new_mode, old_sha, new_sha, path, old_path)`. `old_path` is `""` for every status except `"R"`, where it holds the pre-rename path and `path` holds the post-rename path. `status` for a rename is still just `"R"` (the numeric similarity suffix, e.g. `R100`/`R057`, is dropped the same way it always was for other statuses — Task 4 needs the exact similarity score, so also return it: extend to an 8-tuple with `similarity: Optional[int]`, `None` for non-rename statuses).
+- Consumes (must update): `_gitlink_changes`, `_extract_commit`'s per-file loop.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TestGitDiffTreeRaw` (mcp_server.py:2210), and update the two existing tests' unpacking:
+
+```python
+    def test_regular_file_add(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(git_repo), commits[0][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
+        assert status == "A"
+        assert old_mode == "000000"
+        assert new_mode == "100644"
+        assert path == "auth.py"
+        assert old_path == ""
+        assert similarity is None
+
+    def test_gitlink_add_reports_mode_160000(self, tmp_path):
+        # ... (unchanged body up to the assertions) ...
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(repo), commits[0][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
+        assert status == "A"
+        assert new_mode == "160000"
+        assert new_sha == sub_hash
+        assert path == "vendor/lib"
+        assert old_path == ""
+
+    def test_pure_rename_reports_both_paths_and_similarity(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_name.py").write_text("def login():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "old_name.py", "new_name.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(repo), commits[1][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
+        assert status == "R"
+        assert path == "new_name.py"
+        assert old_path == "old_name.py"
+        assert similarity == 100
+
+    def test_rename_with_content_change_reports_partial_similarity(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_name.py").write_text(
+            "def login():\n    pass\n\ndef a():\n    pass\n\ndef b():\n    pass\n\ndef c():\n    pass\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "old_name.py", "new_name.py"], cwd=repo, check=True, capture_output=True)
+        (repo / "new_name.py").write_text(
+            "def login():\n    pass\n\ndef a():\n    pass\n\ndef extra():\n    pass\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename and edit"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(repo), commits[1][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
+        assert status == "R"
+        assert old_path == "old_name.py"
+        assert path == "new_name.py"
+        assert similarity is not None and 0 < similarity < 100
+
+    def test_unrelated_add_and_delete_not_reported_as_rename(self, tmp_path):
+        """Below git's default 50% similarity threshold, -M must NOT report a rename."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_name.py").write_text("def login():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "rm", "old_name.py"], cwd=repo, check=True, capture_output=True)
+        (repo / "unrelated.py").write_text("class Widget:\n    def render(self):\n        return 42\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "unrelated churn"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(repo), commits[1][0])
+        statuses = {e[0] for e in entries}
+        assert statuses == {"A", "D"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestGitDiffTreeRaw -v`
+Expected: FAIL — `test_regular_file_add`/`test_gitlink_add_reports_mode_160000` fail with `ValueError: not enough values to unpack` (currently 6-tuples); the new rename tests fail with the same or `AssertionError` since `-M` isn't enabled yet (renames currently show as separate `A`/`D`).
+
+- [ ] **Step 3: Implement**
+
+Replace `_git_diff_tree_raw` (mcp_server.py:1489-1513):
+
+```python
+def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
+    """Return (status_char, old_mode, new_mode, old_sha, new_sha, path, old_path,
+    similarity) for every changed path in a commit, via a single
+    `git diff-tree --raw` call.
+
+    -M enables git's own content-similarity rename detection (default 50%
+    threshold, unchanged — see the 2026-07-14 rename-tracking design doc's
+    "Component 1" for why no additional threshold filtering is applied on
+    top of git's own judgment). Deliberately no -C (copy detection) — a copy
+    leaves the original in place *and* creates a new, independent entity;
+    treating it as a rename would misrepresent history.
+
+    A rename/copy raw line has TWO tab-separated paths (old, then new), not
+    one, e.g. ":100644 100644 <sha> <sha> R100\told.py\tnew.py" — naively
+    keeping the old single-partition parse would fold both paths into one
+    bogus string. old_path is "" for every non-rename status. similarity is
+    the numeric suffix of the status (e.g. 100 for "R100", 57 for "R057"),
+    None for non-rename statuses.
+
+    Supersedes running diff-tree a second time just to detect gitlinks:
+    --raw already carries file mode (needed to spot submodule paths, mode
+    160000) in the same subprocess invocation _extract_commit already makes.
+    """
+    result = _subprocess.run(
+        ["git", "diff-tree", "--no-commit-id", "-r", "-M", "--raw", "--root", commit_hash],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    entries = []
+    for line in result.stdout.strip().splitlines():
+        if not line.startswith(":"):
+            continue
+        meta, sep, rest = line.partition("\t")
+        if not sep:
+            continue
+        fields = meta[1:].split(" ")
+        if len(fields) < 5:
+            continue
+        old_mode, new_mode, old_sha, new_sha, status_field = fields[0], fields[1], fields[2], fields[3], fields[4]
+        status = status_field[0]
+        similarity = int(status_field[1:]) if len(status_field) > 1 and status_field[1:].isdigit() else None
+        if status in ("R", "C"):
+            old_path, _, path = rest.partition("\t")
+        else:
+            old_path, path = "", rest
+        entries.append((status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity))
+    return entries
+```
+
+Update `_gitlink_changes` (mcp_server.py:1519-1548) — only the loop header changes, body is untouched (gitlinks are never renamed via this path in practice; `old_path`/`similarity` are simply unused here):
+
+```python
+    for status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity in raw_entries:
+```
+
+Update `_extract_commit`'s loop header (mcp_server.py:3164) the same way — the body's behavior change (handling `status == "R"`) is Task 4, this step only fixes the unpack so the function doesn't crash:
+
+```python
+    for status, old_mode, new_mode, old_sha, new_sha, file_path, old_path, similarity in raw_entries:
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "TestGitDiffTreeRaw or TestExtractCommit or Gitlink" -v`
+Expected: PASS. Also run the broader suite once to catch any other 6-tuple unpack site: `.venv/bin/pytest tests/test_mcp_server.py -q 2>&1 | tail -30` — if anything else unpacks a 6-tuple from `_git_diff_tree_raw`'s output, it will now raise `ValueError`; grep `_git_diff_tree_raw` across `mcp_server.py` and `tests/test_mcp_server.py` to find and fix every call site before moving on.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: enable git -M rename detection, fix two-path raw-diff parsing"
+```
+
+---
+
+## Task 4: `_extract_commit` R-status branch
+
+**Files:**
+- Modify: `mcp_server.py:3115-3191` (`_extract_commit`)
+- Test: near existing `_extract_commit` tests — grep `class TestExtractCommit` in the test file
+
+**Interfaces:**
+- Consumes: Task 3's 8-tuple raw entries.
+- Produces: `_extract_commit`'s returned `results` list gains a 5th tuple element for R-status entries: `(status, file_path, extracted, precomputed, old_path)`. For A/M/D entries, `old_path` is `""` (keeps the tuple shape uniform across all entries — simpler for `_run_ingestion` to consume than a variable-arity tuple).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestExtractCommitRename:
+    def test_rename_status_extracts_new_path_and_tags_old_path(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_name.py").write_text("def login():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "old_name.py", "new_name.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(repo), commits[1][0])[:3]
+        assert len(results) == 1
+        status, file_path, extracted, precomputed, old_path = mcp_server._extract_commit(str(repo), commits[1][0])[0][0]
+        assert status == "R"
+        assert file_path == "new_name.py"
+        assert old_path == "old_name.py"
+        assert "login" in extracted["functions"]
+
+    def test_non_rename_status_has_empty_old_path(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        results = mcp_server._extract_commit(str(git_repo), commits[0][0])[0]
+        status, file_path, extracted, precomputed, old_path = results[0]
+        assert status == "A"
+        assert old_path == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestExtractCommitRename -v`
+Expected: FAIL — `ValueError: not enough values to unpack` (results tuples are still 4-wide) or the rename simply isn't extracted at all (falls into the generic add/modify branch's `git show <hash>:new_name.py` call, which actually still works fine by coincidence since `file_path` is already just the new path post-Task-3-fix — but `old_path` won't be threaded through, so the 5-tuple unpack fails).
+
+- [ ] **Step 3: Implement**
+
+Replace the loop body in `_extract_commit` (mcp_server.py:3164-3184):
+
+```python
+    for status, old_mode, new_mode, old_sha, new_sha, file_path, old_path, similarity in raw_entries:
+        if _is_ignored_path(file_path, ignore_patterns):
+            continue
+        parser = _thread_parser(file_path)
+        if parser is None:
+            continue
+        if status == "D":
+            results.append((status, file_path, None, None, ""))
+            continue
+        try:
+            content = _git_file_content(repo_path, commit_hash, file_path)
+        except Exception:
+            continue
+        extracted = _extract_from_source(content, parser, file_path)
+        if known_files is None:
+            known_files = _known_files_at_commit(repo_path, commit_hash, ignore_patterns)
+            segment_index = _SegmentSuffixIndex(known_files)
+        precomputed = _precompute_file_triples(
+            file_path, extracted, commit_ident, known_files, segment_index=segment_index,
+        )
+        results.append((status, file_path, extracted, precomputed, old_path if status == "R" else ""))
+```
+
+(Only two lines actually changed: the loop header gains `old_path, similarity`, and both `results.append` calls gain a 5th element. Everything else — the ignored-path skip, the parser lookup, the `git show` fetch, extraction, and precomputation — is identical to today's add/modify handling; a rename's new-path content is extracted exactly like a plain add, which is correct: the entity really does need to be introduced under its new ident.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "TestExtractCommitRename or TestExtractCommit" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract rename entries with new-path content and old_path tag"
+```
+
+---
+
+## Task 5: Module-level rename triples in `_run_ingestion` + flip existing test
+
+**Files:**
+- Modify: `mcp_server.py:3194-3563` (`_run_ingestion` — specifically the per-file loop around 3353-3424, and the unpack at line 3328)
+- Modify: `tests/test_mcp_server.py:4572-4597` (`test_renamed_file_closes_old_entities_and_opens_new` — flip assertions)
+
+**Interfaces:**
+- Consumes: Task 4's 5-tuple `extracted_files` entries.
+- Produces: for a status-`"R"` file, `add_triples` gains `[{new_module_ident} :renamed-from {old_module_ident}]`, and the corresponding close entry for the old module ident gains `:renamed-to {new_module_ident}`. This is the first end-to-end rename-triple emission in the plan — later tasks (10, 27) follow the identical pattern for functions/classes/globals/fields.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace `test_renamed_file_closes_old_entities_and_opens_new` (tests/test_mcp_server.py:4572-4597):
+
+```python
+    @pytest.mark.asyncio
+    async def test_renamed_file_links_old_and_new_via_rename_edges(
+        self, mock_minigraf_db, git_repo_with_rename, monkeypatch
+    ):
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(git_repo_with_rename / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(git_repo_with_rename), "HEAD")
+
+        old_module_ident = mcp_server._code_ident("module", "old_auth.py")
+        new_module_ident = mcp_server._code_ident("module", "new_auth.py")
+        new_fn_ident = mcp_server._code_ident("function", "new_auth.py", "login")
+
+        assert any(old_module_ident in t for t in close_triples_seen), \
+            "Old module entities must still be closed when file is renamed"
+        assert any(f"{old_module_ident} :renamed-to {new_module_ident}" in t for t in close_triples_seen), \
+            "Old module's close triples must include :renamed-to pointing at the new ident"
+
+        transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
+        assert new_fn_ident in transact_calls, \
+            "New module's entities must still be created after file is renamed"
+        assert f"{new_module_ident} :renamed-from {old_module_ident}" in transact_calls, \
+            "New module's open triples must include :renamed-from pointing at the old ident"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_renamed_file_links_old_and_new_via_rename_edges -v`
+Expected: FAIL — no `:renamed-to`/`:renamed-from` triples exist anywhere yet.
+
+- [ ] **Step 3: Implement**
+
+In `_run_ingestion`, the per-file loop unpack (mcp_server.py:3353, currently `for status, file_path, extracted, precomputed in extracted_files:`) becomes:
+
+```python
+                        for status, file_path, extracted, precomputed, old_path in extracted_files:
+```
+
+Immediately after the existing `else:  # A or M` branch's body finishes (i.e., right after the dependency-edge block that ends at mcp_server.py:3424, still inside the same `for` iteration, so it only runs for this one file), add the module-rename branch. The cleanest insertion point is right after the initial `if status == "D": ... else:  # A or M` split — change the condition to a three-way branch. Concretely, mcp_server.py:3353-3371 (the `if status == "D":` block) stays as-is; change line 3371's `else:  # A or M` to also handle rename linkage. Insert this block as the FIRST statement inside the existing `else:  # A or M` branch (mcp_server.py:3371), before `previous_idents = set(...)`:
+
+```python
+                            else:  # A or M or R
+                                if status == "R" and old_path:
+                                    old_module_ident = _code_ident("module", old_path)
+                                    new_module_ident = _code_ident("module", file_path)
+                                    add_triples.append(f"[{new_module_ident} :renamed-from {old_module_ident}]")
+                                    old_desc = entity_descriptions.get(old_module_ident, old_path)
+                                    orig_ts = entity_valid_from.get(old_module_ident, commit_ts_iso)
+                                    close_items.append((
+                                        _build_close_triples(old_module_ident, old_desc, old_module_ident)
+                                        + [f"[{old_module_ident} :renamed-to {new_module_ident}]"],
+                                        orig_ts,
+                                    ))
+                                previous_idents = set(file_entities.get(file_path, []))
+```
+
+(The rest of the `else` branch — `triples = _build_code_triples(...)` through the end of the dependency-edge handling — is unchanged. Note this only closes/links the *module* ident; the old module's child functions/classes are NOT separately closed here — Task 4 already ensures `file_entities[old_path]` still holds their idents from when the file was ingested under its old name, and since nothing in this task touches `file_entities[old_path]`, those child idents are simply left dangling as still-open in the graph, attached to a now-renamed-away module ident. This is intentionally deferred to Task 10, which is the point where function/class-level continuity (including for entities that were simply carried along in a renamed file, untouched) gets handled uniformly for both the "file renamed" and "file merely modified" cases via the same matcher — don't try to close old-path child entities here; Task 10 supersedes this gap.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_renamed_file_links_old_and_new_via_rename_edges -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full bitemporal-close test class to check no regression**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestRunIngestionBitemporalClose -v`
+Expected: All PASS (including the untouched deletion/intra-file-deletion tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: emit :renamed-from/:renamed-to edges for renamed modules"
+```
+
+---
+
+## Task 6: Capture function/class body text in extraction
+
+**Files:**
+- Modify: `mcp_server.py:672-725` (`_walk_ast`, `_extract_from_source`)
+- Modify: `tests/test_mcp_server.py:1835-1839` (`test_parse_error_returns_empty` — gains new empty keys)
+
+**Interfaces:**
+- Produces: `_extract_from_source`'s returned dict gains two new keys, additive (existing `"functions"`/`"classes"`/`"imports"`/`"calls"` keys are untouched): `"function_bodies": Dict[str, str]` and `"class_bodies": Dict[str, str]`, mapping entity name → its full source text (via the tree-sitter node's own `.text`, decoded). Consumed by Task 9's matcher.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+    def test_extracts_function_bodies(self):
+        import mcp_server
+        source = b"def login(user):\n    return user.ok\n"
+        result = mcp_server._extract_from_source(source, self._python_parser(), "auth.py")
+        assert "login" in result["function_bodies"]
+        assert "return user.ok" in result["function_bodies"]["login"]
+
+    def test_extracts_class_bodies(self):
+        import mcp_server
+        source = b"class User:\n    def ok(self):\n        return True\n"
+        result = mcp_server._extract_from_source(source, self._python_parser(), "models.py")
+        assert "User" in result["class_bodies"]
+        assert "def ok" in result["class_bodies"]["User"]
+```
+
+Also update `test_parse_error_returns_empty` (tests/test_mcp_server.py:1835-1839):
+
+```python
+    def test_parse_error_returns_empty(self):
+        import mcp_server
+        result = mcp_server._extract_from_source(b"def foo(): pass", None, "x.py")
+        assert result == {
+            "functions": [], "classes": [], "imports": [], "calls": [],
+            "function_bodies": {}, "class_bodies": {},
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "test_extracts_function_bodies or test_extracts_class_bodies or test_parse_error_returns_empty" -v`
+Expected: FAIL — `KeyError: 'function_bodies'` for the first two; the third fails on dict `==` (extra keys missing).
+
+- [ ] **Step 3: Implement**
+
+In `_walk_ast` (mcp_server.py:672-709), extend the two branches that already extract names:
+
+```python
+    if node.type in node_types.get("functions", set()):
+        if lang_name in ("c", "cpp"):
+            name = _c_family_function_name(node)
+            if name:
+                results["functions"].append(name)
+                results["function_bodies"][name] = node.text.decode("utf-8", errors="replace")
+        else:
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                name = name_node.text.decode("utf-8")
+                results["functions"].append(name)
+                results["function_bodies"][name] = node.text.decode("utf-8", errors="replace")
+
+    elif node.type in node_types.get("classes", set()):
+        name_node = node.child_by_field_name("name")
+        if name_node:
+            name = name_node.text.decode("utf-8")
+            results["classes"].append(name)
+            results["class_bodies"][name] = node.text.decode("utf-8", errors="replace")
+```
+
+And `_extract_from_source` (mcp_server.py:712-725), extend the initial `results` dict:
+
+```python
+def _extract_from_source(
+    source: bytes, parser: Any, file_path: str
+) -> Dict[str, Any]:
+    """Parse source bytes and extract functions, classes, imports, calls, and
+    (for functions/classes) their own full source text — the latter used by
+    the rename matcher (see _match_renamed_entities) to compare old vs. new
+    bodies. Body text is captured here, inside the worker process, because
+    tree_sitter Node objects themselves cannot cross the ProcessPoolExecutor
+    boundary (see #116) — only the decoded text can.
+    """
+    results: Dict[str, Any] = {
+        "functions": [], "classes": [], "imports": [], "calls": [],
+        "function_bodies": {}, "class_bodies": {},
+    }
+    try:
+        tree = parser.parse(source)
+        lang_name = _EXT_TO_LANG.get(Path(file_path).suffix.lower(), "")
+        _walk_ast(tree.root_node, results, lang_name)
+    except Exception:
+        pass  # best-effort; parse failures are non-fatal
+    return results
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "test_extracts_function_bodies or test_extracts_class_bodies or test_parse_error_returns_empty" -v`
+Expected: PASS. Also run the full `TestExtractFromSource*` classes to confirm the additive change didn't break anything relying on exact dict equality elsewhere: `.venv/bin/pytest tests/test_mcp_server.py -k "ExtractFromSource" -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: capture function/class body text during extraction"
+```
+
+---
+
+## Task 7: AST-lockstep bijective matcher (single-pair core)
+
+**Files:**
+- Modify: `mcp_server.py` (new function, place near `_walk_ast`/`_extract_from_source`, e.g. directly after `_extract_from_source`)
+- Test: `tests/test_mcp_server.py` (new `TestMatchCandidatePair` class)
+
+**Interfaces:**
+- Produces: `_match_candidate_pair(old_node, new_node, tracked_names: Dict[str, Optional[str]]) -> Optional[Dict[str, str]]`. `tracked_names` maps every entity name known in this commit's context to either `None` (unchanged, must appear identically) or a confirmed new name (must appear renamed). Returns the discovered local-identifier bijection (old→new) on a full match, or `None` if the two nodes don't match. This is a pure function operating on live tree-sitter nodes — must be called from the same process that parsed them (never crosses the `ProcessPoolExecutor` boundary itself; only its caller's *result*, in Task 9, does).
+- Consumes: two `tree_sitter.Node` objects from the same or different parses of the same language.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestMatchCandidatePair:
+    def _parse(self, source: str):
+        import mcp_server
+        parser = mcp_server._get_parser("test.py")
+        tree = parser.parse(source.encode())
+        # first top-level statement's node (a function_definition, in every fixture below)
+        return tree.root_node.children[0]
+
+    def test_identical_bodies_match_with_empty_bijection(self):
+        import mcp_server
+        old = self._parse("def foo(x):\n    return x + 1\n")
+        new = self._parse("def foo(x):\n    return x + 1\n")
+        result = mcp_server._match_candidate_pair(old, new, {})
+        assert result == {}
+
+    def test_renamed_local_variable_matches_via_bijection(self):
+        import mcp_server
+        old = self._parse("def foo(x):\n    y = x + 1\n    return y\n")
+        new = self._parse("def foo(x):\n    z = x + 1\n    return z\n")
+        result = mcp_server._match_candidate_pair(old, new, {})
+        assert result == {"y": "z"}
+
+    def test_inconsistent_local_rename_does_not_match(self):
+        """y is renamed to z in one spot but stays y in another -> not a valid bijection."""
+        import mcp_server
+        old = self._parse("def foo(x):\n    y = x + 1\n    return y + y\n")
+        new = self._parse("def foo(x):\n    z = x + 1\n    return z + y\n")
+        result = mcp_server._match_candidate_pair(old, new, {})
+        assert result is None
+
+    def test_tracked_entity_with_confirmed_rename_must_match_new_name(self):
+        """Body calls a helper that was itself confirmed renamed this round."""
+        import mcp_server
+        old = self._parse("def foo(x):\n    return helper_old(x)\n")
+        new = self._parse("def foo(x):\n    return helper_new(x)\n")
+        result = mcp_server._match_candidate_pair(old, new, {"helper_old": "helper_new"})
+        assert result == {}
+
+    def test_tracked_entity_without_rename_must_match_exactly(self):
+        old = self._parse("def foo(x):\n    return helper(x)\n")
+        new = self._parse("def foo(x):\n    return other(x)\n")
+        import mcp_server
+        result = mcp_server._match_candidate_pair(old, new, {"helper": None})
+        assert result is None
+
+    def test_structurally_different_bodies_do_not_match(self):
+        import mcp_server
+        old = self._parse("def foo(x):\n    return x + 1\n")
+        new = self._parse("def foo(x):\n    if x:\n        return x\n    return 1\n")
+        result = mcp_server._match_candidate_pair(old, new, {})
+        assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestMatchCandidatePair -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_match_candidate_pair'`
+
+- [ ] **Step 3: Implement**
+
+Insert directly after `_extract_from_source` (mcp_server.py, end of Task 6's edit):
+
+```python
+def _match_candidate_pair(
+    old_node: Any, new_node: Any, tracked_names: Dict[str, Optional[str]]
+) -> Optional[Dict[str, str]]:
+    """Lockstep-walk two tree-sitter nodes, allowing local (untracked)
+    identifiers to differ under a one-to-one bijective mapping.
+
+    tracked_names maps every entity name known in this commit's context to
+    either None (must appear unchanged) or a confirmed new name (must appear
+    renamed to exactly that). Any identifier NOT a key in tracked_names is
+    treated as local/unresolved and is free to differ, as long as the
+    mapping stays consistent (same old token always maps to the same new
+    token) and injective (no two distinct old tokens collapse onto one new
+    token) for THIS candidate pair only — the mapping is never reused across
+    other pairs or persisted as an entity.
+
+    Returns the discovered bijection dict on a full match (empty dict if no
+    local identifiers were involved — plain exact match is the case where
+    the bijection happens to be the identity mapping), or None if the nodes
+    don't match structurally or a tracked/bijection constraint is violated.
+    """
+    mapping: Dict[str, str] = {}
+    reverse: Dict[str, str] = {}
+
+    def walk(a: Any, b: Any) -> bool:
+        if a.type != b.type:
+            return False
+        if a.child_count == 0 and b.child_count == 0:
+            a_text = a.text.decode("utf-8", "replace")
+            b_text = b.text.decode("utf-8", "replace")
+            if a.type == "identifier" or a.type.endswith("_identifier"):
+                if a_text in tracked_names:
+                    expected = tracked_names[a_text]
+                    return b_text == (expected if expected is not None else a_text)
+                if a_text in mapping:
+                    return mapping[a_text] == b_text
+                if b_text in reverse:
+                    return False
+                mapping[a_text] = b_text
+                reverse[b_text] = a_text
+                return True
+            return a_text == b_text
+        if a.child_count != b.child_count:
+            return False
+        return all(walk(ac, bc) for ac, bc in zip(a.children, b.children))
+
+    return mapping if walk(old_node, new_node) else None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestMatchCandidatePair -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add AST-lockstep bijective matcher for a single candidate pair"
+```
+
+---
+
+## Task 8: Round-based match orchestration
+
+**Files:**
+- Modify: `mcp_server.py` (new function, directly after `_match_candidate_pair`)
+- Test: `tests/test_mcp_server.py` (new `TestMatchRenamedEntities` class)
+
+**Interfaces:**
+- Produces: `_match_renamed_entities(removed: Dict[str, List[Tuple[str, Any]]], added: Dict[str, List[Tuple[str, Any]]]) -> List[Tuple[str, str, str]]`. `removed`/`added` map a category string (`"function"`, `"class"`, `"variable"`, `"field"` — Tasks 26-27 add the latter two) to a list of `(name, tree_sitter_node)` pairs. Returns confirmed `(category, old_name, new_name)` triples. Mutates its inputs (removes matched entries) — callers that need the leftover unmatched entries after the call can still read them from the now-shrunk `removed`/`added` dicts.
+- Consumes: `_match_candidate_pair` (Task 7).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestMatchRenamedEntities:
+    def _parse_fn(self, source: str):
+        import mcp_server
+        parser = mcp_server._get_parser("test.py")
+        tree = parser.parse(source.encode())
+        return tree.root_node.children[0]
+
+    def test_simple_rename_matched(self):
+        import mcp_server
+        old = self._parse_fn("def foo(x):\n    return x + 1\n")
+        new = self._parse_fn("def bar(x):\n    return x + 1\n")
+        removed = {"function": [("foo", old)]}
+        added = {"function": [("bar", new)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert matches == [("function", "foo", "bar")]
+        assert removed["function"] == []
+        assert added["function"] == []
+
+    def test_cascading_mutual_rename_resolves_across_rounds(self):
+        """A calls B; both A and B are renamed in the same commit."""
+        import mcp_server
+        old_a = self._parse_fn("def a(x):\n    return b(x) + 1\n")
+        old_b = self._parse_fn("def b(x):\n    return x * 2\n")
+        new_a1 = self._parse_fn("def a1(x):\n    return b1(x) + 1\n")
+        new_b1 = self._parse_fn("def b1(x):\n    return x * 2\n")
+        removed = {"function": [("a", old_a), ("b", old_b)]}
+        added = {"function": [("a1", new_a1), ("b1", new_b1)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert ("function", "a", "a1") in matches
+        assert ("function", "b", "b1") in matches
+        assert len(matches) == 2
+
+    def test_ambiguous_duplicate_bodies_not_matched(self):
+        import mcp_server
+        old1 = self._parse_fn("def stub1():\n    pass\n")
+        old2 = self._parse_fn("def stub2():\n    pass\n")
+        new1 = self._parse_fn("def stub3():\n    pass\n")
+        new2 = self._parse_fn("def stub4():\n    pass\n")
+        removed = {"function": [("stub1", old1), ("stub2", old2)]}
+        added = {"function": [("stub3", new1), ("stub4", new2)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert matches == []
+        assert len(removed["function"]) == 2
+        assert len(added["function"]) == 2
+
+    def test_below_minimum_size_not_matched(self):
+        import mcp_server
+        old = self._parse_fn("def x():\n    pass\n")
+        new = self._parse_fn("def y():\n    pass\n")
+        removed = {"function": [("x", old)]}
+        added = {"function": [("y", new)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert matches == []
+
+    def test_cross_category_no_match(self):
+        """A function and a class with coincidentally-matchable text never match across categories."""
+        import mcp_server
+        old = self._parse_fn("def foo(x):\n    return x + 1\n")
+        new = self._parse_fn("def bar(x):\n    return x + 1\n")
+        removed = {"function": [("foo", old)], "class": []}
+        added = {"function": [], "class": [("bar", new)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert matches == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestMatchRenamedEntities -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_match_renamed_entities'`
+
+- [ ] **Step 3: Implement**
+
+```python
+_MAX_MATCH_ROUNDS = 10
+_MIN_MATCH_BODY_LEN = 20  # normalized chars; avoids matching trivial boilerplate stubs
+
+
+def _normalize_body_for_matching(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _match_renamed_entities(
+    removed: Dict[str, List[Tuple[str, Any]]],
+    added: Dict[str, List[Tuple[str, Any]]],
+) -> List[Tuple[str, str, str]]:
+    """Round-based rename matching across entity categories, scoped to a
+    single commit's touched files (callers build removed/added from just
+    that commit — see _extract_commit's use in Task 9).
+
+    A rename confirmed in one category (e.g. a function) becomes available
+    as a "tracked, confirmed-renamed" name for other not-yet-matched pairs
+    (in the same or a different category) evaluated in a later round — this
+    resolves cascading/mutual renames within one commit regardless of
+    dependency order. Capped at _MAX_MATCH_ROUNDS as a defensive bound.
+
+    Mutates removed/added in place, removing matched entries.
+    """
+    matches: List[Tuple[str, str, str]] = []
+    confirmed: Dict[str, str] = {}  # old_name -> new_name, shared across all categories
+
+    all_names: set = set()
+    for pool in (removed, added):
+        for entries in pool.values():
+            all_names.update(name for name, _node in entries)
+
+    for _round in range(_MAX_MATCH_ROUNDS):
+        changed = False
+        tracked_names: Dict[str, Optional[str]] = {
+            name: confirmed.get(name) for name in all_names
+        }
+        for category in list(removed.keys()):
+            r_list = removed.get(category, [])
+            a_list = added.get(category, [])
+            for r_name, r_node in list(r_list):
+                r_text = _normalize_body_for_matching(r_node.text.decode("utf-8", "replace"))
+                if len(r_text) < _MIN_MATCH_BODY_LEN:
+                    continue
+                candidates = []
+                for a_name, a_node in a_list:
+                    if _match_candidate_pair(r_node, a_node, tracked_names) is not None:
+                        candidates.append((a_name, a_node))
+                if len(candidates) == 1:
+                    a_name, a_node = candidates[0]
+                    matches.append((category, r_name, a_name))
+                    confirmed[r_name] = a_name
+                    r_list.remove((r_name, r_node))
+                    a_list.remove((a_name, a_node))
+                    changed = True
+        if not changed:
+            break
+    return matches
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestMatchRenamedEntities -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add round-based rename matching across entity categories"
+```
+
+---
+
+## Task 9: Wire matcher into `_extract_commit`
+
+**Files:**
+- Modify: `mcp_server.py` (new function `_collect_entity_nodes`, and changes inside `_extract_commit`, mcp_server.py:3115-3191)
+- Test: `tests/test_mcp_server.py` (new `TestCollectEntityNodes` class; extend `TestExtractCommitRename`)
+
+**Interfaces:**
+- Produces: `_collect_entity_nodes(root_node: Any, lang_name: str) -> Dict[str, Dict[str, Any]]` — a sibling of `_walk_ast` that returns live `{category: {name: node}}` instead of text, for use only within a single worker process call (never crosses the `ProcessPoolExecutor` boundary). `_extract_commit`'s return signature gains a 4th tuple element: `renamed_pairs: List[Tuple[str, str, str, str, str]]` = `(category, old_file_path, old_name, new_file_path, new_name)` — plain strings, picklable, safe to cross the process boundary. Full return becomes `(results, gitlink_changes, gitmodules_map, renamed_pairs)`.
+- Consumes: `_match_renamed_entities` (Task 8), `_git_blob_content` (Task 2), `_LANG_NODE_TYPES`/`_c_family_function_name` (existing).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestCollectEntityNodes:
+    def test_collects_function_and_class_nodes_by_name(self):
+        import mcp_server
+        parser = mcp_server._get_parser("test.py")
+        source = b"def foo():\n    pass\n\nclass Bar:\n    pass\n"
+        tree = parser.parse(source)
+        result = mcp_server._collect_entity_nodes(tree.root_node, "python")
+        assert "foo" in result["function"]
+        assert result["function"]["foo"].type == "function_definition"
+        assert "Bar" in result["class"]
+        assert result["class"]["Bar"].type == "class_definition"
+```
+
+Extend `TestExtractCommitRename` with a cross-file-move end-to-end case:
+
+```python
+    def test_cross_file_move_produces_renamed_pair(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "fileA.py").write_text(
+            "def stayHere(x):\n    return x + 1\n\ndef moveMe(x):\n    return x * 2 + 7\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "fileA.py").write_text("def stayHere(x):\n    return x + 1\n")
+        (repo / "fileB.py").write_text("def moveMe(x):\n    return x * 2 + 7\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "move function"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        assert ("function", "fileA.py", "moveMe", "fileB.py", "moveMe") in renamed_pairs
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "TestCollectEntityNodes or test_cross_file_move_produces_renamed_pair" -v`
+Expected: FAIL — `_collect_entity_nodes` doesn't exist; `_extract_commit` still returns a 3-tuple.
+
+- [ ] **Step 3: Implement**
+
+Insert `_collect_entity_nodes` directly after `_match_renamed_entities` (Task 8):
+
+```python
+def _collect_entity_nodes(root_node: Any, lang_name: str) -> Dict[str, Dict[str, Any]]:
+    """Like _walk_ast, but returns live nodes keyed by name instead of text —
+    for use only inside a single worker-process call (_extract_commit), never
+    returned across the ProcessPoolExecutor boundary. Only functions/classes
+    are collected here; Task 26 extends this for globals/fields once those
+    categories exist.
+    """
+    node_types = _LANG_NODE_TYPES.get("typescript" if lang_name == "tsx" else lang_name)
+    result: Dict[str, Dict[str, Any]] = {"function": {}, "class": {}}
+    if node_types is None:
+        return result
+
+    def walk(node: Any) -> None:
+        if node.type in node_types.get("functions", set()):
+            if lang_name in ("c", "cpp"):
+                name = _c_family_function_name(node)
+                if name:
+                    result["function"][name] = node
+            else:
+                name_node = node.child_by_field_name("name")
+                if name_node:
+                    result["function"][name_node.text.decode("utf-8")] = node
+        elif node.type in node_types.get("classes", set()):
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                result["class"][name_node.text.decode("utf-8")] = node
+        for child in node.children:
+            walk(child)
+
+    walk(root_node)
+    return result
+```
+
+Now modify `_extract_commit` (mcp_server.py:3115-3191). The signature's return type annotation and docstring gain the 4th element; the body needs three changes: (1) fetch+parse old content for D/M/R status files, (2) build removed/added pools per the rules below, (3) call the matcher and translate results into `renamed_pairs`.
+
+Replace the full function body from `raw_entries = _git_diff_tree_raw(...)` through the final `return` (mcp_server.py:3158-3191):
+
+```python
+    raw_entries = _git_diff_tree_raw(repo_path, commit_hash)
+    commit_ident = f":commit/{commit_hash[:12]}"
+    results: List[tuple] = []
+    known_files: Optional[Dict[str, List[str]]] = None
+    segment_index: Optional[_SegmentSuffixIndex] = None
+
+    # removed/added pools for _match_renamed_entities, scoped to this commit.
+    # Populated alongside the existing per-file loop below; matched entirely
+    # inside this worker process (nodes never cross the process boundary —
+    # only the plain-string renamed_pairs derived from matches does).
+    removed_pool: Dict[str, List[Tuple[str, Any]]] = {"function": [], "class": []}
+    added_pool: Dict[str, List[Tuple[str, Any]]] = {"function": [], "class": []}
+    # (category, old_file_path, old_name, new_file_path, new_name) is only
+    # knowable once we know which FILE each pooled node came from — track
+    # that alongside the pool itself.
+    node_origin: Dict[int, str] = {}  # id(node) -> file_path
+
+    for status, old_mode, new_mode, old_sha, new_sha, file_path, old_path, similarity in raw_entries:
+        if _is_ignored_path(file_path, ignore_patterns):
+            continue
+        parser = _thread_parser(file_path)
+        if parser is None:
+            continue
+
+        old_lang_path = old_path if status == "R" else file_path
+        old_entity_nodes: Dict[str, Dict[str, Any]] = {"function": {}, "class": {}}
+        if status in ("D", "M", "R") and old_sha and old_sha != "0" * len(old_sha):
+            try:
+                old_content = _git_blob_content(repo_path, old_sha)
+                old_tree = parser.parse(old_content)
+                old_lang = _EXT_TO_LANG.get(Path(old_lang_path).suffix.lower(), "")
+                old_entity_nodes = _collect_entity_nodes(old_tree.root_node, old_lang)
+            except Exception:
+                pass  # best-effort: matching degrades to no-match, not a hard failure
+
+        if status == "D":
+            for category in ("function", "class"):
+                for name, node in old_entity_nodes[category].items():
+                    removed_pool[category].append((name, node))
+                    node_origin[id(node)] = old_lang_path
+            results.append((status, file_path, None, None, ""))
+            continue
+
+        try:
+            content = _git_file_content(repo_path, commit_hash, file_path)
+        except Exception:
+            continue
+        extracted = _extract_from_source(content, parser, file_path)
+        if known_files is None:
+            known_files = _known_files_at_commit(repo_path, commit_hash, ignore_patterns)
+            segment_index = _SegmentSuffixIndex(known_files)
+        precomputed = _precompute_file_triples(
+            file_path, extracted, commit_ident, known_files, segment_index=segment_index,
+        )
+        results.append((status, file_path, extracted, precomputed, old_path if status == "R" else ""))
+
+        # Build this file's contribution to the removed/added pools. Live
+        # nodes for the NEW side come from re-parsing (extracted only carries
+        # text, per Task 6) — cheap, since this is the same content already
+        # fetched and parsed once above for tree-sitter extraction; a second
+        # parse of the same bytes is a deliberate simplicity/cost tradeoff
+        # over threading Node references through _extract_from_source's
+        # return value, which must stay plain-data-only for other callers.
+        new_lang = _EXT_TO_LANG.get(Path(file_path).suffix.lower(), "")
+        new_tree = parser.parse(content)
+        new_entity_nodes = _collect_entity_nodes(new_tree.root_node, new_lang)
+
+        if status == "A":
+            for category in ("function", "class"):
+                for name, node in new_entity_nodes[category].items():
+                    added_pool[category].append((name, node))
+                    node_origin[id(node)] = file_path
+        elif status == "R":
+            # Ident changes for every entity in a renamed file, even ones
+            # whose text is byte-identical — pool everything on both sides,
+            # not just the local diff (unlike "M" below).
+            for category in ("function", "class"):
+                for name, node in old_entity_nodes[category].items():
+                    removed_pool[category].append((name, node))
+                    node_origin[id(node)] = old_lang_path
+                for name, node in new_entity_nodes[category].items():
+                    added_pool[category].append((name, node))
+                    node_origin[id(node)] = file_path
+        else:  # "M" — same path, only the local diff needs matching
+            for category in ("function", "class"):
+                old_names = set(old_entity_nodes[category].keys())
+                new_names = set(new_entity_nodes[category].keys())
+                for name in old_names - new_names:
+                    node = old_entity_nodes[category][name]
+                    removed_pool[category].append((name, node))
+                    node_origin[id(node)] = old_lang_path
+                for name in new_names - old_names:
+                    node = new_entity_nodes[category][name]
+                    added_pool[category].append((name, node))
+                    node_origin[id(node)] = file_path
+
+    raw_matches = _match_renamed_entities(removed_pool, added_pool)
+    # raw_matches only carries (category, old_name, new_name) — recover the
+    # file each side came from via node_origin, captured above.
+    renamed_pairs: List[Tuple[str, str, str, str, str]] = []
+    all_removed_nodes = {
+        (category, name): node
+        for category, entries in removed_pool.items()
+        for name, node in entries
+    }
+    # removed_pool/added_pool are mutated (matched entries removed) by
+    # _match_renamed_entities, so look up origin via a snapshot taken before
+    # the call — rebuild from node_origin's id()-keyed map instead, which
+    # survives the mutation since it was populated from the same node objects.
+    for category, old_name, new_name in raw_matches:
+        renamed_pairs.append((category, "", old_name, "", new_name))
+    # Second pass to fill in file paths: node_origin is keyed by id(node), and
+    # matched nodes are gone from removed_pool/added_pool by now, so paths
+    # must be captured at match time instead — see Step 3 refinement below.
+
+    gitlink_changes = _gitlink_changes(raw_entries)
+    gitmodules_map: Dict[str, Dict[str, str]] = {}
+    if any(kind == "add" for kind, _, _ in gitlink_changes):
+        gitmodules_map = _git_gitmodules_at(repo_path, commit_hash)
+
+    return results, gitlink_changes, gitmodules_map, renamed_pairs
+```
+
+**Fix the file-path gap before running tests**: the sketch above loses each match's file path because `_match_renamed_entities` only returns `(category, old_name, new_name)`, and by the time it returns, the matched nodes are already removed from the pools. Resolve this by capturing `(file_path, node)` pairs (not bare nodes) in the pools instead, and adjusting `_match_renamed_entities` (Task 8) is NOT the right place to add file-path plumbing — it's meant to be file-path-agnostic and reusable for Task 26. Instead, keep `node_origin: Dict[int, str]` (already present in the sketch above) and change the final translation loop to look up each match's origin **before** the match removes the node from the pool — i.e., capture `node_origin` lookups eagerly right after building `raw_matches`, using the ORIGINAL node objects, which `_match_renamed_entities` doesn't return but which are still reachable from the `(category, name)` pair only if names are unique per category per commit. Since two different removed entities could coincidentally share a name (e.g. `helper` removed from two different deleted files in one commit), name alone is not a safe lookup key.
+
+The robust fix: change `_match_renamed_entities`'s return type to include the matched nodes themselves — `List[Tuple[str, str, Any, str, Any]]` = `(category, old_name, old_node, new_name, new_node)` — since it already has direct references to both matched nodes at the moment of match (mcp_server.py, the `matches.append(...)` line inside Task 8's implementation). Update Task 8's `matches.append((category, r_name, a_name))` to `matches.append((category, r_name, r_node, a_name, a_node))`, update Task 8's tests' assertions accordingly (`assert matches[0][:2] == ("function", "foo")` style, or unpack and check the node's `.text` instead of comparing tuples directly), and then here in Task 9, the final translation becomes straightforward:
+
+```python
+    raw_matches = _match_renamed_entities(removed_pool, added_pool)
+    renamed_pairs: List[Tuple[str, str, str, str, str]] = []
+    for category, old_name, old_node, new_name, new_node in raw_matches:
+        renamed_pairs.append((
+            category, node_origin[id(old_node)], old_name, node_origin[id(new_node)], new_name,
+        ))
+```
+
+Go back and apply this signature change to Task 8 now (both the implementation and its tests) before proceeding — this is a real interface correction discovered while wiring Task 8 into a real caller, not a deferred TODO.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "TestCollectEntityNodes or TestMatchRenamedEntities or TestExtractCommitRename or TestExtractCommit" -v`
+Expected: PASS
+
+- [ ] **Step 5: Update every other caller of `_extract_commit`/`_match_renamed_entities`**
+
+Grep both names across `mcp_server.py` and `tests/test_mcp_server.py`; any remaining 3-tuple unpack of `_extract_commit`'s return, or 3-tuple-match unpack from Task 8's tests, needs updating to match the new signatures. Run the full suite to catch stragglers: `.venv/bin/pytest tests/test_mcp_server.py -q 2>&1 | tail -40`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: wire AST-lockstep matcher into _extract_commit, return renamed_pairs"
+```
+
+---
+
+## Task 10: Consume confirmed pairs in `_run_ingestion`, emit rename triples for functions/classes
+
+**Files:**
+- Modify: `mcp_server.py:3194-3563` (`_run_ingestion` — the `await fut` unpack at line 3328, and a new block after the per-file loop)
+- Test: `tests/test_mcp_server.py` (new test in `TestRunIngestionBitemporalClose`)
+
+**Interfaces:**
+- Consumes: Task 9's `renamed_pairs` (4th element of `_extract_commit`'s return, threaded through the `await fut` unpack).
+- Produces: for every `(category, old_file, old_name, new_file, new_name)` in `renamed_pairs`, the new ident gets `:renamed-from`, and the old ident's close entry gets `:renamed-to` — same pattern as Task 5's module-level handling, generalized to functions/classes (and reused verbatim by Task 27 for globals/fields).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+    @pytest.mark.asyncio
+    async def test_in_file_function_rename_links_via_rename_edges(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def oldName(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def newName(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename fn"], cwd=repo, check=True, capture_output=True)
+
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        old_fn_ident = mcp_server._code_ident("function", "auth.py", "oldName")
+        new_fn_ident = mcp_server._code_ident("function", "auth.py", "newName")
+
+        assert any(f"{old_fn_ident} :renamed-to {new_fn_ident}" in t for t in close_triples_seen)
+        transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
+        assert f"{new_fn_ident} :renamed-from {old_fn_ident}" in transact_calls
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_in_file_function_rename_links_via_rename_edges -v`
+Expected: FAIL — no rename triples emitted for functions yet.
+
+- [ ] **Step 3: Implement**
+
+The `await fut` unpack (mcp_server.py:3328) gains the 4th element:
+
+```python
+                    extracted_files, gitlink_changes, gitmodules_map, renamed_pairs = await fut
+```
+
+Add a new block immediately after the per-file `for status, file_path, extracted, precomputed, old_path in extracted_files:` loop ends (i.e., after the dependency-edge handling that closes out around mcp_server.py:3424, at the same indentation level as that `for` loop itself — NOT nested inside it, since `renamed_pairs` covers the whole commit, not one file), and before the `# Process gitlink changes` comment:
+
+```python
+                        # Function/class rename linkage (Task 9's renamed_pairs).
+                        # Module-level linkage is handled separately per-file
+                        # above (Task 5) since it comes from git's own -M
+                        # detection, not this commit-wide matcher.
+                        for category, old_file, old_name, new_file, new_name in renamed_pairs:
+                            old_ident = _code_ident(category, old_file, old_name)
+                            new_ident = _code_ident(category, new_file, new_name)
+                            add_triples.append(f"[{new_ident} :renamed-from {old_ident}]")
+                            old_desc = entity_descriptions.get(old_ident, old_name)
+                            old_module_ident = _code_ident("module", old_file)
+                            orig_ts = entity_valid_from.get(old_ident, commit_ts_iso)
+                            close_items.append((
+                                _build_close_triples(old_ident, old_desc, old_module_ident)
+                                + [f"[{old_ident} :renamed-to {new_ident}]"],
+                                orig_ts,
+                            ))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_in_file_function_rename_links_via_rename_edges -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full ingestion/bitemporal-close test suite**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "TestRunIngestionBitemporalClose or Ingestion" -v`
+Expected: All PASS. This is also the natural checkpoint to run the **entire** suite once, since Component 2 (Tasks 6-10) is the riskiest, most structurally invasive part of the whole plan: `.venv/bin/pytest tests/test_mcp_server.py -q`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: emit :renamed-from/:renamed-to edges for renamed functions/classes"
+```
+
+---
+
+## Task 11: Generic `:type/variable`/`:type/field` plumbing (language-agnostic)
+
+**Files:**
+- Modify: `mcp_server.py:2748-2820` (`_precompute_file_triples`)
+- Modify: `mcp_server.py:2823-2891` (`_build_code_triples`)
+- Modify: `mcp_server.py:2894-2954` (`_preload_known_entities`)
+- Test: `tests/test_mcp_server.py` (new tests in the existing `TestIngestionWrites`-area classes)
+
+**Interfaces:**
+- Consumes: assumes `extracted` dicts passed in carry two new keys — `"globals": List[str]` and `"fields": List[Tuple[str, str, bool]]` (name, owning_class_name, is_static). This task hand-constructs these dicts in its own tests; Tasks 13-25 are what actually populate them from real source via `_extract_from_source`.
+- Produces: `_precompute_file_triples`'s returned dict gains `"global_entries"`/`"field_entries"` (same `(ident, name, candidate_triples)` shape as `function_entries`/`class_entries`). `_build_code_triples` gains matching open/modify loops. `_preload_known_entities` reloads `"variable"`/`"field"` idents too.
+- Field idents disambiguate same-named fields across different classes in one file by using `f"{class_name}.{field_name}"` as `_code_ident`'s `name` parameter (module-level globals use the bare name — they have no owning class).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestPrecomputeGlobalsAndFields:
+    def test_global_entries_shape(self):
+        import mcp_server
+        extracted = {
+            "functions": [], "classes": [], "imports": [], "calls": [],
+            "function_bodies": {}, "class_bodies": {},
+            "globals": ["GLOBAL_X"], "global_bodies": {"GLOBAL_X": "GLOBAL_X = 5"},
+            "fields": [], "field_info": {},
+        }
+        result = mcp_server._precompute_file_triples(
+            "config.py", extracted, ":commit/abc123", {}, segment_index=None,
+        )
+        assert len(result["global_entries"]) == 1
+        ident, name, triples = result["global_entries"][0]
+        assert ident == mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
+        assert name == "GLOBAL_X"
+        assert f"[{ident} :entity-type :type/variable]" in triples
+        assert f"[{ident} :introduced-by :commit/abc123]" in triples
+
+    def test_field_entries_shape_disambiguates_by_class(self):
+        import mcp_server
+        extracted = {
+            "functions": [], "classes": ["Foo"], "imports": [], "calls": [],
+            "function_bodies": {}, "class_bodies": {"Foo": "class Foo: ..."},
+            "globals": [], "global_bodies": {},
+            "fields": [("staticField", "Foo", True)],
+            "field_info": {"staticField": {"class": "Foo", "static": True, "body": "staticField = 1"}},
+        }
+        result = mcp_server._precompute_file_triples(
+            "models.py", extracted, ":commit/abc123", {}, segment_index=None,
+        )
+        assert len(result["field_entries"]) == 1
+        ident, name, triples = result["field_entries"][0]
+        expected_ident = mcp_server._code_ident("field", "models.py", "Foo.staticField")
+        assert ident == expected_ident
+        assert f"[{ident} :entity-type :type/field]" in triples
+        assert f"[{ident} :static true]" in triples
+        class_ident = mcp_server._code_ident("class", "models.py", "Foo")
+        assert f"[{ident} :class {class_ident}]" in triples
+
+class TestBuildCodeTriplesGlobalsAndFields:
+    def test_new_global_writes_full_triples(self):
+        import mcp_server
+        extracted = {"functions": [], "classes": [], "imports": [], "calls": [],
+                     "function_bodies": {}, "class_bodies": {},
+                     "globals": ["GLOBAL_X"], "global_bodies": {"GLOBAL_X": "GLOBAL_X = 5"},
+                     "fields": [], "field_info": {}}
+        precomputed = mcp_server._precompute_file_triples("config.py", extracted, ":commit/c1", {})
+        entity_valid_from, entity_descriptions, file_entities = {}, {}, {}
+        triples = mcp_server._build_code_triples(
+            "config.py", extracted, "2024-01-01T00:00:00Z", entity_valid_from,
+            entity_descriptions, file_entities, ":commit/c1", precomputed,
+        )
+        ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
+        assert any(f"{ident} :entity-type :type/variable" in t for t in triples)
+        assert ident in entity_valid_from
+
+    def test_preexisting_global_only_gets_modified_in(self):
+        import mcp_server
+        extracted = {"functions": [], "classes": [], "imports": [], "calls": [],
+                     "function_bodies": {}, "class_bodies": {},
+                     "globals": ["GLOBAL_X"], "global_bodies": {"GLOBAL_X": "GLOBAL_X = 6"},
+                     "fields": [], "field_info": {}}
+        precomputed = mcp_server._precompute_file_triples("config.py", extracted, ":commit/c2", {})
+        ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
+        entity_valid_from = {ident: "2024-01-01T00:00:00Z"}
+        entity_descriptions = {ident: "GLOBAL_X"}
+        file_entities = {"config.py": [ident]}
+        triples = mcp_server._build_code_triples(
+            "config.py", extracted, "2024-01-02T00:00:00Z", entity_valid_from,
+            entity_descriptions, file_entities, ":commit/c2", precomputed,
+        )
+        assert triples == [f"[{ident} :modified-in :commit/c2]"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "TestPrecomputeGlobalsAndFields or TestBuildCodeTriplesGlobalsAndFields" -v`
+Expected: FAIL — `KeyError: 'global_entries'` (not populated yet).
+
+- [ ] **Step 3: Implement**
+
+In `_precompute_file_triples` (mcp_server.py:2748-2820), insert after the existing `class_entries` loop (mcp_server.py:2795-2805), before `resolved_imports`:
+
+```python
+    global_entries: List[Tuple[str, str, List[str]]] = []
+    for gvar_name in extracted.get("globals", []):
+        gvar_ident = _code_ident("variable", file_path, gvar_name)
+        global_entries.append((gvar_ident, gvar_name, [
+            f"[{gvar_ident} :entity-type :type/variable]",
+            f'[{gvar_ident} :ident "{gvar_ident}"]',
+            f'[{gvar_ident} :description "{_edn_escape(gvar_name)}"]',
+            f'[{gvar_ident} :file "{_edn_escape(file_path)}"]',
+            f"[{module_ident} :contains {gvar_ident}]",
+            f"[{gvar_ident} :introduced-by {commit_ident}]",
+        ]))
+
+    field_entries: List[Tuple[str, str, List[str]]] = []
+    for field_name, owning_class, is_static in extracted.get("fields", []):
+        qualified_name = f"{owning_class}.{field_name}"
+        field_ident = _code_ident("field", file_path, qualified_name)
+        class_ident = _code_ident("class", file_path, owning_class)
+        static_literal = "true" if is_static else "false"
+        field_entries.append((field_ident, qualified_name, [
+            f"[{field_ident} :entity-type :type/field]",
+            f'[{field_ident} :ident "{field_ident}"]',
+            f'[{field_ident} :description "{_edn_escape(qualified_name)}"]',
+            f'[{field_ident} :file "{_edn_escape(file_path)}"]',
+            f"[{field_ident} :class {class_ident}]",
+            f"[{field_ident} :static {static_literal}]",
+            f"[{module_ident} :contains {field_ident}]",
+            f"[{field_ident} :introduced-by {commit_ident}]",
+        ]))
+```
+
+And extend the final `return` dict (mcp_server.py:2814-2820) with `"global_entries": global_entries, "field_entries": field_entries,`.
+
+In `_build_code_triples` (mcp_server.py:2823-2891), insert after the existing `class_entries` loop (mcp_server.py:2880-2889), before the final `return triples`:
+
+```python
+    for gvar_ident, gvar_name, candidate_triples in precomputed["global_entries"]:
+        if gvar_ident not in entity_valid_from:
+            triples += candidate_triples
+            if gvar_ident not in idents_for_file:
+                idents_for_file.append(gvar_ident)
+            entity_valid_from[gvar_ident] = commit_ts_iso
+            entity_descriptions[gvar_ident] = gvar_name
+        else:
+            triples.append(f"[{gvar_ident} :modified-in {commit_ident}]")
+
+    for field_ident, field_name, candidate_triples in precomputed["field_entries"]:
+        if field_ident not in entity_valid_from:
+            triples += candidate_triples
+            if field_ident not in idents_for_file:
+                idents_for_file.append(field_ident)
+            entity_valid_from[field_ident] = commit_ts_iso
+            entity_descriptions[field_ident] = field_name
+        else:
+            triples.append(f"[{field_ident} :modified-in {commit_ident}]")
+```
+
+In `_preload_known_entities` (mcp_server.py:2894-2954), change line 2931's entity-type tuple:
+
+```python
+    for entity_type in ("module", "function", "class", "variable", "field", "external-dependency"):
+```
+
+(The loop body already generalizes via `path_attr = "path" if entity_type in ("module", "external-dependency") else "file"` — `"variable"`/`"field"` fall into the `"file"` branch automatically, correct since both carry `:file` not `:path`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "TestPrecomputeGlobalsAndFields or TestBuildCodeTriplesGlobalsAndFields" -v`
+Expected: PASS. Also re-run the existing function/class precompute/build-triples tests to confirm no regression: `.venv/bin/pytest tests/test_mcp_server.py -k "TestIngestionWrites or PrecomputeFileTriples" -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: generic :type/variable and :type/field triple-writing plumbing"
+```
+
+---
+
+## Task 12: Scope-aware traversal skeleton + per-language dispatch table
+
+**Files:**
+- Modify: `mcp_server.py` (new function `_extract_globals_and_fields`, new dispatch table `_GLOBAL_FIELD_EXTRACTORS`, and a call site inside `_extract_from_source`)
+- Test: `tests/test_mcp_server.py` (new `TestExtractGlobalsAndFields` class — only the dispatch/fallback behavior; per-language extraction logic is Tasks 13-25)
+
+**Interfaces:**
+- Produces: `_extract_globals_and_fields(root_node: Any, lang_name: str) -> Dict[str, Any]` returning `{"globals": [...], "global_bodies": {...}, "fields": [(name, class_name, is_static), ...], "field_info": {...}}`. Dispatches to a per-language function via `_GLOBAL_FIELD_EXTRACTORS: Dict[str, Callable]`, defaulting to an empty-result stub for any language not yet in the table — this is what lets Tasks 13-25 land independently, one language at a time, without any of them being a hard blocker for the others.
+- `_extract_from_source` (mcp_server.py, as modified by Task 6) calls this and merges its output into the returned dict, so `extracted["globals"]`/`extracted["fields"]` are always present (possibly empty) for every file, consistent with how `"functions"`/`"classes"` already always exist.
+
+**Why this is NOT a naive full-tree walk (see the design spec's Component 3 correction):** unlike `_walk_ast`, which safely recurses into every node because function/class definitions mean the same thing wherever they appear, an assignment-like node appears on nearly every line of every function body too. Each per-language extractor function (Tasks 13-25) is responsible for only descending into module-level statements and class-body-level statements — explicitly never into a function/method body (except a narrow, per-language, deliberate exception like Python's `self.x = ...` inside `__init__`, handled inside that language's own task, not here).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestExtractGlobalsAndFields:
+    def test_unsupported_language_returns_empty(self):
+        import mcp_server
+        result = mcp_server._extract_globals_and_fields(None, "nonexistent_lang")
+        assert result == {"globals": [], "global_bodies": {}, "fields": [], "field_info": {}}
+
+    def test_dispatches_to_registered_language_extractor(self):
+        import mcp_server
+        sentinel = {"globals": ["X"], "global_bodies": {"X": "X = 1"}, "fields": [], "field_info": {}}
+        mcp_server._GLOBAL_FIELD_EXTRACTORS["_test_lang"] = lambda root: sentinel
+        try:
+            result = mcp_server._extract_globals_and_fields("fake_root", "_test_lang")
+            assert result == sentinel
+        finally:
+            del mcp_server._GLOBAL_FIELD_EXTRACTORS["_test_lang"]
+
+    def test_extract_from_source_merges_globals_and_fields(self):
+        import mcp_server
+        source = b"def foo(): pass"
+        result = mcp_server._extract_from_source(source, self._python_parser(), "x.py")
+        assert result["globals"] == []
+        assert result["fields"] == []
+```
+
+(`self._python_parser()` — this test needs a real parser fixture; place it inside whichever existing test class already defines `_python_parser` — e.g. `TestExtractFromSource` — rather than redefining it, or copy the two-line helper if a standalone class is preferred: `import tree_sitter_python; from tree_sitter import Language, Parser; return Parser(Language(tree_sitter_python.language()))`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestExtractGlobalsAndFields -v`
+Expected: FAIL — `AttributeError: module 'mcp_server' has no attribute '_extract_globals_and_fields'`
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_globals_and_fields(root_node: Any, lang_name: str) -> Dict[str, Any]:
+    """Scope-aware extraction of module-level globals and class fields.
+
+    Deliberately NOT a _walk_ast-style full-tree recursion: an assignment-
+    like node is ubiquitous (appears inside every function body too), so a
+    naive table-driven walk would misclassify every local variable as a
+    global. Each per-language function in _GLOBAL_FIELD_EXTRACTORS is
+    responsible for only descending into module-level and class-body-level
+    statements, never into a function/method body (barring a narrow,
+    per-language, deliberate exception — see each language's own extractor).
+    """
+    empty: Dict[str, Any] = {"globals": [], "global_bodies": {}, "fields": [], "field_info": {}}
+    extractor = _GLOBAL_FIELD_EXTRACTORS.get(lang_name)
+    if extractor is None or root_node is None:
+        return empty
+    return extractor(root_node)
+
+
+_GLOBAL_FIELD_EXTRACTORS: Dict[str, Callable[[Any], Dict[str, Any]]] = {}
+```
+
+Place `_GLOBAL_FIELD_EXTRACTORS` right after `_extract_globals_and_fields` (forward-referenced inside the function body, which is fine in Python since the lookup happens at call time, not definition time — but keep the dict defined at module scope, not nested, so Tasks 13-25 can each register into it with a top-level `_GLOBAL_FIELD_EXTRACTORS["python"] = _extract_python_globals_and_fields`-style line).
+
+In `_extract_from_source` (as modified by Task 6), add the merge right before `return results`:
+
+```python
+    try:
+        tree = parser.parse(source)
+        lang_name = _EXT_TO_LANG.get(Path(file_path).suffix.lower(), "")
+        _walk_ast(tree.root_node, results, lang_name)
+        gf = _extract_globals_and_fields(tree.root_node, "typescript" if lang_name == "tsx" else lang_name)
+        results["globals"] = gf["globals"]
+        results["global_bodies"] = gf["global_bodies"]
+        results["fields"] = gf["fields"]
+        results["field_info"] = gf["field_info"]
+    except Exception:
+        pass
+    return results
+```
+
+And extend `_extract_from_source`'s initial `results` dict (from Task 6) with the same four keys defaulted empty, so a parse failure still returns a complete, consistently-shaped dict:
+
+```python
+    results: Dict[str, Any] = {
+        "functions": [], "classes": [], "imports": [], "calls": [],
+        "function_bodies": {}, "class_bodies": {},
+        "globals": [], "global_bodies": {}, "fields": [], "field_info": {},
+    }
+```
+
+(This also means Task 6's `test_parse_error_returns_empty` update needs these four extra keys too — go back and add them now.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "TestExtractGlobalsAndFields or test_parse_error_returns_empty" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: add scope-aware globals/fields extraction dispatch skeleton"
+```
+
+---
+
+## Task 13: Python globals/fields
+
+**Files:** Modify `mcp_server.py` (new `_extract_python_globals_and_fields`, registered in `_GLOBAL_FIELD_EXTRACTORS`); Test: `tests/test_mcp_server.py` (new `TestPythonGlobalsAndFields`)
+
+**Grammar facts** (verified via live parse, see design conversation): module root is `module`; a top-level `x = 5` is `expression_statement > assignment` with `field:left` = `identifier`; `class Foo:` is `class_definition` with `field:body` = `block`; a class-body-level `class_var = 10` is the same `expression_statement > assignment` shape, one level inside the class's `block`; `self.instance_var = 1` inside `__init__` is `expression_statement > assignment` where `field:left` is an `attribute` node (fields `object`=`self` identifier, `attribute`=the field name identifier).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestPythonGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_python
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_python.language()))
+
+    def test_module_level_global(self):
+        import mcp_server
+        tree = self._parser().parse(b"GLOBAL_X = 5\n")
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        assert "GLOBAL_X" in result["globals"]
+        assert "GLOBAL_X = 5" in result["global_bodies"]["GLOBAL_X"]
+
+    def test_class_variable_is_static_field(self):
+        import mcp_server
+        source = b"class Foo:\n    class_var = 10\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        names = [n for n, _c, _s in result["fields"]]
+        assert "class_var" in names
+        info = result["field_info"]["class_var"]
+        assert info["class"] == "Foo"
+        assert info["static"] is True
+
+    def test_self_attribute_in_init_is_instance_field(self):
+        import mcp_server
+        source = b"class Foo:\n    def __init__(self):\n        self.instance_var = 1\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        names = [n for n, _c, _s in result["fields"]]
+        assert "instance_var" in names
+        info = result["field_info"]["instance_var"]
+        assert info["class"] == "Foo"
+        assert info["static"] is False
+
+    def test_local_variable_inside_function_not_captured(self):
+        import mcp_server
+        source = b"def foo():\n    local_x = 1\n    return local_x\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+    def test_self_attribute_outside_init_not_captured(self):
+        """Scoped deliberately to __init__ only — see design plan's stated limitation."""
+        import mcp_server
+        source = b"class Foo:\n    def other(self):\n        self.dynamic = 1\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        assert result["fields"] == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestPythonGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_python_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def plain_assignment_name(stmt_node: Any) -> Optional[Tuple[str, Any]]:
+        if stmt_node.type != "expression_statement" or stmt_node.child_count == 0:
+            return None
+        assign = stmt_node.children[0]
+        if assign.type != "assignment":
+            return None
+        left = assign.child_by_field_name("left")
+        if left is not None and left.type == "identifier":
+            return left.text.decode("utf-8"), assign
+        return None
+
+    def self_attr_assignment_name(stmt_node: Any) -> Optional[Tuple[str, Any]]:
+        if stmt_node.type != "expression_statement" or stmt_node.child_count == 0:
+            return None
+        assign = stmt_node.children[0]
+        if assign.type != "assignment":
+            return None
+        left = assign.child_by_field_name("left")
+        if left is None or left.type != "attribute":
+            return None
+        obj = left.child_by_field_name("object")
+        attr = left.child_by_field_name("attribute")
+        if obj is not None and obj.type == "identifier" and obj.text == b"self" and attr is not None:
+            return attr.text.decode("utf-8"), assign
+        return None
+
+    for stmt in root_node.children:
+        if stmt.type == "class_definition":
+            class_name_node = stmt.child_by_field_name("name")
+            class_name = class_name_node.text.decode("utf-8") if class_name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                match = plain_assignment_name(member)
+                if match:
+                    field_name, assign_node = match
+                    fields.append((field_name, class_name, True))
+                    field_info[field_name] = {
+                        "class": class_name, "static": True,
+                        "body": assign_node.text.decode("utf-8", "replace"),
+                    }
+                elif member.type == "function_definition":
+                    fn_name_node = member.child_by_field_name("name")
+                    if fn_name_node is not None and fn_name_node.text == b"__init__":
+                        fn_body = member.child_by_field_name("body")
+                        if fn_body is not None:
+                            for fn_stmt in fn_body.children:
+                                self_match = self_attr_assignment_name(fn_stmt)
+                                if self_match:
+                                    field_name, assign_node = self_match
+                                    fields.append((field_name, class_name, False))
+                                    field_info[field_name] = {
+                                        "class": class_name, "static": False,
+                                        "body": assign_node.text.decode("utf-8", "replace"),
+                                    }
+        else:
+            match = plain_assignment_name(stmt)
+            if match:
+                name, assign_node = match
+                globals_.append(name)
+                global_bodies[name] = assign_node.text.decode("utf-8", "replace")
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["python"] = _extract_python_globals_and_fields
+```
+
+**Known limitation** (document, don't chase): only `__init__`'s own direct statements are scanned for `self.x =` assignments — a field first assigned in some other method (a dynamically-added attribute) is not captured. This is a deliberate, bounded heuristic (see the design plan's Component 3 discussion), not an oversight.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestPythonGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Python module globals and class fields"
+```
+
+---
+
+## Task 14: JavaScript + TypeScript globals/fields
+
+**Files:** Modify `mcp_server.py` (new `_extract_js_family_globals_and_fields`, registered for both `"javascript"` and `"typescript"`); Test: `tests/test_mcp_server.py` (new `TestJsFamilyGlobalsAndFields`)
+
+**Grammar facts:** root is `program`; a top-level `const X = 5;`/`let x = 5;` is `lexical_declaration` (or `variable_declaration` for `var`) containing one or more `variable_declarator` children, each with `field:name`. `class Foo { ... }` is `class_declaration` with `field:body` = `class_body`; each member is a `field_definition` (JS) or `public_field_definition` (TS), with `field:property`/`field:name` respectively holding the member's identifier, and a literal `static` child token when the modifier is present (check via `any(c.type == "static" for c in member.children)`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestJsFamilyGlobalsAndFields:
+    def _js_parser(self):
+        import tree_sitter_javascript
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_javascript.language()))
+
+    def _ts_parser(self):
+        import tree_sitter_typescript
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_typescript.language_typescript()))
+
+    def test_js_module_level_global(self):
+        import mcp_server
+        tree = self._js_parser().parse(b"const GLOBAL_X = 5;\n")
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        assert "GLOBAL_X" in result["globals"]
+
+    def test_js_static_and_instance_fields(self):
+        import mcp_server
+        source = b"class Foo {\n  static staticField = 1;\n  instanceField = 2;\n}\n"
+        tree = self._js_parser().parse(source)
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_ts_public_field_definition_static(self):
+        import mcp_server
+        source = b"class Foo {\n  static staticField: number = 1;\n  instanceField: number = 2;\n}\n"
+        tree = self._ts_parser().parse(source)
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_local_variable_not_captured(self):
+        import mcp_server
+        source = b"function foo() {\n  const localX = 1;\n  return localX;\n}\n"
+        tree = self._js_parser().parse(source)
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestJsFamilyGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_js_family_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    for stmt in root_node.children:
+        if stmt.type in ("lexical_declaration", "variable_declaration"):
+            for child in stmt.children:
+                if child.type == "variable_declarator":
+                    name_node = child.child_by_field_name("name")
+                    if name_node is not None and name_node.type == "identifier":
+                        name = name_node.text.decode("utf-8")
+                        globals_.append(name)
+                        global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "class_declaration":
+            class_name_node = stmt.child_by_field_name("name")
+            class_name = class_name_node.text.decode("utf-8") if class_name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type not in ("field_definition", "public_field_definition"):
+                    continue
+                name_node = member.child_by_field_name("property") or member.child_by_field_name("name")
+                if name_node is None or name_node.type not in ("property_identifier",):
+                    continue
+                field_name = name_node.text.decode("utf-8")
+                is_static = any(c.type == "static" for c in member.children)
+                fields.append((field_name, class_name, is_static))
+                field_info[field_name] = {
+                    "class": class_name, "static": is_static,
+                    "body": member.text.decode("utf-8", "replace"),
+                }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["javascript"] = _extract_js_family_globals_and_fields
+_GLOBAL_FIELD_EXTRACTORS["typescript"] = _extract_js_family_globals_and_fields
+```
+
+(`tsx` is handled the same way as elsewhere in the file — `_extract_from_source`'s Task 12 dispatch already aliases `"tsx"` to `"typescript"` before calling `_extract_globals_and_fields`, so no separate `"tsx"` registration is needed here, consistent with how `_walk_ast` and `_extract_import_name` both already treat tsx as a typescript alias.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestJsFamilyGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract JS/TS module globals and class fields"
+```
+
+---
+
+## Task 15: Rust + Go + C globals/fields
+
+**Files:** Modify `mcp_server.py` (three new functions); Test: `tests/test_mcp_server.py` (new `TestRustGoCGlobalsAndFields`)
+
+**Grammar facts:** none of these three languages has a "static struct field" concept — struct/field declarations are always instance-only, so every field in these languages is captured with `is_static=False` unconditionally.
+- Rust: `static X: T = v;`/`const X: T = v;` at module level are `static_item`/`const_item` (`field:name`). `struct Foo { field: T }` is `struct_item` with `field:body` = `field_declaration_list`, each member a `field_declaration` (`field:name`). An `impl Foo { const ASSOC: T = v; }` block's `const_item` (nested inside `impl_item > declaration_list`) is treated as a **static** field of `Foo` (the closest Rust analog to a class-static constant) — the one exception to "always instance" in this task.
+- Go: `var X = v`/`const X = v` at file level are `var_declaration`/`const_declaration`, each containing a `var_spec`/`const_spec` (`field:name`). `type Foo struct { Field T }` is `type_declaration > type_spec` (`field:name`=`Foo`, `field:type`=`struct_type` with `field:body`=`field_declaration_list`, each member `field_declaration` with `field:name`).
+- C: top-level `int x = 5;` is `declaration` directly under `translation_unit` (`field:declarator` → `init_declarator` → `field:declarator` = plain `identifier`, or a bare `identifier` declarator with no initializer). `struct Foo { int field; };` is `struct_specifier` with `field:body` = `field_declaration_list`, each member `field_declaration` with `field:declarator` = `field_identifier`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestRustGoCGlobalsAndFields:
+    def _rust_parser(self):
+        import tree_sitter_rust
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_rust.language()))
+
+    def _go_parser(self):
+        import tree_sitter_go
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_go.language()))
+
+    def _c_parser(self):
+        import tree_sitter_c
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_c.language()))
+
+    def test_rust_static_and_const_are_globals(self):
+        import mcp_server
+        source = b"static GLOBAL_X: i32 = 5;\nconst GLOBAL_Y: i32 = 10;\n"
+        tree = self._rust_parser().parse(source)
+        result = mcp_server._extract_rust_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"GLOBAL_X", "GLOBAL_Y"}
+
+    def test_rust_struct_field_is_instance_only(self):
+        import mcp_server
+        source = b"struct Foo {\n    instance_field: i32,\n}\n"
+        tree = self._rust_parser().parse(source)
+        result = mcp_server._extract_rust_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["instance_field"] == ("Foo", False)
+
+    def test_rust_impl_const_is_static_field(self):
+        import mcp_server
+        source = b"impl Foo {\n    const ASSOC_CONST: i32 = 1;\n}\n"
+        tree = self._rust_parser().parse(source)
+        result = mcp_server._extract_rust_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["ASSOC_CONST"] == ("Foo", True)
+
+    def test_go_package_level_var_and_const_are_globals(self):
+        import mcp_server
+        source = b"package main\n\nvar GlobalX = 5\nconst GlobalY = 10\n"
+        tree = self._go_parser().parse(source)
+        result = mcp_server._extract_go_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"GlobalX", "GlobalY"}
+
+    def test_go_struct_field_is_instance_only(self):
+        import mcp_server
+        source = b"package main\n\ntype Foo struct {\n    InstanceField int\n}\n"
+        tree = self._go_parser().parse(source)
+        result = mcp_server._extract_go_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["InstanceField"] == ("Foo", False)
+
+    def test_c_file_scope_declaration_is_global(self):
+        import mcp_server
+        source = b"int global_x = 5;\nstatic int file_static_x = 10;\n"
+        tree = self._c_parser().parse(source)
+        result = mcp_server._extract_c_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"global_x", "file_static_x"}
+
+    def test_c_struct_field_is_instance_only(self):
+        import mcp_server
+        source = b"struct Foo {\n    int instance_field;\n};\n"
+        tree = self._c_parser().parse(source)
+        result = mcp_server._extract_c_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["instance_field"] == ("Foo", False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestRustGoCGlobalsAndFields -v`
+Expected: FAIL — functions don't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_rust_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    for stmt in root_node.children:
+        if stmt.type in ("static_item", "const_item"):
+            name_node = stmt.child_by_field_name("name")
+            if name_node is not None:
+                name = name_node.text.decode("utf-8")
+                globals_.append(name)
+                global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "struct_item":
+            struct_name_node = stmt.child_by_field_name("name")
+            struct_name = struct_name_node.text.decode("utf-8") if struct_name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is not None:
+                for member in body.children:
+                    if member.type == "field_declaration":
+                        fname_node = member.child_by_field_name("name")
+                        if fname_node is not None:
+                            fname = fname_node.text.decode("utf-8")
+                            fields.append((fname, struct_name, False))
+                            field_info[fname] = {
+                                "class": struct_name, "static": False,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+        elif stmt.type == "impl_item":
+            type_node = stmt.child_by_field_name("type")
+            type_name = type_node.text.decode("utf-8") if type_node is not None else ""
+            body = stmt.child_by_field_name("body")
+            if body is not None:
+                for member in body.children:
+                    if member.type == "const_item":
+                        cname_node = member.child_by_field_name("name")
+                        if cname_node is not None:
+                            cname = cname_node.text.decode("utf-8")
+                            fields.append((cname, type_name, True))
+                            field_info[cname] = {
+                                "class": type_name, "static": True,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+def _extract_go_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    for stmt in root_node.children:
+        if stmt.type in ("var_declaration", "const_declaration"):
+            spec_type = "var_spec" if stmt.type == "var_declaration" else "const_spec"
+            for spec in stmt.children:
+                if spec.type == spec_type:
+                    name_node = spec.child_by_field_name("name")
+                    if name_node is not None:
+                        name = name_node.text.decode("utf-8")
+                        globals_.append(name)
+                        global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "type_declaration":
+            for type_spec in stmt.children:
+                if type_spec.type != "type_spec":
+                    continue
+                type_name_node = type_spec.child_by_field_name("name")
+                type_name = type_name_node.text.decode("utf-8") if type_name_node else ""
+                struct_type = type_spec.child_by_field_name("type")
+                if struct_type is None or struct_type.type != "struct_type":
+                    continue
+                body = struct_type.child_by_field_name("body")
+                if body is None:
+                    continue
+                for member in body.children:
+                    if member.type == "field_declaration":
+                        fname_node = member.child_by_field_name("name")
+                        if fname_node is not None:
+                            fname = fname_node.text.decode("utf-8")
+                            fields.append((fname, type_name, False))
+                            field_info[fname] = {
+                                "class": type_name, "static": False,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+def _extract_c_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def declarator_name(node: Any) -> Optional[str]:
+        if node.type == "identifier":
+            return node.text.decode("utf-8")
+        if node.type == "init_declarator":
+            inner = node.child_by_field_name("declarator")
+            return declarator_name(inner) if inner is not None else None
+        return None
+
+    for stmt in root_node.children:
+        if stmt.type == "declaration":
+            declarator = stmt.child_by_field_name("declarator")
+            if declarator is not None:
+                name = declarator_name(declarator)
+                if name:
+                    globals_.append(name)
+                    global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "struct_specifier":
+            struct_name_node = stmt.child_by_field_name("name")
+            struct_name = struct_name_node.text.decode("utf-8") if struct_name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is not None:
+                for member in body.children:
+                    if member.type == "field_declaration":
+                        declarator = member.child_by_field_name("declarator")
+                        if declarator is not None and declarator.type == "field_identifier":
+                            fname = declarator.text.decode("utf-8")
+                            fields.append((fname, struct_name, False))
+                            field_info[fname] = {
+                                "class": struct_name, "static": False,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["rust"] = _extract_rust_globals_and_fields
+_GLOBAL_FIELD_EXTRACTORS["go"] = _extract_go_globals_and_fields
+_GLOBAL_FIELD_EXTRACTORS["c"] = _extract_c_globals_and_fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestRustGoCGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Rust/Go/C module globals and struct fields"
+```
+
+---
+
+## Task 16: Java + C# globals/fields
+
+**Files:** Modify `mcp_server.py` (two new functions); Test: `tests/test_mcp_server.py` (new `TestJavaCSharpGlobalsAndFields`)
+
+**Grammar facts:** neither language has true top-level globals (all state lives inside a class) — both extractors return `"globals": []` unconditionally. Java: `class_declaration` field:body=`class_body`; members are `field_declaration`, optionally preceded by a `modifiers` node (one wrapper node containing `static`/`public`/etc. as separate children) — static iff any descendant of that `modifiers` node has type `"static"`; name via `field:declarator` → `variable_declarator` → `field:name`. C#: `class_declaration` field:body=`declaration_list`; members are `field_declaration`, but modifiers are direct sibling children of type `modifier` (not wrapped) — static iff any child has type `"modifier"` and text `b"static"`; name via `field:declarator` (well, C#'s `field_declaration` wraps a `variable_declaration` child, itself containing `variable_declarator` with `field:name` — no field-name on the `variable_declaration` step itself per the verified dump, so locate it by type, not field).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestJavaCSharpGlobalsAndFields:
+    def _java_parser(self):
+        import tree_sitter_java
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_java.language()))
+
+    def _csharp_parser(self):
+        import tree_sitter_c_sharp
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_c_sharp.language()))
+
+    def test_java_static_and_instance_fields(self):
+        import mcp_server
+        source = b"public class Foo {\n    static int staticField = 1;\n    int instanceField = 2;\n}\n"
+        tree = self._java_parser().parse(source)
+        result = mcp_server._extract_java_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+        assert result["globals"] == []
+
+    def test_csharp_static_and_instance_fields(self):
+        import mcp_server
+        source = b"public class Foo {\n    static int staticField = 1;\n    int instanceField = 2;\n}\n"
+        tree = self._csharp_parser().parse(source)
+        result = mcp_server._extract_csharp_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+        assert result["globals"] == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestJavaCSharpGlobalsAndFields -v`
+Expected: FAIL — functions don't exist. If the C# `variable_declaration`/`variable_declarator` lookup-by-type below turns out to need adjustment against the real grammar version installed, dump the AST for the fixture source first (`tree.root_node.sexp()` or a manual recursive print, same technique used to ground this plan's other language facts) rather than guessing further.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_java_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def walk_class(class_node: Any) -> None:
+        name_node = class_node.child_by_field_name("name")
+        class_name = name_node.text.decode("utf-8") if name_node else ""
+        body = class_node.child_by_field_name("body")
+        if body is None:
+            return
+        for member in body.children:
+            if member.type != "field_declaration":
+                continue
+            is_static = False
+            for child in member.children:
+                if child.type == "modifiers":
+                    is_static = any(mod.type == "static" for mod in child.children)
+            declarator = member.child_by_field_name("declarator")
+            if declarator is not None and declarator.type == "variable_declarator":
+                fname_node = declarator.child_by_field_name("name")
+                if fname_node is not None:
+                    fname = fname_node.text.decode("utf-8")
+                    fields.append((fname, class_name, is_static))
+                    field_info[fname] = {
+                        "class": class_name, "static": is_static,
+                        "body": member.text.decode("utf-8", "replace"),
+                    }
+
+    def walk(node: Any) -> None:
+        if node.type == "class_declaration":
+            walk_class(node)
+        for child in node.children:
+            walk(child)
+
+    walk(root_node)
+    return {"globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info}
+
+
+def _extract_csharp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def walk_class(class_node: Any) -> None:
+        name_node = class_node.child_by_field_name("name")
+        class_name = name_node.text.decode("utf-8") if name_node else ""
+        body = class_node.child_by_field_name("body")
+        if body is None:
+            return
+        for member in body.children:
+            if member.type != "field_declaration":
+                continue
+            is_static = any(c.type == "modifier" and c.text == b"static" for c in member.children)
+            var_decl = next((c for c in member.children if c.type == "variable_declaration"), None)
+            if var_decl is None:
+                continue
+            for declarator in var_decl.children:
+                if declarator.type == "variable_declarator":
+                    fname_node = declarator.child_by_field_name("name")
+                    if fname_node is not None:
+                        fname = fname_node.text.decode("utf-8")
+                        fields.append((fname, class_name, is_static))
+                        field_info[fname] = {
+                            "class": class_name, "static": is_static,
+                            "body": member.text.decode("utf-8", "replace"),
+                        }
+
+    def walk(node: Any) -> None:
+        if node.type == "class_declaration":
+            walk_class(node)
+        for child in node.children:
+            walk(child)
+
+    walk(root_node)
+    return {"globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["java"] = _extract_java_globals_and_fields
+_GLOBAL_FIELD_EXTRACTORS["c_sharp"] = _extract_csharp_globals_and_fields
+```
+
+Note both `walk` helpers recurse into every node (not just direct children of the root), unlike Tasks 13-15's strictly-direct-children approach — this is still safe scope-wise because `class_declaration` is itself a structural node (same non-ambiguity argument as functions/classes in `_walk_ast`), and nested classes are a real, valid Java/C# construct worth capturing fields from; the recursion only ever *enters* a `field_declaration`'s own member list, never a method body, so the "don't misclassify locals" invariant still holds.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestJavaCSharpGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Java/C# class fields (static via modifier inspection)"
+```
+
+---
+
+## Task 17: C++ globals/fields
+
+**Files:** Modify `mcp_server.py` (new `_extract_cpp_globals_and_fields`); Test: `tests/test_mcp_server.py` (new `TestCppGlobalsAndFields`)
+
+**Grammar facts:** top-level `int x = 5;` is a `declaration` directly under `translation_unit`, same shape as C (reuse the same `declarator_name` logic as Task 15's C extractor). `class Foo { ... };`/`struct Foo { ... };` are `class_specifier`/`struct_specifier` with `field:body` = `field_declaration_list`; each member `field_declaration` optionally has a `storage_class_specifier` child with text `"static"`; the declarator is directly a `field_identifier` (not wrapped in `init_declarator`, per the verified dump — unlike C's free variable declarations).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestCppGlobalsAndFields:
+    def _cpp_parser(self):
+        import tree_sitter_cpp
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_cpp.language()))
+
+    def test_top_level_declaration_is_global(self):
+        import mcp_server
+        tree = self._cpp_parser().parse(b"int global_x = 5;\n")
+        result = mcp_server._extract_cpp_globals_and_fields(tree.root_node)
+        assert "global_x" in result["globals"]
+
+    def test_static_and_instance_class_fields(self):
+        import mcp_server
+        source = b"class Foo {\npublic:\n    static int staticField;\n    int instanceField;\n};\n"
+        tree = self._cpp_parser().parse(source)
+        result = mcp_server._extract_cpp_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestCppGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_cpp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def declarator_name(node: Any) -> Optional[str]:
+        if node.type == "identifier":
+            return node.text.decode("utf-8")
+        if node.type == "init_declarator":
+            inner = node.child_by_field_name("declarator")
+            return declarator_name(inner) if inner is not None else None
+        return None
+
+    for stmt in root_node.children:
+        if stmt.type == "declaration":
+            declarator = stmt.child_by_field_name("declarator")
+            if declarator is not None:
+                name = declarator_name(declarator)
+                if name:
+                    globals_.append(name)
+                    global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type in ("class_specifier", "struct_specifier"):
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type != "field_declaration":
+                    continue
+                is_static = any(c.type == "storage_class_specifier" and c.text == b"static" for c in member.children)
+                declarator = member.child_by_field_name("declarator")
+                if declarator is not None and declarator.type == "field_identifier":
+                    fname = declarator.text.decode("utf-8")
+                    fields.append((fname, class_name, is_static))
+                    field_info[fname] = {
+                        "class": class_name, "static": is_static,
+                        "body": member.text.decode("utf-8", "replace"),
+                    }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["cpp"] = _extract_cpp_globals_and_fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestCppGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract C++ module globals and class/struct fields"
+```
+
+---
+
+## Task 18: Ruby globals/fields
+
+**Files:** Modify `mcp_server.py` (new `_extract_ruby_globals_and_fields`); Test: `tests/test_mcp_server.py` (new `TestRubyGlobalsAndFields`)
+
+**Grammar facts:** the grammar itself distinguishes these via distinct node types (no heuristic needed): top-level `assignment` with `field:left` of type `global_variable` (`$x`) or `constant` (`CONST_VAR`) → global. Inside a `class`'s `field:body` (`body_statement`), a direct-child `assignment` with `field:left` of type `class_variable` (`@@x`) → static field. Inside a `method` named `initialize` (itself a direct child of the class's `body_statement`), its own `field:body`'s direct-child `assignment`s with `field:left` of type `instance_variable` (`@x`) → instance field.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestRubyGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_ruby
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_ruby.language()))
+
+    def test_global_variable_and_constant_are_globals(self):
+        import mcp_server
+        source = b"$global_var = 5\nCONST_VAR = 10\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_ruby_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"$global_var", "CONST_VAR"}
+
+    def test_class_variable_is_static_instance_variable_in_initialize_is_not(self):
+        import mcp_server
+        source = b"class Foo\n  @@class_var = 1\n  def initialize\n    @instance_var = 2\n  end\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_ruby_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["@@class_var"] == ("Foo", True)
+        assert info["@instance_var"] == ("Foo", False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestRubyGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_ruby_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    for stmt in root_node.children:
+        if stmt.type == "assignment":
+            left = stmt.child_by_field_name("left")
+            if left is not None and left.type in ("global_variable", "constant"):
+                name = left.text.decode("utf-8")
+                globals_.append(name)
+                global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "class":
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type == "assignment":
+                    left = member.child_by_field_name("left")
+                    if left is not None and left.type == "class_variable":
+                        fname = left.text.decode("utf-8")
+                        fields.append((fname, class_name, True))
+                        field_info[fname] = {
+                            "class": class_name, "static": True,
+                            "body": member.text.decode("utf-8", "replace"),
+                        }
+                elif member.type == "method":
+                    method_name_node = member.child_by_field_name("name")
+                    if method_name_node is not None and method_name_node.text == b"initialize":
+                        method_body = member.child_by_field_name("body")
+                        if method_body is not None:
+                            for inner in method_body.children:
+                                if inner.type == "assignment":
+                                    left = inner.child_by_field_name("left")
+                                    if left is not None and left.type == "instance_variable":
+                                        fname = left.text.decode("utf-8")
+                                        fields.append((fname, class_name, False))
+                                        field_info[fname] = {
+                                            "class": class_name, "static": False,
+                                            "body": inner.text.decode("utf-8", "replace"),
+                                        }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["ruby"] = _extract_ruby_globals_and_fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestRubyGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Ruby globals/constants and class/instance variables"
+```
+
+---
+
+## Task 19: PHP globals/fields
+
+**Files:** Modify `mcp_server.py` (new `_extract_php_globals_and_fields`); Test: `tests/test_mcp_server.py` (new `TestPhpGlobalsAndFields`)
+
+**Grammar facts:** top-level `$x = 5;` is `expression_statement > assignment_expression` with `field:left` = `variable_name`. `class Foo { ... }` is `class_declaration` with `field:body` = `declaration_list`; each member is a `property_declaration` containing an optional `static_modifier` child and one or more `property_element` children, each with `field:name` = `variable_name`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestPhpGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_php
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_php.language_php()))
+
+    def test_top_level_variable_is_global(self):
+        import mcp_server
+        source = b"<?php\n$globalVar = 5;\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_php_globals_and_fields(tree.root_node)
+        assert "$globalVar" in result["globals"]
+
+    def test_static_and_instance_properties(self):
+        import mcp_server
+        source = b"<?php\nclass Foo {\n    public static $staticField = 1;\n    public $instanceField = 2;\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_php_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["$staticField"] == ("Foo", True)
+        assert info["$instanceField"] == ("Foo", False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestPhpGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_php_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    for stmt in root_node.children:
+        if stmt.type == "expression_statement" and stmt.child_count > 0:
+            expr = stmt.children[0]
+            if expr.type == "assignment_expression":
+                left = expr.child_by_field_name("left")
+                if left is not None and left.type == "variable_name":
+                    name = left.text.decode("utf-8")
+                    globals_.append(name)
+                    global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "class_declaration":
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type != "property_declaration":
+                    continue
+                is_static = any(c.type == "static_modifier" for c in member.children)
+                for elem in member.children:
+                    if elem.type == "property_element":
+                        name_node = elem.child_by_field_name("name")
+                        if name_node is not None:
+                            fname = name_node.text.decode("utf-8")
+                            fields.append((fname, class_name, is_static))
+                            field_info[fname] = {
+                                "class": class_name, "static": is_static,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["php"] = _extract_php_globals_and_fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestPhpGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract PHP globals and class properties"
+```
+
+---
+
+## Task 20: Kotlin globals/fields
+
+**Files:** Modify `mcp_server.py` (new `_extract_kotlin_globals_and_fields`); Test: `tests/test_mcp_server.py` (new `TestKotlinGlobalsAndFields`)
+
+**Grammar facts:** top-level `val`/`var` is a `property_declaration` directly under `source_file`, with a `variable_declaration` child (itself containing a plain `identifier` child — neither step exposes a named field per the verified dump, so both must be located by node type). `class Foo { ... }` is `class_declaration` containing a `class_body` child (also not exposed via a named field in this grammar version); a `property_declaration` that is a **direct** child of `class_body` is an instance field; one nested inside a `companion_object`'s own `class_body` is Kotlin's static-equivalent.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestKotlinGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_kotlin
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_kotlin.language()))
+
+    def test_top_level_property_is_global(self):
+        import mcp_server
+        tree = self._parser().parse(b"val globalX = 5\n")
+        result = mcp_server._extract_kotlin_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_companion_object_property_is_static_plain_is_instance(self):
+        import mcp_server
+        source = b"class Foo {\n    companion object {\n        val staticField = 1\n    }\n    val instanceField = 2\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_kotlin_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestKotlinGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist. If `variable_declaration`'s inner `identifier` lookup-by-type doesn't match the installed grammar version exactly, dump the AST for `"val globalX = 5\n"` first and adjust — this task's field-name gaps were flagged explicitly above because the earlier live dump didn't show named fields at this level.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_kotlin_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def property_name(prop_node: Any) -> Optional[str]:
+        for child in prop_node.children:
+            if child.type == "variable_declaration":
+                for inner in child.children:
+                    if inner.type == "identifier":
+                        return inner.text.decode("utf-8")
+        return None
+
+    for stmt in root_node.children:
+        if stmt.type == "property_declaration":
+            name = property_name(stmt)
+            if name:
+                globals_.append(name)
+                global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "class_declaration":
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            class_body = next((c for c in stmt.children if c.type == "class_body"), None)
+            if class_body is None:
+                continue
+            for member in class_body.children:
+                if member.type == "property_declaration":
+                    fname = property_name(member)
+                    if fname:
+                        fields.append((fname, class_name, False))
+                        field_info[fname] = {
+                            "class": class_name, "static": False,
+                            "body": member.text.decode("utf-8", "replace"),
+                        }
+                elif member.type == "companion_object":
+                    companion_body = next((c for c in member.children if c.type == "class_body"), None)
+                    if companion_body is None:
+                        continue
+                    for inner_member in companion_body.children:
+                        if inner_member.type == "property_declaration":
+                            fname = property_name(inner_member)
+                            if fname:
+                                fields.append((fname, class_name, True))
+                                field_info[fname] = {
+                                    "class": class_name, "static": True,
+                                    "body": inner_member.text.decode("utf-8", "replace"),
+                                }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["kotlin"] = _extract_kotlin_globals_and_fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestKotlinGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Kotlin top-level properties and class/companion fields"
+```
+
+---
+
+## Task 21: Swift globals/fields
+
+**Files:** Modify `mcp_server.py` (new `_extract_swift_globals_and_fields`); Test: `tests/test_mcp_server.py` (new `TestSwiftGlobalsAndFields`)
+
+**Grammar facts:** top-level `let`/`var` is `property_declaration` directly under `source_file`; `field:name` → `pattern` → `field:bound_identifier` → `simple_identifier` holds the actual name. `class Foo { ... }` is `class_declaration` with `field:body` = `class_body`; members are `property_declaration`, static iff it has a `modifiers` child containing a `property_modifier` child with text `"static"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestSwiftGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_swift
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_swift.language()))
+
+    def test_top_level_let_is_global(self):
+        import mcp_server
+        tree = self._parser().parse(b"let globalX = 5\n")
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_static_and_instance_properties(self):
+        import mcp_server
+        source = b"class Foo {\n    static var staticField = 1\n    var instanceField = 2\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestSwiftGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_swift_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def property_name(prop_node: Any) -> Optional[str]:
+        pattern = prop_node.child_by_field_name("name")
+        if pattern is None:
+            return None
+        bound = pattern.child_by_field_name("bound_identifier")
+        return bound.text.decode("utf-8") if bound is not None else None
+
+    for stmt in root_node.children:
+        if stmt.type == "property_declaration":
+            name = property_name(stmt)
+            if name:
+                globals_.append(name)
+                global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "class_declaration":
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type != "property_declaration":
+                    continue
+                is_static = False
+                for child in member.children:
+                    if child.type == "modifiers":
+                        is_static = any(
+                            m.type == "property_modifier" and m.text == b"static"
+                            for m in child.children
+                        )
+                fname = property_name(member)
+                if fname:
+                    fields.append((fname, class_name, is_static))
+                    field_info[fname] = {
+                        "class": class_name, "static": is_static,
+                        "body": member.text.decode("utf-8", "replace"),
+                    }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["swift"] = _extract_swift_globals_and_fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestSwiftGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Swift top-level and class properties"
+```
+
+---
+
+## Task 22: Scala globals/fields
+
+**Files:** Modify `mcp_server.py` (new `_extract_scala_globals_and_fields`); Test: `tests/test_mcp_server.py` (new `TestScalaGlobalsAndFields`)
+
+**Grammar facts:** `class Foo { val instanceField = 2 }` is `class_definition` with `field:body` = `template_body`, containing `val_definition`/`var_definition` members (`field:pattern` holds the plain `identifier`) — always instance (`:static=False`), since Scala classes have no static-member concept.
+
+**Deliberate simplification** (document, don't chase companion-object pairing): Scala's closest analog to "static" is a companion `object` sharing a class's name, but matching an `object_definition` to its companion `class_definition` by name — and only then treating its members as that class's static fields — is real extra complexity for a niche pattern. Instead: a top-level `object_definition` (direct child of `compilation_unit`) is treated as a **globals namespace**, not a fields-owner — its `val_definition`/`var_definition` members are extracted as plain module-level globals (no `:class` edge, no `:static` concept invoked at all), sidestepping the need to resolve companion pairing or risk a dangling `:class` edge to a non-existent class ident. A *nested* `object_definition` (inside a class) is out of scope for this task.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestScalaGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_scala
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_scala.language()))
+
+    def test_top_level_object_members_are_globals(self):
+        import mcp_server
+        source = b"object Globals {\n  val globalX = 5\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_class_members_are_instance_fields(self):
+        import mcp_server
+        source = b"class Foo {\n  val instanceField = 2\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["instanceField"] == ("Foo", False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestScalaGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_scala_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def definition_name(defn_node: Any) -> Optional[str]:
+        pattern = defn_node.child_by_field_name("pattern")
+        if pattern is not None and pattern.type == "identifier":
+            return pattern.text.decode("utf-8")
+        return None
+
+    for stmt in root_node.children:
+        if stmt.type == "object_definition":
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type in ("val_definition", "var_definition"):
+                    name = definition_name(member)
+                    if name:
+                        globals_.append(name)
+                        global_bodies[name] = member.text.decode("utf-8", "replace")
+        elif stmt.type == "class_definition":
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type in ("val_definition", "var_definition"):
+                    fname = definition_name(member)
+                    if fname:
+                        fields.append((fname, class_name, False))
+                        field_info[fname] = {
+                            "class": class_name, "static": False,
+                            "body": member.text.decode("utf-8", "replace"),
+                        }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["scala"] = _extract_scala_globals_and_fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestScalaGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Scala top-level object globals and class fields"
+```
+
+---
+
+## Task 23: Haskell globals/fields
+
+**Files:** Modify `mcp_server.py` (new `_extract_haskell_globals_and_fields`); Test: `tests/test_mcp_server.py` (new `TestHaskellGlobalsAndFields`)
+
+**Grammar facts:** the root node's `field:declarations` holds a `declarations` node whose children include `signature`/`bind`/`data_type` (among others). A zero-argument `bind` node (`field:name` = `variable`) is cleanly distinguished by the grammar itself from a parameterized `function` node (which `_LANG_NODE_TYPES["haskell"]["functions"]` already targets) — this is the "global value" case. `data Foo = Foo { fieldA :: Int }` is `data_type` (`field:name` = the type name) → `field:constructors` → `data_constructors` → each `data_constructor` (`field:constructor`) → if that constructor is a `record` node → `field:fields` → `fields` → each `field` child (`field:field`) → `field:name` → `field_name` → `variable` (the actual field name text). Always `:static=False` (no OOP concept in Haskell).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestHaskellGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_haskell
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_haskell.language()))
+
+    def test_zero_arg_bind_is_global(self):
+        import mcp_server
+        source = b"globalX :: Int\nglobalX = 5\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_record_fields_extracted(self):
+        import mcp_server
+        source = b"data Foo = Foo { fieldA :: Int, fieldB :: String }\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["fieldA"] == ("Foo", False)
+        assert info["fieldB"] == ("Foo", False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestHaskellGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_haskell_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    declarations = root_node.child_by_field_name("declarations")
+    if declarations is None:
+        return {"globals": [], "global_bodies": {}, "fields": [], "field_info": {}}
+
+    for decl in declarations.children:
+        if decl.type == "bind":
+            name_node = decl.child_by_field_name("name")
+            if name_node is not None:
+                name = name_node.text.decode("utf-8")
+                globals_.append(name)
+                global_bodies[name] = decl.text.decode("utf-8", "replace")
+        elif decl.type == "data_type":
+            type_name_node = decl.child_by_field_name("name")
+            type_name = type_name_node.text.decode("utf-8") if type_name_node else ""
+            constructors = decl.child_by_field_name("constructors")
+            if constructors is None:
+                continue
+            for ctor_wrapper in constructors.children:
+                if ctor_wrapper.type != "data_constructor":
+                    continue
+                ctor = ctor_wrapper.child_by_field_name("constructor")
+                if ctor is None or ctor.type != "record":
+                    continue
+                fields_node = ctor.child_by_field_name("fields")
+                if fields_node is None:
+                    continue
+                for field_wrapper in fields_node.children:
+                    if field_wrapper.type != "field":
+                        continue
+                    field_name_node = field_wrapper.child_by_field_name("name")
+                    if field_name_node is None:
+                        continue
+                    variable_node = next(
+                        (c for c in field_name_node.children if c.type == "variable"), None
+                    )
+                    if variable_node is not None:
+                        fname = variable_node.text.decode("utf-8")
+                        fields.append((fname, type_name, False))
+                        field_info[fname] = {
+                            "class": type_name, "static": False,
+                            "body": field_wrapper.text.decode("utf-8", "replace"),
+                        }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["haskell"] = _extract_haskell_globals_and_fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestHaskellGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Haskell top-level bindings and record fields"
+```
+
+---
+
+## Task 24: Lua globals (no fields — no class concept)
+
+**Files:** Modify `mcp_server.py` (new `_extract_lua_globals_and_fields`); Test: `tests/test_mcp_server.py` (new `TestLuaGlobalsAndFields`)
+
+**Grammar facts:** `_LANG_NODE_TYPES["lua"]["classes"]` is already `set()` — Lua has no class node type at all (table-based OOP is a library convention, not a grammar construct), so fields are always empty for Lua, consistent with that existing precedent. A true top-level global is `assignment_statement` directly under `chunk` whose `variable_list` holds a single plain `identifier` (not a `dot_index_expression`, which is a table-field write like `Foo.staticField = 1`, deliberately excluded — no class entity exists for it to attach to) and which is **not** wrapped in a `variable_declaration` (that wrapper node is what `local` produces — its presence means the name is function/file-local, not a true global).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestLuaGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_lua
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_lua.language()))
+
+    def test_true_global_assignment(self):
+        import mcp_server
+        tree = self._parser().parse(b"globalX = 5\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_local_declaration_not_captured(self):
+        import mcp_server
+        tree = self._parser().parse(b"local localY = 10\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+    def test_table_field_assignment_not_captured(self):
+        import mcp_server
+        tree = self._parser().parse(b"Foo = {}\nFoo.staticField = 1\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert result["globals"] == ["Foo"]
+        assert result["fields"] == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestLuaGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_lua_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+
+    for stmt in root_node.children:
+        if stmt.type != "assignment_statement":
+            continue
+        var_list = next((c for c in stmt.children if c.type == "variable_list"), None)
+        if var_list is None:
+            continue
+        name_node = var_list.child_by_field_name("name")
+        if name_node is not None and name_node.type == "identifier":
+            name = name_node.text.decode("utf-8")
+            globals_.append(name)
+            global_bodies[name] = stmt.text.decode("utf-8", "replace")
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": [], "field_info": {}}
+
+
+_GLOBAL_FIELD_EXTRACTORS["lua"] = _extract_lua_globals_and_fields
+```
+
+(A `local x = 5` statement parses as a `variable_declaration` wrapping an `assignment_statement`, per the verified dump — since this loop only matches `assignment_statement` nodes that are *direct* children of `chunk`, a `local`-wrapped one is automatically excluded without needing an explicit check, because its actual `assignment_statement` is one level deeper, inside the `variable_declaration` wrapper.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestLuaGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Lua true global variable assignments"
+```
+
+---
+
+## Task 25: Elixir fields (no globals — module attributes only)
+
+**Files:** Modify `mcp_server.py` (new `_extract_elixir_globals_and_fields`); Test: `tests/test_mcp_server.py` (new `TestElixirGlobalsAndFields`)
+
+**Grammar facts:** no top-level mutable globals exist in Elixir outside module attributes, so `"globals"` is always empty. A module is `call` with `field:target` `identifier` text `"defmodule"`, `field:arguments` holding an `alias` node (the module name), and a `do_block` child. A module attribute (`@module_attr 5`) is a `unary_operator` with `field:operator` = `"@"` and `field:operand` = a `call` node whose `field:target` holds the attribute's name — treated as a `:static=True` field of the enclosing module (the closest Elixir analog to compile-time class-scoped state).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestElixirGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_elixir
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_elixir.language()))
+
+    def test_module_attribute_is_static_field(self):
+        import mcp_server
+        source = b"defmodule Foo do\n  @module_attr 5\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_elixir_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["module_attr"] == ("Foo", True)
+        assert result["globals"] == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestElixirGlobalsAndFields -v`
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _extract_elixir_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def walk(node: Any) -> None:
+        if node.type == "call":
+            target = node.child_by_field_name("target")
+            if target is not None and target.type == "identifier" and target.text == b"defmodule":
+                arguments = node.child_by_field_name("arguments")
+                module_name = ""
+                if arguments is not None:
+                    alias_node = next((c for c in arguments.children if c.type == "alias"), None)
+                    if alias_node is not None:
+                        module_name = alias_node.text.decode("utf-8")
+                do_block = next((c for c in node.children if c.type == "do_block"), None)
+                if do_block is not None:
+                    for member in do_block.children:
+                        if member.type == "unary_operator":
+                            op = member.child_by_field_name("operator")
+                            operand = member.child_by_field_name("operand")
+                            if op is not None and op.text == b"@" and operand is not None and operand.type == "call":
+                                attr_target = operand.child_by_field_name("target")
+                                if attr_target is not None:
+                                    fname = attr_target.text.decode("utf-8")
+                                    fields.append((fname, module_name, True))
+                                    field_info[fname] = {
+                                        "class": module_name, "static": True,
+                                        "body": member.text.decode("utf-8", "replace"),
+                                    }
+        for child in node.children:
+            walk(child)
+
+    walk(root_node)
+    return {"globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["elixir"] = _extract_elixir_globals_and_fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k TestElixirGlobalsAndFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full Component 3 test sweep**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k "GlobalsAndFields" -v`
+Expected: All 13 language-task test classes PASS. Also run the full suite once, since Component 3 touched `_extract_from_source`'s shared return shape (Task 12) which every other language's existing function/class tests also exercise: `.venv/bin/pytest tests/test_mcp_server.py -q`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extract Elixir module attributes as static fields"
+```
+
+---
+
+## Task 26: Extend matcher pools to globals/fields
+
+**Files:**
+- Modify: all 13 per-language extractor functions from Tasks 13-25 (retrofit — see below)
+- Modify: `mcp_server.py` (`_extract_commit`'s pool-building, from Task 9)
+- Test: `tests/test_mcp_server.py` (extend `TestExtractCommitRename` with a global-rename case)
+
+**Required retrofit before this task's own work**: Tasks 13-25's extractor functions return body *text* only (`global_bodies`/`field_info[...]["body"]`), by design (Task 6 established that `_extract_from_source`'s return must stay plain-data since it crosses the `ProcessPoolExecutor` boundary). But the matcher (Tasks 7-9) needs live tree-sitter *nodes*, and those nodes only exist transiently, inside this same worker process, at the moment each extractor walks its tree. Go back to **each of the 13 functions from Tasks 13-25** and add two more keys to their returned dict, captured for free during the same walk (the node is already in hand right before each `.text.decode(...)` call):
+
+```python
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes,   # Dict[str, Any] — name -> node, parallel to global_bodies
+        "field_nodes": field_nodes,     # Dict[str, Any] — qualified "Class.name" -> node, parallel to field_info
+    }
+```
+
+(`global_nodes[name] = <the same node whose .text was decoded into global_bodies[name]>`, populated at the same call site; `field_nodes[f"{class_name}.{field_name}"] = <the field's own node>`, matching the qualified-name convention already used for field idents in Task 11.) Also update `_extract_globals_and_fields`'s empty-result stub (Task 12) to include the two new empty keys, and its dispatch-test fixture (`test_dispatches_to_registered_language_extractor`) sentinel dict to include them too.
+
+**Interfaces:**
+- Produces: `_extract_commit`'s removed/added pools (Task 9) gain `"variable"`/`"field"` categories alongside `"function"`/`"class"`, populated the same way (D/A get full pools, M gets the local diff, R gets both sides in full) — reusing `_extract_globals_and_fields` (called directly, not through `_extract_from_source`, so its `_nodes` keys are available) for both the new-content and old-content (via `_git_blob_content`, same as Task 9's function/class handling) sides.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+    def test_global_rename_produces_renamed_pair(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "config.py").write_text("GLOBAL_X = 12345\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "config.py").write_text("GLOBAL_Y = 12345\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename global"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        assert ("variable", "config.py", "GLOBAL_X", "config.py", "GLOBAL_Y") in renamed_pairs
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_global_rename_produces_renamed_pair -v`
+Expected: FAIL — globals aren't pooled into the matcher yet.
+
+- [ ] **Step 3: Implement**
+
+In `_extract_commit` (as modified by Task 9), extend the pool initialization:
+
+```python
+    removed_pool: Dict[str, List[Tuple[str, Any]]] = {"function": [], "class": [], "variable": [], "field": []}
+    added_pool: Dict[str, List[Tuple[str, Any]]] = {"function": [], "class": [], "variable": [], "field": []}
+```
+
+Add a small local helper right before the main `for status, ... in raw_entries:` loop, and call it everywhere Task 9 currently calls `_collect_entity_nodes` for the old/new sides:
+
+```python
+    def collect_all_nodes(root: Any, lang: str) -> Dict[str, Dict[str, Any]]:
+        base = _collect_entity_nodes(root, lang)
+        gf = _extract_globals_and_fields(root, "typescript" if lang == "tsx" else lang)
+        base["variable"] = dict(gf.get("global_nodes", {}))
+        base["field"] = dict(gf.get("field_nodes", {}))
+        return base
+```
+
+Replace every `_collect_entity_nodes(...)` call inside the loop (both the old-content and new-content sides, per Task 9's D/A/R/M branches) with `collect_all_nodes(...)`, same arguments. Then extend every `for category in ("function", "class"):` loop in those same branches to `for category in ("function", "class", "variable", "field"):` — this covers the D-status pooling, the A-status pooling, the R-status both-sides pooling, and the M-status local-diff pooling, all four of which already iterate `("function", "class")` from Task 9 and just need the tuple widened.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_global_rename_produces_renamed_pair -v`
+Expected: PASS. Also re-run all of Component 3's language tests plus Component 2's matcher tests to confirm the retrofit didn't break anything: `.venv/bin/pytest tests/test_mcp_server.py -k "GlobalsAndFields or TestMatchRenamedEntities or TestExtractCommit" -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "feat: extend rename matcher pools to globals and fields"
+```
+
+---
+
+## Task 27: Wire global/field rename triples
+
+**Files:**
+- Modify: `mcp_server.py:3194-3563` (`_run_ingestion`)
+- Test: `tests/test_mcp_server.py` (new test in `TestRunIngestionBitemporalClose`)
+
+**Interfaces:**
+- Consumes: Task 26's widened `renamed_pairs` (now includes `"variable"`/`"field"` categories).
+- Produces: no new code needed beyond what Task 10 already wrote — Task 10's `for category, old_file, old_name, new_file, new_name in renamed_pairs:` loop is already category-agnostic (`_code_ident(category, ...)` works identically for `"variable"`/`"field"` as it does for `"function"`/`"class"`). This task is verification-only: confirm end-to-end that a global/field rename produces the same `:renamed-from`/`:renamed-to` triples as a function rename, through the full `_run_ingestion` path (not just `_extract_commit` in isolation, as Task 26 tested).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+    @pytest.mark.asyncio
+    async def test_global_rename_links_via_rename_edges_end_to_end(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "config.py").write_text("GLOBAL_X = 12345\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "config.py").write_text("GLOBAL_Y = 12345\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename global"], cwd=repo, check=True, capture_output=True)
+
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        old_ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
+        new_ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_Y")
+
+        assert any(f"{old_ident} :renamed-to {new_ident}" in t for t in close_triples_seen)
+        transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
+        assert f"{new_ident} :renamed-from {old_ident}" in transact_calls
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_global_rename_links_via_rename_edges_end_to_end -v`
+Expected: Most likely PASSES already given Task 10 + Task 26's work — if so, this confirms the design (Task 27 needs no new production code). If it fails, the gap is almost certainly that `entity_descriptions`/`entity_valid_from` lookups in Task 10's loop assume a function/class-shaped ident that doesn't quite match a variable's — re-read Task 10's block and Task 11's `_code_ident("variable", ...)` construction side by side to find the mismatch before adding new code.
+
+- [ ] **Step 3: (Conditional) Fix any gap found in Step 2**
+
+Only if Step 2 failed: the most likely fix is in Task 10's block — `old_module_ident = _code_ident("module", old_file)` is computed unconditionally there for use in `_build_close_triples`'s third argument, which is correct for any category (a variable's `:contains` edge, like a function's, comes from its owning module) — verify this is actually what's failing before changing anything else.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -k test_global_rename_links_via_rename_edges_end_to_end -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "test: verify end-to-end global/field rename linkage through _run_ingestion"
+```
+
+---
+
+## Task 28: SKILL.md docs
+
+**Files:** Modify `SKILL.md`
+
+**Interfaces:** none (docs-only).
+
+- [ ] **Step 1: Update entity-type documentation**
+
+Find the section of `SKILL.md` documenting entity types (grep `:type/module`/`:type/function`/`:type/class` in `SKILL.md` to locate it) and add `:type/variable` and `:type/field` alongside the existing ones, including `:field`'s `:static`/`:class` attributes and the `:renamed-from`/`:renamed-to` attributes now present on all five code entity types (module, function, class, variable, field). Follow the existing doc's format exactly (same style used for `:type/module`'s attribute list).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add SKILL.md
+git commit -m "docs: document :type/variable, :type/field, and rename-tracking attributes"
+```
+
+---
+
+## Task 29: Full suite regression + PR
+
+**Files:** none (verification + PR only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -q`
+Expected: all tests pass, 0 regressions vs. the pre-feature baseline (352 passed, 38 skipped per the most recent prior baseline recorded in project memory — a higher passed-count is expected here given how many new tests this plan adds; investigate immediately if anything *fails* or if the skip count changes unexpectedly).
+
+- [ ] **Step 2: Run with the wasm feature flag too, matching this repo's CI matrix**
+
+Run: `.venv/bin/pytest tests/test_mcp_server.py -q --deselect ""` — actually just re-run plain `pytest -q` a second time if the project's CI config runs a `--features wasm`-equivalent Python-side flag; check `.github/workflows/*.yml` for the exact second CI invocation this repo uses (referenced in project memory as "6/6 checks... across Python 3.8-3.12") and mirror it locally before pushing.
+
+- [ ] **Step 3: Open the PR**
+
+Per the design spec's delivery decision (single PR closing both #111 and #113): create a branch, push, and open a PR with `Fixes #111` and `Fixes #113` both in the body so merging auto-closes both issues (see project memory's recorded lesson from #108's closure — a PR that resolves an issue must have the closing keyword in its own body, merging alone does not auto-close). Follow this repo's established pattern from the most recent several merges: branch name `fix-rename-tracking-111-113` (or similar), PR title referencing both issues, and expect the `REVIEW_REQUIRED` branch-protection gate this repo has hit on every recent PR — do not merge with `--admin` without the user's explicit go-ahead in that specific conversation.
+
+---
+
+## Self-Review
+
+**Spec coverage:** every section of `docs/superpowers/specs/2026-07-14-git-ingestion-rename-tracking-design.md` maps to a task — Schema changes → Task 1; Component 1 → Tasks 3-5; Component 2 → Tasks 6-10; Component 3 → Tasks 11-25; Component 4 → Tasks 26-27; Docs → Task 28. All stated Non-goals (copy detection, `:modified-in` fix, retroactive backfill, local-variable entities, true lexical scope resolution) are honored by omission — no task introduces any of them.
+
+**Placeholder scan:** no task contains "TBD"/"implement later"/"similar to Task N without code" — every step shows real code or a real, runnable command. Two tasks (9, 26) explicitly instruct going back to retrofit an earlier task's interface once a real caller exposed a gap — flagged inline as "Required retrofit," not hidden or deferred as future work.
+
+**Type consistency:** `_code_ident(entity_type, file_path, name)` is used identically across Tasks 1, 5, 10, 11, 27 for all five entity type strings (`"module"`, `"function"`, `"class"`, `"variable"`, `"field"`). `renamed_pairs`' 5-tuple shape `(category, old_file, old_name, new_file, new_name)` is established in Task 9 and consumed unchanged by Tasks 10, 26, 27. The `(name, node)` pool-entry shape from Task 9 is reused unchanged by Task 26's widened categories. `_match_renamed_entities`'s return shape is corrected once, explicitly, in Task 9 (from `(category, old_name, new_name)` to `(category, old_name, old_node, new_name, new_node)`) — Task 8's own tests need that same correction applied before Task 9 can pass; this is called out explicitly rather than left as a silent mismatch.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-07-14-git-ingestion-rename-tracking.md`.** Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-07-14-git-ingestion-rename-tracking-design.md
+++ b/docs/superpowers/specs/2026-07-14-git-ingestion-rename-tracking-design.md
@@ -1,0 +1,270 @@
+# Git Ingestion Rename/Move Tracking — Design
+
+**Date:** 2026-07-14
+**Issues:** #111 (file/function/class rename tracking), #113 (global/field/static extraction, folded in as a prerequisite)
+
+## Problem
+
+Module/function/class identity is computed purely from `(current file path, name)` via
+`_code_ident` (mcp_server.py:1442-1456), which itself slugs through `_canonical_ident`
+(mcp_server.py:1272-1281). There is no content hash, no stable UUID, nothing that survives a
+path change. `_git_diff_tree_raw` (mcp_server.py:1489-1513) never enables git's rename
+detection (`-M`/`-C`), so any commit that renames or moves a file produces a plain delete +
+add in the raw diff — indistinguishable from an unrelated file being deleted and a different
+file being created. `_extract_commit` (mcp_server.py:3115-3191) has no branch for a rename
+status because git never emits one today.
+
+The result: any renamed or moved file gets a brand-new, fully disconnected entity, discarding
+all history. This propagates one level down — function/class identity is *also*
+`(file_path, name)`-derived, so a function untouched by a rename except for living in a
+renamed file gets a second, unrelated entity too. It also propagates to a same-file rename
+(`oldName()` → `newName()`) and a cross-file move (function cut from one file, pasted
+unchanged into another) — both fracture identity the same way, one level below what git's own
+diff machinery can see.
+
+Issue #113 (globals/fields/statics are never extracted at all — no `:type/field`/
+`:type/variable`) is folded into this work: implementing rename tracking for functions/classes
+requires building a general entity-rename-matching mechanism, and extending that same
+mechanism to cover globals/fields costs little extra once it exists, versus building it twice.
+
+## Scope
+
+**In scope:**
+- File/module-level rename and move detection via git's own `-M` (not `-C`).
+- Function/class-level rename and move detection (same-file rename, cross-file move) via a new
+  content-based matcher, since these are below git's diff granularity.
+- New `:type/variable` (module-level globals) and `:type/field` (class members, instance and
+  static) entity types, extracted across all 16 currently-supported languages.
+- Rename/move tracking for the new global/field entities, using the same matcher.
+- New `:renamed-from`/`:renamed-to` schema attributes on all five entity types (module,
+  function, class, variable, field).
+
+**Out of scope:**
+- Copy detection (`-C`). A copy leaves the original in place *and* creates a new, independent
+  entity — treating it as a rename would misrepresent history (the old entity didn't close).
+- The `:modified-in` over-attribution bug flagged in the issue's comment thread (currently
+  attributed to every function/class in a touched file, not just the ones whose text actually
+  changed in that commit's diff). Orthogonal, unconfirmed by its own reporter — file separately
+  once confirmed with a clean repro.
+- Retroactive backfill for already-ingested repos. Forward-only, same as #115's precedent —
+  #114 is the explicitly-scoped follow-up for backfilling #111/#112/#113 into existing graphs.
+- Local variables as graph entities. They participate in the matcher only as a text-level
+  bijective-matching aid (see below) — never get their own ident, never appear in the graph.
+- A function/class that is both renamed *and* has its own logic edited in the same commit.
+  Falls back to today's disconnected close/open — a known limitation, not a regression.
+
+## Identity scheme decision
+
+Considered switching to a stable, non-path-derived identity (content hash or synthetic ID at
+first introduction) so no new ident is ever created on a rename at all. Rejected: idents are
+deeply embedded — every existing query, every doc example (`:module/src-auth-py`), every
+`:calls`/`:depends-on` edge assumes the current path-derived format. Switching would be a much
+larger, invasive change with no corresponding benefit over the alternative.
+
+**Decision:** keep path-derived idents exactly as they are. On a detected rename, close the old
+ident and open the new one through the existing bi-temporal close/open machinery, unchanged —
+but also write an explicit `:renamed-from`/`:renamed-to` edge linking them. Queries that want
+continuous history traverse the edge; everything else (ident format, existing queries, doc
+examples) is untouched.
+
+## Schema changes
+
+New entity types, following the existing `function`/`class` block pattern
+(mcp_server.py:1911-1934):
+
+- `:type/variable` — module-level globals. Optional attrs: `:file`, `:alias`, `:introduced-by`,
+  `:modified-in`, `:renamed-from`, `:renamed-to`.
+- `:type/field` — class members (instance and static). Same attrs as `variable`, plus `:class`
+  (edge to the owning class ident, mirroring how function/class carry `:file`) and `:static`
+  (boolean).
+
+New optional attribute on all five entity types (module, function, class, variable, field):
+`:renamed-from`, `:renamed-to` — string-valued edges to another entity's ident, symmetric with
+the existing `:introduced-by`/`:modified-in` edges to commit idents. Both directions are
+written explicitly at rename time (old entity gets `:renamed-to <new-ident>` when closed, new
+entity gets `:renamed-from <old-ident>` when opened) so a query can traverse either direction
+without needing reverse-edge support from the query engine.
+
+## Component 1 — File/module-level rename detection
+
+Git already computes this reliably and cheaply via content-similarity diffing; no custom
+matching needed at this level.
+
+- `_git_diff_tree_raw` (mcp_server.py:1489-1513): add `-M` (rename detection only, no `-C`) to
+  the `git diff-tree` invocation.
+- **Parser fix required**: the raw-line parser currently does `line.partition("\t")`, which
+  only splits on the *first* tab. A rename/copy raw line has the shape
+  `:oldmode newmode oldsha newsha R100\told_path\tnew_path` — two tab-separated paths, not one.
+  Without fixing this, `path` becomes the literal string `"old_path\tnew_path"`, `status[0]`
+  becomes `"R"` (not the `"D"` branch `_extract_commit` currently checks), so it falls into the
+  add/modify branch, calls `git show <hash>:old_path\tnew_path`, which fails and is silently
+  swallowed by the bare `except Exception: continue` at mcp_server.py:3175-3176 — the file
+  would be **silently dropped from ingestion entirely**, strictly worse than today's
+  split-into-two-entities behavior. The fix must parse both paths and preserve the full status
+  string (e.g. `R100` vs `R057`) instead of truncating to just the first character, since the
+  similarity score should be threaded through (used for observability/debugging, not as a
+  match-acceptance threshold — git's own default 50% threshold is trusted as-is, no additional
+  filtering).
+- `_extract_commit` (mcp_server.py:3115-3191): new branch for `status == "R"` — extract the new
+  path's content as usual (same as today's add/modify path), tag the result with
+  `renamed_from=<old_path>` instead of falling through to the exception-swallowing path above.
+- `_precompute_file_triples` / `_build_code_triples` (mcp_server.py:2748-2820, 2823-2891): when
+  a module's introduction carries `renamed_from`, emit `:renamed-from`/`:renamed-to` triples
+  alongside the normal open/close triples the bi-temporal machinery already writes. No changes
+  needed to the close/open mechanics themselves — this is a pure additive edge.
+
+## Component 2 — Function/class/global/field rename detection
+
+Runs once per commit, scoped only to entities from files touched in that commit (not a
+repo-wide search) — bounds cost and false-positive risk, and matches how the issue's own
+cross-file-move reproduction had both files in the same commit's diff.
+
+### Algorithm: iterative AST-lockstep matching with local bijection
+
+Reuses the tree-sitter ASTs already produced during extraction (no re-parsing). For a candidate
+pair (removed entity body R, added entity body A) within one entity category (function, class,
+variable, field), walk both ASTs in lockstep:
+
+- **Node type mismatch at any position → bail immediately** (cheap early exit).
+- **Identifier tokens** are classified at each position:
+  - References a tracked entity (module/function/class/variable/field) with a confirmed rename
+    **this round** → must equal the confirmed new name exactly.
+  - References a tracked entity with **no rename** (name unchanged, still present) → must match
+    exactly.
+  - **Unrecognized** (a parameter, local variable, or unresolved external reference — anything
+    not a currently-tracked entity name) → free to differ, but must satisfy a running
+    one-to-one mapping (old↔new) for *this candidate pair only*: the same old token always maps
+    to the same new token, and no two distinct old tokens collapse onto one new token. The
+    mapping resets per candidate pair — it is a matching aid only, never persisted, and no
+    entity is ever created for a local variable.
+- **Everything else** (literals, operators, punctuation, keywords) must match exactly.
+
+A full successful walk confirms the match at the entity level (`R`'s ident → `A`'s ident); the
+local-variable mappings discovered along the way are discarded once the pair is confirmed.
+
+This is a strict generalization of plain exact-match (exact match is the case where the
+bijection happens to be the identity mapping), and is precise about scope in a way a
+text/regex-substitution approach would not be — no risk of a word-boundary substitution
+matching inside a string literal or comment.
+
+### Outer round-based loop
+
+A rename confirmed in one category (e.g. a global) needs to become an available "confirmed
+rename" for other not-yet-matched candidate pairs (e.g. a function body that calls it) evaluated
+in a later round. Rounds repeat, re-attempting all not-yet-matched pairs across all four
+categories with the current confirmed-rename set, until a round produces no new matches. Capped
+at 10 rounds as a defensive bound (expected to terminate in 1-2 rounds for realistic commits;
+the cap only guards against pathological inputs).
+
+### Ambiguity and minimum-size guards
+
+- If a removed body has 2+ equally-good candidate matches among added bodies (e.g. duplicate
+  boilerplate), **skip** — do not guess. False continuity is worse than missing continuity: it
+  would corrupt history in a way indistinguishable from a real rename after the fact, whereas a
+  missed match just reproduces today's existing (already-accepted) disconnected behavior.
+  Same-file candidates are preferred over cross-file ones when disambiguating; if ambiguity
+  remains even within the same file, skip.
+- Bodies below a minimum normalized size are excluded from matching entirely, to avoid spurious
+  matches between trivial boilerplate (e.g. `def x(self): pass`-style stubs).
+
+### Known limitations (all conservative — cause missed matches, never false ones)
+
+- A function renamed *and* logically edited in the same commit: not caught, falls back to
+  today's disconnected behavior.
+- No true lexical scope resolution: if a local variable shadows a tracked entity's name, it's
+  misclassified as "must match exactly," blocking the match.
+- A name reused across genuinely different scopes within one body (shadowing) must map
+  consistently to a single new name everywhere in that body — a real edit that renamed two
+  shadowed instances differently would be missed.
+
+## Component 3 — Global/field/static extraction (#113)
+
+New entity categories extracted across all 16 currently-supported languages (python,
+javascript, typescript, tsx, rust, go, java, c, cpp, c_sharp, ruby, php, kotlin, swift, scala,
+haskell, lua, elixir — per `_EXT_TO_LANG`, mcp_server.py:122-131).
+
+- `_extract_from_source` (mcp_server.py:712-725): extend the returned dict with new
+  `"globals"`/`"fields"` keys, alongside the existing `"functions"`/`"classes"`/`"imports"`/
+  `"calls"`.
+- `_LANG_NODE_TYPES` (mcp_server.py:238-342): extend with new category → node-type sets per
+  language for module-level global declarations and class field declarations. Cheap and mostly
+  generic, following the same pattern as the existing `"functions"`/`"classes"` categories
+  (name extraction via `node.child_by_field_name("name")` where the grammar exposes it).
+- **Static vs. instance vs. module-scope classification is new work, not covered by the
+  existing generic pattern** — node type alone (e.g. `field_declaration` in Java/C#) doesn't
+  encode "static"; that's a modifier on the node. Requires new per-language modifier-inspection
+  logic, one function per language, similar in shape to the existing per-language
+  `_extract_import_name` branches (mcp_server.py:534-641).
+- `_precompute_file_triples` / `_build_code_triples`: new `global_entries`/`field_entries`
+  lists mirroring `function_entries`/`class_entries` exactly (mcp_server.py:2783-2793,
+  2795-2805 for the existing pattern).
+- `_preload_known_entities` (mcp_server.py:2894-, loop at 2931): add `"variable"`/`"field"` to
+  the hardcoded entity-type reload list (currently `("module", "function", "class",
+  "external-dependency")`) so incremental/restarted ingestion recognizes pre-existing idents.
+
+## Component 4 — Rename tracking for globals/fields
+
+Uses the same Component 2 matcher — globals and fields are just two more entity categories
+participating in the same round-based matching loop. A global rename confirmed in one round
+becomes available as a "confirmed rename" for function bodies (or other globals/fields)
+referencing it in later rounds, and vice versa.
+
+## Affected functions
+
+| Function | Change |
+|---|---|
+| `_git_diff_tree_raw` | Add `-M`; fix two-path raw-line parsing for `R` status; preserve similarity score |
+| `_extract_commit` | New `R`-status branch; extract new path, tag with `renamed_from` |
+| `_extract_from_source` | New `"globals"`/`"fields"` keys in returned dict |
+| `_LANG_NODE_TYPES` | New per-language node-type sets for globals/fields, across 16 languages |
+| New per-language modifier-inspection helpers | Classify static vs. instance vs. module-scope (new, one per language) |
+| New matcher module (e.g. `_match_renamed_entities`) | Component 2's AST-lockstep round-based matching loop |
+| `_precompute_file_triples` | New `global_entries`/`field_entries`; emit `:renamed-from`/`:renamed-to` when paired with a confirmed rename |
+| `_build_code_triples` | New entity-category loops for globals/fields, mirroring function/class handling |
+| `_run_ingestion` | Invoke the new matcher after computing removed/added ident sets, before finalizing per-commit triples |
+| `_preload_known_entities` | Add `"variable"`/`"field"` to the reloaded entity-type list |
+| `MINIGRAF_SCHEMA` | New `variable`/`field` entity types; `:renamed-from`/`:renamed-to` on all five code entity types |
+
+## Testing
+
+Following existing conventions (`tests/test_mcp_server.py`, real throwaway git repos in
+`tmp_path`, grouped `TestXxx` classes, `@pytest.mark.asyncio` for `_run_ingestion`-touching
+tests):
+
+- **Flip** `test_renamed_file_closes_old_entities_and_opens_new`
+  (tests/test_mcp_server.py:4572-4597) — it currently asserts the *broken* disconnected
+  behavior as correct (closes old, opens new, no link). Update to assert the new
+  `:renamed-from`/`:renamed-to` edges are present.
+- New `_git_diff_tree_raw` cases: `-M` raw lines for exact (`R100`) and partial (`R057`-style)
+  similarity, verifying both old and new paths parse correctly and don't corrupt adjacent
+  add/delete/modify line parsing.
+- New `_extract_commit` tests for `R`-status handling, including the failure path (renamed file
+  that fails to extract — must not silently drop, must log and treat gracefully).
+- New matcher unit tests: pure in-place function rename; cross-file move (unchanged body);
+  cascading mutual rename (A calls B, both renamed same commit); rename with an internal local
+  variable also renamed (the bijection case); rename + logic edit in the same commit (expect no
+  match — limitation test); duplicate-boilerplate ambiguity (expect no match); local variable
+  shadowing a tracked entity name (expect no match — limitation test).
+- Per-language (16) fixtures exercising: module-level global, instance field, static
+  field/member extraction — at minimum one of each per language.
+- New rename-tracking tests for globals/fields, mirroring the function/class rename tests.
+- Full suite regression run before merge.
+
+## Docs
+
+- `SKILL.md`: document the new `:type/variable`/`:type/field` entity types and the
+  `:renamed-from`/`:renamed-to` attributes, alongside the existing entity-type documentation.
+- `ROADMAP.md:59` currently claims "The graph stores `:calls` and `:depends-on` edges that are
+  entity-addressed, not file-addressed. Refactors do not break the history" — this is the
+  aspirational claim #111 falsifies today and this work is meant to fulfill. Worth revisiting
+  once this ships to confirm the claim now holds (or narrowing it if it still doesn't fully).
+
+## Non-goals
+
+- No copy detection (`-C`).
+- No fix for the `:modified-in` over-attribution bug (separate issue).
+- No retroactive backfill for already-ingested repos (#114's scope).
+- No local-variable entities.
+- No true lexical scope resolution in the bijective matcher.
+- No coverage guarantee for a function that is both renamed and logically edited in the same
+  commit.

--- a/docs/superpowers/specs/2026-07-14-git-ingestion-rename-tracking-design.md
+++ b/docs/superpowers/specs/2026-07-14-git-ingestion-rename-tracking-design.md
@@ -162,8 +162,15 @@ the cap only guards against pathological inputs).
   boilerplate), **skip** — do not guess. False continuity is worse than missing continuity: it
   would corrupt history in a way indistinguishable from a real rename after the fact, whereas a
   missed match just reproduces today's existing (already-accepted) disconnected behavior.
-  Same-file candidates are preferred over cross-file ones when disambiguating; if ambiguity
-  remains even within the same file, skip.
+
+  **Accepted deviation from this section's original text**: the implementation does not
+  currently prefer same-file candidates over cross-file ones when disambiguating — any 2+-way
+  ambiguity, same-file or not, is skipped uniformly. This was flagged by post-implementation
+  review as a documented behavior gap rather than fixed, since the effect is strictly
+  conservative (a same-file rename that's ambiguous only because of a coincidental cross-file
+  match is missed, never falsely matched) and the added matching complexity wasn't judged worth
+  it for a narrow edge case. Revisit if same-file-preference disambiguation turns out to matter
+  in practice.
 - Bodies below a minimum normalized size are excluded from matching entirely, to avoid spurious
   matches between trivial boilerplate (e.g. `def x(self): pass`-style stubs).
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -686,20 +686,17 @@ def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
             name = _c_family_function_name(node)
             if name:
                 results["functions"].append(name)
-                results["function_bodies"][name] = node.text.decode("utf-8", errors="replace")
         else:
             name_node = node.child_by_field_name("name")
             if name_node:
                 name = name_node.text.decode("utf-8")
                 results["functions"].append(name)
-                results["function_bodies"][name] = node.text.decode("utf-8", errors="replace")
 
     elif node.type in node_types.get("classes", set()):
         name_node = node.child_by_field_name("name")
         if name_node:
             name = name_node.text.decode("utf-8")
             results["classes"].append(name)
-            results["class_bodies"][name] = node.text.decode("utf-8", errors="replace")
 
     elif node.type in node_types.get("imports", set()):
         names = _extract_import_name(node, lang_name)
@@ -2364,17 +2361,24 @@ _GLOBAL_FIELD_EXTRACTORS["elixir"] = _extract_elixir_globals_and_fields
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:
-    """Parse source bytes and extract functions, classes, imports, calls, and
-    (for functions/classes) their own full source text — the latter used by
-    the rename matcher (see _match_renamed_entities) to compare old vs. new
-    bodies. Body text is captured here, inside the worker process, because
-    tree_sitter Node objects themselves cannot cross the ProcessPoolExecutor
-    boundary (see #116) — only the decoded text can.
+    """Parse source bytes and extract functions, classes, imports, calls,
+    module-level globals, and class fields — the plain-data structural summary
+    of a file.
+
+    This dict crosses the ProcessPoolExecutor boundary (see #116) as part of
+    _extract_commit's return value, so it deliberately carries ONLY the
+    lightweight name/structure lists the downstream pipeline actually consumes.
+    It does NOT carry entity body text: the rename matcher
+    (_match_renamed_entities) operates on live, re-parsed tree_sitter nodes
+    collected inside the worker process (_collect_entity_nodes /
+    _extract_globals_and_fields' *_nodes keys, via _extract_commit), never on
+    decoded body text — so shipping full function/class/global bodies and
+    per-field metadata across the process boundary would be pure serialization
+    cost for no consumer.
     """
     results: Dict[str, Any] = {
         "functions": [], "classes": [], "imports": [], "calls": [],
-        "function_bodies": {}, "class_bodies": {},
-        "globals": [], "global_bodies": {}, "fields": [], "field_info": {},
+        "globals": [], "fields": [],
     }
     try:
         tree = parser.parse(source)
@@ -2382,9 +2386,7 @@ def _extract_from_source(
         _walk_ast(tree.root_node, results, lang_name)
         gf = _extract_globals_and_fields(tree.root_node, "typescript" if lang_name == "tsx" else lang_name)
         results["globals"] = gf["globals"]
-        results["global_bodies"] = gf["global_bodies"]
         results["fields"] = gf["fields"]
-        results["field_info"] = gf["field_info"]
     except Exception:
         pass  # best-effort; parse failures are non-fatal
     return results

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3444,7 +3444,17 @@ def _extract_commit(
         if status in ("D", "M", "R") and old_sha and old_sha != "0" * len(old_sha):
             try:
                 old_content = _git_blob_content(repo_path, old_sha)
-                old_tree = parser.parse(old_content)
+                # For "R" (rename), old_lang_path is the PRE-rename path,
+                # which can map to a different language than file_path (the
+                # NEW path) on a cross-extension rename — reuse `parser`
+                # (already selected for file_path) would silently walk the
+                # old blob with the wrong grammar. _thread_parser(old_lang_path)
+                # selects the grammar matching the blob's own language. For
+                # "M"/"D", old_lang_path == file_path already (no rename), so
+                # this is the same parser instance as `parser` (thread-local
+                # cache hit) — no behavior change there.
+                old_parser = _thread_parser(old_lang_path) if status == "R" else parser
+                old_tree = old_parser.parse(old_content)
                 old_lang = _EXT_TO_LANG.get(Path(old_lang_path).suffix.lower(), "")
                 old_entity_nodes = _collect_entity_nodes(old_tree.root_node, old_lang)
             except Exception:
@@ -3478,9 +3488,21 @@ def _extract_commit(
         # simplicity/cost tradeoff over threading Node references through
         # _extract_from_source's return value, which must stay plain-data-only
         # for other callers.
+        #
+        # Wrapped best-effort, same as the old-side call above: a
+        # pathologically nested file parses fine under tree-sitter but can
+        # blow the Python recursion limit inside _collect_entity_nodes's
+        # own recursive walk() (RecursionError). Left unguarded, that
+        # exception would propagate out of _extract_commit and (in the real
+        # ProcessPoolExecutor pipeline) abort the entire ingestion run
+        # rather than just this one commit — contradicting this function's
+        # own contract that ordinary exceptions fail only the one commit.
         new_lang = _EXT_TO_LANG.get(Path(file_path).suffix.lower(), "")
-        new_tree = parser.parse(content)
-        new_entity_nodes = _collect_entity_nodes(new_tree.root_node, new_lang)
+        try:
+            new_tree = parser.parse(content)
+            new_entity_nodes = _collect_entity_nodes(new_tree.root_node, new_lang)
+        except Exception:
+            new_entity_nodes = {"function": {}, "class": {}}  # best-effort: matching degrades to no-match
 
         if status == "A":
             for category in ("function", "class"):

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1801,6 +1801,157 @@ def _extract_swift_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["swift"] = _extract_swift_globals_and_fields
 
 
+def _extract_scala_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware Scala globals/fields extraction.
+
+    Deliberate simplification (do not "fix" -- this is an intentional,
+    reasoned non-goal, not an oversight): Scala's closest analog to
+    "static" is a companion `object` sharing a class's name, but
+    matching an object_definition to its companion class_definition by
+    name -- and only then treating its members as that class's static
+    fields -- is real extra complexity for a niche pattern. Instead, a
+    top-level object_definition (direct child of compilation_unit, or
+    of a package block -- see below) is treated as a globals namespace,
+    not a fields-owner: its members are extracted as plain
+    module-level globals, no `:class` edge and no `:static` concept
+    invoked at all. Only genuine class_definition members become
+    instance fields, always `:static=False` (Scala classes have no
+    static-member concept). A nested object_definition found inside a
+    class's template_body is out of scope (it simply doesn't match the
+    val_definition/var_definition type filter used there, so it is
+    skipped without special-casing).
+
+    `class Foo { val instanceField = 2 }` is class_definition with
+    field:body = template_body, containing val_definition/
+    var_definition members whose field:pattern normally holds a plain
+    identifier -- verified empirically against the real installed
+    tree-sitter-scala grammar.
+
+    Multi-binding in one val/var statement is real in Scala and comes
+    in TWO distinct structural forms, both verified empirically (same
+    multi-declarator lesson as nearly every other language in this
+    plan):
+      - Tuple destructuring (`val (a, b) = (1, 2)`) puts a
+        tuple_pattern in field:pattern, whose children are `(`, `,`,
+        `)`, and nested identifier/tuple_pattern nodes (tuple patterns
+        can nest, e.g. `val (a, (b, c)) = ...`).
+      - Comma-separated multi-name binding (`val a, b = 5`, binding
+        both names to the same value) puts an "identifiers" node --
+        NOT a tuple_pattern -- in field:pattern, whose children are
+        `,`-separated identifier nodes.
+    Both shapes are handled by a single recursive pattern_names()
+    helper so no destructured/multi-bound name is silently dropped.
+
+    Scala's primary-constructor property shorthand (`class Foo(val x:
+    Int, var y: String)`) is idiomatic and extremely common (case
+    classes in particular), but it is structurally a class_parameter
+    inside class_definition's own field:class_parameters list -- NOT a
+    val_definition/var_definition under template_body -- verified
+    empirically, the same kind of justified, narrowly-scoped extension
+    Kotlin's task added for its analogous primary-constructor shorthand.
+    Unlike Kotlin's grammar, tree-sitter-scala DOES expose a `name`
+    field directly on class_parameter, so no by-type child search is
+    needed for the identifier; only the optional `val`/`var` keyword
+    child is found by type (it carries no field name). A
+    class_parameter with neither a `val` nor `var` child is a plain
+    (non-property) constructor parameter and is excluded -- this
+    deliberately also excludes case class parameters that lack an
+    explicit `val`/`var` keyword, even though Scala implicitly treats
+    unmarked case class parameters as public vals; recognizing that
+    implicit rule would require keying off the class_definition's
+    `case` child, a separate semantic inference beyond the structural,
+    by-keyword scope of this extension, so it is left out.
+
+    Scala's `package foo { ... }` block form wraps its contents in
+    package_clause's field:body (a template_body) -- verified
+    empirically -- the same shape-changing-wrapper hazard as JS's
+    export_statement and PHP's block-style namespace_definition
+    elsewhere in this plan. Without unwrapping it, every global/class
+    inside a braced package block would be silently dropped. The bare
+    `package foo` form (no braces) does NOT wrap subsequent statements
+    -- they remain direct siblings under compilation_unit, verified
+    empirically -- so no special handling is needed for that form.
+    package_clause blocks can nest, so they are unwrapped recursively.
+
+    Never recurses into a class_definition's or object_definition's
+    template_body looking for further nested class/object definitions,
+    nor into any function/method body.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def pattern_names(pattern: Any) -> List[str]:
+        if pattern is None:
+            return []
+        if pattern.type == "identifier":
+            return [pattern.text.decode("utf-8")]
+        if pattern.type in ("tuple_pattern", "identifiers"):
+            names: List[str] = []
+            for child in pattern.children:
+                names.extend(pattern_names(child))
+            return names
+        return []
+
+    def record_constructor_param_fields(class_node: Any, class_name: str) -> None:
+        params = class_node.child_by_field_name("class_parameters")
+        if params is None:
+            return
+        for param in params.children:
+            if param.type != "class_parameter":
+                continue
+            if not any(c.type in ("val", "var") for c in param.children):
+                continue
+            name_node = param.child_by_field_name("name")
+            if name_node is None:
+                continue
+            fname = name_node.text.decode("utf-8")
+            fields.append((fname, class_name, False))
+            field_info[fname] = {
+                "class": class_name, "static": False,
+                "body": param.text.decode("utf-8", "replace"),
+            }
+
+    def handle_stmts(stmts: Sequence[Any]) -> None:
+        for stmt in stmts:
+            if stmt.type == "object_definition":
+                body = stmt.child_by_field_name("body")
+                if body is None:
+                    continue
+                for member in body.children:
+                    if member.type in ("val_definition", "var_definition"):
+                        for name in pattern_names(member.child_by_field_name("pattern")):
+                            globals_.append(name)
+                            global_bodies[name] = member.text.decode("utf-8", "replace")
+            elif stmt.type == "class_definition":
+                name_node = stmt.child_by_field_name("name")
+                class_name = name_node.text.decode("utf-8") if name_node else ""
+                record_constructor_param_fields(stmt, class_name)
+                body = stmt.child_by_field_name("body")
+                if body is None:
+                    continue
+                for member in body.children:
+                    if member.type in ("val_definition", "var_definition"):
+                        for name in pattern_names(member.child_by_field_name("pattern")):
+                            fields.append((name, class_name, False))
+                            field_info[name] = {
+                                "class": class_name, "static": False,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+            elif stmt.type == "package_clause":
+                pkg_body = stmt.child_by_field_name("body")
+                if pkg_body is not None:
+                    handle_stmts(pkg_body.children)
+
+    handle_stmts(root_node.children)
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["scala"] = _extract_scala_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -811,7 +811,7 @@ def _normalize_body_for_matching(text: str) -> str:
 def _match_renamed_entities(
     removed: Dict[str, List[Tuple[str, Any]]],
     added: Dict[str, List[Tuple[str, Any]]],
-) -> List[Tuple[str, str, str]]:
+) -> List[Tuple[str, str, Any, str, Any]]:
     """Round-based rename matching across entity categories, scoped to a
     single commit's touched files (callers build removed/added from just
     that commit — see _extract_commit's use in Task 9).
@@ -823,8 +823,18 @@ def _match_renamed_entities(
     dependency order. Capped at _MAX_MATCH_ROUNDS as a defensive bound.
 
     Mutates removed/added in place, removing matched entries.
+
+    Returns (category, old_name, old_node, new_name, new_node) 5-tuples —
+    the matched node objects are included (not just their names) because
+    this function is file-path-agnostic by design (reused as-is for Task
+    26's globals/fields), yet callers like _extract_commit need to recover
+    which file each side came from. Two different removed entities in two
+    different deleted files can coincidentally share a name, so the name
+    alone isn't a safe lookup key back to a file — the node identity is.
+    (Retrofitted here, while wiring this into _extract_commit in Task 9,
+    from the original 3-tuple (category, old_name, new_name) shape.)
     """
-    matches: List[Tuple[str, str, str]] = []
+    matches: List[Tuple[str, str, Any, str, Any]] = []
     confirmed: Dict[str, str] = {}  # old_name -> new_name, shared across all categories
 
     all_names: set = set()
@@ -861,7 +871,7 @@ def _match_renamed_entities(
                         candidates.append((a_name, a_node))
                 if len(candidates) == 1:
                     a_name, a_node = candidates[0]
-                    matches.append((category, r_name, a_name))
+                    matches.append((category, r_name, r_node, a_name, a_node))
                     confirmed[r_name] = a_name
                     r_list.remove((r_name, r_node))
                     a_list.remove((a_name, a_node))
@@ -869,6 +879,39 @@ def _match_renamed_entities(
         if not changed:
             break
     return matches
+
+
+def _collect_entity_nodes(root_node: Any, lang_name: str) -> Dict[str, Dict[str, Any]]:
+    """Like _walk_ast, but returns live nodes keyed by name instead of text —
+    for use only inside a single worker-process call (_extract_commit), never
+    returned across the ProcessPoolExecutor boundary. Only functions/classes
+    are collected here; Task 26 extends this for globals/fields once those
+    categories exist.
+    """
+    node_types = _LANG_NODE_TYPES.get("typescript" if lang_name == "tsx" else lang_name)
+    result: Dict[str, Dict[str, Any]] = {"function": {}, "class": {}}
+    if node_types is None:
+        return result
+
+    def walk(node: Any) -> None:
+        if node.type in node_types.get("functions", set()):
+            if lang_name in ("c", "cpp"):
+                name = _c_family_function_name(node)
+                if name:
+                    result["function"][name] = node
+            else:
+                name_node = node.child_by_field_name("name")
+                if name_node:
+                    result["function"][name_node.text.decode("utf-8")] = node
+        elif node.type in node_types.get("classes", set()):
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                result["class"][name_node.text.decode("utf-8")] = node
+        for child in node.children:
+            walk(child)
+
+    walk(root_node)
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -3318,7 +3361,7 @@ def _ingest_tags(db: Any, repo_path: str, run_ts_iso: str) -> None:
 
 def _extract_commit(
     repo_path: str, commit_hash: str, ignore_patterns: Sequence[str] = ()
-) -> Tuple[List[tuple], List[tuple], Dict[str, Dict[str, str]]]:
+) -> Tuple[List[tuple], List[tuple], Dict[str, Dict[str, str]], List[Tuple[str, str, str, str, str]]]:
     """Read-only, stateless per-commit extraction: diff-tree + git-show + tree-sitter parse,
     plus import resolution and "if this turns out to be new" triple precomputation —
     both pure functions of this commit alone (see _known_files_at_commit and
@@ -3334,7 +3377,7 @@ def _extract_commit(
     a thread pool here let tree-sitter's GIL-holding C parse starve the event
     loop). Touches no shared mutable state and no DB — a hard requirement now
     that this crosses a process boundary, not just a nice property. Returns
-    (file_results, gitlink_changes, gitmodules_map):
+    (file_results, gitlink_changes, gitmodules_map, renamed_pairs):
 
       file_results: one entry per changed file that has a supported parser, as
         (status, file_path, extracted, precomputed, old_path). A/M files whose
@@ -3350,6 +3393,13 @@ def _extract_commit(
       gitmodules_map: path -> {"name", "url"}, populated only when this commit has at
         least one gitlink "add" — avoids a wasted git-show call on the (overwhelmingly
         common) case of a commit that touches no submodules at all.
+      renamed_pairs: (category, old_file_path, old_name, new_file_path, new_name)
+        plain-string 5-tuples — one per function/class the AST-lockstep matcher
+        (_match_renamed_entities, Task 8) confirmed renamed and/or moved within
+        this commit. Deliberately plain strings, not the tree_sitter Node
+        objects _match_renamed_entities itself works with — those live only
+        for the duration of this call and cannot cross the ProcessPoolExecutor
+        boundary back to the main process (see #116).
 
     Sources both file_results and gitlink_changes from a single
     `git diff-tree --raw` call (via _git_diff_tree_raw) rather than a --name-status
@@ -3368,15 +3418,46 @@ def _extract_commit(
     known_files: Optional[Dict[str, List[str]]] = None
     segment_index: Optional[_SegmentSuffixIndex] = None
 
+    # removed/added pools for _match_renamed_entities, scoped to this commit.
+    # Populated alongside the per-file loop below; matched entirely inside
+    # this worker process — tree_sitter Node objects never cross the process
+    # boundary (#116), only the plain-string renamed_pairs derived from
+    # matches does.
+    removed_pool: Dict[str, List[Tuple[str, Any]]] = {"function": [], "class": []}
+    added_pool: Dict[str, List[Tuple[str, Any]]] = {"function": [], "class": []}
+    # (category, old_file_path, old_name, new_file_path, new_name) is only
+    # knowable once we know which FILE each pooled node came from — track
+    # that alongside the pool itself, keyed by node identity (id()), since
+    # two different removed entities in two different deleted files could
+    # coincidentally share a name.
+    node_origin: Dict[int, str] = {}  # id(node) -> file_path
+
     for status, old_mode, new_mode, old_sha, new_sha, file_path, old_path, similarity in raw_entries:
         if _is_ignored_path(file_path, ignore_patterns):
             continue
         parser = _thread_parser(file_path)
         if parser is None:
             continue
+
+        old_lang_path = old_path if status == "R" else file_path
+        old_entity_nodes: Dict[str, Dict[str, Any]] = {"function": {}, "class": {}}
+        if status in ("D", "M", "R") and old_sha and old_sha != "0" * len(old_sha):
+            try:
+                old_content = _git_blob_content(repo_path, old_sha)
+                old_tree = parser.parse(old_content)
+                old_lang = _EXT_TO_LANG.get(Path(old_lang_path).suffix.lower(), "")
+                old_entity_nodes = _collect_entity_nodes(old_tree.root_node, old_lang)
+            except Exception:
+                pass  # best-effort: matching degrades to no-match, not a hard failure
+
         if status == "D":
+            for category in ("function", "class"):
+                for name, node in old_entity_nodes[category].items():
+                    removed_pool[category].append((name, node))
+                    node_origin[id(node)] = old_lang_path
             results.append((status, file_path, None, None, ""))
             continue
+
         try:
             content = _git_file_content(repo_path, commit_hash, file_path)
         except Exception:
@@ -3390,12 +3471,67 @@ def _extract_commit(
         )
         results.append((status, file_path, extracted, precomputed, old_path if status == "R" else ""))
 
+        # Build this file's contribution to the removed/added pools. Live
+        # nodes for the NEW side come from re-parsing (extracted only carries
+        # text, per Task 6) — cheap, since this is the same content already
+        # fetched above; a second parse of the same bytes is a deliberate
+        # simplicity/cost tradeoff over threading Node references through
+        # _extract_from_source's return value, which must stay plain-data-only
+        # for other callers.
+        new_lang = _EXT_TO_LANG.get(Path(file_path).suffix.lower(), "")
+        new_tree = parser.parse(content)
+        new_entity_nodes = _collect_entity_nodes(new_tree.root_node, new_lang)
+
+        if status == "A":
+            for category in ("function", "class"):
+                for name, node in new_entity_nodes[category].items():
+                    added_pool[category].append((name, node))
+                    node_origin[id(node)] = file_path
+        elif status == "R":
+            # Ident changes for every entity in a renamed file, even ones
+            # whose text is byte-identical — pool everything on both sides,
+            # not just the local diff (unlike "M" below).
+            for category in ("function", "class"):
+                for name, node in old_entity_nodes[category].items():
+                    removed_pool[category].append((name, node))
+                    node_origin[id(node)] = old_lang_path
+                for name, node in new_entity_nodes[category].items():
+                    added_pool[category].append((name, node))
+                    node_origin[id(node)] = file_path
+        else:  # "M" — same path, only the local diff needs matching
+            for category in ("function", "class"):
+                old_names = set(old_entity_nodes[category].keys())
+                new_names = set(new_entity_nodes[category].keys())
+                for name in old_names - new_names:
+                    node = old_entity_nodes[category][name]
+                    removed_pool[category].append((name, node))
+                    node_origin[id(node)] = old_lang_path
+                for name in new_names - old_names:
+                    node = new_entity_nodes[category][name]
+                    added_pool[category].append((name, node))
+                    node_origin[id(node)] = file_path
+
+    raw_matches = _match_renamed_entities(removed_pool, added_pool)
+    # raw_matches carries the matched node objects themselves (see Task 8's
+    # _match_renamed_entities retrofit), so file paths can be recovered
+    # directly via node_origin — no second pass or pre-mutation snapshot
+    # needed. (The brief's original sketch tried to translate from bare
+    # (category, old_name, new_name) 3-tuples, which loses the file path
+    # whenever a name collides across two different files touched in the
+    # same commit; that gap is why _match_renamed_entities' return type was
+    # widened to include the nodes.)
+    renamed_pairs: List[Tuple[str, str, str, str, str]] = []
+    for category, old_name, old_node, new_name, new_node in raw_matches:
+        renamed_pairs.append((
+            category, node_origin[id(old_node)], old_name, node_origin[id(new_node)], new_name,
+        ))
+
     gitlink_changes = _gitlink_changes(raw_entries)
     gitmodules_map: Dict[str, Dict[str, str]] = {}
     if any(kind == "add" for kind, _, _ in gitlink_changes):
         gitmodules_map = _git_gitmodules_at(repo_path, commit_hash)
 
-    return results, gitlink_changes, gitmodules_map
+    return results, gitlink_changes, gitmodules_map, renamed_pairs
 
 
 async def _run_ingestion(repo_path: str, branch: str) -> None:
@@ -3532,7 +3668,15 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                         break
 
                     (commit_hash, commit_ts_iso, author, subject), fut = pending.popleft()
-                    extracted_files, gitlink_changes, gitmodules_map = await fut
+                    # renamed_pairs (Task 9's 4th _extract_commit return element) is
+                    # unpacked here but not yet consumed — Task 10 wires it into
+                    # :renamed-from/:renamed-to triple emission for functions/classes.
+                    # Widening this unpack now (rather than leaving it a 3-tuple) is
+                    # required as soon as _extract_commit returns 4 elements: every
+                    # ingestion run — including the many existing tests that drive
+                    # _run_ingestion through a real ProcessPoolExecutor worker — would
+                    # otherwise fail with "too many values to unpack".
+                    extracted_files, gitlink_changes, gitmodules_map, renamed_pairs = await fut
                     submit_next()
 
                     last_hash = commit_hash

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1269,6 +1269,90 @@ def _extract_csharp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["c_sharp"] = _extract_csharp_globals_and_fields
 
 
+def _extract_cpp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware C++ globals/fields extraction.
+
+    Top-level `int x = 5;` is a `declaration` directly under
+    `translation_unit`, same shape as C -- reuses C's declarator_name
+    helper (identifier, or init_declarator wrapping one).
+
+    `class Foo { ... };` / `struct Foo { ... };` are `class_specifier` /
+    `struct_specifier` nodes with `field:body` = `field_declaration_list`;
+    verified empirically against the real installed tree-sitter-cpp
+    grammar that both node types expose `name`/`body` fields identically,
+    so class and struct fields are handled by the same code path (structs
+    default to public, classes to private, but that doesn't affect the
+    AST shape used here). `access_specifier` nodes (public:/private:/
+    protected:) are just plain sibling children of field_declaration_list
+    -- multiple such sections in one class don't disrupt iteration since
+    non-field_declaration members are simply skipped.
+
+    Each member `field_declaration` optionally has a
+    `storage_class_specifier` child with text b"static"; a plain
+    (non-method) field's declarator is directly a `field_identifier`, not
+    wrapped in `init_declarator` (unlike C's free variable declarations,
+    verified empirically). A method declaration's declarator is a
+    `function_declarator` wrapping a `field_identifier` -- filtering on
+    `declarator.type == "field_identifier"` naturally excludes methods.
+
+    NOTE: `int a, b;` (at file scope, or as a field inside a class/struct)
+    puts more than one node under the `declarator` field of a single
+    declaration/field_declaration -- child_by_field_name (singular) only
+    returns the first one and silently drops the rest. Verified
+    empirically against the real installed tree-sitter-cpp grammar (same
+    lesson as Task 15's C extractor and Task 16's Java extractor);
+    children_by_field_name (plural) is used instead to capture all of
+    them, for both globals and fields.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def declarator_name(node: Any) -> Optional[str]:
+        if node.type == "identifier":
+            return node.text.decode("utf-8")
+        if node.type == "init_declarator":
+            inner = node.child_by_field_name("declarator")
+            return declarator_name(inner) if inner is not None else None
+        return None
+
+    for stmt in root_node.children:
+        if stmt.type == "declaration":
+            for declarator in stmt.children_by_field_name("declarator"):
+                name = declarator_name(declarator)
+                if name:
+                    globals_.append(name)
+                    global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type in ("class_specifier", "struct_specifier"):
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type != "field_declaration":
+                    continue
+                is_static = any(
+                    c.type == "storage_class_specifier" and c.text == b"static"
+                    for c in member.children
+                )
+                for declarator in member.children_by_field_name("declarator"):
+                    if declarator.type != "field_identifier":
+                        continue
+                    fname = declarator.text.decode("utf-8")
+                    fields.append((fname, class_name, is_static))
+                    field_info[fname] = {
+                        "class": class_name, "static": is_static,
+                        "body": member.text.decode("utf-8", "replace"),
+                    }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["cpp"] = _extract_cpp_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3051,6 +3051,35 @@ def _precompute_file_triples(
             f"[{cls_ident} :introduced-by {commit_ident}]",
         ]))
 
+    global_entries: List[Tuple[str, str, List[str]]] = []
+    for gvar_name in extracted.get("globals", []):
+        gvar_ident = _code_ident("variable", file_path, gvar_name)
+        global_entries.append((gvar_ident, gvar_name, [
+            f"[{gvar_ident} :entity-type :type/variable]",
+            f'[{gvar_ident} :ident "{gvar_ident}"]',
+            f'[{gvar_ident} :description "{_edn_escape(gvar_name)}"]',
+            f'[{gvar_ident} :file "{_edn_escape(file_path)}"]',
+            f"[{module_ident} :contains {gvar_ident}]",
+            f"[{gvar_ident} :introduced-by {commit_ident}]",
+        ]))
+
+    field_entries: List[Tuple[str, str, List[str]]] = []
+    for field_name, owning_class, is_static in extracted.get("fields", []):
+        qualified_name = f"{owning_class}.{field_name}"
+        field_ident = _code_ident("field", file_path, qualified_name)
+        class_ident = _code_ident("class", file_path, owning_class)
+        static_literal = "true" if is_static else "false"
+        field_entries.append((field_ident, qualified_name, [
+            f"[{field_ident} :entity-type :type/field]",
+            f'[{field_ident} :ident "{field_ident}"]',
+            f'[{field_ident} :description "{_edn_escape(qualified_name)}"]',
+            f'[{field_ident} :file "{_edn_escape(file_path)}"]',
+            f"[{field_ident} :class {class_ident}]",
+            f"[{field_ident} :static {static_literal}]",
+            f"[{module_ident} :contains {field_ident}]",
+            f"[{field_ident} :introduced-by {commit_ident}]",
+        ]))
+
     resolved_imports: List[Tuple[str, str, bool]] = []
     for import_name in set(extracted.get("imports", [])):
         dep_ident, is_resolved = _resolve_module_import(
@@ -3063,6 +3092,8 @@ def _precompute_file_triples(
         "module_candidate_triples": module_candidate_triples,
         "function_entries": function_entries,
         "class_entries": class_entries,
+        "global_entries": global_entries,
+        "field_entries": field_entries,
         "resolved_imports": resolved_imports,
     }
 
@@ -3135,6 +3166,26 @@ def _build_code_triples(
             # Pre-existing class: record that this commit modified it
             triples.append(f"[{cls_ident} :modified-in {commit_ident}]")
 
+    for gvar_ident, gvar_name, candidate_triples in precomputed["global_entries"]:
+        if gvar_ident not in entity_valid_from:
+            triples += candidate_triples
+            if gvar_ident not in idents_for_file:
+                idents_for_file.append(gvar_ident)
+            entity_valid_from[gvar_ident] = commit_ts_iso
+            entity_descriptions[gvar_ident] = gvar_name
+        else:
+            triples.append(f"[{gvar_ident} :modified-in {commit_ident}]")
+
+    for field_ident, field_name, candidate_triples in precomputed["field_entries"]:
+        if field_ident not in entity_valid_from:
+            triples += candidate_triples
+            if field_ident not in idents_for_file:
+                idents_for_file.append(field_ident)
+            entity_valid_from[field_ident] = commit_ts_iso
+            entity_descriptions[field_ident] = field_name
+        else:
+            triples.append(f"[{field_ident} :modified-in {commit_ident}]")
+
     return triples
 
 
@@ -3175,7 +3226,7 @@ def _preload_known_entities(db: Any, repo_path: str) -> tuple:
     except Exception:
         pass
 
-    for entity_type in ("module", "function", "class", "external-dependency"):
+    for entity_type in ("module", "function", "class", "variable", "field", "external-dependency"):
         path_attr = "path" if entity_type in ("module", "external-dependency") else "file"
         try:
             raw = _db_execute(

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1487,29 +1487,50 @@ def _git_commits(
 
 
 def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
-    """Return (status_char, old_mode, new_mode, old_sha, new_sha, path) for
-    every changed path in a commit, via a single `git diff-tree --raw` call.
+    """Return (status_char, old_mode, new_mode, old_sha, new_sha, path, old_path,
+    similarity) for every changed path in a commit, via a single
+    `git diff-tree --raw` call.
+
+    -M enables git's own content-similarity rename detection (default 50%
+    threshold, unchanged — see the 2026-07-14 rename-tracking design doc's
+    "Component 1" for why no additional threshold filtering is applied on
+    top of git's own judgment). Deliberately no -C (copy detection) — a copy
+    leaves the original in place *and* creates a new, independent entity;
+    treating it as a rename would misrepresent history.
+
+    A rename/copy raw line has TWO tab-separated paths (old, then new), not
+    one, e.g. ":100644 100644 <sha> <sha> R100\told.py\tnew.py" — naively
+    keeping the old single-partition parse would fold both paths into one
+    bogus string. old_path is "" for every non-rename status. similarity is
+    the numeric suffix of the status (e.g. 100 for "R100", 57 for "R057"),
+    None for non-rename statuses.
 
     Supersedes running diff-tree a second time just to detect gitlinks:
     --raw already carries file mode (needed to spot submodule paths, mode
     160000) in the same subprocess invocation _extract_commit already makes.
     """
     result = _subprocess.run(
-        ["git", "diff-tree", "--no-commit-id", "-r", "--raw", "--root", commit_hash],
+        ["git", "diff-tree", "--no-commit-id", "-r", "-M", "--raw", "--root", commit_hash],
         cwd=repo_path, capture_output=True, text=True, check=True,
     )
     entries = []
     for line in result.stdout.strip().splitlines():
         if not line.startswith(":"):
             continue
-        meta, sep, path = line.partition("\t")
+        meta, sep, rest = line.partition("\t")
         if not sep:
             continue
         fields = meta[1:].split(" ")
         if len(fields) < 5:
             continue
-        old_mode, new_mode, old_sha, new_sha, status = fields[0], fields[1], fields[2], fields[3], fields[4]
-        entries.append((status[0], old_mode, new_mode, old_sha, new_sha, path))
+        old_mode, new_mode, old_sha, new_sha, status_field = fields[0], fields[1], fields[2], fields[3], fields[4]
+        status = status_field[0]
+        similarity = int(status_field[1:]) if len(status_field) > 1 and status_field[1:].isdigit() else None
+        if status in ("R", "C"):
+            old_path, _, path = rest.partition("\t")
+        else:
+            old_path, path = "", rest
+        entries.append((status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity))
     return entries
 
 
@@ -1534,7 +1555,7 @@ def _gitlink_changes(raw_entries: List[tuple]) -> List[tuple]:
     commit for "remove" (needed by the caller to close the right fact).
     """
     changes = []
-    for status, old_mode, new_mode, old_sha, new_sha, path in raw_entries:
+    for status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity in raw_entries:
         old_is_link = old_mode == _GITLINK_MODE
         new_is_link = new_mode == _GITLINK_MODE
         if not old_is_link and not new_is_link:
@@ -3197,7 +3218,7 @@ def _extract_commit(
     known_files: Optional[Dict[str, List[str]]] = None
     segment_index: Optional[_SegmentSuffixIndex] = None
 
-    for status, old_mode, new_mode, old_sha, new_sha, file_path in raw_entries:
+    for status, old_mode, new_mode, old_sha, new_sha, file_path, old_path, similarity in raw_entries:
         if _is_ignored_path(file_path, ignore_patterns):
             continue
         parser = _thread_parser(file_path)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -22,7 +22,7 @@ import threading
 import time
 from collections import deque
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -714,6 +714,27 @@ def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
         _walk_ast(child, results, lang_name)
 
 
+def _extract_globals_and_fields(root_node: Any, lang_name: str) -> Dict[str, Any]:
+    """Scope-aware extraction of module-level globals and class fields.
+
+    Deliberately NOT a _walk_ast-style full-tree recursion: an assignment-
+    like node is ubiquitous (appears inside every function body too), so a
+    naive table-driven walk would misclassify every local variable as a
+    global. Each per-language function in _GLOBAL_FIELD_EXTRACTORS is
+    responsible for only descending into module-level and class-body-level
+    statements, never into a function/method body (barring a narrow,
+    per-language, deliberate exception — see each language's own extractor).
+    """
+    empty: Dict[str, Any] = {"globals": [], "global_bodies": {}, "fields": [], "field_info": {}}
+    extractor = _GLOBAL_FIELD_EXTRACTORS.get(lang_name)
+    if extractor is None or root_node is None:
+        return empty
+    return extractor(root_node)
+
+
+_GLOBAL_FIELD_EXTRACTORS: Dict[str, Callable[[Any], Dict[str, Any]]] = {}
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:
@@ -727,11 +748,17 @@ def _extract_from_source(
     results: Dict[str, Any] = {
         "functions": [], "classes": [], "imports": [], "calls": [],
         "function_bodies": {}, "class_bodies": {},
+        "globals": [], "global_bodies": {}, "fields": [], "field_info": {},
     }
     try:
         tree = parser.parse(source)
         lang_name = _EXT_TO_LANG.get(Path(file_path).suffix.lower(), "")
         _walk_ast(tree.root_node, results, lang_name)
+        gf = _extract_globals_and_fields(tree.root_node, "typescript" if lang_name == "tsx" else lang_name)
+        results["globals"] = gf["globals"]
+        results["global_bodies"] = gf["global_bodies"]
+        results["fields"] = gf["fields"]
+        results["field_info"] = gf["field_info"]
     except Exception:
         pass  # best-effort; parse failures are non-fatal
     return results

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -22,7 +22,7 @@ import threading
 import time
 from collections import deque
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -2491,6 +2491,7 @@ def _match_body_name(category: str, name: str) -> str:
 def _match_renamed_entities(
     removed: Dict[str, List[Tuple[str, Any]]],
     added: Dict[str, List[Tuple[str, Any]]],
+    unchanged_names: Optional[Set[str]] = None,
 ) -> List[Tuple[str, str, Any, str, Any]]:
     """Round-based rename matching across entity categories, scoped to a
     single commit's touched files (callers build removed/added from just
@@ -2501,6 +2502,23 @@ def _match_renamed_entities(
     (in the same or a different category) evaluated in a later round — this
     resolves cascading/mutual renames within one commit regardless of
     dependency order. Capped at _MAX_MATCH_ROUNDS as a defensive bound.
+
+    unchanged_names is the set of BARE body-text identifiers (see
+    _match_body_name) that are present, with the SAME name, on BOTH the old
+    and new side of a touched file this commit — i.e. tracked entities that
+    survived unrenamed. The design requires a reference to such an entity to
+    "match exactly" rather than be treated as a free local eligible for
+    bijective substitution. These names never appear in the removed/added
+    pools (an unchanged same-path entity is excluded from both by the "M"
+    diff), so without seeding them here the matcher would treat a reference
+    to a surviving helper as a free local and could confirm a FALSE rename
+    between two entities that merely call two different, still-present
+    helpers. They are seeded into tracked_names with target None (must appear
+    identically); a name that is ALSO confirmed renamed this round takes the
+    confirmed target instead (confirmed wins, so a genuine rename still
+    resolves). The pair under test always excludes its own name from the
+    constraint (see the self-exclusion below), so a real rename whose old and
+    new bodies share an unchanged helper still matches.
 
     Mutates removed/added in place, removing matched entries.
 
@@ -2520,13 +2538,18 @@ def _match_renamed_entities(
     # a token in any body text — only its bare leaf does.
     confirmed: Dict[str, str] = {}  # bare old_name -> bare new_name, shared across all categories
 
-    all_names: set = set()
+    all_names: set = set(unchanged_names or ())
     for pool in (removed, added):
         for category, entries in pool.items():
             all_names.update(_match_body_name(category, name) for name, _node in entries)
 
     for _round in range(_MAX_MATCH_ROUNDS):
         changed = False
+        # Seed every known name to its confirmed rename target if it has one,
+        # else None ("must match exactly"). Unchanged-tracked names (folded
+        # into all_names above) therefore default to None unless a genuine
+        # rename was confirmed for them this round, in which case confirmed
+        # wins.
         tracked_names: Dict[str, Optional[str]] = {
             name: confirmed.get(name) for name in all_names
         }
@@ -5183,6 +5206,15 @@ def _extract_commit(
     # two different removed entities in two different deleted files could
     # coincidentally share a name.
     node_origin: Dict[int, str] = {}  # id(node) -> file_path
+    # Bare body-text names (see _match_body_name) present, with the SAME name,
+    # on BOTH the old and new side of some touched file this commit — tracked
+    # entities that survived unrenamed. Passed to _match_renamed_entities so a
+    # reference to one of them must match exactly rather than be treated as a
+    # free local (see the P1 false-continuity fix). Unchanged same-path
+    # entities never enter removed_pool/added_pool (the "M" diff excludes
+    # them), so they must be threaded separately to constrain OTHER entities'
+    # candidate walks.
+    unchanged_names: Set[str] = set()
 
     def collect_all_nodes(root: Any, lang: str) -> Dict[str, Dict[str, Any]]:
         # Widens _collect_entity_nodes's function/class-only result with the
@@ -5273,6 +5305,18 @@ def _extract_commit(
                 "function": {}, "class": {}, "variable": {}, "field": {},
             }  # best-effort: matching degrades to no-match
 
+        # Record every entity whose name is present, unchanged, on BOTH sides
+        # of this file — these survive the commit unrenamed and so must be
+        # matched exactly (not treated as free locals) when they appear inside
+        # some OTHER entity's candidate body. Uses the bare body-text name
+        # (via _match_body_name) to match how the matcher keys tracked names.
+        # For "A" the old side is empty and for "D" we already `continue`d, so
+        # only "M"/"R" (both-sides) files contribute here.
+        for category in ("function", "class", "variable", "field"):
+            common = set(old_entity_nodes[category].keys()) & set(new_entity_nodes[category].keys())
+            for name in common:
+                unchanged_names.add(_match_body_name(category, name))
+
         if status == "A":
             for category in ("function", "class", "variable", "field"):
                 for name, node in new_entity_nodes[category].items():
@@ -5302,7 +5346,7 @@ def _extract_commit(
                     added_pool[category].append((name, node))
                     node_origin[id(node)] = file_path
 
-    raw_matches = _match_renamed_entities(removed_pool, added_pool)
+    raw_matches = _match_renamed_entities(removed_pool, added_pool, unchanged_names)
     # raw_matches carries the matched node objects themselves (see Task 8's
     # _match_renamed_entities retrofit), so file paths can be recovered
     # directly via node_origin — no second pass or pre-mutation snapshot

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4343,7 +4343,7 @@ def _handle_memory_prepare_turn_heuristic(user_message: str) -> str:
     for entity in entities:
         try:
             raw = _db_execute(
-                db, f'(query [:find ?a ?v {temporal_clauses} :where [?e ?a ?v] (contains? ?v "{entity}")])'
+                db, f'(query [:find ?a ?v {temporal_clauses} :where [?e ?a ?v] [(contains? ?v "{entity}")]])'
             )
             data = json.loads(raw)
             for row in data.get("results", []):

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1916,6 +1916,8 @@ MINIGRAF_SCHEMA: Dict[str, Dict[str, Dict[str, type]]] = {
             ":contains": str, ":depends-on": str, ":calls": str,
             # commit cross-references
             ":introduced-by": str, ":modified-in": str,
+            # rename/move continuity (see 2026-07-14 rename-tracking design doc)
+            ":renamed-from": str, ":renamed-to": str,
         },
     },
     "function": {
@@ -1923,6 +1925,7 @@ MINIGRAF_SCHEMA: Dict[str, Dict[str, Dict[str, type]]] = {
         "optional": {
             ":file": str, ":alias": str,
             ":introduced-by": str, ":modified-in": str,
+            ":renamed-from": str, ":renamed-to": str,
         },
     },
     "class": {
@@ -1930,6 +1933,23 @@ MINIGRAF_SCHEMA: Dict[str, Dict[str, Dict[str, type]]] = {
         "optional": {
             ":file": str, ":alias": str,
             ":introduced-by": str, ":modified-in": str,
+            ":renamed-from": str, ":renamed-to": str,
+        },
+    },
+    "variable": {
+        "required": {":description": str},
+        "optional": {
+            ":file": str, ":alias": str,
+            ":introduced-by": str, ":modified-in": str,
+            ":renamed-from": str, ":renamed-to": str,
+        },
+    },
+    "field": {
+        "required": {":description": str},
+        "optional": {
+            ":file": str, ":alias": str, ":class": str, ":static": bool,
+            ":introduced-by": str, ":modified-in": str,
+            ":renamed-from": str, ":renamed-to": str,
         },
     },
     "ingestion": {

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2461,6 +2461,33 @@ def _normalize_body_for_matching(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
+def _match_body_name(category: str, name: str) -> str:
+    """Map an entity's pool key to the bare identifier that actually appears in
+    its body text, for the matcher's internal name bookkeeping.
+
+    Fields are pooled under QUALIFIED keys ("Class.leaf", per Task 11) so that
+    same-named fields in different classes get distinct, collision-free
+    :type/field idents downstream — that qualification MUST stay on the pool
+    keys and on _match_renamed_entities' returned pairs (both the ident
+    construction in Task 11/27 and renamed_pairs depend on it). But a field's
+    body text only ever contains its BARE leaf identifier: the declaration
+    `Config = 1` contains the token `Config`, never `A.Config`.
+
+    _match_candidate_pair matches body-text tokens, so _match_renamed_entities'
+    tracked-name set, confirmed-rename map, and per-pair self-exclusion must all
+    key on that bare leaf, not the qualified pool key. Otherwise a field's own
+    leaf token is never excluded from its own candidate test and can be captured
+    by an UNRELATED already-confirmed rename that happens to share the bare name
+    (e.g. a function `Config`->`ConfigFn` confirmed in an earlier round), which
+    forces the field's body token to a specific new spelling and produces a
+    WRONG confirmed match. Non-field categories are already unqualified (pool
+    key == body identifier), so they pass through unchanged.
+    """
+    if category == "field":
+        return name.rsplit(".", 1)[-1]
+    return name
+
+
 def _match_renamed_entities(
     removed: Dict[str, List[Tuple[str, Any]]],
     added: Dict[str, List[Tuple[str, Any]]],
@@ -2488,12 +2515,15 @@ def _match_renamed_entities(
     from the original 3-tuple (category, old_name, new_name) shape.)
     """
     matches: List[Tuple[str, str, Any, str, Any]] = []
-    confirmed: Dict[str, str] = {}  # old_name -> new_name, shared across all categories
+    # Keyed by BARE body-text identifier (see _match_body_name), not the pool
+    # key, because a field's qualified pool key ("Class.leaf") never appears as
+    # a token in any body text — only its bare leaf does.
+    confirmed: Dict[str, str] = {}  # bare old_name -> bare new_name, shared across all categories
 
     all_names: set = set()
     for pool in (removed, added):
-        for entries in pool.values():
-            all_names.update(name for name, _node in entries)
+        for category, entries in pool.items():
+            all_names.update(_match_body_name(category, name) for name, _node in entries)
 
     for _round in range(_MAX_MATCH_ROUNDS):
         changed = False
@@ -2507,25 +2537,39 @@ def _match_renamed_entities(
                 r_text = _normalize_body_for_matching(r_node.text.decode("utf-8", "replace"))
                 if len(r_text) < _MIN_MATCH_BODY_LEN:
                     continue
+                # The bare identifier the pair-under-test actually spells in its
+                # body (equal to the pool key for non-field categories). Used
+                # for self-exclusion below so the walker treats the pair's own
+                # name as free/under-test, never as an inherited constraint.
+                r_match_name = _match_body_name(category, r_name)
                 candidates = []
                 for a_name, a_node in a_list:
+                    a_match_name = _match_body_name(category, a_name)
                     # Exclude this specific pair's own old/new names from the
                     # tracked set: they are exactly what's under test here
                     # (is r_name renamed to a_name?), not an already-known
                     # constraint. Without this, an unconfirmed entity's own
                     # name would be treated as "must stay unchanged" and no
-                    # rename could ever be confirmed for it.
+                    # rename could ever be confirmed for it. Excluding by BARE
+                    # name (not the qualified pool key) is essential for fields:
+                    # the body token is the bare leaf, so excluding "A.Config"
+                    # would leave the field's own "Config" token still bound to
+                    # an unrelated confirmed "Config"->... rename (the false
+                    # positive this fix closes).
                     pair_tracked_names = {
                         name: target
                         for name, target in tracked_names.items()
-                        if name != r_name and name != a_name
+                        if name != r_match_name and name != a_match_name
                     }
                     if _match_candidate_pair(r_node, a_node, pair_tracked_names) is not None:
                         candidates.append((a_name, a_node))
                 if len(candidates) == 1:
                     a_name, a_node = candidates[0]
+                    # Returned pair keeps the QUALIFIED pool keys (r_name/a_name)
+                    # for downstream ident construction; only the shared
+                    # confirmed map records the bare body names.
                     matches.append((category, r_name, r_node, a_name, a_node))
-                    confirmed[r_name] = a_name
+                    confirmed[r_match_name] = _match_body_name(category, a_name)
                     r_list.remove((r_name, r_node))
                     a_list.remove((a_name, a_node))
                     changed = True

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -826,9 +826,13 @@ def _extract_js_family_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     Only descends into: program-root direct children (globals, from
     lexical_declaration/variable_declaration's variable_declarator
     children) and a class_declaration's class_body direct children
-    (field_definition for JS, public_field_definition for TS). Never
-    recurses into a function/method body, so a class field assigned only
-    inside a constructor (e.g. `this.x = 1` with no class-body field
+    (field_definition for JS, public_field_definition for TS). A
+    program-root `export_statement` (covering `export const`/`export
+    let`/`export class`/`export default class`) is unwrapped via its
+    `declaration` field before the same type checks apply — this is the
+    one extra step permitted; it does not add any further recursion.
+    Never recurses into a function/method body, so a class field assigned
+    only inside a constructor (e.g. `this.x = 1` with no class-body field
     declaration) is not captured — deliberate, bounded heuristic
     consistent with the Python extractor's __init__-only scope.
     """
@@ -837,7 +841,20 @@ def _extract_js_family_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
 
-    for stmt in root_node.children:
+    for raw_stmt in root_node.children:
+        stmt = raw_stmt
+        if stmt.type == "export_statement":
+            # `export const X = 5;`, `export class Foo {...}`, and
+            # `export default class Bar {...}` all wrap the actual
+            # declaration inside an export_statement node, exposed
+            # uniformly via the `declaration` field (verified against the
+            # real installed tree-sitter-javascript/typescript grammars,
+            # including the `export default class` variant). Unwrap it
+            # once here; no further recursion is added beyond this.
+            declaration = stmt.child_by_field_name("declaration")
+            if declaration is None:
+                continue
+            stmt = declaration
         if stmt.type in ("lexical_declaration", "variable_declaration"):
             for child in stmt.children:
                 if child.type == "variable_declarator":
@@ -845,7 +862,10 @@ def _extract_js_family_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                     if name_node is not None and name_node.type == "identifier":
                         name = name_node.text.decode("utf-8")
                         globals_.append(name)
-                        global_bodies[name] = stmt.text.decode("utf-8", "replace")
+                        # Use raw_stmt (not the unwrapped stmt) so an
+                        # exported global's body includes the `export`
+                        # keyword, matching its actual source text.
+                        global_bodies[name] = raw_stmt.text.decode("utf-8", "replace")
         elif stmt.type == "class_declaration":
             class_name_node = stmt.child_by_field_name("name")
             class_name = class_name_node.text.decode("utf-8") if class_name_node else ""

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1583,6 +1583,22 @@ def _git_file_content(repo_path: str, commit_hash: str, file_path: str) -> bytes
     return result.stdout
 
 
+def _git_blob_content(repo_path: str, blob_sha: str) -> bytes:
+    """Return raw bytes of a blob by its own SHA, independent of any commit/path.
+
+    Used to fetch a file's *old* content directly from _git_diff_tree_raw's
+    old_sha field (a plain blob SHA) when comparing pre/post rename or
+    modification content — cheaper than resolving a parent commit hash and
+    re-deriving the old path, and correct even when the old path no longer
+    exists at any reachable commit-ish (e.g. mid-history rewrites).
+    """
+    result = _subprocess.run(
+        ["git", "cat-file", "blob", blob_sha],
+        cwd=repo_path, capture_output=True, check=True,
+    )
+    return result.stdout
+
+
 def _is_ignored_path(file_path: str, patterns: Sequence[str]) -> bool:
     """Simplified .gitignore-style match: no negation, no ** anchoring, no new
     dependency (see 2026-07-14 path-ignore design doc's "Matching" section for

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2147,6 +2147,91 @@ def _extract_lua_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["lua"] = _extract_lua_globals_and_fields
 
 
+def _extract_elixir_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Extract Elixir module attributes as static fields of their module.
+
+    Elixir has no top-level mutable globals outside module attributes --
+    verified empirically there is no syntactic construct (destructuring or
+    otherwise) that produces one -- so `"globals"` is always empty here.
+
+    A module is a `call` node whose `field:target` is an `identifier` with
+    text `"defmodule"`, whose module-name argument is an `alias` node inside
+    an `arguments` child, and which has a `do_block` child holding the
+    module's body. A module attribute (`@module_attr 5`) is a
+    `unary_operator` with `field:operator` text `"@"` and `field:operand` a
+    `call` node whose `field:target` is the attribute's name; it is treated
+    as a `:static=True` field of the enclosing module -- the closest Elixir
+    analog to compile-time class-scoped state.
+
+    Verified empirically: unlike `field:target`/`field:operator`/
+    `field:operand` (which do resolve via `child_by_field_name`), the
+    `arguments` child of a `defmodule` call is *not* exposed under a field
+    name here -- `child_by_field_name("arguments")` returns None even though
+    an `arguments` node is present as a plain (unnamed-field) child. It must
+    be located by scanning `node.children` for `type == "arguments"`
+    instead, matching the existing precedent in `_elixir_module_name` above.
+
+    Nested modules (`defmodule Foo do defmodule Bar do ... end end`) are
+    handled correctly by this recursive walk: each `defmodule` call's own
+    `do_block` is scanned only for its *direct* children when processing
+    that module, and a nested `defmodule` call is itself just another node
+    the walk recurses into separately, so its attributes are attributed to
+    its own (inner) module name -- verified empirically. A dotted single
+    declaration (`defmodule Foo.Bar do ... end`) is one `call` node whose
+    `alias` node's text is already the full dotted name "Foo.Bar", not two
+    levels of AST nesting -- verified empirically.
+
+    A bare attribute reference with no value (`@attr`, reading a
+    previously-defined attribute rather than defining one) parses with
+    `operand.type == "identifier"`, not `"call"` -- verified empirically --
+    so it is naturally excluded by the `operand.type == "call"` check below
+    and never mistaken for a field definition.
+
+    `@moduledoc`/`@doc`/`@spec`/`@type` (Elixir's built-in documentation/
+    typespec attributes) parse identically to any other module attribute --
+    verified empirically, same `unary_operator` -> `call` shape -- and are
+    deliberately *not* excluded as noise here: no other language task in
+    this plan special-cases built-in annotations/decorators, and inventing
+    a bespoke exclusion list was not requested by this task's spec.
+    """
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def walk(node: Any) -> None:
+        if node.type == "call":
+            target = node.child_by_field_name("target")
+            if target is not None and target.type == "identifier" and target.text == b"defmodule":
+                arguments = next((c for c in node.children if c.type == "arguments"), None)
+                module_name = ""
+                if arguments is not None:
+                    alias_node = next((c for c in arguments.children if c.type == "alias"), None)
+                    if alias_node is not None:
+                        module_name = alias_node.text.decode("utf-8")
+                do_block = next((c for c in node.children if c.type == "do_block"), None)
+                if do_block is not None:
+                    for member in do_block.children:
+                        if member.type == "unary_operator":
+                            op = member.child_by_field_name("operator")
+                            operand = member.child_by_field_name("operand")
+                            if op is not None and op.text == b"@" and operand is not None and operand.type == "call":
+                                attr_target = operand.child_by_field_name("target")
+                                if attr_target is not None:
+                                    fname = attr_target.text.decode("utf-8")
+                                    fields.append((fname, module_name, True))
+                                    field_info[fname] = {
+                                        "class": module_name, "static": True,
+                                        "body": member.text.decode("utf-8", "replace"),
+                                    }
+        for child in node.children:
+            walk(child)
+
+    walk(root_node)
+    return {"globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["elixir"] = _extract_elixir_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3428,7 +3428,18 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                         ([f"[{module_ident} :depends-on {dep_ident}]"], orig_ts)
                                     )
                                 file_deps.pop(file_path, None)
-                            else:  # A or M
+                            else:  # A or M or R
+                                if status == "R" and old_path:
+                                    old_module_ident = _code_ident("module", old_path)
+                                    new_module_ident = _code_ident("module", file_path)
+                                    add_triples.append(f"[{new_module_ident} :renamed-from {old_module_ident}]")
+                                    old_desc = entity_descriptions.get(old_module_ident, old_path)
+                                    orig_ts = entity_valid_from.get(old_module_ident, commit_ts_iso)
+                                    close_items.append((
+                                        _build_close_triples(old_module_ident, old_desc, old_module_ident)
+                                        + [f"[{old_module_ident} :renamed-to {new_module_ident}]"],
+                                        orig_ts,
+                                    ))
                                 previous_idents = set(file_entities.get(file_path, []))
                                 triples = _build_code_triples(
                                     file_path, extracted, commit_ts_iso, entity_valid_from,

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5647,6 +5647,10 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                         ]
                         close_items: List[tuple] = []  # (triples, original_ts_iso)
                         dep_add_triples: List[str] = []  # :depends-on triples to transact individually
+                        # Old paths of files renamed this commit (R status). Their
+                        # unmatched child entities / dependency edges are closed in a
+                        # final pass after renamed_pairs is consumed (see below).
+                        renamed_old_paths: set = set()
 
                         for status, file_path, extracted, precomputed, old_path in extracted_files:
                             if status == "D":
@@ -5668,14 +5672,20 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                 file_deps.pop(file_path, None)
                             else:  # A or M or R
                                 if status == "R" and old_path:
+                                    renamed_old_paths.add(old_path)
                                     old_module_ident = _code_ident("module", old_path)
                                     new_module_ident = _code_ident("module", file_path)
                                     add_triples.append(f"[{new_module_ident} :renamed-from {old_module_ident}]")
+                                    # :renamed-to is a brand-new fact that becomes
+                                    # true at the rename commit and stays true forever
+                                    # after — it must be transacted open-ended (like
+                                    # :renamed-from), NOT closed with the old entity's
+                                    # historical valid window via _ingest_close.
+                                    add_triples.append(f"[{old_module_ident} :renamed-to {new_module_ident}]")
                                     old_desc = entity_descriptions.get(old_module_ident, old_path)
                                     orig_ts = entity_valid_from.get(old_module_ident, commit_ts_iso)
                                     close_items.append((
-                                        _build_close_triples(old_module_ident, old_desc, old_module_ident)
-                                        + [f"[{old_module_ident} :renamed-to {new_module_ident}]"],
+                                        _build_close_triples(old_module_ident, old_desc, old_module_ident),
                                         orig_ts,
                                     ))
                                 previous_idents = set(file_entities.get(file_path, []))
@@ -5695,7 +5705,25 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                         current_extracted_idents.add(fn_ident)
                                     for cls_ident, _cls_name, _cls_triples in precomputed["class_entries"]:
                                         current_extracted_idents.add(cls_ident)
+                                    # Globals and fields are tracked in file_entities too
+                                    # (see _build_code_triples): omitting them here would
+                                    # make every still-present global/field look "removed"
+                                    # on any later edit and wrongly close it (#113).
+                                    for gvar_ident, _gvar_name, _gvar_triples in precomputed["global_entries"]:
+                                        current_extracted_idents.add(gvar_ident)
+                                    for field_ident, _field_name, _field_triples in precomputed["field_entries"]:
+                                        current_extracted_idents.add(field_ident)
                                     removed_idents = previous_idents - current_extracted_idents
+                                    # An in-place rename (old->new in the same file) is
+                                    # closed with :renamed-to linkage by the renamed_pairs
+                                    # loop below; exclude those old idents here so they are
+                                    # not ALSO closed as a plain removal (double close).
+                                    same_file_renamed_old_idents = {
+                                        _code_ident(cat, o_file, o_name)
+                                        for cat, o_file, o_name, _n_file, _n_name in renamed_pairs
+                                        if o_file == file_path
+                                    }
+                                    removed_idents -= same_file_renamed_old_idents
                                     for ident in removed_idents:
                                         orig_ts = entity_valid_from.get(ident, commit_ts_iso)
                                         desc = entity_descriptions.get(ident, "")
@@ -5740,14 +5768,49 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                             old_ident = _code_ident(category, old_file, old_name)
                             new_ident = _code_ident(category, new_file, new_name)
                             add_triples.append(f"[{new_ident} :renamed-from {old_ident}]")
+                            # :renamed-to becomes true at the rename commit and stays
+                            # open-ended thereafter — transact it via the add path, do
+                            # NOT fold it into the old entity's _ingest_close window.
+                            add_triples.append(f"[{old_ident} :renamed-to {new_ident}]")
                             old_desc = entity_descriptions.get(old_ident, old_name)
                             old_module_ident = _code_ident("module", old_file)
                             orig_ts = entity_valid_from.get(old_ident, commit_ts_iso)
                             close_items.append((
-                                _build_close_triples(old_ident, old_desc, old_module_ident)
-                                + [f"[{old_ident} :renamed-to {new_ident}]"],
+                                _build_close_triples(old_ident, old_desc, old_module_ident),
                                 orig_ts,
                             ))
+
+                        # A file rename (R status) only closes the old MODULE above.
+                        # Child entities and dependency edges under the old path are
+                        # closed here as plain removals UNLESS the matcher established
+                        # a rename continuity edge for them (handled with :renamed-to
+                        # by the loop above). This runs after renamed_pairs is fully
+                        # consumed so those confirmed renames can be excluded; without
+                        # it, unmatched old children/deps leak open forever under the
+                        # old path while new ones open under the new path.
+                        if renamed_old_paths:
+                            renamed_covered_idents = {
+                                _code_ident(cat, o_file, o_name)
+                                for cat, o_file, o_name, _n_file, _n_name in renamed_pairs
+                            }
+                            for r_old_path in renamed_old_paths:
+                                r_old_module_ident = _code_ident("module", r_old_path)
+                                for ident in file_entities.get(r_old_path, []):
+                                    if ident == r_old_module_ident:
+                                        continue  # already closed by the R block above
+                                    if ident in renamed_covered_idents:
+                                        continue  # already closed with :renamed-to linkage
+                                    orig_ts = entity_valid_from.get(ident, commit_ts_iso)
+                                    desc = entity_descriptions.get(ident, "")
+                                    close_items.append(
+                                        (_build_close_triples(ident, desc, r_old_module_ident), orig_ts)
+                                    )
+                                for dep_ident in file_deps.get(r_old_path, set()):
+                                    orig_ts = dep_valid_from.get((r_old_module_ident, dep_ident), commit_ts_iso)
+                                    close_items.append(
+                                        ([f"[{r_old_module_ident} :depends-on {dep_ident}]"], orig_ts)
+                                    )
+                                file_deps.pop(r_old_path, None)
 
                         # Process gitlink changes (submodule add/bump/remove).
                         # The "remove" case's interaction with the ordinary per-file module-open

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -760,14 +760,20 @@ def _match_candidate_pair(
     Internally, `mapping`/`reverse` record EVERY local identifier
     correspondence seen (including identity ones, e.g. an untouched
     parameter name) so consistency and injectivity can be enforced across
-    the whole pair. `renamed` mirrors only the entries where the old and
-    new text actually differ; that's what gets returned, per the docstring
-    contract above (identity-only correspondences shouldn't show up in the
-    reported bijection).
+    the whole pair. `reverse` is seeded up front with every tracked entity's
+    new-side text (its confirmed rename target, or its own unchanged name
+    when tracked_names[name] is None) — otherwise a local/untracked
+    identifier could silently claim the exact new text already reserved for
+    a different, tracked entity, which is a real injectivity violation (two
+    distinct old tokens collapsing onto one new token) that the tracked-name
+    equality check alone doesn't catch since it lives in a disjoint
+    namespace from `mapping`/`reverse`.
     """
     mapping: Dict[str, str] = {}
-    reverse: Dict[str, str] = {}
-    renamed: Dict[str, str] = {}
+    reverse: Dict[str, str] = {
+        (target if target is not None else name): name
+        for name, target in tracked_names.items()
+    }
 
     def walk(a: Any, b: Any) -> bool:
         if a.type != b.type:
@@ -785,15 +791,14 @@ def _match_candidate_pair(
                     return False
                 mapping[a_text] = b_text
                 reverse[b_text] = a_text
-                if a_text != b_text:
-                    renamed[a_text] = b_text
                 return True
             return a_text == b_text
         if a.child_count != b.child_count:
             return False
         return all(walk(ac, bc) for ac, bc in zip(a.children, b.children))
 
-    return renamed if walk(old_node, new_node) else None
+    return {k: v for k, v in mapping.items() if k != v} if walk(old_node, new_node) else None
+
 
 # ---------------------------------------------------------------------------
 # DB lifecycle

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3790,12 +3790,21 @@ def _build_close_triples(
     ident: str,
     description: str,
     module_ident: str,
+    extra_contains_parent: Optional[str] = None,
 ) -> List[str]:
     """Return triple strings needed to bi-temporally close an entity.
 
     Closes :ident (canonical existence fact), :description (with real value),
     and the parent module's :contains edge.  The module's own :contains triple
     is omitted when ident == module_ident (modules have no parent module here).
+
+    extra_contains_parent closes a SECOND :contains edge alongside the module's
+    one.  Fields with a real (extracted) owning class carry two containment
+    parents — [module :contains field] AND [class :contains field] (see
+    _precompute_file_triples) — so both must be retracted when the field closes,
+    or the class-contains edge leaks open forever.  Callers pass the field's
+    class ident here (from field_class_ident); it is ignored when None or equal
+    to ident/module_ident so non-field close sites are unaffected.
     """
     triples = [
         f'[{ident} :ident "{_edn_escape(ident)}"]',
@@ -3803,6 +3812,12 @@ def _build_close_triples(
     ]
     if ident != module_ident:
         triples.append(f"[{module_ident} :contains {ident}]")
+    if (
+        extra_contains_parent is not None
+        and extra_contains_parent != ident
+        and extra_contains_parent != module_ident
+    ):
+        triples.append(f"[{extra_contains_parent} :contains {ident}]")
     return triples
 
 
@@ -4862,21 +4877,37 @@ def _precompute_file_triples(
         ]))
 
     field_entries: List[Tuple[str, str, List[str]]] = []
+    # field_ident -> owning class_ident, but ONLY for fields whose owning class
+    # is genuinely extracted as a :type/class entity in this same file. Threaded
+    # to close sites via field_class_ident so the class-contains edge is retracted
+    # when the field closes.
+    field_class_map: Dict[str, str] = {}
+    extracted_class_names = set(extracted.get("classes", []))
     for field_name, owning_class, is_static in extracted.get("fields", []):
         qualified_name = f"{owning_class}.{field_name}"
         field_ident = _code_ident("field", file_path, qualified_name)
-        class_ident = _code_ident("class", file_path, owning_class)
         static_literal = "true" if is_static else "false"
-        field_entries.append((field_ident, qualified_name, [
+        candidate_triples = [
             f"[{field_ident} :entity-type :type/field]",
             f'[{field_ident} :ident "{field_ident}"]',
             f'[{field_ident} :description "{_edn_escape(qualified_name)}"]',
             f'[{field_ident} :file "{_edn_escape(file_path)}"]',
-            f"[{field_ident} :class {class_ident}]",
             f"[{field_ident} :static {static_literal}]",
             f"[{module_ident} :contains {field_ident}]",
             f"[{field_ident} :introduced-by {commit_ident}]",
-        ]))
+        ]
+        # Only emit class-level linkage (:class edge + class :contains edge) when
+        # the owning class is a real extracted :type/class entity. Otherwise the
+        # owner name (e.g. an Elixir defmodule attribute or a Haskell newtype) is
+        # never opened as a class, so a :class edge would dangle and a class
+        # :contains edge would point at a nonexistent parent. Module containment
+        # alone is kept in that case (see issues.md P2 findings).
+        if owning_class in extracted_class_names:
+            class_ident = _code_ident("class", file_path, owning_class)
+            candidate_triples.append(f"[{field_ident} :class {class_ident}]")
+            candidate_triples.append(f"[{class_ident} :contains {field_ident}]")
+            field_class_map[field_ident] = class_ident
+        field_entries.append((field_ident, qualified_name, candidate_triples))
 
     resolved_imports: List[Tuple[str, str, bool]] = []
     for import_name in set(extracted.get("imports", [])):
@@ -4892,6 +4923,7 @@ def _precompute_file_triples(
         "class_entries": class_entries,
         "global_entries": global_entries,
         "field_entries": field_entries,
+        "field_class_map": field_class_map,
         "resolved_imports": resolved_imports,
     }
 
@@ -4905,6 +4937,7 @@ def _build_code_triples(
     file_entities: Dict[str, List[str]],
     commit_ident: str,
     precomputed: Dict[str, Any],
+    field_class_ident: Optional[Dict[str, str]] = None,
 ) -> List[str]:
     """Return Datalog triple strings for a file's extracted code entities.
 
@@ -4927,6 +4960,7 @@ def _build_code_triples(
     """
     triples: List[str] = []
     module_ident = precomputed["module_ident"]
+    field_class_map = precomputed.get("field_class_map", {})
 
     is_new_module = module_ident not in entity_valid_from
     # Track all idents for this file (for deletion cleanup)
@@ -4981,6 +5015,11 @@ def _build_code_triples(
                 idents_for_file.append(field_ident)
             entity_valid_from[field_ident] = commit_ts_iso
             entity_descriptions[field_ident] = field_name
+            # Record the field's real owning-class parent so every close path
+            # can retract the [class :contains field] edge alongside the module
+            # one. Only fields with an extracted owning class appear in the map.
+            if field_class_ident is not None and field_ident in field_class_map:
+                field_class_ident[field_ident] = field_class_map[field_ident]
         else:
             triples.append(f"[{field_ident} :modified-in {commit_ident}]")
 
@@ -5048,6 +5087,35 @@ def _preload_known_entities(db: Any, repo_path: str) -> tuple:
             pass
 
     return entity_valid_from, entity_descriptions, file_entities
+
+
+def _preload_field_class_idents(db: Any) -> Dict[str, str]:
+    """Reload field_ident -> owning class_ident for every field with a live :class edge.
+
+    A field only carries a :class edge when its owning class was genuinely
+    extracted as a :type/class entity (see _precompute_file_triples). Without
+    this reload, field_class_ident starts empty on every restart, so a field
+    introduced in an earlier run would have its [class :contains field] edge
+    silently leaked open when a later run closes the field (its module-contains
+    edge would still close, but not the class one). Current-time query semantics
+    naturally exclude already-closed fields' edges.
+    """
+    field_class_ident: Dict[str, str] = {}
+    try:
+        # Bind the field's :ident object (the canonical ":field/…" string), not
+        # the subject variable — minigraf returns an internal UUID for a subject
+        # in find position, whereas close sites key field_class_ident by the same
+        # ident string _code_ident produces. This mirrors _preload_known_entities.
+        raw = _db_execute(
+            db,
+            "(query [:find ?fi ?c :where "
+            "[?f :entity-type :type/field] [?f :ident ?fi] [?f :class ?c]])",
+        )
+        for field_ident, class_ident in json.loads(raw).get("results", []):
+            field_class_ident[field_ident] = class_ident
+    except Exception:
+        pass
+    return field_class_ident
 
 
 _VALID_TIME_FOREVER_MS = (1 << 63) - 1  # minigraf's i64::MAX "still open" :valid-to sentinel
@@ -5171,9 +5239,11 @@ def _load_ingestion_preload_state(repo_path: str) -> tuple:
     entity_valid_from, entity_descriptions, file_entities = _preload_known_entities(db, repo_path)
     file_deps, dep_valid_from = _preload_known_deps(db, file_entities)
     pinned_commit_state = _preload_pinned_commits(db)
+    field_class_ident = _preload_field_class_idents(db)
     return (
         watermark, prior_ingested, entity_valid_from, entity_descriptions,
         file_entities, file_deps, dep_valid_from, pinned_commit_state,
+        field_class_ident,
     )
 
 
@@ -5519,6 +5589,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
             (
                 watermark, prior_ingested, entity_valid_from, entity_descriptions,
                 file_entities, file_deps, dep_valid_from, pinned_commit_state,
+                field_class_ident,
             ) = await loop.run_in_executor(preload_executor, _load_ingestion_preload_state, repo_path)
         # minigraf exposes no explicit close(): the file lock is only released once
         # every reference to the handle is gone — the worker thread's own `db`
@@ -5661,7 +5732,10 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                     orig_ts = entity_valid_from.get(ident, commit_ts_iso)
                                     desc = entity_descriptions.get(ident, "")
                                     close_items.append(
-                                        (_build_close_triples(ident, desc, module_ident), orig_ts)
+                                        (_build_close_triples(
+                                            ident, desc, module_ident,
+                                            field_class_ident.get(ident),
+                                        ), orig_ts)
                                     )
                                 # Close all :depends-on edges for the deleted module
                                 for dep_ident in file_deps.get(file_path, set()):
@@ -5692,6 +5766,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                 triples = _build_code_triples(
                                     file_path, extracted, commit_ts_iso, entity_valid_from,
                                     entity_descriptions, file_entities, commit_ident, precomputed,
+                                    field_class_ident,
                                 )
                                 add_triples.extend(triples)
                                 # Detect entities removed from a modified file.
@@ -5728,7 +5803,10 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                         orig_ts = entity_valid_from.get(ident, commit_ts_iso)
                                         desc = entity_descriptions.get(ident, "")
                                         close_items.append(
-                                            (_build_close_triples(ident, desc, module_ident), orig_ts)
+                                            (_build_close_triples(
+                                                ident, desc, module_ident,
+                                                field_class_ident.get(ident),
+                                            ), orig_ts)
                                         )
                                 # Compute dep edges for this file and diff against previous.
                                 # Resolution itself already happened in _extract_commit
@@ -5776,7 +5854,10 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                             old_module_ident = _code_ident("module", old_file)
                             orig_ts = entity_valid_from.get(old_ident, commit_ts_iso)
                             close_items.append((
-                                _build_close_triples(old_ident, old_desc, old_module_ident),
+                                _build_close_triples(
+                                    old_ident, old_desc, old_module_ident,
+                                    field_class_ident.get(old_ident),
+                                ),
                                 orig_ts,
                             ))
 
@@ -5803,7 +5884,10 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                     orig_ts = entity_valid_from.get(ident, commit_ts_iso)
                                     desc = entity_descriptions.get(ident, "")
                                     close_items.append(
-                                        (_build_close_triples(ident, desc, r_old_module_ident), orig_ts)
+                                        (_build_close_triples(
+                                            ident, desc, r_old_module_ident,
+                                            field_class_ident.get(ident),
+                                        ), orig_ts)
                                     )
                                 for dep_ident in file_deps.get(r_old_path, set()):
                                     orig_ts = dep_valid_from.get((r_old_module_ident, dep_ident), commit_ts_iso)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1952,6 +1952,142 @@ def _extract_scala_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["scala"] = _extract_scala_globals_and_fields
 
 
+def _extract_haskell_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware Haskell top-level bindings/record-fields extraction.
+
+    Haskell is a genuinely different paradigm from every other language in
+    this plan -- no OOP, no static/instance concept, so extracted fields
+    are always `:static=False`.
+
+    A zero-argument top-level `bind` node (field:name = a `variable` node)
+    is the "global value" signal, cleanly distinguished by the grammar
+    itself from a parameterized `function` node (already targeted by
+    `_LANG_NODE_TYPES["haskell"]["functions"]`). A destructuring bind such
+    as `(a, b) = (1, 2)` puts a `tuple` node in field:pattern instead --
+    NOT field:name -- verified empirically; child_by_field_name("name")
+    correctly returns None for it, so it is silently excluded rather than
+    partially/incorrectly extracted. This is a deliberate simplification,
+    not a bug: recognizing destructured tuple binds as multiple globals
+    would require pattern-name recursion for comparatively rare top-level
+    syntax.
+
+    `module Foo where` produces a sibling `header` field on the root
+    node -- verified empirically -- it does NOT wrap the declarations the
+    way JS's export_statement or PHP's block-style namespace_definition
+    do elsewhere in this plan. field:declarations still holds top-level
+    declarations directly regardless of whether a module header is
+    present, so no unwrapping is needed.
+
+    `where`-clause local bindings (`f x = y where y = 1`) live nested
+    inside the enclosing function node's body (as a `local_binds` node),
+    NOT as direct children of field:declarations -- verified empirically
+    -- so they are correctly excluded without any special-casing, the
+    same as this extractor never recursing into function bodies elsewhere.
+
+    `data Foo = Foo { fieldA :: Int }` is `data_type` (field:name = the
+    type name) -> field:constructors -> `data_constructors` -> each
+    `data_constructor` (field:constructor) -> if that constructor is
+    specifically a `record` node -> field:fields -> `fields` -> each
+    `field` child (field:name) -> `field_name` -> `variable` (the actual
+    field name text). A `data` type with MULTIPLE constructors mixing
+    record and non-record shapes (e.g. `data Shape = Circle { radius ::
+    Double } | Rectangle { width :: Double } | Point`) works correctly
+    because each `data_constructor` within `data_constructors` gets its
+    own independent record-shape check in the loop -- verified
+    empirically; a non-record constructor (a `prefix` node, e.g. `Point`)
+    is simply skipped, not mistaken for a record.
+
+    `newtype Foo = Foo { unFoo :: Int }` -- a newtype's single record
+    field is a very common real Haskell pattern -- is a STRUCTURALLY
+    DIFFERENT top-level node from data_type: a `newtype` node (not
+    `data_type`) whose field:constructor holds a `newtype_constructor`
+    directly (no intermediate `data_constructor`/`data_constructors`
+    wrapper at all), and whose record child is reached via the
+    confusingly-named field:field (NOT field:record or field:fields) --
+    verified empirically. A braces-less newtype (`newtype Foo = Foo
+    Int`) puts a plain `field` node (not `record`) at that same
+    field:field, so the `.type != "record"` check correctly excludes it
+    without misreading its wrapped type name as a field.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def add_field_from_wrapper(field_wrapper: Any, type_name: str) -> None:
+        if field_wrapper.type != "field":
+            return
+        field_name_node = field_wrapper.child_by_field_name("name")
+        if field_name_node is None:
+            return
+        variable_node = next(
+            (c for c in field_name_node.children if c.type == "variable"), None
+        )
+        if variable_node is not None:
+            fname = variable_node.text.decode("utf-8")
+            fields.append((fname, type_name, False))
+            field_info[fname] = {
+                "class": type_name, "static": False,
+                "body": field_wrapper.text.decode("utf-8", "replace"),
+            }
+
+    def record_fields(record_node: Any, type_name: str) -> None:
+        # A record with multiple comma-separated fields (the shape
+        # data_type constructors use) wraps them in a "fields" node at
+        # field:fields. A newtype's record -- restricted by the
+        # language to exactly one field -- instead exposes that single
+        # field node directly at field:field (no wrapper) -- verified
+        # empirically. Both shapes are handled here.
+        fields_node = record_node.child_by_field_name("fields")
+        if fields_node is not None:
+            for field_wrapper in fields_node.children:
+                add_field_from_wrapper(field_wrapper, type_name)
+            return
+        single_field = record_node.child_by_field_name("field")
+        if single_field is not None:
+            add_field_from_wrapper(single_field, type_name)
+
+    declarations = root_node.child_by_field_name("declarations")
+    if declarations is None:
+        return {"globals": [], "global_bodies": {}, "fields": [], "field_info": {}}
+
+    for decl in declarations.children:
+        if decl.type == "bind":
+            name_node = decl.child_by_field_name("name")
+            if name_node is not None:
+                name = name_node.text.decode("utf-8")
+                globals_.append(name)
+                global_bodies[name] = decl.text.decode("utf-8", "replace")
+        elif decl.type == "data_type":
+            type_name_node = decl.child_by_field_name("name")
+            type_name = type_name_node.text.decode("utf-8") if type_name_node else ""
+            constructors = decl.child_by_field_name("constructors")
+            if constructors is None:
+                continue
+            for ctor_wrapper in constructors.children:
+                if ctor_wrapper.type != "data_constructor":
+                    continue
+                ctor = ctor_wrapper.child_by_field_name("constructor")
+                if ctor is None or ctor.type != "record":
+                    continue
+                record_fields(ctor, type_name)
+        elif decl.type == "newtype":
+            type_name_node = decl.child_by_field_name("name")
+            type_name = type_name_node.text.decode("utf-8") if type_name_node else ""
+            newtype_ctor = decl.child_by_field_name("constructor")
+            if newtype_ctor is None:
+                continue
+            record = newtype_ctor.child_by_field_name("field")
+            if record is None or record.type != "record":
+                continue
+            record_fields(record, type_name)
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["haskell"] = _extract_haskell_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1565,6 +1565,134 @@ def _extract_php_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["php"] = _extract_php_globals_and_fields
 
 
+def _extract_kotlin_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware Kotlin globals/fields extraction.
+
+    Top-level `val`/`var` is a property_declaration directly under
+    source_file, wrapping a variable_declaration (single name) or a
+    multi_variable_declaration (destructuring, e.g. `val (a, b) =
+    ...`) -- NEITHER exposes a named field for the identifier(s) in the
+    real installed tree-sitter-kotlin grammar, verified empirically, so
+    both are located purely by node type. `class Foo { ... }` is a
+    class_declaration whose `class_body` child is likewise not exposed
+    via a named field (only `name` is a named field on
+    class_declaration) -- verified empirically. A property_declaration
+    that is a direct child of class_body is an instance field; one
+    nested inside a companion_object's own class_body is Kotlin's
+    static-equivalent.
+
+    Multi-declarator/destructuring (`val (a, b) = Pair(1, 2)`) wraps
+    its names in multi_variable_declaration instead of a bare
+    variable_declaration -- verified empirically, same lesson as the
+    multi-declarator gaps found in every prior language in this plan
+    (Go/C/Java/C++/Ruby): every identifier inside it is extracted, not
+    just treated as absent.
+
+    Kotlin's primary-constructor property shorthand (`class Foo(val x:
+    Int)`) is an idiomatic and extremely common way to declare instance
+    fields (near-universal in `data class`), but it is structurally a
+    class_parameter inside primary_constructor's class_parameters list
+    -- NOT a property_declaration under class_body -- verified
+    empirically. class_parameter exposes no named fields either; its
+    optional `val`/`var` keyword child and its `identifier` name child
+    are both located by node type, taking only the direct-child
+    identifier so the nested one inside the parameter's type
+    annotation (e.g. `Int` in `val x: Int`) is never matched. A
+    class_parameter with neither a `val` nor `var` child is a plain
+    (non-property) constructor parameter and is excluded. These are
+    always instance fields: Kotlin has no syntax for a `val`/`var`
+    primary-constructor parameter inside a companion object (companion
+    objects are declared with `object`, which has no primary
+    constructor), so no static variant of this exists.
+
+    Never recurses into a nested class_declaration found inside a
+    class_body (fields two classes deep are out of scope, consistent
+    with every other language in this plan) or into any function/method
+    body.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def property_names(prop_node: Any) -> List[str]:
+        names: List[str] = []
+        for child in prop_node.children:
+            if child.type == "variable_declaration":
+                for inner in child.children:
+                    if inner.type == "identifier":
+                        names.append(inner.text.decode("utf-8"))
+                        break
+            elif child.type == "multi_variable_declaration":
+                for decl in child.children:
+                    if decl.type == "variable_declaration":
+                        for inner in decl.children:
+                            if inner.type == "identifier":
+                                names.append(inner.text.decode("utf-8"))
+                                break
+        return names
+
+    def record_constructor_param_fields(class_node: Any, class_name: str) -> None:
+        primary_ctor = next((c for c in class_node.children if c.type == "primary_constructor"), None)
+        if primary_ctor is None:
+            return
+        params = next((c for c in primary_ctor.children if c.type == "class_parameters"), None)
+        if params is None:
+            return
+        for param in params.children:
+            if param.type != "class_parameter":
+                continue
+            if not any(c.type in ("val", "var") for c in param.children):
+                continue
+            name_node = next((c for c in param.children if c.type == "identifier"), None)
+            if name_node is None:
+                continue
+            fname = name_node.text.decode("utf-8")
+            fields.append((fname, class_name, False))
+            field_info[fname] = {
+                "class": class_name, "static": False,
+                "body": param.text.decode("utf-8", "replace"),
+            }
+
+    for stmt in root_node.children:
+        if stmt.type == "property_declaration":
+            for name in property_names(stmt):
+                globals_.append(name)
+                global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "class_declaration":
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            record_constructor_param_fields(stmt, class_name)
+            class_body = next((c for c in stmt.children if c.type == "class_body"), None)
+            if class_body is None:
+                continue
+            for member in class_body.children:
+                if member.type == "property_declaration":
+                    for fname in property_names(member):
+                        fields.append((fname, class_name, False))
+                        field_info[fname] = {
+                            "class": class_name, "static": False,
+                            "body": member.text.decode("utf-8", "replace"),
+                        }
+                elif member.type == "companion_object":
+                    companion_body = next((c for c in member.children if c.type == "class_body"), None)
+                    if companion_body is None:
+                        continue
+                    for inner_member in companion_body.children:
+                        if inner_member.type == "property_declaration":
+                            for fname in property_names(inner_member):
+                                fields.append((fname, class_name, True))
+                                field_info[fname] = {
+                                    "class": class_name, "static": True,
+                                    "body": inner_member.text.decode("utf-8", "replace"),
+                                }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["kotlin"] = _extract_kotlin_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3063,7 +3063,7 @@ def handle_minigraf_transact(facts: str, reason: str) -> Dict[str, Any]:
     _refresh_if_stale()
     db = get_db()
     try:
-        raw = _db_execute(db, f'(transact {facts} {{:valid-from "{_now_utc_ms()}"}})')
+        raw = _db_execute(db, f'(transact {{:valid-from "{_now_utc_ms()}"}} {facts})')
         _db_checkpoint(db)
         _update_mtime()
         result = _parse_tx_result(raw)
@@ -3816,7 +3816,7 @@ def _ingest_transact(
     if not triples:
         return
     facts_str = "[" + " ".join(triples) + "]"
-    _db_execute(db, f'(transact {facts_str} {{:valid-from "{commit_ts_iso}"}})')
+    _db_execute(db, f'(transact {{:valid-from "{commit_ts_iso}"}} {facts_str})')
 
 
 def _ingest_close(
@@ -3849,7 +3849,7 @@ def _ingest_close(
     facts_str = "[" + " ".join(triples) + "]"
     _db_execute(
         db,
-        f'(transact {facts_str} {{:valid-from "{original_ts_iso}" :valid-to "{commit_ts_iso}"}})',
+        f'(transact {{:valid-from "{original_ts_iso}" :valid-to "{commit_ts_iso}"}} {facts_str})',
     )
 
 
@@ -3891,11 +3891,11 @@ def _watermark_update(db: Any, commit_hash: str, commit_ts_iso: str, reason: str
         _db_execute(db, f'(retract [[:ingestion/watermark :hash "{existing}"]])')
     _db_execute(
         db,
-        f'(transact [[:ingestion/watermark :entity-type :type/ingestion] '
+        f'(transact {{:valid-from "{commit_ts_iso}"}} '
+        f'[[:ingestion/watermark :entity-type :type/ingestion] '
         f'[:ingestion/watermark :ident ":ingestion/watermark"] '
         f'[:ingestion/watermark :description "git ingestion watermark"] '
-        f'[:ingestion/watermark :hash "{commit_hash}"]] '
-        f'{{:valid-from "{commit_ts_iso}"}})',
+        f'[:ingestion/watermark :hash "{commit_hash}"]])',
     )
 
 
@@ -4493,7 +4493,7 @@ def _transact_extracted_facts(facts: List[Dict[str, str]], valid_from: Optional[
                 )
             else:
                 triples = f'[{entity} {attribute} "{value}"]'
-            _db_execute(db, f'(transact [{triples}] {{:valid-from "{now_z}"}})')
+            _db_execute(db, f'(transact {{:valid-from "{now_z}"}} [{triples}])')
             stored += 1
         except MiniGrafError:
             continue
@@ -4735,7 +4735,7 @@ async def _agent_extract_and_transact(conversation_delta: str) -> Dict[str, Any]
             return {"ok": True, "stored_count": 0, "strategy": "agent"}
         _refresh_if_stale()
         db = get_db()
-        _db_execute(db, f'(transact {datalog} {{:valid-from "{valid_at}"}})')
+        _db_execute(db, f'(transact {{:valid-from "{valid_at}"}} {datalog})')
         _db_checkpoint(db)
         _update_mtime()
         # Approximate: count "[:" occurrences as a proxy for triple count.
@@ -5203,7 +5203,7 @@ def _ingest_tags(db: Any, repo_path: str, run_ts_iso: str) -> None:
             ]
             if date_raw:
                 triples.append(f'[{tag_ident} :date "{_edn_escape(date_raw)}"]')
-            _db_execute(db, f'(transact [{" ".join(triples)}] {{:valid-from "{run_ts_iso}"}})')
+            _db_execute(db, f'(transact {{:valid-from "{run_ts_iso}"}} [{" ".join(triples)}])')
         except Exception:
             pass  # non-fatal per tag
 
@@ -5896,8 +5896,8 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                     write_executor,
                                     _db_execute,
                                     db,
-                                    f'(transact [[{commit_ident} :parent {parent_ident}]] '
-                                    f'{{:valid-from "{commit_ts_iso}"}})',
+                                    f'(transact {{:valid-from "{commit_ts_iso}"}} '
+                                    f'[[{commit_ident} :parent {parent_ident}]])',
                                 )
                         except Exception:
                             pass  # non-fatal; parent edges are best-effort

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3807,6 +3807,23 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                         )
                                 file_deps[file_path] = current_deps
 
+                        # Function/class rename linkage (Task 9's renamed_pairs).
+                        # Module-level linkage is handled separately per-file
+                        # above (Task 5) since it comes from git's own -M
+                        # detection, not this commit-wide matcher.
+                        for category, old_file, old_name, new_file, new_name in renamed_pairs:
+                            old_ident = _code_ident(category, old_file, old_name)
+                            new_ident = _code_ident(category, new_file, new_name)
+                            add_triples.append(f"[{new_ident} :renamed-from {old_ident}]")
+                            old_desc = entity_descriptions.get(old_ident, old_name)
+                            old_module_ident = _code_ident("module", old_file)
+                            orig_ts = entity_valid_from.get(old_ident, commit_ts_iso)
+                            close_items.append((
+                                _build_close_triples(old_ident, old_desc, old_module_ident)
+                                + [f"[{old_ident} :renamed-to {new_ident}]"],
+                                orig_ts,
+                            ))
+
                         # Process gitlink changes (submodule add/bump/remove).
                         # The "remove" case's interaction with the ordinary per-file module-open
                         # logic (elsewhere in this loop) is only sound because real submodule paths

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2088,6 +2088,65 @@ def _extract_haskell_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["haskell"] = _extract_haskell_globals_and_fields
 
 
+def _extract_lua_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Extract true top-level global variable assignments in Lua.
+
+    `_LANG_NODE_TYPES["lua"]["classes"]` is already `set()` -- Lua has no
+    class node type at all (table-based OOP is a library convention, not a
+    grammar construct) -- so fields are always empty here, consistent with
+    that existing precedent. Table-field writes (`Foo.staticField = 1`) are
+    deliberately excluded: there is no class entity for such a field to
+    attach a `:class` edge to.
+
+    A true global is an `assignment_statement` that is a *direct* child of
+    `chunk` whose `variable_list` holds one or more plain `identifier`
+    nodes (not `dot_index_expression`, the table-field-write shape) -- and
+    which is not wrapped in a `variable_declaration` (the wrapper node
+    `local` produces). Because this loop only matches `assignment_statement`
+    nodes directly under `chunk`, a `local`-wrapped assignment is
+    automatically excluded: its actual `assignment_statement` is one level
+    deeper, inside the `variable_declaration` wrapper -- verified
+    empirically.
+
+    `local function foo() ... end` and top-level `function foo() ... end`
+    both parse as `function_declaration` nodes, never `assignment_statement`
+    -- verified empirically -- so they cannot be misidentified as global
+    variable assignments here; functions are handled separately by
+    `_LANG_NODE_TYPES["lua"]["functions"]`.
+
+    Lua supports multiple assignment in one statement (`a, b = 1, 2`): the
+    `variable_list` node exposes each name via a repeated `field:name` --
+    verified empirically -- so `children_by_field_name` (plural) is used
+    instead of `child_by_field_name`, which would silently return only the
+    first name. This is the Lua analog of the multi-assignment gap found in
+    every prior language in this plan (Ruby, Kotlin, Swift, Scala). A
+    variable_list can also mix plain identifiers with dot_index_expressions
+    in the same statement (`a, Foo.x = 1, 2`) -- verified empirically --
+    each name node is checked individually so only the plain identifiers
+    are captured.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+
+    for stmt in root_node.children:
+        if stmt.type != "assignment_statement":
+            continue
+        var_list = next((c for c in stmt.children if c.type == "variable_list"), None)
+        if var_list is None:
+            continue
+        stmt_text = stmt.text.decode("utf-8", "replace")
+        for name_node in var_list.children_by_field_name("name"):
+            if name_node.type == "identifier":
+                name = name_node.text.decode("utf-8")
+                globals_.append(name)
+                global_bodies[name] = stmt_text
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": [], "field_info": {}}
+
+
+_GLOBAL_FIELD_EXTRACTORS["lua"] = _extract_lua_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3190,11 +3190,14 @@ def _extract_commit(
     (file_results, gitlink_changes, gitmodules_map):
 
       file_results: one entry per changed file that has a supported parser, as
-        (status, file_path, extracted, precomputed). A/M files whose content fetch
-        fails are omitted entirely, mirroring the previous inline `continue` — same
-        as before this pipeline existed. For a "D" (deleted) file, extracted and
-        precomputed are both None — the main thread only needs file_path to know
-        what to close.
+        (status, file_path, extracted, precomputed, old_path). A/M files whose
+        content fetch fails are omitted entirely, mirroring the previous inline
+        `continue` — same as before this pipeline existed. For a "D" (deleted)
+        file, extracted and precomputed are both None — the main thread only
+        needs file_path to know what to close. old_path is the pre-rename path
+        for "R" entries and "" for every other status (A/M/D) — kept as a fixed
+        5th tuple element rather than variable arity so downstream consumers
+        (_run_ingestion) can unpack uniformly.
       gitlink_changes: _gitlink_changes' output — gitlink-involving rows, never fed
         through the tree-sitter parser (gitlink paths never have a resolvable extension).
       gitmodules_map: path -> {"name", "url"}, populated only when this commit has at
@@ -3225,7 +3228,7 @@ def _extract_commit(
         if parser is None:
             continue
         if status == "D":
-            results.append((status, file_path, None, None))
+            results.append((status, file_path, None, None, ""))
             continue
         try:
             content = _git_file_content(repo_path, commit_hash, file_path)
@@ -3238,7 +3241,7 @@ def _extract_commit(
         precomputed = _precompute_file_triples(
             file_path, extracted, commit_ident, known_files, segment_index=segment_index,
         )
-        results.append((status, file_path, extracted, precomputed))
+        results.append((status, file_path, extracted, precomputed, old_path if status == "R" else ""))
 
     gitlink_changes = _gitlink_changes(raw_entries)
     gitmodules_map: Dict[str, Dict[str, str]] = {}
@@ -3407,7 +3410,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                         close_items: List[tuple] = []  # (triples, original_ts_iso)
                         dep_add_triples: List[str] = []  # :depends-on triples to transact individually
 
-                        for status, file_path, extracted, precomputed in extracted_files:
+                        for status, file_path, extracted, precomputed, old_path in extracted_files:
                             if status == "D":
                                 # Close module and all known child entities for this file
                                 idents = file_entities.get(file_path, [_code_ident("module", file_path)])

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -735,6 +735,91 @@ def _extract_globals_and_fields(root_node: Any, lang_name: str) -> Dict[str, Any
 _GLOBAL_FIELD_EXTRACTORS: Dict[str, Callable[[Any], Dict[str, Any]]] = {}
 
 
+def _extract_python_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware Python globals/fields extraction.
+
+    Only descends into: module-root direct children (globals), a
+    class_definition's body direct children (class-level/static fields),
+    and __init__'s own body direct children (self.x = ... instance
+    fields). Never recurses into any other function/method body, so a
+    known limitation is that fields first assigned outside __init__ (e.g.
+    dynamically added attributes) are not captured — deliberate, bounded
+    heuristic, not an oversight.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def plain_assignment_name(stmt_node: Any) -> Optional[Tuple[str, Any]]:
+        if stmt_node.type != "expression_statement" or stmt_node.child_count == 0:
+            return None
+        assign = stmt_node.children[0]
+        if assign.type != "assignment":
+            return None
+        left = assign.child_by_field_name("left")
+        if left is not None and left.type == "identifier":
+            return left.text.decode("utf-8"), assign
+        return None
+
+    def self_attr_assignment_name(stmt_node: Any) -> Optional[Tuple[str, Any]]:
+        if stmt_node.type != "expression_statement" or stmt_node.child_count == 0:
+            return None
+        assign = stmt_node.children[0]
+        if assign.type != "assignment":
+            return None
+        left = assign.child_by_field_name("left")
+        if left is None or left.type != "attribute":
+            return None
+        obj = left.child_by_field_name("object")
+        attr = left.child_by_field_name("attribute")
+        if obj is not None and obj.type == "identifier" and obj.text == b"self" and attr is not None:
+            return attr.text.decode("utf-8"), assign
+        return None
+
+    for stmt in root_node.children:
+        if stmt.type == "class_definition":
+            class_name_node = stmt.child_by_field_name("name")
+            class_name = class_name_node.text.decode("utf-8") if class_name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                match = plain_assignment_name(member)
+                if match:
+                    field_name, assign_node = match
+                    fields.append((field_name, class_name, True))
+                    field_info[field_name] = {
+                        "class": class_name, "static": True,
+                        "body": assign_node.text.decode("utf-8", "replace"),
+                    }
+                elif member.type == "function_definition":
+                    fn_name_node = member.child_by_field_name("name")
+                    if fn_name_node is not None and fn_name_node.text == b"__init__":
+                        fn_body = member.child_by_field_name("body")
+                        if fn_body is not None:
+                            for fn_stmt in fn_body.children:
+                                self_match = self_attr_assignment_name(fn_stmt)
+                                if self_match:
+                                    field_name, assign_node = self_match
+                                    fields.append((field_name, class_name, False))
+                                    field_info[field_name] = {
+                                        "class": class_name, "static": False,
+                                        "body": assign_node.text.decode("utf-8", "replace"),
+                                    }
+        else:
+            match = plain_assignment_name(stmt)
+            if match:
+                name, assign_node = match
+                globals_.append(name)
+                global_bodies[name] = assign_node.text.decode("utf-8", "replace")
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["python"] = _extract_python_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -940,6 +940,20 @@ def _extract_rust_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                             }
         elif stmt.type == "impl_item":
             type_node = stmt.child_by_field_name("type")
+            # For a generic impl (`impl<T> Foo<T> { ... }`), the `type` field
+            # is a `generic_type` node whose own `type` sub-field holds the
+            # bare `type_identifier` ("Foo"). Unwrap it so the owning-class
+            # name matches the clean name registered for the struct itself
+            # (struct_item's `name` field never includes generic params).
+            # Verified empirically against the installed tree-sitter-rust
+            # grammar for both `impl<T> Foo<T> { const CAP: ... }` (type
+            # field = generic_type -> type = type_identifier "Foo") and
+            # `impl Foo { const ASSOC: ... }` (type field = type_identifier
+            # "Foo" directly, unchanged by this unwrap).
+            if type_node is not None and type_node.type == "generic_type":
+                inner_type_node = type_node.child_by_field_name("type")
+                if inner_type_node is not None:
+                    type_node = inner_type_node
             type_name = type_node.text.decode("utf-8") if type_node is not None else ""
             body = stmt.child_by_field_name("body")
             if body is not None:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3821,6 +3821,57 @@ def _build_close_triples(
     return triples
 
 
+def _forget_closed_entity(
+    ident: str,
+    file_path: Optional[str],
+    entity_valid_from: Dict[str, str],
+    entity_descriptions: Dict[str, str],
+    field_class_ident: Dict[str, str],
+    file_entities: Dict[str, List[str]],
+) -> None:
+    """Purge a just-closed ident from all in-memory lifecycle bookkeeping.
+
+    Once an entity's bi-temporal window is genuinely closed (i.e. the fact is
+    invisible at current time — true only since the transact-ordering fix in
+    1b2e262), its stale entries in these serially-threaded dicts must be
+    dropped so a later commit is not misled by them:
+
+    - entity_valid_from: _build_code_triples keys "is this genuinely new?" on
+      absence here. Leaving a stale entry makes a re-introduction at the same
+      ident take the "already known, only :modified-in" branch, so its
+      :ident/:description/:path/:introduced-by never get re-asserted — a ghost
+      entity with no current :ident fact.
+    - file_entities[file_path]: a stale ident lingering here is re-discovered by
+      a later commit's removal-detection diff (previous_idents - current) if the
+      path is reused, and closed a SECOND time; because entity_valid_from still
+      held its ORIGINAL introduction timestamp, that second close would span the
+      whole gap and silently resurrect the entity across its closed window.
+    - entity_descriptions / field_class_ident: purged for consistency so no
+      stale description or class-containment parent is read for a future
+      re-introduction of the same ident.
+
+    Call this at EVERY entity close site, AFTER that site has read whatever it
+    needs (description, orig_ts, class ident) to build its close triples — never
+    before. Each ident is closed at exactly one site per commit, so purging one
+    ident never removes state another site in the same commit still needs.
+
+    file_path is the owning file's path (the module the ident lives under); pass
+    None to skip the file_entities removal (e.g. idents not tracked per-file).
+    Callers that iterate a file_entities list while calling this MUST iterate a
+    copy, since this mutates file_entities[file_path] in place.
+    """
+    entity_valid_from.pop(ident, None)
+    entity_descriptions.pop(ident, None)
+    field_class_ident.pop(ident, None)
+    if file_path is not None:
+        idents = file_entities.get(file_path)
+        if idents is not None:
+            try:
+                idents.remove(ident)
+            except ValueError:
+                pass
+
+
 def _ingest_transact(
     db: Any,
     triples: List[str],
@@ -5725,8 +5776,10 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
 
                         for status, file_path, extracted, precomputed, old_path in extracted_files:
                             if status == "D":
-                                # Close module and all known child entities for this file
-                                idents = file_entities.get(file_path, [_code_ident("module", file_path)])
+                                # Close module and all known child entities for this file.
+                                # Iterate a copy: _forget_closed_entity mutates
+                                # file_entities[file_path] in place as it purges.
+                                idents = list(file_entities.get(file_path, [_code_ident("module", file_path)]))
                                 module_ident = _code_ident("module", file_path)
                                 for ident in idents:
                                     orig_ts = entity_valid_from.get(ident, commit_ts_iso)
@@ -5737,6 +5790,13 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                             field_class_ident.get(ident),
                                         ), orig_ts)
                                     )
+                                    _forget_closed_entity(
+                                        ident, file_path, entity_valid_from,
+                                        entity_descriptions, field_class_ident, file_entities,
+                                    )
+                                # Whole file is gone: drop its (now-empty) file_entities key
+                                # so nothing stale lingers under this path (matches file_deps).
+                                file_entities.pop(file_path, None)
                                 # Close all :depends-on edges for the deleted module
                                 for dep_ident in file_deps.get(file_path, set()):
                                     orig_ts = dep_valid_from.get((module_ident, dep_ident), commit_ts_iso)
@@ -5762,6 +5822,16 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                         _build_close_triples(old_module_ident, old_desc, old_module_ident),
                                         orig_ts,
                                     ))
+                                    # Purge the closed old module. Its remaining child
+                                    # entities under old_path are closed+purged by the
+                                    # renamed_old_paths pass below, which also pops the
+                                    # whole file_entities[old_path] key — so only the
+                                    # scalar dicts and the module's own list slot need
+                                    # dropping here.
+                                    _forget_closed_entity(
+                                        old_module_ident, old_path, entity_valid_from,
+                                        entity_descriptions, field_class_ident, file_entities,
+                                    )
                                 previous_idents = set(file_entities.get(file_path, []))
                                 triples = _build_code_triples(
                                     file_path, extracted, commit_ts_iso, entity_valid_from,
@@ -5807,6 +5877,12 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                                 ident, desc, module_ident,
                                                 field_class_ident.get(ident),
                                             ), orig_ts)
+                                        )
+                                        # File survives (M), only this child was removed:
+                                        # purge just this ident from the file's list.
+                                        _forget_closed_entity(
+                                            ident, file_path, entity_valid_from,
+                                            entity_descriptions, field_class_ident, file_entities,
                                         )
                                 # Compute dep edges for this file and diff against previous.
                                 # Resolution itself already happened in _extract_commit
@@ -5860,6 +5936,10 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                 ),
                                 orig_ts,
                             ))
+                            _forget_closed_entity(
+                                old_ident, old_file, entity_valid_from,
+                                entity_descriptions, field_class_ident, file_entities,
+                            )
 
                         # A file rename (R status) only closes the old MODULE above.
                         # Child entities and dependency edges under the old path are
@@ -5876,11 +5956,13 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                             }
                             for r_old_path in renamed_old_paths:
                                 r_old_module_ident = _code_ident("module", r_old_path)
-                                for ident in file_entities.get(r_old_path, []):
+                                # Iterate a copy: _forget_closed_entity mutates
+                                # file_entities[r_old_path] in place as it purges.
+                                for ident in list(file_entities.get(r_old_path, [])):
                                     if ident == r_old_module_ident:
-                                        continue  # already closed by the R block above
+                                        continue  # already closed+purged by the R block above
                                     if ident in renamed_covered_idents:
-                                        continue  # already closed with :renamed-to linkage
+                                        continue  # already closed+purged with :renamed-to linkage
                                     orig_ts = entity_valid_from.get(ident, commit_ts_iso)
                                     desc = entity_descriptions.get(ident, "")
                                     close_items.append(
@@ -5889,6 +5971,14 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                             field_class_ident.get(ident),
                                         ), orig_ts)
                                     )
+                                    _forget_closed_entity(
+                                        ident, r_old_path, entity_valid_from,
+                                        entity_descriptions, field_class_ident, file_entities,
+                                    )
+                                # Whole old path is gone (renamed away): drop the key so
+                                # no stale ident lingers to be re-discovered by a later
+                                # commit that reuses this path (e.g. a shim at old_path).
+                                file_entities.pop(r_old_path, None)
                                 for dep_ident in file_deps.get(r_old_path, set()):
                                     orig_ts = dep_valid_from.get((r_old_module_ident, dep_ident), commit_ts_iso)
                                     close_items.append(
@@ -5939,6 +6029,14 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                 desc = entity_descriptions.get(ext_ident, "")
                                 close_items.append(
                                     (_build_close_triples(ext_ident, desc, ext_ident), orig_ts)
+                                )
+                                # Submodule removed: purge lifecycle state so a later
+                                # re-add at the same path is treated as genuinely new.
+                                # (Submodule paths aren't tracked in file_entities, so the
+                                # path arg is a no-op there, but pass it for consistency.)
+                                _forget_closed_entity(
+                                    ext_ident, path, entity_valid_from,
+                                    entity_descriptions, field_class_ident, file_entities,
                                 )
                                 old_sha, pin_orig_ts = pinned_commit_state.pop(ext_ident, (None, commit_ts_iso))
                                 if old_sha is not None:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -725,7 +725,10 @@ def _extract_globals_and_fields(root_node: Any, lang_name: str) -> Dict[str, Any
     statements, never into a function/method body (barring a narrow,
     per-language, deliberate exception — see each language's own extractor).
     """
-    empty: Dict[str, Any] = {"globals": [], "global_bodies": {}, "fields": [], "field_info": {}}
+    empty: Dict[str, Any] = {
+        "globals": [], "global_bodies": {}, "fields": [], "field_info": {},
+        "global_nodes": {}, "field_nodes": {},
+    }
     extractor = _GLOBAL_FIELD_EXTRACTORS.get(lang_name)
     if extractor is None or root_node is None:
         return empty
@@ -748,8 +751,10 @@ def _extract_python_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def plain_assignment_name(stmt_node: Any) -> Optional[Tuple[str, Any]]:
         if stmt_node.type != "expression_statement" or stmt_node.child_count == 0:
@@ -793,6 +798,7 @@ def _extract_python_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                         "class": class_name, "static": True,
                         "body": assign_node.text.decode("utf-8", "replace"),
                     }
+                    field_nodes[f"{class_name}.{field_name}"] = assign_node
                 elif member.type == "function_definition":
                     fn_name_node = member.child_by_field_name("name")
                     if fn_name_node is not None and fn_name_node.text == b"__init__":
@@ -807,14 +813,20 @@ def _extract_python_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                         "class": class_name, "static": False,
                                         "body": assign_node.text.decode("utf-8", "replace"),
                                     }
+                                    field_nodes[f"{class_name}.{field_name}"] = assign_node
         else:
             match = plain_assignment_name(stmt)
             if match:
                 name, assign_node = match
                 globals_.append(name)
                 global_bodies[name] = assign_node.text.decode("utf-8", "replace")
+                global_nodes[name] = assign_node
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["python"] = _extract_python_globals_and_fields
@@ -838,8 +850,10 @@ def _extract_js_family_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     for raw_stmt in root_node.children:
         stmt = raw_stmt
@@ -866,6 +880,7 @@ def _extract_js_family_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                         # exported global's body includes the `export`
                         # keyword, matching its actual source text.
                         global_bodies[name] = raw_stmt.text.decode("utf-8", "replace")
+                        global_nodes[name] = raw_stmt
         elif stmt.type == "class_declaration":
             class_name_node = stmt.child_by_field_name("name")
             class_name = class_name_node.text.decode("utf-8") if class_name_node else ""
@@ -885,8 +900,13 @@ def _extract_js_family_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                     "class": class_name, "static": is_static,
                     "body": member.text.decode("utf-8", "replace"),
                 }
+                field_nodes[f"{class_name}.{field_name}"] = member
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["javascript"] = _extract_js_family_globals_and_fields
@@ -913,8 +933,10 @@ def _extract_rust_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     for stmt in root_node.children:
         if stmt.type in ("static_item", "const_item"):
@@ -923,6 +945,7 @@ def _extract_rust_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 name = name_node.text.decode("utf-8")
                 globals_.append(name)
                 global_bodies[name] = stmt.text.decode("utf-8", "replace")
+                global_nodes[name] = stmt
         elif stmt.type == "struct_item":
             struct_name_node = stmt.child_by_field_name("name")
             struct_name = struct_name_node.text.decode("utf-8") if struct_name_node else ""
@@ -938,6 +961,7 @@ def _extract_rust_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                 "class": struct_name, "static": False,
                                 "body": member.text.decode("utf-8", "replace"),
                             }
+                            field_nodes[f"{struct_name}.{fname}"] = member
         elif stmt.type == "impl_item":
             type_node = stmt.child_by_field_name("type")
             # For a generic impl (`impl<T> Foo<T> { ... }`), the `type` field
@@ -967,8 +991,13 @@ def _extract_rust_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                 "class": type_name, "static": True,
                                 "body": member.text.decode("utf-8", "replace"),
                             }
+                            field_nodes[f"{type_name}.{cname}"] = member
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["rust"] = _extract_rust_globals_and_fields
@@ -1007,8 +1036,10 @@ def _extract_go_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def iter_specs(stmt: Any, spec_type: str) -> Any:
         list_type = f"{spec_type}_list"
@@ -1029,6 +1060,7 @@ def _extract_go_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                     name = name_node.text.decode("utf-8")
                     globals_.append(name)
                     global_bodies[name] = stmt.text.decode("utf-8", "replace")
+                    global_nodes[name] = stmt
         elif stmt.type == "type_declaration":
             for type_spec in stmt.children:
                 if type_spec.type != "type_spec":
@@ -1059,8 +1091,13 @@ def _extract_go_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                 "class": type_name, "static": False,
                                 "body": member.text.decode("utf-8", "replace"),
                             }
+                            field_nodes[f"{type_name}.{fname}"] = member
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["go"] = _extract_go_globals_and_fields
@@ -1091,8 +1128,10 @@ def _extract_c_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def declarator_name(node: Any) -> Optional[str]:
         if node.type == "identifier":
@@ -1109,6 +1148,7 @@ def _extract_c_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 if name:
                     globals_.append(name)
                     global_bodies[name] = stmt.text.decode("utf-8", "replace")
+                    global_nodes[name] = stmt
         elif stmt.type == "struct_specifier":
             struct_name_node = stmt.child_by_field_name("name")
             struct_name = struct_name_node.text.decode("utf-8") if struct_name_node else ""
@@ -1124,8 +1164,13 @@ def _extract_c_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                     "class": struct_name, "static": False,
                                     "body": member.text.decode("utf-8", "replace"),
                                 }
+                                field_nodes[f"{struct_name}.{fname}"] = member
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["c"] = _extract_c_globals_and_fields
@@ -1164,6 +1209,7 @@ def _extract_java_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def walk_class(class_node: Any) -> None:
         name_node = class_node.child_by_field_name("name")
@@ -1189,6 +1235,7 @@ def _extract_java_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                         "class": class_name, "static": is_static,
                         "body": member.text.decode("utf-8", "replace"),
                     }
+                    field_nodes[f"{class_name}.{fname}"] = member
 
     def walk(node: Any) -> None:
         if node.type == "class_declaration":
@@ -1197,7 +1244,10 @@ def _extract_java_globals_and_fields(root_node: Any) -> Dict[str, Any]:
             walk(child)
 
     walk(root_node)
-    return {"globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info}
+    return {
+        "globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info,
+        "global_nodes": {}, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["java"] = _extract_java_globals_and_fields
@@ -1231,6 +1281,7 @@ def _extract_csharp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def walk_class(class_node: Any) -> None:
         name_node = class_node.child_by_field_name("name")
@@ -1255,6 +1306,7 @@ def _extract_csharp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                             "class": class_name, "static": is_static,
                             "body": member.text.decode("utf-8", "replace"),
                         }
+                        field_nodes[f"{class_name}.{fname}"] = member
 
     def walk(node: Any) -> None:
         if node.type == "class_declaration":
@@ -1263,7 +1315,10 @@ def _extract_csharp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
             walk(child)
 
     walk(root_node)
-    return {"globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info}
+    return {
+        "globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info,
+        "global_nodes": {}, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["c_sharp"] = _extract_csharp_globals_and_fields
@@ -1306,8 +1361,10 @@ def _extract_cpp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def declarator_name(node: Any) -> Optional[str]:
         if node.type == "identifier":
@@ -1324,6 +1381,7 @@ def _extract_cpp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 if name:
                     globals_.append(name)
                     global_bodies[name] = stmt.text.decode("utf-8", "replace")
+                    global_nodes[name] = stmt
         elif stmt.type in ("class_specifier", "struct_specifier"):
             name_node = stmt.child_by_field_name("name")
             class_name = name_node.text.decode("utf-8") if name_node else ""
@@ -1346,8 +1404,13 @@ def _extract_cpp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                         "class": class_name, "static": is_static,
                         "body": member.text.decode("utf-8", "replace"),
                     }
+                    field_nodes[f"{class_name}.{fname}"] = member
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["cpp"] = _extract_cpp_globals_and_fields
@@ -1394,8 +1457,10 @@ def _extract_ruby_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def left_targets(left_node: Any, target_types: Tuple[str, ...]) -> List[Any]:
         if left_node.type in target_types:
@@ -1413,6 +1478,7 @@ def _extract_ruby_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 name = target.text.decode("utf-8")
                 globals_.append(name)
                 global_bodies[name] = stmt.text.decode("utf-8", "replace")
+                global_nodes[name] = stmt
         elif stmt.type == "class":
             name_node = stmt.child_by_field_name("name")
             class_name = name_node.text.decode("utf-8") if name_node else ""
@@ -1431,6 +1497,7 @@ def _extract_ruby_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                             "class": class_name, "static": True,
                             "body": member.text.decode("utf-8", "replace"),
                         }
+                        field_nodes[f"{class_name}.{fname}"] = member
                 elif member.type == "method":
                     method_name_node = member.child_by_field_name("name")
                     if method_name_node is not None and method_name_node.text == b"initialize":
@@ -1448,8 +1515,13 @@ def _extract_ruby_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                             "class": class_name, "static": False,
                                             "body": inner.text.decode("utf-8", "replace"),
                                         }
+                                        field_nodes[f"{class_name}.{fname}"] = inner
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["ruby"] = _extract_ruby_globals_and_fields
@@ -1502,8 +1574,10 @@ def _extract_php_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def handle_class(stmt: Any) -> None:
         name_node = stmt.child_by_field_name("name")
@@ -1524,6 +1598,7 @@ def _extract_php_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                 "class": class_name, "static": is_static,
                                 "body": member.text.decode("utf-8", "replace"),
                             }
+                            field_nodes[f"{class_name}.{fname}"] = member
             elif member.type == "method_declaration":
                 method_name_node = member.child_by_field_name("name")
                 if method_name_node is not None and method_name_node.text == b"__construct":
@@ -1539,6 +1614,7 @@ def _extract_php_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                         "class": class_name, "static": False,
                                         "body": param.text.decode("utf-8", "replace"),
                                     }
+                                    field_nodes[f"{class_name}.{fname}"] = param
 
     def handle_stmts(stmts: Sequence[Any]) -> None:
         for stmt in stmts:
@@ -1550,6 +1626,7 @@ def _extract_php_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                         name = left.text.decode("utf-8")
                         globals_.append(name)
                         global_bodies[name] = stmt.text.decode("utf-8", "replace")
+                        global_nodes[name] = stmt
             elif stmt.type == "class_declaration":
                 handle_class(stmt)
             elif stmt.type == "namespace_definition":
@@ -1559,7 +1636,11 @@ def _extract_php_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 
     handle_stmts(root_node.children)
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["php"] = _extract_php_globals_and_fields
@@ -1612,8 +1693,10 @@ def _extract_kotlin_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def property_names(prop_node: Any) -> List[str]:
         names: List[str] = []
@@ -1653,12 +1736,14 @@ def _extract_kotlin_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 "class": class_name, "static": False,
                 "body": param.text.decode("utf-8", "replace"),
             }
+            field_nodes[f"{class_name}.{fname}"] = param
 
     for stmt in root_node.children:
         if stmt.type == "property_declaration":
             for name in property_names(stmt):
                 globals_.append(name)
                 global_bodies[name] = stmt.text.decode("utf-8", "replace")
+                global_nodes[name] = stmt
         elif stmt.type == "class_declaration":
             name_node = stmt.child_by_field_name("name")
             class_name = name_node.text.decode("utf-8") if name_node else ""
@@ -1674,6 +1759,7 @@ def _extract_kotlin_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                             "class": class_name, "static": False,
                             "body": member.text.decode("utf-8", "replace"),
                         }
+                        field_nodes[f"{class_name}.{fname}"] = member
                 elif member.type == "companion_object":
                     companion_body = next((c for c in member.children if c.type == "class_body"), None)
                     if companion_body is None:
@@ -1686,8 +1772,13 @@ def _extract_kotlin_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                     "class": class_name, "static": True,
                                     "body": inner_member.text.decode("utf-8", "replace"),
                                 }
+                                field_nodes[f"{class_name}.{fname}"] = inner_member
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["kotlin"] = _extract_kotlin_globals_and_fields
@@ -1756,8 +1847,10 @@ def _extract_swift_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def property_names(prop_node: Any) -> List[str]:
         names: List[str] = []
@@ -1772,6 +1865,7 @@ def _extract_swift_globals_and_fields(root_node: Any) -> Dict[str, Any]:
             for name in property_names(stmt):
                 globals_.append(name)
                 global_bodies[name] = stmt.text.decode("utf-8", "replace")
+                global_nodes[name] = stmt
         elif stmt.type == "class_declaration":
             name_node = stmt.child_by_field_name("name")
             class_name = name_node.text.decode("utf-8") if name_node else ""
@@ -1794,8 +1888,13 @@ def _extract_swift_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                         "class": class_name, "static": is_static,
                         "body": member.text.decode("utf-8", "replace"),
                     }
+                    field_nodes[f"{class_name}.{fname}"] = member
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["swift"] = _extract_swift_globals_and_fields
@@ -1879,8 +1978,10 @@ def _extract_scala_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def pattern_names(pattern: Any) -> List[str]:
         if pattern is None:
@@ -1912,6 +2013,7 @@ def _extract_scala_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 "class": class_name, "static": False,
                 "body": param.text.decode("utf-8", "replace"),
             }
+            field_nodes[f"{class_name}.{fname}"] = param
 
     def handle_stmts(stmts: Sequence[Any]) -> None:
         for stmt in stmts:
@@ -1924,6 +2026,7 @@ def _extract_scala_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                         for name in pattern_names(member.child_by_field_name("pattern")):
                             globals_.append(name)
                             global_bodies[name] = member.text.decode("utf-8", "replace")
+                            global_nodes[name] = member
             elif stmt.type == "class_definition":
                 name_node = stmt.child_by_field_name("name")
                 class_name = name_node.text.decode("utf-8") if name_node else ""
@@ -1939,6 +2042,7 @@ def _extract_scala_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                 "class": class_name, "static": False,
                                 "body": member.text.decode("utf-8", "replace"),
                             }
+                            field_nodes[f"{class_name}.{name}"] = member
             elif stmt.type == "package_clause":
                 pkg_body = stmt.child_by_field_name("body")
                 if pkg_body is not None:
@@ -1946,7 +2050,11 @@ def _extract_scala_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 
     handle_stmts(root_node.children)
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["scala"] = _extract_scala_globals_and_fields
@@ -2011,8 +2119,10 @@ def _extract_haskell_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def add_field_from_wrapper(field_wrapper: Any, type_name: str) -> None:
         if field_wrapper.type != "field":
@@ -2030,6 +2140,7 @@ def _extract_haskell_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 "class": type_name, "static": False,
                 "body": field_wrapper.text.decode("utf-8", "replace"),
             }
+            field_nodes[f"{type_name}.{fname}"] = field_wrapper
 
     def record_fields(record_node: Any, type_name: str) -> None:
         # A record with multiple comma-separated fields (the shape
@@ -2049,7 +2160,10 @@ def _extract_haskell_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 
     declarations = root_node.child_by_field_name("declarations")
     if declarations is None:
-        return {"globals": [], "global_bodies": {}, "fields": [], "field_info": {}}
+        return {
+            "globals": [], "global_bodies": {}, "fields": [], "field_info": {},
+            "global_nodes": {}, "field_nodes": {},
+        }
 
     for decl in declarations.children:
         if decl.type == "bind":
@@ -2058,6 +2172,7 @@ def _extract_haskell_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 name = name_node.text.decode("utf-8")
                 globals_.append(name)
                 global_bodies[name] = decl.text.decode("utf-8", "replace")
+                global_nodes[name] = decl
         elif decl.type == "data_type":
             type_name_node = decl.child_by_field_name("name")
             type_name = type_name_node.text.decode("utf-8") if type_name_node else ""
@@ -2082,7 +2197,11 @@ def _extract_haskell_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 continue
             record_fields(record, type_name)
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+    return {
+        "globals": globals_, "global_bodies": global_bodies,
+        "fields": fields, "field_info": field_info,
+        "global_nodes": global_nodes, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["haskell"] = _extract_haskell_globals_and_fields
@@ -2127,6 +2246,7 @@ def _extract_lua_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     globals_: List[str] = []
     global_bodies: Dict[str, str] = {}
+    global_nodes: Dict[str, Any] = {}
 
     for stmt in root_node.children:
         if stmt.type != "assignment_statement":
@@ -2140,8 +2260,12 @@ def _extract_lua_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                 name = name_node.text.decode("utf-8")
                 globals_.append(name)
                 global_bodies[name] = stmt_text
+                global_nodes[name] = stmt
 
-    return {"globals": globals_, "global_bodies": global_bodies, "fields": [], "field_info": {}}
+    return {
+        "globals": globals_, "global_bodies": global_bodies, "fields": [], "field_info": {},
+        "global_nodes": global_nodes, "field_nodes": {},
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["lua"] = _extract_lua_globals_and_fields
@@ -2196,6 +2320,7 @@ def _extract_elixir_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     """
     fields: List[Tuple[str, str, bool]] = []
     field_info: Dict[str, Dict[str, Any]] = {}
+    field_nodes: Dict[str, Any] = {}
 
     def walk(node: Any) -> None:
         if node.type == "call":
@@ -2222,11 +2347,15 @@ def _extract_elixir_globals_and_fields(root_node: Any) -> Dict[str, Any]:
                                         "class": module_name, "static": True,
                                         "body": member.text.decode("utf-8", "replace"),
                                     }
+                                    field_nodes[f"{module_name}.{fname}"] = member
         for child in node.children:
             walk(child)
 
     walk(root_node)
-    return {"globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info}
+    return {
+        "globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info,
+        "global_nodes": {}, "field_nodes": field_nodes,
+    }
 
 
 _GLOBAL_FIELD_EXTRACTORS["elixir"] = _extract_elixir_globals_and_fields
@@ -4998,14 +5127,31 @@ def _extract_commit(
     # this worker process — tree_sitter Node objects never cross the process
     # boundary (#116), only the plain-string renamed_pairs derived from
     # matches does.
-    removed_pool: Dict[str, List[Tuple[str, Any]]] = {"function": [], "class": []}
-    added_pool: Dict[str, List[Tuple[str, Any]]] = {"function": [], "class": []}
+    removed_pool: Dict[str, List[Tuple[str, Any]]] = {
+        "function": [], "class": [], "variable": [], "field": [],
+    }
+    added_pool: Dict[str, List[Tuple[str, Any]]] = {
+        "function": [], "class": [], "variable": [], "field": [],
+    }
     # (category, old_file_path, old_name, new_file_path, new_name) is only
     # knowable once we know which FILE each pooled node came from — track
     # that alongside the pool itself, keyed by node identity (id()), since
     # two different removed entities in two different deleted files could
     # coincidentally share a name.
     node_origin: Dict[int, str] = {}  # id(node) -> file_path
+
+    def collect_all_nodes(root: Any, lang: str) -> Dict[str, Dict[str, Any]]:
+        # Widens _collect_entity_nodes's function/class-only result with the
+        # variable/field categories from Component 3 (Tasks 13-25), reusing
+        # _extract_globals_and_fields directly (not through
+        # _extract_from_source) so its live-node keys — never exposed across
+        # the ProcessPoolExecutor boundary — are available here, entirely
+        # inside this worker process (Task 26).
+        base = _collect_entity_nodes(root, lang)
+        gf = _extract_globals_and_fields(root, "typescript" if lang == "tsx" else lang)
+        base["variable"] = dict(gf.get("global_nodes", {}))
+        base["field"] = dict(gf.get("field_nodes", {}))
+        return base
 
     for status, old_mode, new_mode, old_sha, new_sha, file_path, old_path, similarity in raw_entries:
         if _is_ignored_path(file_path, ignore_patterns):
@@ -5015,7 +5161,9 @@ def _extract_commit(
             continue
 
         old_lang_path = old_path if status == "R" else file_path
-        old_entity_nodes: Dict[str, Dict[str, Any]] = {"function": {}, "class": {}}
+        old_entity_nodes: Dict[str, Dict[str, Any]] = {
+            "function": {}, "class": {}, "variable": {}, "field": {},
+        }
         if status in ("D", "M", "R") and old_sha and old_sha != "0" * len(old_sha):
             try:
                 old_content = _git_blob_content(repo_path, old_sha)
@@ -5031,12 +5179,12 @@ def _extract_commit(
                 old_parser = _thread_parser(old_lang_path) if status == "R" else parser
                 old_tree = old_parser.parse(old_content)
                 old_lang = _EXT_TO_LANG.get(Path(old_lang_path).suffix.lower(), "")
-                old_entity_nodes = _collect_entity_nodes(old_tree.root_node, old_lang)
+                old_entity_nodes = collect_all_nodes(old_tree.root_node, old_lang)
             except Exception:
                 pass  # best-effort: matching degrades to no-match, not a hard failure
 
         if status == "D":
-            for category in ("function", "class"):
+            for category in ("function", "class", "variable", "field"):
                 for name, node in old_entity_nodes[category].items():
                     removed_pool[category].append((name, node))
                     node_origin[id(node)] = old_lang_path
@@ -5075,12 +5223,14 @@ def _extract_commit(
         new_lang = _EXT_TO_LANG.get(Path(file_path).suffix.lower(), "")
         try:
             new_tree = parser.parse(content)
-            new_entity_nodes = _collect_entity_nodes(new_tree.root_node, new_lang)
+            new_entity_nodes = collect_all_nodes(new_tree.root_node, new_lang)
         except Exception:
-            new_entity_nodes = {"function": {}, "class": {}}  # best-effort: matching degrades to no-match
+            new_entity_nodes = {
+                "function": {}, "class": {}, "variable": {}, "field": {},
+            }  # best-effort: matching degrades to no-match
 
         if status == "A":
-            for category in ("function", "class"):
+            for category in ("function", "class", "variable", "field"):
                 for name, node in new_entity_nodes[category].items():
                     added_pool[category].append((name, node))
                     node_origin[id(node)] = file_path
@@ -5088,7 +5238,7 @@ def _extract_commit(
             # Ident changes for every entity in a renamed file, even ones
             # whose text is byte-identical — pool everything on both sides,
             # not just the local diff (unlike "M" below).
-            for category in ("function", "class"):
+            for category in ("function", "class", "variable", "field"):
                 for name, node in old_entity_nodes[category].items():
                     removed_pool[category].append((name, node))
                     node_origin[id(node)] = old_lang_path
@@ -5096,7 +5246,7 @@ def _extract_commit(
                     added_pool[category].append((name, node))
                     node_origin[id(node)] = file_path
         else:  # "M" — same path, only the local diff needs matching
-            for category in ("function", "class"):
+            for category in ("function", "class", "variable", "field"):
                 old_names = set(old_entity_nodes[category].keys())
                 new_names = set(new_entity_nodes[category].keys())
                 for name in old_names - new_names:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1693,6 +1693,114 @@ def _extract_kotlin_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["kotlin"] = _extract_kotlin_globals_and_fields
 
 
+def _extract_swift_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware Swift globals/fields extraction.
+
+    Top-level `let`/`var` is a property_declaration directly under
+    source_file. `class Foo { ... }`, `struct Foo { ... }`, `enum Foo
+    { ... }`, and `extension Foo { ... }` are ALL parsed as the same
+    class_declaration node type (distinguished only by a
+    `declaration_kind` field whose text is "class"/"struct"/"enum"/
+    "extension") -- verified empirically against the real installed
+    tree-sitter-swift grammar. Members are fetched via
+    `child_by_field_name("body")`, which works uniformly even though
+    the body node's *type* differs (class_body for class/struct/
+    extension, enum_class_body for enum), because it's identified by
+    field name, not type.
+
+    A property_declaration can bind MULTIPLE names in one statement
+    (`let a = 1, b = 2`), each its own `field:name` -> pattern ->
+    field:bound_identifier chain -- verified empirically. This is the
+    Swift analog of the multi-declarator gap found in every prior
+    language in this plan: `children_by_field_name("name")` is used
+    (not `child_by_field_name`, which would silently return only the
+    first binding) so every name in the statement is extracted.
+
+    Tuple destructuring (`let (x, y) = (1, 2)`) wraps names in a
+    pattern whose nested per-name patterns expose no bound_identifier
+    field -- verified empirically -- so it is safely skipped (no name
+    extracted), consistent with other out-of-scope destructuring forms
+    in this plan (e.g. Kotlin's multi_variable_declaration, which IS
+    in scope there because it exposes a different structural shape;
+    Swift's tuple pattern here does not surface identifiers via any
+    field, only by node type, so it is left alone).
+
+    Swift has no primary-constructor property shorthand analogous to
+    Kotlin's `class Foo(val x: Int)`: properties are always declared
+    inside the body via property_declaration regardless of how `init`
+    initializes them -- verified empirically (a class with only an
+    `init` and no property_declaration produces zero fields, and `init`
+    parameters/assignments are never treated as field declarations).
+
+    `extension Foo { ... }` is in scope as a side effect of sharing the
+    class_declaration node type with `class`/`struct`/`enum`: its
+    `field:name` is a user_type node wrapping Foo's type_identifier,
+    and `.text` on that node still resolves to the plain name "Foo" --
+    verified empirically -- so properties declared in an extension are
+    picked up and correctly attributed to class "Foo" rather than
+    silently dropped or misattributed. This is not explicitly
+    requested by the task brief but is a safe, useful side effect
+    rather than a misbehavior: it does not crash and does not merge
+    unrelated types.
+
+    Static iff the member's `modifiers` child has a `property_modifier`
+    child with text "static" (Swift's `class var` for overridable
+    static-like properties uses modifier text "class", not "static",
+    and is therefore treated as instance per the task brief's
+    definition).
+
+    Never recurses into a nested class_declaration found inside a
+    class/enum body (fields two types deep are out of scope, consistent
+    with every other language in this plan) or into any function/method
+    body.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def property_names(prop_node: Any) -> List[str]:
+        names: List[str] = []
+        for pattern in prop_node.children_by_field_name("name"):
+            bound = pattern.child_by_field_name("bound_identifier")
+            if bound is not None:
+                names.append(bound.text.decode("utf-8"))
+        return names
+
+    for stmt in root_node.children:
+        if stmt.type == "property_declaration":
+            for name in property_names(stmt):
+                globals_.append(name)
+                global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "class_declaration":
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type != "property_declaration":
+                    continue
+                is_static = False
+                for child in member.children:
+                    if child.type == "modifiers":
+                        is_static = any(
+                            m.type == "property_modifier" and m.text == b"static"
+                            for m in child.children
+                        )
+                for fname in property_names(member):
+                    fields.append((fname, class_name, is_static))
+                    field_info[fname] = {
+                        "class": class_name, "static": is_static,
+                        "body": member.text.decode("utf-8", "replace"),
+                    }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["swift"] = _extract_swift_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -800,6 +800,77 @@ def _match_candidate_pair(
     return {k: v for k, v in mapping.items() if k != v} if walk(old_node, new_node) else None
 
 
+_MAX_MATCH_ROUNDS = 10
+_MIN_MATCH_BODY_LEN = 20  # normalized chars; avoids matching trivial boilerplate stubs
+
+
+def _normalize_body_for_matching(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _match_renamed_entities(
+    removed: Dict[str, List[Tuple[str, Any]]],
+    added: Dict[str, List[Tuple[str, Any]]],
+) -> List[Tuple[str, str, str]]:
+    """Round-based rename matching across entity categories, scoped to a
+    single commit's touched files (callers build removed/added from just
+    that commit — see _extract_commit's use in Task 9).
+
+    A rename confirmed in one category (e.g. a function) becomes available
+    as a "tracked, confirmed-renamed" name for other not-yet-matched pairs
+    (in the same or a different category) evaluated in a later round — this
+    resolves cascading/mutual renames within one commit regardless of
+    dependency order. Capped at _MAX_MATCH_ROUNDS as a defensive bound.
+
+    Mutates removed/added in place, removing matched entries.
+    """
+    matches: List[Tuple[str, str, str]] = []
+    confirmed: Dict[str, str] = {}  # old_name -> new_name, shared across all categories
+
+    all_names: set = set()
+    for pool in (removed, added):
+        for entries in pool.values():
+            all_names.update(name for name, _node in entries)
+
+    for _round in range(_MAX_MATCH_ROUNDS):
+        changed = False
+        tracked_names: Dict[str, Optional[str]] = {
+            name: confirmed.get(name) for name in all_names
+        }
+        for category in list(removed.keys()):
+            r_list = removed.get(category, [])
+            a_list = added.get(category, [])
+            for r_name, r_node in list(r_list):
+                r_text = _normalize_body_for_matching(r_node.text.decode("utf-8", "replace"))
+                if len(r_text) < _MIN_MATCH_BODY_LEN:
+                    continue
+                candidates = []
+                for a_name, a_node in a_list:
+                    # Exclude this specific pair's own old/new names from the
+                    # tracked set: they are exactly what's under test here
+                    # (is r_name renamed to a_name?), not an already-known
+                    # constraint. Without this, an unconfirmed entity's own
+                    # name would be treated as "must stay unchanged" and no
+                    # rename could ever be confirmed for it.
+                    pair_tracked_names = {
+                        name: target
+                        for name, target in tracked_names.items()
+                        if name != r_name and name != a_name
+                    }
+                    if _match_candidate_pair(r_node, a_node, pair_tracked_names) is not None:
+                        candidates.append((a_name, a_node))
+                if len(candidates) == 1:
+                    a_name, a_node = candidates[0]
+                    matches.append((category, r_name, a_name))
+                    confirmed[r_name] = a_name
+                    r_list.remove((r_name, r_node))
+                    a_list.remove((a_name, a_node))
+                    changed = True
+        if not changed:
+            break
+    return matches
+
+
 # ---------------------------------------------------------------------------
 # DB lifecycle
 # ---------------------------------------------------------------------------

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1131,6 +1131,144 @@ def _extract_c_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["c"] = _extract_c_globals_and_fields
 
 
+def _extract_java_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware Java globals/fields extraction.
+
+    Java has no true top-level globals -- all state lives inside a class
+    -- so this always returns "globals": []. Only descends into a
+    class_declaration's class_body direct children (field_declaration).
+    Never recurses into a method/constructor body.
+
+    `walk()` recurses into every node (not just direct children of the
+    root), unlike this plan's C/Go/Rust extractors' strictly-direct-
+    children approach -- this is still safe scope-wise because
+    class_declaration is itself a structural node (same non-ambiguity
+    argument as functions/classes in `_walk_ast`), and nested/inner
+    classes are a real, valid Java construct worth capturing fields from.
+    The recursion only ever *enters* a matched class's own member list
+    (walk_class only looks at class_node's body's direct children), never
+    a method body, so the "don't misclassify locals" invariant holds even
+    though walk() itself descends everywhere.
+
+    A field_declaration is optionally preceded by a `modifiers` wrapper
+    node (one node containing `static`/`public`/etc. as separate
+    children, e.g. "public static final") -- verified empirically against
+    the real installed tree-sitter-java grammar; static iff any child of
+    that `modifiers` node has type "static".
+
+    NOTE: `int a, b;` puts more than one node under the `declarator`
+    field of a single field_declaration -- child_by_field_name (singular)
+    only returns the first, silently dropping `b`. Verified empirically
+    (same lesson as Go's multi-name struct field and C's multi-declarator
+    statement); children_by_field_name (plural) is used instead.
+    """
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def walk_class(class_node: Any) -> None:
+        name_node = class_node.child_by_field_name("name")
+        class_name = name_node.text.decode("utf-8") if name_node else ""
+        body = class_node.child_by_field_name("body")
+        if body is None:
+            return
+        for member in body.children:
+            if member.type != "field_declaration":
+                continue
+            is_static = False
+            for child in member.children:
+                if child.type == "modifiers":
+                    is_static = any(mod.type == "static" for mod in child.children)
+            for declarator in member.children_by_field_name("declarator"):
+                if declarator.type != "variable_declarator":
+                    continue
+                fname_node = declarator.child_by_field_name("name")
+                if fname_node is not None:
+                    fname = fname_node.text.decode("utf-8")
+                    fields.append((fname, class_name, is_static))
+                    field_info[fname] = {
+                        "class": class_name, "static": is_static,
+                        "body": member.text.decode("utf-8", "replace"),
+                    }
+
+    def walk(node: Any) -> None:
+        if node.type == "class_declaration":
+            walk_class(node)
+        for child in node.children:
+            walk(child)
+
+    walk(root_node)
+    return {"globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["java"] = _extract_java_globals_and_fields
+
+
+def _extract_csharp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware C# globals/fields extraction.
+
+    C# has no true top-level globals -- all state lives inside a class --
+    so this always returns "globals": []. Only descends into a
+    class_declaration's declaration_list body direct children
+    (field_declaration). Never recurses into a method/constructor body.
+
+    `walk()` recurses into every node, same rationale and same "never
+    enters a method body" invariant as the Java extractor above -- nested
+    classes are a real, valid C# construct.
+
+    Unlike Java, a field_declaration's modifiers are direct sibling
+    children of type "modifier" (not wrapped in an intermediate node) --
+    verified empirically against the real installed tree-sitter-c-sharp
+    grammar; static iff any child has type "modifier" and text b"static".
+
+    A field_declaration wraps a single variable_declaration child, itself
+    containing one or more variable_declarator children (via field:name
+    on the declarator, not on the variable_declaration step -- the
+    variable_declaration node has no field-name of its own per the
+    verified dump, so it's located by type). `int a, b;` puts multiple
+    variable_declarator nodes as plain positional children of that one
+    variable_declaration -- iterating them directly (no field lookup)
+    already captures all of them, verified empirically.
+    """
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def walk_class(class_node: Any) -> None:
+        name_node = class_node.child_by_field_name("name")
+        class_name = name_node.text.decode("utf-8") if name_node else ""
+        body = class_node.child_by_field_name("body")
+        if body is None:
+            return
+        for member in body.children:
+            if member.type != "field_declaration":
+                continue
+            is_static = any(c.type == "modifier" and c.text == b"static" for c in member.children)
+            var_decl = next((c for c in member.children if c.type == "variable_declaration"), None)
+            if var_decl is None:
+                continue
+            for declarator in var_decl.children:
+                if declarator.type == "variable_declarator":
+                    fname_node = declarator.child_by_field_name("name")
+                    if fname_node is not None:
+                        fname = fname_node.text.decode("utf-8")
+                        fields.append((fname, class_name, is_static))
+                        field_info[fname] = {
+                            "class": class_name, "static": is_static,
+                            "body": member.text.decode("utf-8", "replace"),
+                        }
+
+    def walk(node: Any) -> None:
+        if node.type == "class_declaration":
+            walk_class(node)
+        for child in node.children:
+            walk(child)
+
+    walk(root_node)
+    return {"globals": [], "global_bodies": {}, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["c_sharp"] = _extract_csharp_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -893,6 +893,230 @@ _GLOBAL_FIELD_EXTRACTORS["javascript"] = _extract_js_family_globals_and_fields
 _GLOBAL_FIELD_EXTRACTORS["typescript"] = _extract_js_family_globals_and_fields
 
 
+def _extract_rust_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware Rust globals/fields extraction.
+
+    Only descends into: module-root direct children (`static_item`/
+    `const_item` globals, `struct_item` field lists) and, as the one
+    deliberate exception to "fields are always instance-only" in this
+    language, an `impl_item` block's direct `const_item` children --
+    treated as static fields of the impl'd type (the closest Rust analog
+    to a class-static constant). Never recurses into a function/method
+    body.
+
+    A leading `pub` visibility_modifier is a CHILD of static_item/
+    const_item/struct_item/field_declaration in the real installed
+    tree-sitter-rust grammar, not a wrapping node (unlike JS's `export`
+    wrapping the declaration in an export_statement) -- so no unwrapping
+    step is needed here; `child_by_field_name("name")` resolves correctly
+    regardless of `pub`. Verified empirically before writing this code.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    for stmt in root_node.children:
+        if stmt.type in ("static_item", "const_item"):
+            name_node = stmt.child_by_field_name("name")
+            if name_node is not None:
+                name = name_node.text.decode("utf-8")
+                globals_.append(name)
+                global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "struct_item":
+            struct_name_node = stmt.child_by_field_name("name")
+            struct_name = struct_name_node.text.decode("utf-8") if struct_name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is not None:
+                for member in body.children:
+                    if member.type == "field_declaration":
+                        fname_node = member.child_by_field_name("name")
+                        if fname_node is not None:
+                            fname = fname_node.text.decode("utf-8")
+                            fields.append((fname, struct_name, False))
+                            field_info[fname] = {
+                                "class": struct_name, "static": False,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+        elif stmt.type == "impl_item":
+            type_node = stmt.child_by_field_name("type")
+            type_name = type_node.text.decode("utf-8") if type_node is not None else ""
+            body = stmt.child_by_field_name("body")
+            if body is not None:
+                for member in body.children:
+                    if member.type == "const_item":
+                        cname_node = member.child_by_field_name("name")
+                        if cname_node is not None:
+                            cname = cname_node.text.decode("utf-8")
+                            fields.append((cname, type_name, True))
+                            field_info[cname] = {
+                                "class": type_name, "static": True,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["rust"] = _extract_rust_globals_and_fields
+
+
+def _extract_go_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware Go globals/fields extraction.
+
+    Only descends into: file-root direct children (`var_declaration`/
+    `const_declaration` globals, via their `var_spec`/`const_spec`
+    children) and a `type_declaration > type_spec`'s `struct_type` body
+    direct children (fields). Never recurses into a function/method body.
+
+    Go has no export keyword -- exported identifiers are just capitalized
+    -- so there is no wrapping-node analog to JS's `export_statement` to
+    unwrap here; verified empirically that field:name resolves the same
+    way regardless of capitalization.
+
+    NOTE: `struct_type`'s `field_declaration_list` child is NOT exposed
+    via a `body` field in the real installed tree-sitter-go grammar (it's
+    a plain positional child, unlike Rust's struct_item/C's
+    struct_specifier which both do expose `field:body`) -- verified
+    empirically. It must be located by node type instead of
+    child_by_field_name("body").
+
+    NOTE: a grouped/parenthesized `var (\n A = 1\n B = 2\n)` -- an
+    idiomatic and common real-world Go pattern -- wraps its `var_spec`
+    children in an intermediate `var_spec_list` node, unlike a grouped
+    `const (...)` or `type (...)`, which do NOT wrap their specs (their
+    `const_spec`/`type_spec` children stay direct children of the
+    declaration node even when grouped) -- verified empirically against
+    the real installed tree-sitter-go grammar. `_iter_specs` below
+    unwraps a `{spec_type}_list` if present so grouped var declarations
+    aren't silently dropped; it's a no-op for const/type, which never
+    produce that wrapper.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def iter_specs(stmt: Any, spec_type: str) -> Any:
+        list_type = f"{spec_type}_list"
+        for child in stmt.children:
+            if child.type == spec_type:
+                yield child
+            elif child.type == list_type:
+                for inner in child.children:
+                    if inner.type == spec_type:
+                        yield inner
+
+    for stmt in root_node.children:
+        if stmt.type in ("var_declaration", "const_declaration"):
+            spec_type = "var_spec" if stmt.type == "var_declaration" else "const_spec"
+            for spec in iter_specs(stmt, spec_type):
+                name_node = spec.child_by_field_name("name")
+                if name_node is not None:
+                    name = name_node.text.decode("utf-8")
+                    globals_.append(name)
+                    global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "type_declaration":
+            for type_spec in stmt.children:
+                if type_spec.type != "type_spec":
+                    continue
+                type_name_node = type_spec.child_by_field_name("name")
+                type_name = type_name_node.text.decode("utf-8") if type_name_node else ""
+                struct_type = type_spec.child_by_field_name("type")
+                if struct_type is None or struct_type.type != "struct_type":
+                    continue
+                body = next(
+                    (c for c in struct_type.children if c.type == "field_declaration_list"),
+                    None,
+                )
+                if body is None:
+                    continue
+                for member in body.children:
+                    if member.type == "field_declaration":
+                        # `X, Y int` inside a struct puts more than one
+                        # node under the `name` field of one
+                        # field_declaration -- child_by_field_name
+                        # (singular) only returns the first, silently
+                        # dropping `Y`. Verified empirically; use the
+                        # plural children_by_field_name to capture all.
+                        for fname_node in member.children_by_field_name("name"):
+                            fname = fname_node.text.decode("utf-8")
+                            fields.append((fname, type_name, False))
+                            field_info[fname] = {
+                                "class": type_name, "static": False,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["go"] = _extract_go_globals_and_fields
+
+
+def _extract_c_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware C globals/fields extraction.
+
+    Only descends into: translation-unit-root direct `declaration`
+    children (globals, whether a bare `identifier` declarator or an
+    `init_declarator` wrapping one) and a `struct_specifier`'s
+    `field_declaration_list` body direct children (fields, via each
+    `field_declaration`'s `field:declarator` = `field_identifier`).
+    Never recurses into a function body.
+
+    C has no export/visibility keyword; `static`/`extern` show up as a
+    `storage_class_specifier` sibling of the declarator inside
+    `declaration`, not a wrapper around it -- verified empirically that
+    field:declarator resolves the same way with or without them present.
+
+    NOTE: a multi-declarator statement (`int a, b = 2;` at file scope, or
+    `int a, b;` inside a struct) -- an ordinary, common C pattern -- puts
+    more than one node under the `declarator` field, so
+    `child_by_field_name("declarator")` (singular) only returns the
+    first one and silently drops the rest. Verified empirically against
+    the real installed tree-sitter-c grammar; `children_by_field_name`
+    (plural) is used instead to capture all of them.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def declarator_name(node: Any) -> Optional[str]:
+        if node.type == "identifier":
+            return node.text.decode("utf-8")
+        if node.type == "init_declarator":
+            inner = node.child_by_field_name("declarator")
+            return declarator_name(inner) if inner is not None else None
+        return None
+
+    for stmt in root_node.children:
+        if stmt.type == "declaration":
+            for declarator in stmt.children_by_field_name("declarator"):
+                name = declarator_name(declarator)
+                if name:
+                    globals_.append(name)
+                    global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "struct_specifier":
+            struct_name_node = stmt.child_by_field_name("name")
+            struct_name = struct_name_node.text.decode("utf-8") if struct_name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is not None:
+                for member in body.children:
+                    if member.type == "field_declaration":
+                        for declarator in member.children_by_field_name("declarator"):
+                            if declarator.type == "field_identifier":
+                                fname = declarator.text.decode("utf-8")
+                                fields.append((fname, struct_name, False))
+                                field_info[fname] = {
+                                    "class": struct_name, "static": False,
+                                    "body": member.text.decode("utf-8", "replace"),
+                                }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["c"] = _extract_c_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -686,15 +686,20 @@ def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
             name = _c_family_function_name(node)
             if name:
                 results["functions"].append(name)
+                results["function_bodies"][name] = node.text.decode("utf-8", errors="replace")
         else:
             name_node = node.child_by_field_name("name")
             if name_node:
-                results["functions"].append(name_node.text.decode("utf-8"))
+                name = name_node.text.decode("utf-8")
+                results["functions"].append(name)
+                results["function_bodies"][name] = node.text.decode("utf-8", errors="replace")
 
     elif node.type in node_types.get("classes", set()):
         name_node = node.child_by_field_name("name")
         if name_node:
-            results["classes"].append(name_node.text.decode("utf-8"))
+            name = name_node.text.decode("utf-8")
+            results["classes"].append(name)
+            results["class_bodies"][name] = node.text.decode("utf-8", errors="replace")
 
     elif node.type in node_types.get("imports", set()):
         names = _extract_import_name(node, lang_name)
@@ -711,10 +716,17 @@ def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
 
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
-) -> Dict[str, List[str]]:
-    """Parse source bytes and extract functions, classes, imports, calls."""
-    results: Dict[str, List[str]] = {
-        "functions": [], "classes": [], "imports": [], "calls": []
+) -> Dict[str, Any]:
+    """Parse source bytes and extract functions, classes, imports, calls, and
+    (for functions/classes) their own full source text — the latter used by
+    the rename matcher (see _match_renamed_entities) to compare old vs. new
+    bodies. Body text is captured here, inside the worker process, because
+    tree_sitter Node objects themselves cannot cross the ProcessPoolExecutor
+    boundary (see #116) — only the decoded text can.
+    """
+    results: Dict[str, Any] = {
+        "functions": [], "classes": [], "imports": [], "calls": [],
+        "function_bodies": {}, "class_bodies": {},
     }
     try:
         tree = parser.parse(source)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -736,6 +736,65 @@ def _extract_from_source(
         pass  # best-effort; parse failures are non-fatal
     return results
 
+
+def _match_candidate_pair(
+    old_node: Any, new_node: Any, tracked_names: Dict[str, Optional[str]]
+) -> Optional[Dict[str, str]]:
+    """Lockstep-walk two tree-sitter nodes, allowing local (untracked)
+    identifiers to differ under a one-to-one bijective mapping.
+
+    tracked_names maps every entity name known in this commit's context to
+    either None (must appear unchanged) or a confirmed new name (must appear
+    renamed to exactly that). Any identifier NOT a key in tracked_names is
+    treated as local/unresolved and is free to differ, as long as the
+    mapping stays consistent (same old token always maps to the same new
+    token) and injective (no two distinct old tokens collapse onto one new
+    token) for THIS candidate pair only — the mapping is never reused across
+    other pairs or persisted as an entity.
+
+    Returns the discovered bijection dict on a full match (empty dict if no
+    local identifiers were involved — plain exact match is the case where
+    the bijection happens to be the identity mapping), or None if the nodes
+    don't match structurally or a tracked/bijection constraint is violated.
+
+    Internally, `mapping`/`reverse` record EVERY local identifier
+    correspondence seen (including identity ones, e.g. an untouched
+    parameter name) so consistency and injectivity can be enforced across
+    the whole pair. `renamed` mirrors only the entries where the old and
+    new text actually differ; that's what gets returned, per the docstring
+    contract above (identity-only correspondences shouldn't show up in the
+    reported bijection).
+    """
+    mapping: Dict[str, str] = {}
+    reverse: Dict[str, str] = {}
+    renamed: Dict[str, str] = {}
+
+    def walk(a: Any, b: Any) -> bool:
+        if a.type != b.type:
+            return False
+        if a.child_count == 0 and b.child_count == 0:
+            a_text = a.text.decode("utf-8", "replace")
+            b_text = b.text.decode("utf-8", "replace")
+            if a.type == "identifier" or a.type.endswith("_identifier"):
+                if a_text in tracked_names:
+                    expected = tracked_names[a_text]
+                    return b_text == (expected if expected is not None else a_text)
+                if a_text in mapping:
+                    return mapping[a_text] == b_text
+                if b_text in reverse:
+                    return False
+                mapping[a_text] = b_text
+                reverse[b_text] = a_text
+                if a_text != b_text:
+                    renamed[a_text] = b_text
+                return True
+            return a_text == b_text
+        if a.child_count != b.child_count:
+            return False
+        return all(walk(ac, bc) for ac, bc in zip(a.children, b.children))
+
+    return renamed if walk(old_node, new_node) else None
+
 # ---------------------------------------------------------------------------
 # DB lifecycle
 # ---------------------------------------------------------------------------

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -820,6 +820,59 @@ def _extract_python_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["python"] = _extract_python_globals_and_fields
 
 
+def _extract_js_family_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware JavaScript/TypeScript globals/fields extraction.
+
+    Only descends into: program-root direct children (globals, from
+    lexical_declaration/variable_declaration's variable_declarator
+    children) and a class_declaration's class_body direct children
+    (field_definition for JS, public_field_definition for TS). Never
+    recurses into a function/method body, so a class field assigned only
+    inside a constructor (e.g. `this.x = 1` with no class-body field
+    declaration) is not captured — deliberate, bounded heuristic
+    consistent with the Python extractor's __init__-only scope.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    for stmt in root_node.children:
+        if stmt.type in ("lexical_declaration", "variable_declaration"):
+            for child in stmt.children:
+                if child.type == "variable_declarator":
+                    name_node = child.child_by_field_name("name")
+                    if name_node is not None and name_node.type == "identifier":
+                        name = name_node.text.decode("utf-8")
+                        globals_.append(name)
+                        global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "class_declaration":
+            class_name_node = stmt.child_by_field_name("name")
+            class_name = class_name_node.text.decode("utf-8") if class_name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type not in ("field_definition", "public_field_definition"):
+                    continue
+                name_node = member.child_by_field_name("property") or member.child_by_field_name("name")
+                if name_node is None or name_node.type not in ("property_identifier",):
+                    continue
+                field_name = name_node.text.decode("utf-8")
+                is_static = any(c.type == "static" for c in member.children)
+                fields.append((field_name, class_name, is_static))
+                field_info[field_name] = {
+                    "class": class_name, "static": is_static,
+                    "body": member.text.decode("utf-8", "replace"),
+                }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["javascript"] = _extract_js_family_globals_and_fields
+_GLOBAL_FIELD_EXTRACTORS["typescript"] = _extract_js_family_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -986,7 +986,7 @@ def _extract_go_globals_and_fields(root_node: Any) -> Dict[str, Any]:
     `const (...)` or `type (...)`, which do NOT wrap their specs (their
     `const_spec`/`type_spec` children stay direct children of the
     declaration node even when grouped) -- verified empirically against
-    the real installed tree-sitter-go grammar. `_iter_specs` below
+    the real installed tree-sitter-go grammar. `iter_specs` below
     unwraps a `{spec_type}_list` if present so grouped var declarations
     aren't silently dropped; it's a no-op for const/type, which never
     produce that wrapper.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5308,8 +5308,42 @@ def _extract_commit(
         return base
 
     for status, old_mode, new_mode, old_sha, new_sha, file_path, old_path, similarity in raw_entries:
-        if _is_ignored_path(file_path, ignore_patterns):
+        # Trackable == not ignored AND has a supported parser. Short-circuits
+        # so an ignored path never pays for a parser build (see the docstring's
+        # "ignored file costs zero parse time" contract).
+        new_trackable = (
+            not _is_ignored_path(file_path, ignore_patterns)
+            and _thread_parser(file_path) is not None
+        )
+        if status == "R":
+            # -M folds a rename's old+new sides into ONE "R" row, but each side
+            # can have a different trackability (cross-extension rename, or a
+            # move into/out of an ignored directory). Keying the skip on the
+            # NEW path alone (as A/M/D do) silently drops the whole row when the
+            # new side is untrackable — leaking the old module/children/deps
+            # open forever — and, in reverse, closes a phantom old module that
+            # was never opened. So resolve the OLD side independently, with its
+            # own ignore/parser lookup keyed on old_path's extension.
+            old_trackable = (
+                not _is_ignored_path(old_path, ignore_patterns)
+                and _thread_parser(old_path) is not None
+            )
+            if old_trackable and not new_trackable:
+                # Forward (tracked -> unsupported/ignored): rewrite the row as a
+                # synthetic delete of the OLD path so the existing "D" handling
+                # below closes the old module, its children, and its deps.
+                status, file_path, old_path = "D", old_path, ""
+            elif new_trackable and not old_trackable:
+                # Reverse (unsupported/ignored -> tracked): the new path is a
+                # brand-new entity and the old ident was never opened. Treat as
+                # a plain add — no rename linkage, no old-module close.
+                status, old_path = "A", ""
+            elif not new_trackable:  # neither side trackable — nothing to do
+                continue
+            # else: both sides trackable — unchanged "R" handling below.
+        elif not new_trackable:
             continue
+
         parser = _thread_parser(file_path)
         if parser is None:
             continue

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1455,6 +1455,116 @@ def _extract_ruby_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["ruby"] = _extract_ruby_globals_and_fields
 
 
+def _extract_php_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware PHP globals/fields extraction.
+
+    Top-level `$x = 5;` is `expression_statement > assignment_expression`
+    with field:left = variable_name -> global. `class Foo { ... }` is
+    class_declaration with field:body = declaration_list; each member is
+    a property_declaration containing an optional static_modifier child
+    and one or more property_element children (field:name =
+    variable_name) -> field.
+
+    Multi-property declarations (`public static $a = 1, $b = 2;`)
+    already work with plain iteration: verified empirically that a
+    single property_declaration node holds multiple property_element
+    children directly, unlike the multi-declarator gaps found in every
+    other C-family language in this plan (Go/Java/C++) -- no unwrapping
+    needed here.
+
+    Typed properties (`public int $x = 5;`, PHP 7.4+) add a
+    primitive_type/named_type child to property_declaration but keep the
+    same property_element shape -- verified empirically -- so no special
+    handling is required.
+
+    Namespaces have two forms, verified empirically against the real
+    installed tree-sitter-php grammar:
+      - Semicolon style (`namespace App; $x = 5;`) does NOT wrap
+        subsequent statements; they remain direct children of `program`,
+        so the plain top-level loop already sees them.
+      - Block style (`namespace App { $x = 5; }`) wraps its statements in
+        a compound_statement exposed via namespace_definition's
+        field:body. Without recursing into it, every global/class inside
+        a block-style namespace would be silently dropped -- the same
+        shape-changing-wrapper lesson as JS's export_statement. PHP
+        namespaces are extremely common in real-world code, so
+        namespace_definition nodes are unwrapped recursively (namespaces
+        can themselves be nested).
+
+    PHP 8+ constructor property promotion
+    (`public function __construct(public int $x) {}`) produces a
+    property_promotion_parameter node inside the constructor's
+    formal_parameters -- NOT a property_declaration under the class
+    body -- verified empirically, so it requires separate handling.
+    Promoted properties cannot carry a `static` modifier in real PHP
+    (verified: adding one produces a parse ERROR node), so they are
+    always recorded as instance (non-static) fields.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def handle_class(stmt: Any) -> None:
+        name_node = stmt.child_by_field_name("name")
+        class_name = name_node.text.decode("utf-8") if name_node else ""
+        body = stmt.child_by_field_name("body")
+        if body is None:
+            return
+        for member in body.children:
+            if member.type == "property_declaration":
+                is_static = any(c.type == "static_modifier" for c in member.children)
+                for elem in member.children:
+                    if elem.type == "property_element":
+                        elem_name_node = elem.child_by_field_name("name")
+                        if elem_name_node is not None:
+                            fname = elem_name_node.text.decode("utf-8")
+                            fields.append((fname, class_name, is_static))
+                            field_info[fname] = {
+                                "class": class_name, "static": is_static,
+                                "body": member.text.decode("utf-8", "replace"),
+                            }
+            elif member.type == "method_declaration":
+                method_name_node = member.child_by_field_name("name")
+                if method_name_node is not None and method_name_node.text == b"__construct":
+                    params = member.child_by_field_name("parameters")
+                    if params is not None:
+                        for param in params.children:
+                            if param.type == "property_promotion_parameter":
+                                param_name_node = param.child_by_field_name("name")
+                                if param_name_node is not None:
+                                    fname = param_name_node.text.decode("utf-8")
+                                    fields.append((fname, class_name, False))
+                                    field_info[fname] = {
+                                        "class": class_name, "static": False,
+                                        "body": param.text.decode("utf-8", "replace"),
+                                    }
+
+    def handle_stmts(stmts: Sequence[Any]) -> None:
+        for stmt in stmts:
+            if stmt.type == "expression_statement" and stmt.child_count > 0:
+                expr = stmt.children[0]
+                if expr.type == "assignment_expression":
+                    left = expr.child_by_field_name("left")
+                    if left is not None and left.type == "variable_name":
+                        name = left.text.decode("utf-8")
+                        globals_.append(name)
+                        global_bodies[name] = stmt.text.decode("utf-8", "replace")
+            elif stmt.type == "class_declaration":
+                handle_class(stmt)
+            elif stmt.type == "namespace_definition":
+                ns_body = stmt.child_by_field_name("body")
+                if ns_body is not None:
+                    handle_stmts(ns_body.children)
+
+    handle_stmts(root_node.children)
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["php"] = _extract_php_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1353,6 +1353,108 @@ def _extract_cpp_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 _GLOBAL_FIELD_EXTRACTORS["cpp"] = _extract_cpp_globals_and_fields
 
 
+def _extract_ruby_globals_and_fields(root_node: Any) -> Dict[str, Any]:
+    """Scope-aware Ruby globals/fields extraction.
+
+    Ruby's grammar distinguishes `$global`/`CONST`/`@@class_var`/
+    `@instance_var` via distinct node types (global_variable, constant,
+    class_variable, instance_variable), so -- unlike every other
+    language in this plan -- no heuristic modifier-inspection is needed;
+    classification is purely by field:left's node type.
+
+    Only descends into: program-root direct children (globals, from a
+    top-level `assignment` whose field:left is global_variable/constant),
+    a `class` node's field:body (body_statement) direct children
+    (class_variable assignment -> static field), and a `method` named
+    "initialize" that is itself a direct child of that same body_statement
+    (its own field:body's direct-child assignments with field:left of
+    type instance_variable -> instance field). Never recurses into any
+    other method body.
+
+    A `module Foo ... end` node has type "module", not "class" -- a
+    distinct node type in the real installed tree-sitter-ruby grammar
+    even though it exposes the same name/body fields -- so it is simply
+    not matched by the `stmt.type == "class"` check below; module-level
+    constants/class variables are out of scope for this extractor by
+    design. Verified empirically.
+
+    `attr_accessor`/`attr_reader`/`attr_writer` are ordinary method
+    calls (node type `call`), not assignments -- verified empirically --
+    so they are naturally excluded without any special-casing.
+
+    NOTE: Ruby's multi-assignment (`$a, $b = 1, 2` or, inside a class,
+    `@@a, @@b = 1, 2` / `@x, @y = 1, 2`) wraps the left side in a
+    `left_assignment_list` node instead of exposing a bare
+    global_variable/constant/class_variable/instance_variable directly
+    under field:left -- verified empirically against the real installed
+    tree-sitter-ruby grammar. Same lesson as the multi-declarator gaps
+    found in every other language in this plan (Go/C/Java/C++): iterate
+    `left_assignment_list`'s children too, or every name but the first
+    is silently dropped.
+    """
+    globals_: List[str] = []
+    global_bodies: Dict[str, str] = {}
+    fields: List[Tuple[str, str, bool]] = []
+    field_info: Dict[str, Dict[str, Any]] = {}
+
+    def left_targets(left_node: Any, target_types: Tuple[str, ...]) -> List[Any]:
+        if left_node.type in target_types:
+            return [left_node]
+        if left_node.type == "left_assignment_list":
+            return [c for c in left_node.children if c.type in target_types]
+        return []
+
+    for stmt in root_node.children:
+        if stmt.type == "assignment":
+            left = stmt.child_by_field_name("left")
+            if left is None:
+                continue
+            for target in left_targets(left, ("global_variable", "constant")):
+                name = target.text.decode("utf-8")
+                globals_.append(name)
+                global_bodies[name] = stmt.text.decode("utf-8", "replace")
+        elif stmt.type == "class":
+            name_node = stmt.child_by_field_name("name")
+            class_name = name_node.text.decode("utf-8") if name_node else ""
+            body = stmt.child_by_field_name("body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type == "assignment":
+                    left = member.child_by_field_name("left")
+                    if left is None:
+                        continue
+                    for target in left_targets(left, ("class_variable",)):
+                        fname = target.text.decode("utf-8")
+                        fields.append((fname, class_name, True))
+                        field_info[fname] = {
+                            "class": class_name, "static": True,
+                            "body": member.text.decode("utf-8", "replace"),
+                        }
+                elif member.type == "method":
+                    method_name_node = member.child_by_field_name("name")
+                    if method_name_node is not None and method_name_node.text == b"initialize":
+                        method_body = member.child_by_field_name("body")
+                        if method_body is not None:
+                            for inner in method_body.children:
+                                if inner.type == "assignment":
+                                    left = inner.child_by_field_name("left")
+                                    if left is None:
+                                        continue
+                                    for target in left_targets(left, ("instance_variable",)):
+                                        fname = target.text.decode("utf-8")
+                                        fields.append((fname, class_name, False))
+                                        field_info[fname] = {
+                                            "class": class_name, "static": False,
+                                            "body": inner.text.decode("utf-8", "replace"),
+                                        }
+
+    return {"globals": globals_, "global_bodies": global_bodies, "fields": fields, "field_info": field_info}
+
+
+_GLOBAL_FIELD_EXTRACTORS["ruby"] = _extract_ruby_globals_and_fields
+
+
 def _extract_from_source(
     source: bytes, parser: Any, file_path: str
 ) -> Dict[str, Any]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2393,7 +2393,12 @@ def _extract_from_source(
 
 
 def _match_candidate_pair(
-    old_node: Any, new_node: Any, tracked_names: Dict[str, Optional[str]]
+    old_node: Any,
+    new_node: Any,
+    tracked_names: Dict[str, Optional[str]],
+    tracked_reserved: Optional[Dict[str, int]] = None,
+    exclude_names: Tuple[str, ...] = (),
+    exclude_reserved: Tuple[str, ...] = (),
 ) -> Optional[Dict[str, str]]:
     """Lockstep-walk two tree-sitter nodes, allowing local (untracked)
     identifiers to differ under a one-to-one bijective mapping.
@@ -2412,23 +2417,39 @@ def _match_candidate_pair(
     the bijection happens to be the identity mapping), or None if the nodes
     don't match structurally or a tracked/bijection constraint is violated.
 
-    Internally, `mapping`/`reverse` record EVERY local identifier
+    Internally, `mapping`/`local_reverse` record EVERY local identifier
     correspondence seen (including identity ones, e.g. an untouched
     parameter name) so consistency and injectivity can be enforced across
-    the whole pair. `reverse` is seeded up front with every tracked entity's
-    new-side text (its confirmed rename target, or its own unchanged name
-    when tracked_names[name] is None) — otherwise a local/untracked
-    identifier could silently claim the exact new text already reserved for
-    a different, tracked entity, which is a real injectivity violation (two
-    distinct old tokens collapsing onto one new token) that the tracked-name
-    equality check alone doesn't catch since it lives in a disjoint
-    namespace from `mapping`/`reverse`.
+    the whole pair. Injectivity against *tracked* entities is enforced
+    separately via `tracked_reserved`, a multiset {new-side-token: count}
+    covering every tracked entity's new-side text (its confirmed rename
+    target, or its own unchanged name when tracked_names[name] is None) —
+    otherwise a local/untracked identifier could silently claim the exact
+    new text already reserved for a different, tracked entity, which is a
+    real injectivity violation (two distinct old tokens collapsing onto one
+    new token) that the tracked-name equality check alone doesn't catch
+    since it lives in a disjoint namespace from `mapping`.
+
+    Performance (see the O(n^3) matcher fix): tracked_names/tracked_reserved
+    are built ONCE per matching round by _match_renamed_entities and passed
+    in read-only, rather than reconstructed per candidate pair. The pair's
+    own two names are excluded cheaply via exclude_names (skip the tracked
+    equality constraint — they are exactly what's under test) and
+    exclude_reserved (their reserved new-side tokens, decremented from the
+    multiset so the pair may legitimately map onto them). Both are tiny
+    (<=2 entries), so exclusion is O(1) per identifier instead of an
+    O(all_names) dict rebuild per pair. When tracked_reserved is None it is
+    derived from tracked_names (the standalone/test call path); production
+    callers pass it precomputed.
     """
+    if tracked_reserved is None:
+        tracked_reserved = {}
+        for name, target in tracked_names.items():
+            tok = target if target is not None else name
+            tracked_reserved[tok] = tracked_reserved.get(tok, 0) + 1
+
     mapping: Dict[str, str] = {}
-    reverse: Dict[str, str] = {
-        (target if target is not None else name): name
-        for name, target in tracked_names.items()
-    }
+    local_reverse: Dict[str, str] = {}
 
     def walk(a: Any, b: Any) -> bool:
         if a.type != b.type:
@@ -2437,15 +2458,22 @@ def _match_candidate_pair(
             a_text = a.text.decode("utf-8", "replace")
             b_text = b.text.decode("utf-8", "replace")
             if a.type == "identifier" or a.type.endswith("_identifier"):
-                if a_text in tracked_names:
+                if a_text in tracked_names and a_text not in exclude_names:
                     expected = tracked_names[a_text]
                     return b_text == (expected if expected is not None else a_text)
                 if a_text in mapping:
                     return mapping[a_text] == b_text
-                if b_text in reverse:
+                if b_text in local_reverse:
+                    return False
+                # Injectivity vs tracked entities: b_text may not claim a
+                # new-side token already reserved by a tracked name, EXCEPT
+                # the (<=2) reserved tokens belonging to this pair's own
+                # excluded names.
+                reserved = tracked_reserved.get(b_text, 0) - exclude_reserved.count(b_text)
+                if reserved > 0:
                     return False
                 mapping[a_text] = b_text
-                reverse[b_text] = a_text
+                local_reverse[b_text] = a_text
                 return True
             return a_text == b_text
         if a.child_count != b.child_count:
@@ -2457,6 +2485,12 @@ def _match_candidate_pair(
 
 _MAX_MATCH_ROUNDS = 10
 _MIN_MATCH_BODY_LEN = 20  # normalized chars; avoids matching trivial boilerplate stubs
+# Above this total pool size (removed + added entries across all categories)
+# the matcher skips a commit entirely, mirroring git's own `-M` rename-limit
+# degradation: a missed rename is the accepted fallback, never an unbounded
+# (~cubic) stall on a 20k+-file vendored-dependency commit. Overridable via
+# MINIGRAF_MATCH_MAX_POOL, following the env-var pattern used elsewhere here.
+_MAX_MATCH_POOL_SIZE = int(os.environ.get("MINIGRAF_MATCH_MAX_POOL", "3000"))
 
 
 def _normalize_body_for_matching(text: str) -> str:
@@ -2540,6 +2574,14 @@ def _match_renamed_entities(
     # a token in any body text — only its bare leaf does.
     confirmed: Dict[str, str] = {}  # bare old_name -> bare new_name, shared across all categories
 
+    # Pool-size guard: above _MAX_MATCH_POOL_SIZE total entries the pairwise
+    # scan (inherently O(removed x added) per category per round) is skipped
+    # outright, mirroring git's -M rename-limit degradation. A missed rename
+    # is the accepted fallback; the entity is simply treated as removed+added.
+    total_pool = sum(len(v) for v in removed.values()) + sum(len(v) for v in added.values())
+    if total_pool > _MAX_MATCH_POOL_SIZE:
+        return matches
+
     all_names: set = set(unchanged_names or ())
     for pool in (removed, added):
         for category, entries in pool.items():
@@ -2551,10 +2593,18 @@ def _match_renamed_entities(
         # else None ("must match exactly"). Unchanged-tracked names (folded
         # into all_names above) therefore default to None unless a genuine
         # rename was confirmed for them this round, in which case confirmed
-        # wins.
+        # wins. Both tracked_names and its derived new-side reserved-token
+        # multiset are built ONCE per round and passed read-only into every
+        # _match_candidate_pair call — the pair's own two names are excluded
+        # cheaply per-pair (see below) instead of rebuilding an O(all_names)
+        # dict per candidate, which was the cubic term in the old code.
         tracked_names: Dict[str, Optional[str]] = {
             name: confirmed.get(name) for name in all_names
         }
+        tracked_reserved: Dict[str, int] = {}
+        for name, target in tracked_names.items():
+            tok = target if target is not None else name
+            tracked_reserved[tok] = tracked_reserved.get(tok, 0) + 1
         for category in list(removed.keys()):
             r_list = removed.get(category, [])
             a_list = added.get(category, [])
@@ -2566,28 +2616,54 @@ def _match_renamed_entities(
                 # body (equal to the pool key for non-field categories). Used
                 # for self-exclusion below so the walker treats the pair's own
                 # name as free/under-test, never as an inherited constraint.
+                # Its reserved new-side token (own confirmed target, else the
+                # name itself) is excluded from the injectivity multiset for
+                # the same reason.
                 r_match_name = _match_body_name(category, r_name)
+                r_reserved_token = confirmed.get(r_match_name, r_match_name)
                 candidates = []
                 for a_name, a_node in a_list:
                     a_match_name = _match_body_name(category, a_name)
+                    a_reserved_token = confirmed.get(a_match_name, a_match_name)
                     # Exclude this specific pair's own old/new names from the
-                    # tracked set: they are exactly what's under test here
-                    # (is r_name renamed to a_name?), not an already-known
-                    # constraint. Without this, an unconfirmed entity's own
-                    # name would be treated as "must stay unchanged" and no
-                    # rename could ever be confirmed for it. Excluding by BARE
-                    # name (not the qualified pool key) is essential for fields:
-                    # the body token is the bare leaf, so excluding "A.Config"
-                    # would leave the field's own "Config" token still bound to
-                    # an unrelated confirmed "Config"->... rename (the false
-                    # positive this fix closes).
-                    pair_tracked_names = {
-                        name: target
-                        for name, target in tracked_names.items()
-                        if name != r_match_name and name != a_match_name
-                    }
-                    if _match_candidate_pair(r_node, a_node, pair_tracked_names) is not None:
+                    # tracked-equality constraint and their reserved tokens
+                    # from the injectivity multiset: they are exactly what's
+                    # under test here (is r_name renamed to a_name?), not an
+                    # already-known constraint. Without this, an unconfirmed
+                    # entity's own name would be treated as "must stay
+                    # unchanged" and no rename could ever be confirmed for it.
+                    # Excluding by BARE name (not the qualified pool key) is
+                    # essential for fields: the body token is the bare leaf, so
+                    # excluding "A.Config" would leave the field's own "Config"
+                    # token still bound to an unrelated confirmed
+                    # "Config"->... rename (the false positive this closes).
+                    try:
+                        matched = _match_candidate_pair(
+                            r_node,
+                            a_node,
+                            tracked_names,
+                            tracked_reserved=tracked_reserved,
+                            exclude_names=(r_match_name, a_match_name),
+                            exclude_reserved=(r_reserved_token, a_reserved_token),
+                        )
+                    except RecursionError:
+                        # A single pathological pair — an AST deep enough to
+                        # survive _collect_entity_nodes but blow the recursion
+                        # limit inside the pair walk (which uses more stack per
+                        # level) — must degrade to no-match for THIS pair only,
+                        # not abort the whole commit's matching (and, via
+                        # _extract_commit's outer propagation, the entire
+                        # ingestion run). Skip it and keep testing the rest.
+                        continue
+                    if matched is not None:
                         candidates.append((a_name, a_node))
+                        # Ambiguity is already certain at 2 candidates: the
+                        # match is only kept when exactly one survives, so
+                        # walking the 3rd, 4th, ... against this same removed
+                        # entry is pure wasted work. Bail the inner scan (never
+                        # the outer removed-entries loop).
+                        if len(candidates) >= 2:
+                            break
                 if len(candidates) == 1:
                     a_name, a_node = candidates[0]
                     # Returned pair keeps the QUALIFIED pool keys (r_name/a_name)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3492,6 +3492,51 @@ class TestMatchRenamedEntities:
         assert field_matches == [], f"field must stay ambiguous, got {field_matches}"
         assert ("field", "A.Config", "A.ConfigFn") not in projected
 
+    def test_unchanged_tracked_helper_blocks_false_rename(self):
+        """P1 (second-pass): an identifier referencing a still-present, unchanged
+        tracked entity must match EXACTLY, not be treated as a free local that
+        can be bijectively substituted.
+
+        `load_users` (removed) calls unchanged helper `fetch_users`;
+        `load_orders` (added) calls unchanged helper `fetch_orders`. Bodies are
+        otherwise structurally identical. Without the unchanged-name constraint
+        the matcher maps `fetch_users -> fetch_orders` as a free-local bijection
+        and produces a FALSE rename `load_users -> load_orders`. Passing both
+        helper names as unchanged (must-match-exactly) blocks it.
+        """
+        import mcp_server
+        old = self._parse_fn(
+            "def load_users(db):\n    rows = fetch_users(db)\n    return [r for r in rows]\n"
+        )
+        new = self._parse_fn(
+            "def load_orders(db):\n    rows = fetch_orders(db)\n    return [r for r in rows]\n"
+        )
+        removed = {"function": [("load_users", old)]}
+        added = {"function": [("load_orders", new)]}
+        matches = mcp_server._match_renamed_entities(
+            removed, added, unchanged_names={"fetch_users", "fetch_orders"}
+        )
+        assert matches == [], f"expected no match, got {matches}"
+
+    def test_unchanged_helper_shared_by_genuine_rename_still_matches(self):
+        """The unchanged-name constraint must not block a genuine rename: both
+        the old and new body reference the SAME unchanged helper, so the exact
+        match is satisfied and the rename is still confirmed."""
+        import mcp_server
+        old = self._parse_fn(
+            "def process_old(db):\n    rows = fetch_data(db)\n    return [r for r in rows]\n"
+        )
+        new = self._parse_fn(
+            "def process_new(db):\n    rows = fetch_data(db)\n    return [r for r in rows]\n"
+        )
+        removed = {"function": [("process_old", old)]}
+        added = {"function": [("process_new", new)]}
+        matches = mcp_server._match_renamed_entities(
+            removed, added, unchanged_names={"fetch_data"}
+        )
+        projected = [(c, o, n) for c, o, _, n, _ in matches]
+        assert projected == [("function", "process_old", "process_new")]
+
 
 class TestCollectEntityNodes:
     def test_collects_function_and_class_nodes_by_name(self):
@@ -4634,6 +4679,74 @@ class TestExtractCommitRename:
         commits = mcp_server._git_commits(str(repo), watermark_hash=None)
         _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
         assert ("variable", "config.py", "GLOBAL_X", "config.py", "GLOBAL_Y") in renamed_pairs
+
+    def test_unchanged_helpers_block_false_rename_in_modified_file(self, tmp_path):
+        """P1 (second-pass) end-to-end repro: a modified file keeps two unchanged
+        helpers `fetch_users`/`fetch_orders`; the commit deletes `load_users`
+        (which calls `fetch_users`) and adds `load_orders` (which calls
+        `fetch_orders`), bodies otherwise structurally identical. The unchanged
+        helpers never appear in the removed/added pools, so pre-fix the matcher
+        treated `fetch_users -> fetch_orders` as a free-local bijection and
+        produced a FALSE `load_users -> load_orders` rename. Post-fix the
+        unchanged names are seeded as must-match-exactly, so NO rename is
+        produced.
+        """
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "svc.py").write_text(
+            "def fetch_users(db):\n    return db.query('users')\n\n"
+            "def fetch_orders(db):\n    return db.query('orders')\n\n"
+            "def load_users(db):\n    rows = fetch_users(db)\n    return [r for r in rows]\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "svc.py").write_text(
+            "def fetch_users(db):\n    return db.query('users')\n\n"
+            "def fetch_orders(db):\n    return db.query('orders')\n\n"
+            "def load_orders(db):\n    rows = fetch_orders(db)\n    return [r for r in rows]\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "swap load fn"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        false_pairs = [
+            p for p in renamed_pairs
+            if p[0] == "function" and p[2] == "load_users" and p[4] == "load_orders"
+        ]
+        assert false_pairs == [], f"false rename produced: {false_pairs}"
+
+    def test_genuine_rename_with_unchanged_helper_still_tracked(self, tmp_path):
+        """Positive counterpart: a genuine same-file function rename whose body
+        references an UNCHANGED helper must still be detected post-fix — the
+        must-match-exactly constraint is satisfied because both bodies call the
+        same surviving helper."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "svc.py").write_text(
+            "def fetch_data(db):\n    return db.query('rows')\n\n"
+            "def process_old(db):\n    rows = fetch_data(db)\n    return [r for r in rows]\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "svc.py").write_text(
+            "def fetch_data(db):\n    return db.query('rows')\n\n"
+            "def process_new(db):\n    rows = fetch_data(db)\n    return [r for r in rows]\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename process fn"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        assert ("function", "svc.py", "process_old", "svc.py", "process_new") in renamed_pairs
 
 
 class TestIngestionWrites:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4684,7 +4684,7 @@ class TestRunIngestionBitemporalClose:
             "login() still present in file must not be closed"
 
     @pytest.mark.asyncio
-    async def test_renamed_file_closes_old_entities_and_opens_new(
+    async def test_renamed_file_links_old_and_new_via_rename_edges(
         self, mock_minigraf_db, git_repo_with_rename, monkeypatch
     ):
         mock_class, db_instance = mock_minigraf_db
@@ -4702,14 +4702,19 @@ class TestRunIngestionBitemporalClose:
         await mcp_server._run_ingestion(str(git_repo_with_rename), "HEAD")
 
         old_module_ident = mcp_server._code_ident("module", "old_auth.py")
+        new_module_ident = mcp_server._code_ident("module", "new_auth.py")
         new_fn_ident = mcp_server._code_ident("function", "new_auth.py", "login")
 
         assert any(old_module_ident in t for t in close_triples_seen), \
-            "Old module entities must be closed when file is renamed"
+            "Old module entities must still be closed when file is renamed"
+        assert any(f"{old_module_ident} :renamed-to {new_module_ident}" in t for t in close_triples_seen), \
+            "Old module's close triples must include :renamed-to pointing at the new ident"
 
         transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
         assert new_fn_ident in transact_calls, \
-            "New module entities must be created after file is renamed"
+            "New module's entities must still be created after file is renamed"
+        assert f"{new_module_ident} :renamed-from {old_module_ident}" in transact_calls, \
+            "New module's open triples must include :renamed-from pointing at the old ident"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1943,6 +1943,71 @@ class TestMatchCandidatePair:
         assert result is None
 
 
+class TestMatchRenamedEntities:
+    def _parse_fn(self, source: str):
+        import mcp_server
+        parser = mcp_server._get_parser("test.py")
+        tree = parser.parse(source.encode())
+        return tree.root_node.children[0]
+
+    def test_simple_rename_matched(self):
+        import mcp_server
+        old = self._parse_fn("def foo(x):\n    return x + 1\n")
+        new = self._parse_fn("def bar(x):\n    return x + 1\n")
+        removed = {"function": [("foo", old)]}
+        added = {"function": [("bar", new)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert matches == [("function", "foo", "bar")]
+        assert removed["function"] == []
+        assert added["function"] == []
+
+    def test_cascading_mutual_rename_resolves_across_rounds(self):
+        """A calls B; both A and B are renamed in the same commit."""
+        import mcp_server
+        old_a = self._parse_fn("def a(x):\n    return b(x) + 1\n")
+        old_b = self._parse_fn("def b(x):\n    return x * 2\n")
+        new_a1 = self._parse_fn("def a1(x):\n    return b1(x) + 1\n")
+        new_b1 = self._parse_fn("def b1(x):\n    return x * 2\n")
+        removed = {"function": [("a", old_a), ("b", old_b)]}
+        added = {"function": [("a1", new_a1), ("b1", new_b1)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert ("function", "a", "a1") in matches
+        assert ("function", "b", "b1") in matches
+        assert len(matches) == 2
+
+    def test_ambiguous_duplicate_bodies_not_matched(self):
+        import mcp_server
+        old1 = self._parse_fn("def stub1():\n    pass\n")
+        old2 = self._parse_fn("def stub2():\n    pass\n")
+        new1 = self._parse_fn("def stub3():\n    pass\n")
+        new2 = self._parse_fn("def stub4():\n    pass\n")
+        removed = {"function": [("stub1", old1), ("stub2", old2)]}
+        added = {"function": [("stub3", new1), ("stub4", new2)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert matches == []
+        assert len(removed["function"]) == 2
+        assert len(added["function"]) == 2
+
+    def test_below_minimum_size_not_matched(self):
+        import mcp_server
+        old = self._parse_fn("def x():\n    pass\n")
+        new = self._parse_fn("def y():\n    pass\n")
+        removed = {"function": [("x", old)]}
+        added = {"function": [("y", new)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert matches == []
+
+    def test_cross_category_no_match(self):
+        """A function and a class with coincidentally-matchable text never match across categories."""
+        import mcp_server
+        old = self._parse_fn("def foo(x):\n    return x + 1\n")
+        new = self._parse_fn("def bar(x):\n    return x + 1\n")
+        removed = {"function": [("foo", old)], "class": []}
+        added = {"function": [], "class": [("bar", new)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert matches == []
+
+
 class TestExtractFromSourceCFamily:
     """Regression tests for issue #92 bug 1: the generic `name` field lookup
     in _walk_ast doesn't match the C/C++ grammar for functions — a C/C++

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2627,13 +2627,14 @@ class TestExtractCommit:
         results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), first_hash)
 
         assert len(results) == 1
-        status, file_path, extracted, precomputed = results[0]
+        status, file_path, extracted, precomputed, old_path = results[0]
         assert status == "A"
         assert file_path == "auth.py"
         assert "login" in extracted["functions"]
         assert "resolved_imports" in precomputed
         assert "function_entries" in precomputed
         assert "class_entries" in precomputed
+        assert old_path == ""
         assert gitlink_changes == []
         assert gitmodules_map == {}
 
@@ -2755,6 +2756,38 @@ class TestExtractCommit:
         results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), first_hash)
         assert len(results) == 1
         assert results[0][1] == "auth.py"
+
+
+class TestExtractCommitRename:
+    def test_rename_status_extracts_new_path_and_tags_old_path(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_name.py").write_text("def login():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "old_name.py", "new_name.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(repo), commits[1][0])[:3]
+        assert len(results) == 1
+        status, file_path, extracted, precomputed, old_path = mcp_server._extract_commit(str(repo), commits[1][0])[0][0]
+        assert status == "R"
+        assert file_path == "new_name.py"
+        assert old_path == "old_name.py"
+        assert "login" in extracted["functions"]
+
+    def test_non_rename_status_has_empty_old_path(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        results = mcp_server._extract_commit(str(git_repo), commits[0][0])[0]
+        status, file_path, extracted, precomputed, old_path = results[0]
+        assert status == "A"
+        assert old_path == ""
 
 
 class TestIngestionWrites:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1886,6 +1886,57 @@ class TestExtractGlobalsAndFields:
         assert result["fields"] == []
 
 
+class TestPythonGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_python
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_python.language()))
+
+    def test_module_level_global(self):
+        import mcp_server
+        tree = self._parser().parse(b"GLOBAL_X = 5\n")
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        assert "GLOBAL_X" in result["globals"]
+        assert "GLOBAL_X = 5" in result["global_bodies"]["GLOBAL_X"]
+
+    def test_class_variable_is_static_field(self):
+        import mcp_server
+        source = b"class Foo:\n    class_var = 10\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        names = [n for n, _c, _s in result["fields"]]
+        assert "class_var" in names
+        info = result["field_info"]["class_var"]
+        assert info["class"] == "Foo"
+        assert info["static"] is True
+
+    def test_self_attribute_in_init_is_instance_field(self):
+        import mcp_server
+        source = b"class Foo:\n    def __init__(self):\n        self.instance_var = 1\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        names = [n for n, _c, _s in result["fields"]]
+        assert "instance_var" in names
+        info = result["field_info"]["instance_var"]
+        assert info["class"] == "Foo"
+        assert info["static"] is False
+
+    def test_local_variable_inside_function_not_captured(self):
+        import mcp_server
+        source = b"def foo():\n    local_x = 1\n    return local_x\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+    def test_self_attribute_outside_init_not_captured(self):
+        """Scoped deliberately to __init__ only — see design plan's stated limitation."""
+        import mcp_server
+        source = b"class Foo:\n    def other(self):\n        self.dynamic = 1\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_python_globals_and_fields(tree.root_node)
+        assert result["fields"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1937,6 +1937,49 @@ class TestPythonGlobalsAndFields:
         assert result["fields"] == []
 
 
+class TestJsFamilyGlobalsAndFields:
+    def _js_parser(self):
+        import tree_sitter_javascript
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_javascript.language()))
+
+    def _ts_parser(self):
+        import tree_sitter_typescript
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_typescript.language_typescript()))
+
+    def test_js_module_level_global(self):
+        import mcp_server
+        tree = self._js_parser().parse(b"const GLOBAL_X = 5;\n")
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        assert "GLOBAL_X" in result["globals"]
+
+    def test_js_static_and_instance_fields(self):
+        import mcp_server
+        source = b"class Foo {\n  static staticField = 1;\n  instanceField = 2;\n}\n"
+        tree = self._js_parser().parse(source)
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_ts_public_field_definition_static(self):
+        import mcp_server
+        source = b"class Foo {\n  static staticField: number = 1;\n  instanceField: number = 2;\n}\n"
+        tree = self._ts_parser().parse(source)
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_local_variable_not_captured(self):
+        import mcp_server
+        source = b"function foo() {\n  const localX = 1;\n  return localX;\n}\n"
+        tree = self._js_parser().parse(source)
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2026,6 +2026,146 @@ class TestJsFamilyGlobalsAndFields:
         assert info["c"] == ("Bar", False)
 
 
+class TestRustGoCGlobalsAndFields:
+    def _rust_parser(self):
+        import tree_sitter_rust
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_rust.language()))
+
+    def _go_parser(self):
+        import tree_sitter_go
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_go.language()))
+
+    def _c_parser(self):
+        import tree_sitter_c
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_c.language()))
+
+    def test_rust_static_and_const_are_globals(self):
+        import mcp_server
+        source = b"static GLOBAL_X: i32 = 5;\nconst GLOBAL_Y: i32 = 10;\n"
+        tree = self._rust_parser().parse(source)
+        result = mcp_server._extract_rust_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"GLOBAL_X", "GLOBAL_Y"}
+
+    def test_rust_struct_field_is_instance_only(self):
+        import mcp_server
+        source = b"struct Foo {\n    instance_field: i32,\n}\n"
+        tree = self._rust_parser().parse(source)
+        result = mcp_server._extract_rust_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["instance_field"] == ("Foo", False)
+
+    def test_rust_impl_const_is_static_field(self):
+        import mcp_server
+        source = b"impl Foo {\n    const ASSOC_CONST: i32 = 1;\n}\n"
+        tree = self._rust_parser().parse(source)
+        result = mcp_server._extract_rust_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["ASSOC_CONST"] == ("Foo", True)
+
+    def test_rust_pub_visibility_does_not_break_extraction(self):
+        # `pub` is a visibility_modifier CHILD of static_item/struct_item/
+        # field_declaration/const_item (verified against the real installed
+        # tree-sitter-rust grammar) -- it does NOT wrap the declaration in a
+        # separate node the way JS's `export` does. This test locks in that
+        # finding: pub items must still be captured, with the same
+        # field:name resolution as their non-pub counterparts.
+        import mcp_server
+        source = (
+            b"pub static GLOBAL_X: i32 = 5;\n"
+            b"pub struct Foo {\n    pub instance_field: i32,\n}\n"
+            b"impl Foo {\n    pub const ASSOC_CONST: i32 = 1;\n}\n"
+        )
+        tree = self._rust_parser().parse(source)
+        result = mcp_server._extract_rust_globals_and_fields(tree.root_node)
+        assert "GLOBAL_X" in result["globals"]
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["instance_field"] == ("Foo", False)
+        assert info["ASSOC_CONST"] == ("Foo", True)
+
+    def test_go_package_level_var_and_const_are_globals(self):
+        import mcp_server
+        source = b"package main\n\nvar GlobalX = 5\nconst GlobalY = 10\n"
+        tree = self._go_parser().parse(source)
+        result = mcp_server._extract_go_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"GlobalX", "GlobalY"}
+
+    def test_go_grouped_var_declaration_captures_all_specs(self):
+        # A grouped `var (...)` block wraps its var_spec children in an
+        # intermediate var_spec_list node in the real installed
+        # tree-sitter-go grammar -- unlike grouped const/type blocks,
+        # which don't wrap. Verified empirically; this locks in that a
+        # grouped var block (an idiomatic, common real-world Go pattern)
+        # isn't silently dropped the way an unwrapped implementation
+        # would drop it.
+        import mcp_server
+        source = b"package main\n\nvar (\n\tA = 1\n\tB = 2\n)\nconst (\n\tC = 3\n\tD = 4\n)\n"
+        tree = self._go_parser().parse(source)
+        result = mcp_server._extract_go_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"A", "B", "C", "D"}
+
+    def test_go_struct_field_is_instance_only(self):
+        import mcp_server
+        source = b"package main\n\ntype Foo struct {\n    InstanceField int\n}\n"
+        tree = self._go_parser().parse(source)
+        result = mcp_server._extract_go_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["InstanceField"] == ("Foo", False)
+
+    def test_go_multi_name_struct_field_captures_all_names(self):
+        # `X, Y int` inside a struct puts more than one node under the
+        # `name` field of a single field_declaration -- singular
+        # child_by_field_name only returns the first, silently dropping
+        # `Y`. Verified empirically against the real installed
+        # tree-sitter-go grammar; children_by_field_name (plural) is
+        # used instead.
+        import mcp_server
+        source = b"package main\n\ntype Foo struct {\n\tX, Y int\n}\n"
+        tree = self._go_parser().parse(source)
+        result = mcp_server._extract_go_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["X"] == ("Foo", False)
+        assert info["Y"] == ("Foo", False)
+
+    def test_c_file_scope_declaration_is_global(self):
+        import mcp_server
+        source = b"int global_x = 5;\nstatic int file_static_x = 10;\n"
+        tree = self._c_parser().parse(source)
+        result = mcp_server._extract_c_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"global_x", "file_static_x"}
+
+    def test_c_struct_field_is_instance_only(self):
+        import mcp_server
+        source = b"struct Foo {\n    int instance_field;\n};\n"
+        tree = self._c_parser().parse(source)
+        result = mcp_server._extract_c_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["instance_field"] == ("Foo", False)
+
+    def test_c_multi_declarator_statement_captures_all_names(self):
+        # `int a, b = 2;` puts more than one node under the `declarator`
+        # field of a single `declaration` node -- child_by_field_name
+        # (singular) only returns the first one, silently dropping `b`.
+        # Verified empirically against the real installed tree-sitter-c
+        # grammar; children_by_field_name (plural) must be used instead.
+        import mcp_server
+        source = b"int a, b = 2;\n"
+        tree = self._c_parser().parse(source)
+        result = mcp_server._extract_c_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"a", "b"}
+
+    def test_c_multi_declarator_struct_field_captures_all_names(self):
+        import mcp_server
+        source = b"struct Foo {\n    int a, b;\n};\n"
+        tree = self._c_parser().parse(source)
+        result = mcp_server._extract_c_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["a"] == ("Foo", False)
+        assert info["b"] == ("Foo", False)
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1838,23 +1838,22 @@ class TestExtractFromSource:
         result = mcp_server._extract_from_source(b"def foo(): pass", None, "x.py")
         assert result == {
             "functions": [], "classes": [], "imports": [], "calls": [],
-            "function_bodies": {}, "class_bodies": {},
-            "globals": [], "global_bodies": {}, "fields": [], "field_info": {},
+            "globals": [], "fields": [],
         }
 
-    def test_extracts_function_bodies(self):
+    def test_body_text_not_shipped_across_process_boundary(self):
+        """_extract_from_source's dict crosses the ProcessPoolExecutor boundary
+        (via _extract_commit), so it must NOT carry full entity body text — the
+        matcher works on live re-parsed nodes, never on this text. These four
+        keys used to be pickled per-file for no consumer (P3)."""
         import mcp_server
-        source = b"def login(user):\n    return user.ok\n"
+        source = b"GLOBAL_X = 5\n\ndef login(user):\n    return user.ok\n\nclass User:\n    field = 1\n"
         result = mcp_server._extract_from_source(source, self._python_parser(), "auth.py")
-        assert "login" in result["function_bodies"]
-        assert "return user.ok" in result["function_bodies"]["login"]
-
-    def test_extracts_class_bodies(self):
-        import mcp_server
-        source = b"class User:\n    def ok(self):\n        return True\n"
-        result = mcp_server._extract_from_source(source, self._python_parser(), "models.py")
-        assert "User" in result["class_bodies"]
-        assert "def ok" in result["class_bodies"]["User"]
+        assert "login" in result["functions"]
+        assert "User" in result["classes"]
+        assert "GLOBAL_X" in result["globals"]
+        for dead_key in ("function_bodies", "class_bodies", "global_bodies", "field_info"):
+            assert dead_key not in result, f"{dead_key} must not cross the process boundary"
 
 
 class TestExtractGlobalsAndFields:
@@ -5098,9 +5097,7 @@ class TestPrecomputeGlobalsAndFields:
         import mcp_server
         extracted = {
             "functions": [], "classes": [], "imports": [], "calls": [],
-            "function_bodies": {}, "class_bodies": {},
-            "globals": ["GLOBAL_X"], "global_bodies": {"GLOBAL_X": "GLOBAL_X = 5"},
-            "fields": [], "field_info": {},
+            "globals": ["GLOBAL_X"], "fields": [],
         }
         result = mcp_server._precompute_file_triples(
             "config.py", extracted, ":commit/abc123", {}, segment_index=None,
@@ -5116,10 +5113,8 @@ class TestPrecomputeGlobalsAndFields:
         import mcp_server
         extracted = {
             "functions": [], "classes": ["Foo"], "imports": [], "calls": [],
-            "function_bodies": {}, "class_bodies": {"Foo": "class Foo: ..."},
-            "globals": [], "global_bodies": {},
+            "globals": [],
             "fields": [("staticField", "Foo", True)],
-            "field_info": {"staticField": {"class": "Foo", "static": True, "body": "staticField = 1"}},
         }
         result = mcp_server._precompute_file_triples(
             "models.py", extracted, ":commit/abc123", {}, segment_index=None,
@@ -5138,9 +5133,7 @@ class TestBuildCodeTriplesGlobalsAndFields:
     def test_new_global_writes_full_triples(self):
         import mcp_server
         extracted = {"functions": [], "classes": [], "imports": [], "calls": [],
-                     "function_bodies": {}, "class_bodies": {},
-                     "globals": ["GLOBAL_X"], "global_bodies": {"GLOBAL_X": "GLOBAL_X = 5"},
-                     "fields": [], "field_info": {}}
+                     "globals": ["GLOBAL_X"], "fields": []}
         precomputed = mcp_server._precompute_file_triples("config.py", extracted, ":commit/c1", {})
         entity_valid_from, entity_descriptions, file_entities = {}, {}, {}
         triples = mcp_server._build_code_triples(
@@ -5154,9 +5147,7 @@ class TestBuildCodeTriplesGlobalsAndFields:
     def test_preexisting_global_only_gets_modified_in(self):
         import mcp_server
         extracted = {"functions": [], "classes": [], "imports": [], "calls": [],
-                     "function_bodies": {}, "class_bodies": {},
-                     "globals": ["GLOBAL_X"], "global_bodies": {"GLOBAL_X": "GLOBAL_X = 6"},
-                     "fields": [], "field_info": {}}
+                     "globals": ["GLOBAL_X"], "fields": []}
         precomputed = mcp_server._precompute_file_triples("config.py", extracted, ":commit/c2", {})
         ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
         module_ident = mcp_server._code_ident("module", "config.py")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2946,6 +2946,53 @@ class TestExtractCommit:
         assert len(results) == 1
         assert results[0][1] == "auth.py"
 
+    def test_new_side_pathological_nesting_does_not_abort_commit(self, tmp_path):
+        """Reviewer finding 1 on Task 9 (47b962e): the new-side
+        `_collect_entity_nodes` call in _extract_commit's per-file loop was
+        NOT wrapped in a best-effort try/except, unlike the structurally
+        identical old-side call a few lines above. A file whose body is
+        pathologically deeply nested parses fine under tree-sitter (a C
+        parser) but blows the Python recursion limit in
+        _collect_entity_nodes's own recursive `walk()`, raising
+        RecursionError. Uncaught, that propagates out of _extract_commit and
+        (in the real pipeline) aborts the entire ingestion run rather than
+        just this one commit — contradicting _extract_commit's own docstring
+        promise that "ordinary exceptions... still fail only the one commit
+        as before". This must degrade gracefully: the pathological file's
+        new-side node pool ends up empty, matching just doesn't happen for
+        it, but the commit still processes and _extract_commit still returns.
+        """
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        nested = "(" * 6000 + "1" + ")" * 6000
+        (repo / "deep.py").write_text(f"def f():\n    x = {nested}\n    return x\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add pathologically nested file"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+
+        # Sanity check the reproduction still triggers RecursionError from
+        # _collect_entity_nodes specifically (not _extract_from_source, which
+        # is already wrapped) before asserting _extract_commit survives it.
+        parser = mcp_server._get_parser("deep.py")
+        content = mcp_server._git_file_content(str(repo), commits[0][0], "deep.py")
+        tree = parser.parse(content)
+        with pytest.raises(RecursionError):
+            mcp_server._collect_entity_nodes(tree.root_node, "python")
+
+        results, gitlink_changes, gitmodules_map, renamed_pairs = mcp_server._extract_commit(
+            str(repo), commits[0][0]
+        )
+        assert len(results) == 1
+        status, file_path, extracted, precomputed, old_path = results[0]
+        assert status == "A"
+        assert file_path == "deep.py"
+        assert renamed_pairs == []
+
 
 class TestExtractCommitRename:
     def test_rename_status_extracts_new_path_and_tags_old_path(self, tmp_path):
@@ -2998,6 +3045,92 @@ class TestExtractCommitRename:
         commits = mcp_server._git_commits(str(repo), watermark_hash=None)
         _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
         assert ("function", "fileA.py", "moveMe", "fileB.py", "moveMe") in renamed_pairs
+
+    def test_cross_extension_rename_parses_old_blob_with_old_grammar(self, tmp_path, monkeypatch):
+        """Reviewer finding 2 on Task 9 (47b962e): for status "R", `parser =
+        _thread_parser(file_path)` is selected using the NEW path's
+        extension, then reused to parse `old_content` (the OLD blob) even
+        when the old path's extension maps to a different language.
+        `old_lang` is correctly computed from `old_lang_path` for the
+        node-type lookup inside _collect_entity_nodes, but the Tree actually
+        walked was built with the wrong grammar — silently losing/misparsing
+        old-side structure on a genuine cross-language-extension rename.
+
+        Renames old_name.cpp (real C++ requiring the C++ grammar: a
+        destructor and an out-of-line qualified definition) to new_name.c.
+        Under the bug, `parser` is built for the NEW path's extension (.c ->
+        C grammar) and reused on the OLD (C++) blob; the C grammar cannot
+        parse `Foo::baz(...)` / `~Foo()` correctly and the class vanishes
+        entirely from the resulting tree (proven directly below), even
+        though old_lang is still correctly computed as "cpp" for the
+        node-type lookup.
+        """
+        import mcp_server
+        pytest.importorskip("tree_sitter_c")
+        pytest.importorskip("tree_sitter_cpp")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        old_source = (
+            "class Foo {\n"
+            "public:\n"
+            "    ~Foo() {}\n"
+            "};\n"
+            "int Foo::baz() { return 0; }\n"
+        )
+        (repo / "old_name.cpp").write_text(old_source)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add cpp file"], cwd=repo, check=True, capture_output=True)
+        # A pure rename (no content change) so git's rename detection reports
+        # status "R" with 100% similarity rather than a delete+add pair —
+        # the new file's content doesn't matter for what this test checks
+        # (the OLD blob's grammar), only its extension does.
+        _subprocess.run(["git", "mv", "old_name.cpp", "new_name.c"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename cpp to c"], cwd=repo, check=True, capture_output=True)
+
+        # Sanity check: prove the wrong-grammar parse actually loses the
+        # class, so this test would fail before the fix and isn't
+        # vacuously true.
+        mcp_server._grammar_cache.clear()
+        c_parser = mcp_server._get_parser("new_name.c")
+        cpp_parser = mcp_server._get_parser("old_name.cpp")
+        wrong_tree = c_parser.parse(old_source.encode())
+        correct_tree = cpp_parser.parse(old_source.encode())
+        wrong_result = mcp_server._collect_entity_nodes(wrong_tree.root_node, "cpp")
+        correct_result = mcp_server._collect_entity_nodes(correct_tree.root_node, "cpp")
+        assert wrong_result["class"] == {}
+        assert "Foo" in correct_result["class"]
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        rename_hash = commits[1][0]
+
+        captured_old_side = []
+        original_collect = mcp_server._collect_entity_nodes
+
+        def spy(root_node, lang_name):
+            result = original_collect(root_node, lang_name)
+            if lang_name == "cpp":
+                captured_old_side.append(result)
+            return result
+
+        monkeypatch.setattr(mcp_server, "_collect_entity_nodes", spy)
+
+        results, gitlink_changes, gitmodules_map, renamed_pairs = mcp_server._extract_commit(
+            str(repo), rename_hash
+        )
+
+        assert len(results) == 1
+        status, file_path, extracted, precomputed, old_path = results[0]
+        assert status == "R"
+        assert file_path == "new_name.c"
+        assert old_path == "old_name.cpp"
+
+        assert len(captured_old_side) == 1
+        assert "Foo" in captured_old_side[0]["class"]
+        assert "baz" in captured_old_side[0]["function"]
+        assert "~Foo" in captured_old_side[0]["function"]
 
 
 class TestIngestionWrites:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3536,6 +3536,94 @@ class TestMatchRenamedEntities:
         projected = [(c, o, n) for c, o, _, n, _ in matches]
         assert projected == [("function", "process_old", "process_new")]
 
+    def test_pathological_nesting_degrades_to_no_match_not_recursionerror(self):
+        """P2 (second-pass): a pair whose AST is deep enough to survive
+        _collect_entity_nodes but blow the recursion limit inside
+        _match_candidate_pair's walk() must degrade to no-match for that pair,
+        never raise RecursionError out of _match_renamed_entities (which would
+        propagate out of _extract_commit and abort the whole ingestion run).
+
+        Depth 600 was found empirically to pass collection while breaking the
+        matcher walk pre-fix (300-400 pass both; 500+ break the matcher).
+        """
+        import mcp_server
+        depth = 600
+        nested = "(" * depth + "1" + ")" * depth
+        old = self._parse_fn(f"def f(a):\n    x = {nested}\n    return x\n")
+        new = self._parse_fn(f"def g(a):\n    x = {nested}\n    return x\n")
+        # Sanity: collection survives this depth (so the nodes ARE pooled).
+        old_root = mcp_server._get_parser("test.py").parse(
+            f"def f(a):\n    x = {nested}\n    return x\n".encode()
+        ).root_node
+        assert "f" in mcp_server._collect_entity_nodes(old_root, "python")["function"]
+        removed = {"function": [("f", old)]}
+        added = {"function": [("g", new)]}
+        # Must not raise; the pathological pair simply isn't matched.
+        matches = mcp_server._match_renamed_entities(removed, added)
+        assert matches == []
+
+    def test_pathological_pair_does_not_discard_other_commit_matches(self):
+        """Per-pair RecursionError isolation: a pathological pair in the pool
+        must not prevent an unrelated, well-formed rename in the same pool from
+        being confirmed."""
+        import mcp_server
+        depth = 600
+        nested = "(" * depth + "1" + ")" * depth
+        bad_old = self._parse_fn(f"def bad_old(a):\n    x = {nested}\n    return x\n")
+        bad_new = self._parse_fn(f"def bad_new(a):\n    x = {nested}\n    return x\n")
+        good_old = self._parse_fn("def foo(x):\n    return x + 1\n")
+        good_new = self._parse_fn("def bar(x):\n    return x + 1\n")
+        removed = {"function": [("bad_old", bad_old), ("foo", good_old)]}
+        added = {"function": [("bad_new", bad_new), ("bar", good_new)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        projected = [(c, o, n) for c, o, _, n, _ in matches]
+        assert ("function", "foo", "bar") in projected
+
+    def test_pool_size_cap_skips_matching(self, monkeypatch):
+        """P2 (second-pass): above _MAX_MATCH_POOL_SIZE total entries the
+        matcher skips entirely (git -M rename-limit style degradation) rather
+        than paying the ~cubic pairwise cost on a giant vendored-dependency
+        commit. A rename that WOULD match under a normal pool is left
+        unmatched once the cap is exceeded."""
+        import mcp_server
+        old = self._parse_fn("def foo(x):\n    return x + 1\n")
+        new = self._parse_fn("def bar(x):\n    return x + 1\n")
+        removed = {"function": [("foo", old)]}
+        added = {"function": [("bar", new)]}
+        # Sanity: matches under the default cap.
+        assert len(mcp_server._match_renamed_entities(
+            {"function": [("foo", old)]}, {"function": [("bar", new)]}
+        )) == 1
+        monkeypatch.setattr(mcp_server, "_MAX_MATCH_POOL_SIZE", 1)
+        assert mcp_server._match_renamed_entities(removed, added) == []
+        # Pools are left untouched when matching is skipped.
+        assert removed["function"] == [("foo", old)]
+        assert added["function"] == [("bar", new)]
+
+    def test_matcher_growth_is_bounded_not_cubic(self):
+        """P2 (second-pass) performance regression guard. The per-pair
+        O(all_names) dict rebuild (the cubic term) is gone; a 600x600 pool of
+        realistic small functions must complete well within a generous bound.
+        Pre-fix a 600x600 pool took ~32s (and grew ~cubically); post-fix it is
+        ~5s. The 12s bound is chosen to sit cleanly between the two — loose
+        enough to stay non-flaky on slower CI, tight enough that a regression
+        back to the cubic rebuild (which would blow past ~30s) fails here."""
+        import mcp_server
+        parser = mcp_server._get_parser("test.py")
+        n = 600
+        removed = {"function": [], "class": [], "variable": [], "field": []}
+        added = {"function": [], "class": [], "variable": [], "field": []}
+        for i in range(n):
+            src_o = f"def old_{i}(a, b):\n    total = a + b + {i}\n    return total * a\n"
+            src_n = f"def new_{i}(a, b):\n    total = a + b + {i}\n    return total * a\n"
+            removed["function"].append((f"old_{i}", parser.parse(src_o.encode()).root_node.children[0]))
+            added["function"].append((f"new_{i}", parser.parse(src_n.encode()).root_node.children[0]))
+        start = time.perf_counter()
+        matches = mcp_server._match_renamed_entities(removed, added)
+        elapsed = time.perf_counter() - start
+        assert len(matches) == n
+        assert elapsed < 12.0, f"600x600 matcher took {elapsed:.2f}s (expected ~5s; cubic regression?)"
+
 
 class TestCollectEntityNodes:
     def test_collects_function_and_class_nodes_by_name(self):
@@ -4513,6 +4601,56 @@ class TestExtractCommit:
         status, file_path, extracted, precomputed, old_path = results[0]
         assert status == "A"
         assert file_path == "deep.py"
+        assert renamed_pairs == []
+
+    def test_matcher_side_pathological_nesting_does_not_abort_commit(self, tmp_path):
+        """P2 (second-pass): the `_match_renamed_entities` call in
+        _extract_commit was outside any try/except, and
+        _match_candidate_pair's walk uses more stack per AST level than
+        _collect_entity_nodes. A file whose AST depth SURVIVES collection (so
+        its nodes ARE pooled) can still blow the recursion limit inside the
+        pair walk, raising RecursionError that escapes _extract_commit and
+        aborts the whole ingestion run.
+
+        Reproduced with an in-place function rename of a body whose parenthesis
+        nesting (depth 600) passes collection on both sides but breaks the
+        matcher walk pre-fix. The commit must still process and _extract_commit
+        must still return, degrading to no confirmed rename for that pair.
+        """
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        nested = "(" * 600 + "1" + ")" * 600
+        (repo / "svc.py").write_text(f"def handler_old(a):\n    x = {nested}\n    return x\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "v1"], cwd=repo, check=True, capture_output=True)
+        # Same file, function renamed in place (structurally identical body) ->
+        # the deep node lands in BOTH removed and added pools for this "M"
+        # commit, so the matcher walks it.
+        (repo / "svc.py").write_text(f"def handler_new(a):\n    x = {nested}\n    return x\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "v2"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+
+        # Sanity: collection survives on both sides (nodes ARE pooled) so the
+        # failure, if any, is inside the matcher walk — not collection.
+        parser = mcp_server._get_parser("svc.py")
+        for h in (commits[0][0], commits[1][0]):
+            content = mcp_server._git_file_content(str(repo), h, "svc.py")
+            tree = parser.parse(content)
+            mcp_server._collect_entity_nodes(tree.root_node, "python")  # must not raise
+
+        # Must not raise RecursionError; commit processes, no confirmed rename.
+        results, gitlink_changes, gitmodules_map, renamed_pairs = mcp_server._extract_commit(
+            str(repo), commits[1][0]
+        )
+        assert len(results) == 1
+        assert results[0][0] == "M"
+        assert results[0][1] == "svc.py"
         assert renamed_pairs == []
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4885,6 +4885,113 @@ class TestExtractCommitRename:
         _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
         assert ("function", "svc.py", "process_old", "svc.py", "process_new") in renamed_pairs
 
+    def _init_repo(self, repo):
+        import subprocess as _sp
+        repo.mkdir()
+        _sp.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _sp.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _sp.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _commit(self, repo, msg):
+        _subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True)
+
+    def test_rename_tracked_to_unsupported_ext_emits_synthetic_delete(self, tmp_path):
+        """Forward -M regression: `git mv auth.py auth.txt`. The new path has
+        no parser, so keying the skip on it alone would drop the whole "R" row
+        and leak the old module open forever. The fix must rewrite the row as a
+        synthetic delete of the OLD path so downstream close logic runs."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        self._init_repo(repo)
+        (repo / "auth.py").write_text("AUTH_KEY = 1234567890123\n\ndef login(x):\n    return x + 1\n")
+        self._commit(repo, "add")
+        _subprocess.run(["git", "mv", "auth.py", "auth.txt"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "rename to txt")
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        # Exactly one result: a synthetic delete keyed to the OLD path.
+        assert len(results) == 1
+        status, file_path, extracted, precomputed, old_path = results[0]
+        assert status == "D"
+        assert file_path == "auth.py"
+        assert extracted is None and precomputed is None
+        assert old_path == ""
+        # No rename linkage should be attempted for an untrackable new side.
+        assert renamed_pairs == []
+
+    def test_rename_tracked_into_ignored_dir_emits_synthetic_delete(self, tmp_path):
+        """Forward -M regression via ignore pattern: `git mv auth.py
+        vendor/auth.py` under ignore_patterns=["vendor/"]. New path is ignored,
+        old path is tracked -> synthetic delete of the old path."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        self._init_repo(repo)
+        (repo / "auth.py").write_text("AUTH_KEY = 1234567890123\n\ndef login(x):\n    return x + 1\n")
+        self._commit(repo, "add")
+        (repo / "vendor").mkdir()
+        _subprocess.run(["git", "mv", "auth.py", "vendor/auth.py"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "move into vendor")
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, _, _, renamed_pairs = mcp_server._extract_commit(
+            str(repo), commits[1][0], ignore_patterns=["vendor/"]
+        )
+        assert len(results) == 1
+        status, file_path, extracted, precomputed, old_path = results[0]
+        assert status == "D"
+        assert file_path == "auth.py"
+        assert old_path == ""
+        assert renamed_pairs == []
+
+    def test_rename_unsupported_ext_to_tracked_is_plain_add(self, tmp_path):
+        """Reverse -M regression: `git mv notes.txt notes.py`. The old path was
+        never tracked (.txt has no parser), so the fix must treat the row as a
+        plain add — extracting the new path but attaching NO rename linkage
+        (no old_path), so no phantom old module gets closed downstream."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        self._init_repo(repo)
+        (repo / "notes.txt").write_text("def login(x):\n    return x + 1\n")
+        self._commit(repo, "add txt")
+        _subprocess.run(["git", "mv", "notes.txt", "notes.py"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "rename to py")
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        assert len(results) == 1
+        status, file_path, extracted, precomputed, old_path = results[0]
+        assert status == "A"
+        assert file_path == "notes.py"
+        # Crucially: old_path is empty, so _run_ingestion's R-close never fires.
+        assert old_path == ""
+        assert "login" in extracted["functions"]
+        assert renamed_pairs == []
+
+    def test_rename_ignored_to_tracked_is_plain_add(self, tmp_path):
+        """Reverse -M regression via ignore pattern: moving a file OUT of an
+        ignored dir into a tracked location. Old side ignored -> plain add."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        self._init_repo(repo)
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "auth.py").write_text("def login(x):\n    return x + 1\n")
+        self._commit(repo, "add vendored")
+        _subprocess.run(["git", "mv", "vendor/auth.py", "auth.py"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "un-vendor")
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, _, _, renamed_pairs = mcp_server._extract_commit(
+            str(repo), commits[1][0], ignore_patterns=["vendor/"]
+        )
+        assert len(results) == 1
+        status, file_path, extracted, precomputed, old_path = results[0]
+        assert status == "A"
+        assert file_path == "auth.py"
+        assert old_path == ""
+        assert renamed_pairs == []
+
 
 class TestIngestionWrites:
     def test_ingest_transact_uses_valid_from(self, mock_minigraf_db, tmp_path):
@@ -6972,6 +7079,106 @@ class TestRunIngestionBitemporalClose:
         assert any(f"{old_ident} :renamed-to {new_ident}" in t for t in close_triples_seen)
         transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
         assert f"{new_ident} :renamed-from {old_ident}" in transact_calls
+
+    @pytest.mark.asyncio
+    async def test_rename_to_unsupported_ext_closes_old_entities(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """Forward -M regression, end-to-end through _run_ingestion: renaming a
+        tracked .py to an unsupported .txt must close the old module AND its
+        child function/global via the synthetic-delete path. Pre-fix the whole
+        "R" row was dropped in _extract_commit, so nothing was ever closed and
+        the old entities leaked open forever."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("AUTH_KEY = 1234567890123\n\ndef login(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "auth.py", "auth.txt"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename to txt"], cwd=repo, check=True, capture_output=True)
+
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        module_ident = mcp_server._code_ident("module", "auth.py")
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        var_ident = mcp_server._code_ident("variable", "auth.py", "AUTH_KEY")
+
+        assert any(":ident" in t and module_ident in t for t in close_triples_seen), \
+            "Old module must be closed when renamed to an unsupported extension"
+        assert any(":ident" in t and fn_ident in t for t in close_triples_seen), \
+            "Old function must be closed when its file is renamed to an unsupported extension"
+        assert any(":ident" in t and var_ident in t for t in close_triples_seen), \
+            "Old global must be closed when its file is renamed to an unsupported extension"
+        # No .txt module should ever be opened.
+        transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
+        txt_module_ident = mcp_server._code_ident("module", "auth.txt")
+        assert txt_module_ident not in transact_calls, \
+            "No module entity should be created for the unsupported .txt path"
+
+    @pytest.mark.asyncio
+    async def test_rename_from_unsupported_ext_creates_no_phantom_module(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """Reverse -M regression, end-to-end: renaming an unsupported .txt into
+        a tracked .py must NOT close a phantom old module (the .txt ident was
+        never opened) and must NOT write a dangling :renamed-from edge. Pre-fix
+        _run_ingestion's R-branch unconditionally closed :module/notes-txt and
+        wrote a :renamed-from pointing at it."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "notes.txt").write_text("def login(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add txt"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "notes.txt", "notes.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename to py"], cwd=repo, check=True, capture_output=True)
+
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        old_module_ident = mcp_server._code_ident("module", "notes.txt")
+        new_module_ident = mcp_server._code_ident("module", "notes.py")
+        new_fn_ident = mcp_server._code_ident("function", "notes.py", "login")
+
+        # No phantom old module closed, no dangling rename edges either way.
+        assert not any(old_module_ident in t for t in close_triples_seen), \
+            "The never-opened .txt module must not be closed (no phantom)"
+        transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
+        assert f"{new_module_ident} :renamed-from {old_module_ident}" not in transact_calls, \
+            "No :renamed-from edge should dangle at the never-opened .txt module"
+        assert old_module_ident not in transact_calls, \
+            "The .txt module ident must appear nowhere in transacted triples"
+        # The new .py path is still ingested normally.
+        assert new_fn_ident in transact_calls, \
+            "The new .py file's entities must still be created as a plain add"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7081,6 +7081,140 @@ def git_repo_with_rename(tmp_path):
     return repo
 
 
+def _reused_path_repo(repo, variant):
+    """Build a 4-commit repo that reuses path a.py after it is closed.
+
+    commit1: add a.py with function f
+    commit2: rename a.py -> b.py  (variant="rename")  OR  delete a.py (variant="delete")
+    commit3: re-create a.py with a DIFFERENT function g (a "leave a shim" pattern)
+    commit4: edit the shim
+
+    Commit timestamps are pinned to distinct days so point-in-time queries can
+    target the window a.py's original function f was closed for.
+    """
+    env_base = dict(os.environ)
+
+    def _commit(msg, day):
+        env = dict(env_base)
+        ts = f"2020-01-0{day}T00:00:00Z"
+        env["GIT_AUTHOR_DATE"] = ts
+        env["GIT_COMMITTER_DATE"] = ts
+        _subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True, env=env)
+
+    repo.mkdir(parents=True, exist_ok=True)
+    _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    (repo / "a.py").write_text("def f():\n    return 1\n")
+    _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    _commit("c1 add a.py f", 1)
+
+    if variant == "rename":
+        _subprocess.run(["git", "mv", "a.py", "b.py"], cwd=repo, check=True, capture_output=True)
+    else:
+        _subprocess.run(["git", "rm", "a.py"], cwd=repo, check=True, capture_output=True)
+    _commit("c2 close a.py", 2)
+
+    (repo / "a.py").write_text("def g():\n    return 2\n")
+    _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    _commit("c3 re-add a.py g", 3)
+
+    (repo / "a.py").write_text("def g():\n    return 3\n")
+    _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    _commit("c4 edit a.py g", 4)
+    return repo
+
+
+class TestClosedEntityLifecyclePurge:
+    """Real-backend regression tests for the closed-entity lifecycle purge.
+
+    Before the purge fix, close sites in _run_ingestion left the entity's ident
+    in the in-memory bookkeeping dicts (entity_valid_from / entity_descriptions /
+    field_class_ident / file_entities). Once closes became genuinely real (commit
+    1b2e262), reusing a closed path produced two corruptions:
+
+      * ghost entity: a NEW entity re-created at a previously-closed ident took
+        _build_code_triples' "already known" branch (its ident was still in
+        entity_valid_from) and never re-asserted :ident/:description/:path, so it
+        had no current :ident fact — invisible to nearly every query.
+      * phantom resurrection: a stale ident lingering in file_entities got closed
+        a SECOND time by a later removal diff, but with its ORIGINAL introduction
+        timestamp, widening its valid window across the span it was closed for.
+    """
+
+    def _make_progress(self):
+        return {"status": "idle", "processed": 0, "total": 0, "current_commit": "",
+                "error": None, "prior_ingested": 0}
+
+    async def _ingest_and_open(self, repo, monkeypatch):
+        import mcp_server
+        graph = str(repo / "memory.graph")
+        monkeypatch.setenv("MINIGRAF_GRAPH_PATH", graph)
+        mcp_server._db = None
+        mcp_server._graph_path = graph
+        mcp_server._ingest_progress = self._make_progress()
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+        assert mcp_server._ingest_progress["status"] == "complete", mcp_server._ingest_progress
+        mcp_server._db = None  # release the lock so we can reopen for querying
+        from minigraf import MiniGrafDb
+        return MiniGrafDb.open(graph)
+
+    @staticmethod
+    def _results(db, datalog):
+        return json.loads(db.execute(datalog))["results"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("variant", ["rename", "delete"])
+    async def test_reused_path_new_entity_is_not_a_ghost(self, tmp_path, monkeypatch, variant):
+        """The module re-created at the reused path a.py must have a CURRENT
+        :ident fact (join target for nearly every query)."""
+        repo = _reused_path_repo(tmp_path / "repo", variant)
+        db = await self._ingest_and_open(repo, monkeypatch)
+
+        import mcp_server
+        module_ident = mcp_server._code_ident("module", "a.py")
+        g_ident = mcp_server._code_ident("function", "a.py", "g")
+
+        module_now = self._results(db, f'(query [:find ?i :where [{module_ident} :ident ?i]])')
+        assert module_now == [[module_ident]], \
+            f"[{variant}] re-created module at reused path has no current :ident (ghost): {module_now}"
+
+        # The re-created function g must also exist as a genuine current entity.
+        g_now = self._results(db, f'(query [:find ?i :where [{g_ident} :ident ?i]])')
+        assert g_now == [[g_ident]], f"[{variant}] re-created function g missing current :ident: {g_now}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("variant", ["rename", "delete"])
+    async def test_reused_path_no_phantom_resurrection_window(self, tmp_path, monkeypatch, variant):
+        """The original function f (closed at commit2) must NOT be visible at any
+        point-in-time between its close (commit2) and the final commit."""
+        repo = _reused_path_repo(tmp_path / "repo", variant)
+        db = await self._ingest_and_open(repo, monkeypatch)
+
+        import mcp_server
+        f_ident = mcp_server._code_ident("function", "a.py", "f")
+
+        # f was introduced at commit1 (2020-01-01) and closed at commit2 (2020-01-02).
+        # It must be visible strictly inside [c1, c2) and invisible at/after c2.
+        visible_before = self._results(
+            db, f'(query [:find ?i :valid-at "2020-01-01T12:00:00Z" :where [{f_ident} :ident ?i]])')
+        assert visible_before == [[f_ident]], \
+            f"[{variant}] f must remain visible within its true window [c1,c2): {visible_before}"
+
+        for label, when in [("c2", "2020-01-02T00:00:00Z"),
+                            ("between c2 and c4", "2020-01-03T00:00:00Z"),
+                            ("c4", "2020-01-04T00:00:00Z")]:
+            phantom = self._results(
+                db, f'(query [:find ?i :valid-at "{when}" :where [{f_ident} :ident ?i]])')
+            assert phantom == [], \
+                f"[{variant}] f (closed at c2) phantom-resurrected at {label} ({when}): {phantom}"
+
+        # And f must have no CURRENT :ident either.
+        assert self._results(db, f'(query [:find ?i :where [{f_ident} :ident ?i]])') == [], \
+            f"[{variant}] f (closed at c2) must not be visible at current time"
+
+
 class TestRunIngestionBitemporalClose:
     """Integration tests verifying bi-temporal correctness of entity lifecycle handling."""
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2954,6 +2954,129 @@ class TestScalaGlobalsAndFields:
         assert result["fields"] == []
 
 
+class TestHaskellGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_haskell
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_haskell.language()))
+
+    def test_zero_arg_bind_is_global(self):
+        import mcp_server
+        source = b"globalX :: Int\nglobalX = 5\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_record_fields_extracted(self):
+        import mcp_server
+        source = b"data Foo = Foo { fieldA :: Int, fieldB :: String }\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["fieldA"] == ("Foo", False)
+        assert info["fieldB"] == ("Foo", False)
+
+    def test_parameterized_function_is_not_a_global(self):
+        # A parameterized top-level declaration is a "function" node
+        # (targeted separately by _LANG_NODE_TYPES["haskell"]["functions"]),
+        # structurally distinct from a zero-argument "bind" node -- it
+        # must NOT also be picked up here as a global value.
+        import mcp_server
+        source = b"double :: Int -> Int\ndouble x = x * 2\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        assert "double" not in result["globals"]
+
+    def test_module_header_does_not_hide_declarations(self):
+        # `module Foo where` produces a sibling "header" field on the
+        # root node -- verified empirically -- it does NOT wrap
+        # declarations the way JS's export_statement or PHP's
+        # block-style namespace_definition do elsewhere in this plan.
+        # field:declarations still holds them directly.
+        import mcp_server
+        source = b"module Foo where\n\nglobalX :: Int\nglobalX = 5\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_tuple_pattern_bind_excluded(self):
+        # `(a, b) = (1, 2)` puts a "tuple" node in field:pattern instead
+        # of field:name holding a "variable" -- verified empirically.
+        # Deliberate simplification (not a bug): only simple
+        # single-name binds are recognized as globals here; destructured
+        # binds are silently skipped.
+        import mcp_server
+        source = b"(a, b) = (1, 2)\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+    def test_where_clause_local_binds_not_treated_as_globals(self):
+        # local_binds under a function's `where` clause are nested
+        # inside the function node's body, not direct children of
+        # field:declarations -- verified empirically -- so they are
+        # correctly excluded without any special-casing.
+        import mcp_server
+        source = b"f x = y + z\n  where\n    y = 1\n    z = 2\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+    def test_multiple_record_constructors_each_extracted(self):
+        # `data Shape = Circle {..} | Rectangle {..} | Point` -- each
+        # data_constructor within data_constructors needs its own
+        # record-shape check; a non-record constructor (Point, a
+        # "prefix" node) mixed in must not break extraction of the
+        # record ones -- verified empirically.
+        import mcp_server
+        source = (
+            b"data Shape = Circle { radius :: Double } "
+            b"| Rectangle { width :: Double, height :: Double } "
+            b"| Point\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["radius"] == ("Shape", False)
+        assert info["width"] == ("Shape", False)
+        assert info["height"] == ("Shape", False)
+        assert "Point" not in info
+
+    def test_newtype_record_field_extracted(self):
+        # `newtype Foo = Foo { unFoo :: Int }` is a completely different
+        # top-level node type ("newtype", not "data_type") -- verified
+        # empirically. Its constructor is a "newtype_constructor" node
+        # whose record child is reached via field:field (a confusingly
+        # named but real field name in the grammar) directly holding the
+        # "record" node -- there is no intermediate data_constructor
+        # wrapper the way data_type has. A newtype's single field is a
+        # very common real Haskell pattern and must be extracted.
+        import mcp_server
+        source = b"newtype Foo = Foo { unFoo :: Int }\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["unFoo"] == ("Foo", False)
+
+    def test_newtype_without_record_yields_no_fields(self):
+        # `newtype Foo = Foo Int` (no braces) puts a plain "field" node
+        # (not "record") at field:field -- verified empirically -- must
+        # not be misidentified as a record field.
+        import mcp_server
+        source = b"newtype Foo = Foo Int\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        assert result["fields"] == []
+
+    def test_no_globals_or_fields_when_absent(self):
+        import mcp_server
+        source = b"double :: Int -> Int\ndouble x = x * 2\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_haskell_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+        assert result["fields"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5559,3 +5559,18 @@ class TestExtractImportName:
         assert "os" in result
         assert "github.com/user/pkg" in result
 
+
+def test_schema_has_renamed_from_and_to_on_code_entities():
+    import mcp_server
+    for entity_type in ("module", "function", "class", "variable", "field"):
+        optional = mcp_server.MINIGRAF_SCHEMA[entity_type]["optional"]
+        assert optional[":renamed-from"] is str
+        assert optional[":renamed-to"] is str
+
+
+def test_schema_has_variable_and_field_types():
+    import mcp_server
+    assert mcp_server.MINIGRAF_SCHEMA["variable"]["required"][":description"] is str
+    field_optional = mcp_server.MINIGRAF_SCHEMA["field"]["optional"]
+    assert field_optional[":static"] is bool
+    assert field_optional[":class"] is str

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2777,6 +2777,183 @@ class TestSwiftGlobalsAndFields:
         assert result["fields"] == []
 
 
+class TestScalaGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_scala
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_scala.language()))
+
+    def test_top_level_object_members_are_globals(self):
+        import mcp_server
+        source = b"object Globals {\n  val globalX = 5\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_class_members_are_instance_fields(self):
+        import mcp_server
+        source = b"class Foo {\n  val instanceField = 2\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_tuple_destructuring_captures_all_names(self):
+        # `val (a, b) = (1, 2)` puts a tuple_pattern in field:pattern
+        # instead of a bare identifier -- verified empirically. Same
+        # multi-declarator lesson as nearly every other language in
+        # this plan: every identifier inside it must be extracted.
+        import mcp_server
+        source = b"object O {\n  val (a, b) = (1, 2)\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        assert "a" in result["globals"]
+        assert "b" in result["globals"]
+
+    def test_nested_tuple_destructuring_captures_all_names(self):
+        import mcp_server
+        source = b"object O {\n  val (a, (b, c)) = (1, (2, 3))\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        for name in ("a", "b", "c"):
+            assert name in result["globals"]
+
+    def test_comma_separated_multi_name_binding_captures_all_names(self):
+        # `val a, b = 5` binds both names to the same value via an
+        # "identifiers" node in field:pattern -- a structurally
+        # DIFFERENT shape from tuple destructuring, verified
+        # empirically. Both must be handled.
+        import mcp_server
+        source = b"object O {\n  val a, b = 5\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        assert "a" in result["globals"]
+        assert "b" in result["globals"]
+
+    def test_primary_constructor_val_param_is_instance_field_plain_param_excluded(self):
+        # `class Foo(val x: Int, y: Int)` -- x is a val/var-marked
+        # class_parameter (idiomatic, extremely common for case
+        # classes); y has neither val nor var and is a plain
+        # constructor parameter, excluded -- same shape as Kotlin's
+        # analogous primary-constructor shorthand.
+        import mcp_server
+        source = b"class Foo(val x: Int, y: Int) {\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["x"] == ("Foo", False)
+        assert "y" not in info
+
+    def test_case_class_implicit_val_param_excluded(self):
+        # Case class parameters without an explicit val/var keyword are
+        # semantically public vals in real Scala, but recognizing that
+        # requires keying off the `case` child -- separate semantic
+        # inference outside the structural, by-keyword scope of this
+        # extension -- so it is deliberately excluded, not extracted.
+        import mcp_server
+        source = b"case class Foo(x: Int, y: String)\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert "x" not in info
+        assert "y" not in info
+
+    def test_constructor_param_and_body_val_combined(self):
+        import mcp_server
+        source = (
+            b"class Point(val x: Int, val y: Int) {\n"
+            b"    val label = \"point\"\n"
+            b"}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["x"] == ("Point", False)
+        assert info["y"] == ("Point", False)
+        assert info["label"] == ("Point", False)
+
+    def test_braced_package_block_is_unwrapped(self):
+        # `package foo { ... }` wraps its contents in package_clause's
+        # field:body -- the same shape-changing-wrapper hazard as JS's
+        # export_statement and PHP's block-style namespace_definition
+        # -- verified empirically. Without unwrapping, everything
+        # inside would be silently dropped.
+        import mcp_server
+        source = (
+            b"package foo {\n"
+            b"  object Globals {\n"
+            b"    val globalX = 5\n"
+            b"  }\n"
+            b"  class Foo {\n"
+            b"    val instanceField = 2\n"
+            b"  }\n"
+            b"}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert "globalX" in result["globals"]
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_bare_package_clause_does_not_hide_siblings(self):
+        # The bare `package foo` form (no braces) does NOT wrap
+        # subsequent statements -- they remain direct siblings under
+        # compilation_unit -- verified empirically, so no unwrapping
+        # is needed (and none should be attempted) for this form.
+        import mcp_server
+        source = b"package foo\n\nobject Globals {\n  val globalX = 5\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_nested_object_inside_class_is_not_a_globals_namespace(self):
+        # Deliberate simplification: only a TOP-LEVEL (or
+        # package-wrapped top-level) object_definition is a globals
+        # namespace. One nested inside a class's template_body is out
+        # of scope -- it doesn't match the val/var_definition type
+        # filter used there, so it is silently skipped, and no
+        # companion-object pairing is ever attempted.
+        import mcp_server
+        source = (
+            b"class Foo {\n"
+            b"  object Inner {\n"
+            b"    val innerX = 1\n"
+            b"  }\n"
+            b"  val instanceField = 2\n"
+            b"}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert "innerX" not in result["globals"]
+        assert "innerX" not in info
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_nested_class_not_recursed_into(self):
+        import mcp_server
+        source = (
+            b"class Outer {\n"
+            b"    class Inner {\n"
+            b"        val innerField = 3\n"
+            b"    }\n"
+            b"    val outerField = 4\n"
+            b"}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["outerField"] == ("Outer", False)
+        assert "innerField" not in info
+
+    def test_no_globals_or_fields_when_absent(self):
+        import mcp_server
+        source = b"def main(): Unit = {\n  println(\"hi\")\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_scala_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+        assert result["fields"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6688,6 +6688,49 @@ class TestRunIngestionBitemporalClose:
         transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
         assert f"{new_fn_ident} :renamed-from {old_fn_ident}" in transact_calls
 
+    @pytest.mark.asyncio
+    async def test_global_rename_links_via_rename_edges_end_to_end(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        # Value padded to a 13-digit literal (not a bare "12345") so the
+        # assignment's normalized body clears _match_renamed_entities'
+        # _MIN_MATCH_BODY_LEN=20 floor (Task 8) -- see
+        # test_global_rename_produces_renamed_pair's identical note. A
+        # shorter literal is silently dropped as a "trivial stub" before
+        # matching, producing an empty renamed_pairs and no rename triples.
+        (repo / "config.py").write_text("GLOBAL_X = 1234567890123\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "config.py").write_text("GLOBAL_Y = 1234567890123\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename global"], cwd=repo, check=True, capture_output=True)
+
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        old_ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
+        new_ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_Y")
+
+        assert any(f"{old_ident} :renamed-to {new_ident}" in t for t in close_triples_seen)
+        transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
+        assert f"{new_ident} :renamed-from {old_ident}" in transact_calls
+
 
 # ---------------------------------------------------------------------------
 # Fixtures for bi-temporal :depends-on integration tests

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1918,6 +1918,30 @@ class TestMatchCandidatePair:
         result = mcp_server._match_candidate_pair(old, new, {})
         assert result is None
 
+    def test_local_identifier_colliding_with_confirmed_tracked_rename_does_not_match(self):
+        """A local (untracked) old identifier 'y' must not be allowed to map
+        to 'helper_new' when 'helper_new' is already claimed as the confirmed
+        new name of a different, tracked old entity 'helper_old'. Both old
+        tokens are genuinely distinct, so collapsing them onto the same new
+        token violates injectivity even though 'y' isn't itself tracked."""
+        import mcp_server
+        old = self._parse("def foo(x):\n    y = helper_old(x)\n    return y\n")
+        new = self._parse(
+            "def foo(x):\n    helper_new = helper_new(x)\n    return helper_new\n"
+        )
+        result = mcp_server._match_candidate_pair(old, new, {"helper_old": "helper_new"})
+        assert result is None
+
+    def test_local_identifier_colliding_with_unchanged_tracked_name_does_not_match(self):
+        """Same collision, but the tracked entity is unchanged (tracked_names
+        value is None) rather than renamed: a local old identifier must not
+        be allowed to map to the tracked entity's own (unchanged) text."""
+        import mcp_server
+        old = self._parse("def foo(x):\n    y = helper(x)\n    return y\n")
+        new = self._parse("def foo(x):\n    helper = helper(x)\n    return helper\n")
+        result = mcp_server._match_candidate_pair(old, new, {"helper": None})
+        assert result is None
+
 
 class TestExtractFromSourceCFamily:
     """Regression tests for issue #92 bug 1: the generic `name` field lookup

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3435,6 +3435,63 @@ class TestMatchRenamedEntities:
         matches = mcp_server._match_renamed_entities(removed, added)
         assert matches == []
 
+    def test_field_leaf_not_captured_by_unrelated_confirmed_rename(self):
+        """Regression for the task-26 false-positive: a field is pooled under a
+        QUALIFIED key ("A.Config") but its body text contains only the BARE
+        leaf token ("Config"). If an UNRELATED entity with the same bare name
+        (a function `Config`) is confirmed-renamed to `ConfigFn` in an earlier
+        round, the field's own `Config` token must NOT inherit that constraint
+        — otherwise the field is wrongly forced to a specific candidate.
+
+        Here the field rename is genuinely ambiguous (`A.Config`'s body
+        `Config = <n>` matches BOTH `A.ConfigFn` and `A.ConfigField` as a
+        single-token rename), so the matcher must stay conservative and leave
+        the field UNMATCHED. Pre-fix, the stale `Config -> ConfigFn` constraint
+        from the function disambiguated it into the WRONG match
+        `A.Config -> A.ConfigFn`.
+        """
+        import mcp_server
+        parser = mcp_server._get_parser("test.py")
+
+        def parse(src):
+            return parser.parse(src.encode()).root_node
+
+        old_root = parse(
+            "def Config(x):\n    return x + 1\n"
+            "class A:\n    Config = 1234567890123\n"
+        )
+        new_root = parse(
+            "def ConfigFn(x):\n    return x + 1\n"
+            "class A:\n    ConfigFn = 1234567890123\n    ConfigField = 1234567890123\n"
+        )
+
+        old_fn = mcp_server._collect_entity_nodes(old_root, "python")["function"]
+        new_fn = mcp_server._collect_entity_nodes(new_root, "python")["function"]
+        old_fields = mcp_server._extract_globals_and_fields(old_root, "python")["field_nodes"]
+        new_fields = mcp_server._extract_globals_and_fields(new_root, "python")["field_nodes"]
+
+        removed = {
+            "function": [("Config", old_fn["Config"])],
+            "field": [("A.Config", old_fields["A.Config"])],
+        }
+        added = {
+            "function": [("ConfigFn", new_fn["ConfigFn"])],
+            "field": [
+                ("A.ConfigFn", new_fields["A.ConfigFn"]),
+                ("A.ConfigField", new_fields["A.ConfigField"]),
+            ],
+        }
+
+        matches = mcp_server._match_renamed_entities(removed, added)
+        projected = [(c, o, n) for c, o, _, n, _ in matches]
+
+        # The unrelated function rename is legitimate and expected.
+        assert ("function", "Config", "ConfigFn") in projected
+        # The field rename is genuinely ambiguous -> must stay UNMATCHED.
+        field_matches = [m for m in projected if m[0] == "field"]
+        assert field_matches == [], f"field must stay ambiguous, got {field_matches}"
+        assert ("field", "A.Config", "A.ConfigFn") not in projected
+
 
 class TestCollectEntityNodes:
     def test_collects_function_and_class_nodes_by_name(self):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5010,8 +5010,8 @@ class TestIngestionWrites:
         call_args = db_instance.execute.call_args[0][0]
         assert ':valid-from "2025-03-01T10:00:00Z"' in call_args
         assert ":valid-to" not in call_args
-        # facts vector must come before the options map
-        assert call_args.index("[:module/foo") < call_args.index(":valid-from")
+        # Documented grammar: options map must come BEFORE the fact vector.
+        assert call_args.index(":valid-from") < call_args.index("[:module/foo")
 
     def test_ingest_close_uses_valid_from_and_valid_to(self, mock_minigraf_db, tmp_path):
         mock_class, db_instance = mock_minigraf_db
@@ -5030,8 +5030,8 @@ class TestIngestionWrites:
         call_args = db_instance.execute.call_args[0][0]
         assert ':valid-from "2025-01-01T00:00:00Z"' in call_args
         assert ':valid-to "2025-03-01T10:00:00Z"' in call_args
-        # facts vector must come before the options map
-        assert call_args.index("[:module/foo") < call_args.index(":valid-from")
+        # Documented grammar: options map must come BEFORE the fact vector.
+        assert call_args.index(":valid-from") < call_args.index("[:module/foo")
 
     def test_watermark_update_transacts_hash(self, mock_minigraf_db, tmp_path):
         mock_class, db_instance = mock_minigraf_db
@@ -7219,17 +7219,17 @@ class TestRunIngestionBitemporalClose:
         then also query the real graph to confirm both rename directions
         resolve.
 
-        NOTE on the "as-of before the rename" check the review also asked for:
-        the installed minigraf 1.2.1 does not honour the `:valid-from` /
-        `:valid-to` options passed to `transact` on this code path — every fact
-        is stamped with wall-clock now and `:valid-at "<iso>"` reads cannot
-        observe a historical window (empirically verified). A point-in-time
-        "renamed-to not visible before the rename" query is therefore not
-        expressible against this build, which is *why* the whole suite mocks
-        the DB. We instead assert the equivalent invariant on the real backend:
-        the :renamed-to fact's `:valid-from` equals the RENAME commit's
-        timestamp (so it is introduced at the rename, not before) and it is
-        never emitted with a `:valid-to`.
+        Point-in-time verification: we query the real graph with `:valid-at`
+        at a timestamp BEFORE the rename commit and confirm :renamed-to /
+        :renamed-from are NOT yet visible, then query at the rename commit
+        timestamp and confirm they ARE visible. This is now expressible because
+        the `transact` argument-order bug (options map was passed AFTER the
+        fact vector, so minigraf ignored `:valid-from`/`:valid-to` and stamped
+        every fact with wall-clock now) has been fixed — the options map now
+        correctly precedes the fact vector, matching the documented grammar
+        `(transact {:valid-from ...} [facts...])`. The earlier claim that the
+        historical window "was not honoured by this build" was a symptom of
+        that bug, not a real minigraf limitation.
         """
         import mcp_server
         repo = tmp_path / "repo"
@@ -7297,6 +7297,28 @@ class TestRunIngestionBitemporalClose:
         rf = json.loads(real_execute(db, f"(query [:find ?x :where [{new_module} :renamed-from ?x]])")).get("results", [])
         assert rt == [[new_module]], f"forward :renamed-to must resolve to new module, got {rt}"
         assert rf == [[old_module]], f"reverse :renamed-from must resolve to old module, got {rf}"
+
+        # REAL point-in-time verification (the check the review originally asked
+        # for, now expressible after the transact argument-order fix): the rename
+        # edges become true AT the rename commit, so a :valid-at BEFORE that
+        # commit must NOT observe them, and a :valid-at at the rename commit must.
+        rt_before = json.loads(real_execute(
+            db, f'(query [:find ?x :valid-at "2000-01-01T00:00:00Z" :where [{old_module} :renamed-to ?x]])'
+        )).get("results", [])
+        rf_before = json.loads(real_execute(
+            db, f'(query [:find ?x :valid-at "2000-01-01T00:00:00Z" :where [{new_module} :renamed-from ?x]])'
+        )).get("results", [])
+        assert rt_before == [], f":renamed-to must NOT be visible before the rename commit, got {rt_before}"
+        assert rf_before == [], f":renamed-from must NOT be visible before the rename commit, got {rf_before}"
+
+        rt_at = json.loads(real_execute(
+            db, f'(query [:find ?x :valid-at "{rename_commit_ts}" :where [{old_module} :renamed-to ?x]])'
+        )).get("results", [])
+        rf_at = json.loads(real_execute(
+            db, f'(query [:find ?x :valid-at "{rename_commit_ts}" :where [{new_module} :renamed-from ?x]])'
+        )).get("results", [])
+        assert rt_at == [[new_module]], f":renamed-to must be visible at the rename commit, got {rt_at}"
+        assert rf_at == [[old_module]], f":renamed-from must be visible at the rename commit, got {rf_at}"
 
         mcp_server._db = None  # release the real file lock for subsequent tests
 
@@ -7485,6 +7507,60 @@ def git_repo_with_dep_removal(tmp_path):
     _subprocess.run(["git", "commit", "-m", "remove import"], cwd=repo, check=True, capture_output=True)
 
     return repo
+
+
+class TestTransactValidTimeArgumentOrder:
+    """Regression tests for the transact argument-order bug.
+
+    minigraf's documented grammar is `(transact {options} [facts...])` — the
+    valid-time options map MUST precede the fact vector. Every valid-time-bounded
+    transact in mcp_server.py historically emitted the reversed order
+    `(transact [facts...] {options})`, which minigraf silently ignored: the fact
+    was stamped with wall-clock now instead of the intended window. This meant a
+    "closed" (bounded) fact stayed visible in current-time queries forever, and
+    `:valid-at` point-in-time reads could never observe the intended window.
+
+    These tests run against a REAL temp minigraf .graph file (no MiniGrafDb mock)
+    and prove the fixed order behaves exactly as documented.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bounded_window_honoured_against_real_graph(self, tmp_path):
+        """Transact a fact with a bounded historical valid window and confirm:
+        (a) a default/current-time query does NOT see it,
+        (b) a :valid-at WITHIN the window DOES see it,
+        (c) a :valid-at BEFORE the window does NOT see it.
+        """
+        import mcp_server
+        mcp_server._db = None
+        mcp_server._graph_path = None
+        mcp_server.open_db(str(tmp_path / "vt.graph"))
+        db = mcp_server.get_db()
+
+        try:
+            # Bounded historical window: valid 2020-01-01 .. 2021-01-01 only.
+            mcp_server._db_execute(
+                db,
+                '(transact {:valid-from "2020-01-01T00:00:00Z" '
+                ':valid-to "2021-01-01T00:00:00Z"} [[:alice :employment/status :active]])',
+            )
+
+            def q(extra=""):
+                raw = mcp_server._db_execute(
+                    db, f"(query [:find ?s {extra} :where [:alice :employment/status ?s]])"
+                )
+                return json.loads(raw).get("results", [])
+
+            # (a) current time is AFTER the closed window -> not visible.
+            assert q() == [], "closed bounded fact must NOT appear in a current-time query"
+            # (b) point-in-time inside the window -> visible.
+            assert q(':valid-at "2020-06-01T00:00:00Z"') == [[":active"]], \
+                "fact must be visible at a :valid-at inside its window"
+            # (c) point-in-time before the window -> not visible.
+            assert q(':valid-at "2019-06-01T00:00:00Z"') == [], \
+                "fact must NOT be visible at a :valid-at before its window"
+        finally:
+            mcp_server._db = None  # release the real file lock for subsequent tests
 
 
 class TestRunIngestionBitemporalDeps:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2561,6 +2561,103 @@ class TestPhpGlobalsAndFields:
         assert info["$y"] == ("Foo", False)
 
 
+class TestKotlinGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_kotlin
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_kotlin.language()))
+
+    def test_top_level_property_is_global(self):
+        import mcp_server
+        tree = self._parser().parse(b"val globalX = 5\n")
+        result = mcp_server._extract_kotlin_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_companion_object_property_is_static_plain_is_instance(self):
+        import mcp_server
+        source = b"class Foo {\n    companion object {\n        val staticField = 1\n    }\n    val instanceField = 2\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_kotlin_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_top_level_destructuring_declaration_captures_all_names(self):
+        # `val (a, b) = Pair(1, 2)` wraps its names in a
+        # multi_variable_declaration instead of a bare
+        # variable_declaration -- verified empirically against the real
+        # installed tree-sitter-kotlin grammar. Same multi-declarator
+        # lesson as every prior language in this plan (Go/C/Java/C++/
+        # Ruby): every identifier inside it must be extracted, not just
+        # treated as absent.
+        import mcp_server
+        source = b"val (a, b) = Pair(1, 2)\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_kotlin_globals_and_fields(tree.root_node)
+        assert "a" in result["globals"]
+        assert "b" in result["globals"]
+
+    def test_primary_constructor_val_param_is_instance_field_plain_param_excluded(self):
+        # Kotlin's primary-constructor property shorthand (`class
+        # Foo(val x: Int)`) is an idiomatic and extremely common way to
+        # declare instance fields (near-universal in `data class`), but
+        # it is structurally a class_parameter inside primary_
+        # constructor's class_parameters list -- NOT a property_
+        # declaration under class_body -- verified empirically. A plain
+        # constructor parameter with neither `val` nor `var` (`y: Int`
+        # below) is not a property and must be excluded.
+        import mcp_server
+        source = b"class Foo(val x: Int, y: Int) {\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_kotlin_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["x"] == ("Foo", False)
+        assert "y" not in info
+
+    def test_data_class_constructor_properties_and_body_property_combined(self):
+        import mcp_server
+        source = (
+            b"data class Point(val x: Int, val y: Int) {\n"
+            b"    val label = \"point\"\n"
+            b"}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_kotlin_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["x"] == ("Point", False)
+        assert info["y"] == ("Point", False)
+        assert info["label"] == ("Point", False)
+
+    def test_nested_class_not_recursed_into(self):
+        # Fields two classes deep are out of scope, consistent with
+        # every other language in this plan: only class_body's direct
+        # children are inspected, so a nested class_declaration is
+        # skipped without crashing and without contributing its own
+        # field to the outer class.
+        import mcp_server
+        source = (
+            b"class Outer {\n"
+            b"    class Inner {\n"
+            b"        val innerField = 3\n"
+            b"    }\n"
+            b"    val outerField = 4\n"
+            b"}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_kotlin_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["outerField"] == ("Outer", False)
+        assert "innerField" not in info
+
+    def test_no_globals_or_fields_when_absent(self):
+        import mcp_server
+        source = b"fun main() {\n    println(\"hi\")\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_kotlin_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+        assert result["fields"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2221,11 +2221,13 @@ class TestGitDiffTreeRaw:
         commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
         entries = mcp_server._git_diff_tree_raw(str(git_repo), commits[0][0])
         assert len(entries) == 1
-        status, old_mode, new_mode, old_sha, new_sha, path = entries[0]
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
         assert status == "A"
         assert old_mode == "000000"
         assert new_mode == "100644"
         assert path == "auth.py"
+        assert old_path == ""
+        assert similarity is None
 
     def test_gitlink_add_reports_mode_160000(self, tmp_path):
         import mcp_server
@@ -2254,11 +2256,83 @@ class TestGitDiffTreeRaw:
         commits = mcp_server._git_commits(str(repo), watermark_hash=None)
         entries = mcp_server._git_diff_tree_raw(str(repo), commits[0][0])
         assert len(entries) == 1
-        status, old_mode, new_mode, old_sha, new_sha, path = entries[0]
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
         assert status == "A"
         assert new_mode == "160000"
         assert new_sha == sub_hash
         assert path == "vendor/lib"
+        assert old_path == ""
+
+    def test_pure_rename_reports_both_paths_and_similarity(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_name.py").write_text("def login():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "old_name.py", "new_name.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(repo), commits[1][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
+        assert status == "R"
+        assert path == "new_name.py"
+        assert old_path == "old_name.py"
+        assert similarity == 100
+
+    def test_rename_with_content_change_reports_partial_similarity(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_name.py").write_text(
+            "def login():\n    pass\n\ndef a():\n    pass\n\ndef b():\n    pass\n\ndef c():\n    pass\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "old_name.py", "new_name.py"], cwd=repo, check=True, capture_output=True)
+        (repo / "new_name.py").write_text(
+            "def login():\n    pass\n\ndef a():\n    pass\n\ndef extra():\n    pass\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename and edit"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(repo), commits[1][0])
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
+        assert status == "R"
+        assert old_path == "old_name.py"
+        assert path == "new_name.py"
+        assert similarity is not None and 0 < similarity < 100
+
+    def test_unrelated_add_and_delete_not_reported_as_rename(self, tmp_path):
+        """Below git's default 50% similarity threshold, -M must NOT report a rename."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_name.py").write_text("def login():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "rm", "old_name.py"], cwd=repo, check=True, capture_output=True)
+        (repo / "unrelated.py").write_text("class Widget:\n    def render(self):\n        return 42\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "unrelated churn"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(repo), commits[1][0])
+        statuses = {e[0] for e in entries}
+        assert statuses == {"A", "D"}
 
 
 class TestIsIgnoredPath:
@@ -2459,32 +2533,32 @@ class TestKnownFilesAtCommit:
 class TestGitlinkChanges:
     def test_non_gitlink_rows_are_ignored(self):
         import mcp_server
-        raw = [("A", "000000", "100644", "0" * 40, "a" * 40, "auth.py")]
+        raw = [("A", "000000", "100644", "0" * 40, "a" * 40, "auth.py", "", None)]
         assert mcp_server._gitlink_changes(raw) == []
 
     def test_add_when_new_mode_is_gitlink(self):
         import mcp_server
-        raw = [("A", "000000", "160000", "0" * 40, "b" * 40, "vendor/lib")]
+        raw = [("A", "000000", "160000", "0" * 40, "b" * 40, "vendor/lib", "", None)]
         assert mcp_server._gitlink_changes(raw) == [("add", "b" * 40, "vendor/lib")]
 
     def test_bump_when_both_modes_are_gitlink(self):
         import mcp_server
-        raw = [("M", "160000", "160000", "b" * 40, "c" * 40, "vendor/lib")]
+        raw = [("M", "160000", "160000", "b" * 40, "c" * 40, "vendor/lib", "", None)]
         assert mcp_server._gitlink_changes(raw) == [("bump", "c" * 40, "vendor/lib")]
 
     def test_remove_when_old_mode_is_gitlink(self):
         import mcp_server
-        raw = [("D", "160000", "000000", "c" * 40, "0" * 40, "vendor/lib")]
+        raw = [("D", "160000", "000000", "c" * 40, "0" * 40, "vendor/lib", "", None)]
         assert mcp_server._gitlink_changes(raw) == [("remove", "c" * 40, "vendor/lib")]
 
     def test_type_change_into_internal_reported_as_remove(self):
         import mcp_server
-        raw = [("T", "160000", "100644", "c" * 40, "d" * 40, "vendor/lib")]
+        raw = [("T", "160000", "100644", "c" * 40, "d" * 40, "vendor/lib", "", None)]
         assert mcp_server._gitlink_changes(raw) == [("remove", "c" * 40, "vendor/lib")]
 
     def test_type_change_into_external_reported_as_add(self):
         import mcp_server
-        raw = [("T", "100644", "160000", "d" * 40, "e" * 40, "vendor/lib")]
+        raw = [("T", "100644", "160000", "d" * 40, "e" * 40, "vendor/lib", "", None)]
         assert mcp_server._gitlink_changes(raw) == [("add", "e" * 40, "vendor/lib")]
 
 
@@ -2578,7 +2652,7 @@ class TestExtractCommit:
         import mcp_server
         monkeypatch.setattr(
             mcp_server, "_git_diff_tree_raw",
-            lambda repo, commit: [("A", "000000", "100644", "0" * 40, "a" * 40, "notes.txt")],
+            lambda repo, commit: [("A", "000000", "100644", "0" * 40, "a" * 40, "notes.txt", "", None)],
         )
         results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), "deadbeef")
         assert results == []
@@ -2587,7 +2661,7 @@ class TestExtractCommit:
         import mcp_server
         monkeypatch.setattr(
             mcp_server, "_git_diff_tree_raw",
-            lambda repo, commit: [("A", "000000", "100644", "0" * 40, "a" * 40, "auth.py")],
+            lambda repo, commit: [("A", "000000", "100644", "0" * 40, "a" * 40, "auth.py", "", None)],
         )
 
         def boom(repo, commit, path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3154,6 +3154,123 @@ class TestLuaGlobalsAndFields:
         assert result["fields"] == []
 
 
+class TestElixirGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_elixir
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_elixir.language()))
+
+    def test_module_attribute_is_static_field(self):
+        import mcp_server
+        source = b"defmodule Foo do\n  @module_attr 5\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_elixir_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["module_attr"] == ("Foo", True)
+        assert result["globals"] == []
+
+    def test_globals_always_empty(self):
+        # Elixir has no top-level mutable globals outside module attributes --
+        # verified empirically there is no syntactic form that would produce one.
+        import mcp_server
+        source = b"defmodule Foo do\n  @a 1\n  @b 2\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_elixir_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+        assert result["global_bodies"] == {}
+
+    def test_multiple_attributes_in_one_module(self):
+        import mcp_server
+        source = b"defmodule Foo do\n  @a 1\n  @b 2\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_elixir_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["a"] == ("Foo", True)
+        assert info["b"] == ("Foo", True)
+
+    def test_nested_module_attribute_attributed_to_inner_module(self):
+        # A nested `defmodule` is itself a `call` node reachable by the
+        # recursive walk -- verified empirically its own do_block members
+        # are scanned independently of the outer module's, so an inner
+        # module's attribute must be attributed to the inner module's name,
+        # not the outer one.
+        import mcp_server
+        source = (
+            b"defmodule Outer do\n"
+            b"  @outer_attr 1\n\n"
+            b"  defmodule Inner do\n"
+            b"    @inner_attr 2\n"
+            b"  end\n"
+            b"end\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_elixir_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["outer_attr"] == ("Outer", True)
+        assert info["inner_attr"] == ("Inner", True)
+        assert result["globals"] == []
+
+    def test_dotted_nested_module_name(self):
+        # `defmodule Foo.Bar do ... end` is a single call whose alias node's
+        # text is the full dotted name "Foo.Bar" -- verified empirically --
+        # rather than two levels of AST nesting.
+        import mcp_server
+        source = b"defmodule Foo.Bar do\n  @attr 1\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_elixir_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["attr"] == ("Foo.Bar", True)
+
+    def test_attribute_reference_without_value_not_captured_as_field(self):
+        # `@attr` (no value, a read-reference to a previously defined
+        # attribute) parses with operand type "identifier", not "call" --
+        # verified empirically -- so it is correctly excluded here; only
+        # `@attr value` (operand type "call") defines a field.
+        import mcp_server
+        source = (
+            b"defmodule Foo do\n"
+            b"  @attr 1\n"
+            b"  def bar do\n"
+            b"    @attr\n"
+            b"  end\n"
+            b"end\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_elixir_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["attr"] == ("Foo", True)
+        assert len(result["fields"]) == 1
+
+    def test_moduledoc_and_doc_attributes_are_captured_as_fields(self):
+        # @moduledoc/@doc/@spec parse identically to any other module
+        # attribute (unary_operator -> call with an identifier target) --
+        # verified empirically -- so this extractor does not special-case
+        # them as noise, consistent with no other language task in this
+        # plan inventing bespoke exclusion lists for built-in
+        # annotations/decorators. Documented here as a known characteristic,
+        # not a bug.
+        import mcp_server
+        source = (
+            b"defmodule Foo do\n"
+            b'  @moduledoc "hi"\n'
+            b"  @attr 1\n"
+            b"end\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_elixir_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["moduledoc"] == ("Foo", True)
+        assert info["attr"] == ("Foo", True)
+
+    def test_no_globals_or_fields_when_absent(self):
+        import mcp_server
+        source = b"defmodule Foo do\n  def bar do\n    :ok\n  end\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_elixir_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+        assert result["fields"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1856,6 +1856,69 @@ class TestExtractFromSource:
         assert "def ok" in result["class_bodies"]["User"]
 
 
+class TestMatchCandidatePair:
+    def _parse(self, source: str):
+        import mcp_server
+        parser = mcp_server._get_parser("test.py")
+        tree = parser.parse(source.encode())
+        # first top-level statement's node (a function_definition, in every fixture below)
+        return tree.root_node.children[0]
+
+    def test_identical_bodies_match_with_empty_bijection(self):
+        import mcp_server
+        old = self._parse("def foo(x):\n    return x + 1\n")
+        new = self._parse("def foo(x):\n    return x + 1\n")
+        result = mcp_server._match_candidate_pair(old, new, {})
+        assert result == {}
+
+    def test_renamed_local_variable_matches_via_bijection(self):
+        import mcp_server
+        old = self._parse("def foo(x):\n    y = x + 1\n    return y\n")
+        new = self._parse("def foo(x):\n    z = x + 1\n    return z\n")
+        result = mcp_server._match_candidate_pair(old, new, {})
+        assert result == {"y": "z"}
+
+    def test_inconsistent_local_rename_does_not_match(self):
+        """y is renamed to z in one spot but stays y in another -> not a valid bijection."""
+        import mcp_server
+        old = self._parse("def foo(x):\n    y = x + 1\n    return y + y\n")
+        new = self._parse("def foo(x):\n    z = x + 1\n    return z + y\n")
+        result = mcp_server._match_candidate_pair(old, new, {})
+        assert result is None
+
+    def test_two_distinct_locals_collapsing_onto_one_new_name_does_not_match(self):
+        """y and w are two distinct old locals; if both map to the same new
+        name 'z' that is not a valid bijection (not injective) even though
+        each individual old->new mapping is internally consistent."""
+        import mcp_server
+        old = self._parse("def foo(x):\n    y = x + 1\n    w = x + 2\n    return y + w\n")
+        new = self._parse("def foo(x):\n    z = x + 1\n    z = x + 2\n    return z + z\n")
+        result = mcp_server._match_candidate_pair(old, new, {})
+        assert result is None
+
+    def test_tracked_entity_with_confirmed_rename_must_match_new_name(self):
+        """Body calls a helper that was itself confirmed renamed this round."""
+        import mcp_server
+        old = self._parse("def foo(x):\n    return helper_old(x)\n")
+        new = self._parse("def foo(x):\n    return helper_new(x)\n")
+        result = mcp_server._match_candidate_pair(old, new, {"helper_old": "helper_new"})
+        assert result == {}
+
+    def test_tracked_entity_without_rename_must_match_exactly(self):
+        old = self._parse("def foo(x):\n    return helper(x)\n")
+        new = self._parse("def foo(x):\n    return other(x)\n")
+        import mcp_server
+        result = mcp_server._match_candidate_pair(old, new, {"helper": None})
+        assert result is None
+
+    def test_structurally_different_bodies_do_not_match(self):
+        import mcp_server
+        old = self._parse("def foo(x):\n    return x + 1\n")
+        new = self._parse("def foo(x):\n    if x:\n        return x\n    return 1\n")
+        result = mcp_server._match_candidate_pair(old, new, {})
+        assert result is None
+
+
 class TestExtractFromSourceCFamily:
     """Regression tests for issue #92 bug 1: the generic `name` field lookup
     in _walk_ast doesn't match the C/C++ grammar for functions — a C/C++

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1866,11 +1866,17 @@ class TestExtractGlobalsAndFields:
     def test_unsupported_language_returns_empty(self):
         import mcp_server
         result = mcp_server._extract_globals_and_fields(None, "nonexistent_lang")
-        assert result == {"globals": [], "global_bodies": {}, "fields": [], "field_info": {}}
+        assert result == {
+            "globals": [], "global_bodies": {}, "fields": [], "field_info": {},
+            "global_nodes": {}, "field_nodes": {},
+        }
 
     def test_dispatches_to_registered_language_extractor(self):
         import mcp_server
-        sentinel = {"globals": ["X"], "global_bodies": {"X": "X = 1"}, "fields": [], "field_info": {}}
+        sentinel = {
+            "globals": ["X"], "global_bodies": {"X": "X = 1"}, "fields": [], "field_info": {},
+            "global_nodes": {}, "field_nodes": {},
+        }
         mcp_server._GLOBAL_FIELD_EXTRACTORS["_test_lang"] = lambda root: sentinel
         try:
             result = mcp_server._extract_globals_and_fields("fake_root", "_test_lang")
@@ -4546,6 +4552,31 @@ class TestExtractCommitRename:
         assert "Foo" in captured_old_side[0]["class"]
         assert "baz" in captured_old_side[0]["function"]
         assert "~Foo" in captured_old_side[0]["function"]
+
+    def test_global_rename_produces_renamed_pair(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        # Value padded to a 13-digit literal (not the brief's bare "12345")
+        # so the assignment's normalized body clears _match_renamed_entities'
+        # _MIN_MATCH_BODY_LEN=20 floor (Task 8) -- confirmed empirically that
+        # the brief's literal "GLOBAL_X = 12345" (16 normalized chars) is
+        # silently dropped as a "trivial stub" before this padding was added,
+        # producing an empty renamed_pairs regardless of the pooling/matcher
+        # logic under test here.
+        (repo / "config.py").write_text("GLOBAL_X = 1234567890123\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "config.py").write_text("GLOBAL_Y = 1234567890123\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename global"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        assert ("variable", "config.py", "GLOBAL_X", "config.py", "GLOBAL_Y") in renamed_pairs
 
 
 class TestIngestionWrites:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3477,6 +3477,95 @@ class TestPrecomputeFileTriples:
         assert dep_ident == mcp_server._canonical_ident("module", "totally_unknown_crate")
 
 
+class TestPrecomputeGlobalsAndFields:
+    def test_global_entries_shape(self):
+        import mcp_server
+        extracted = {
+            "functions": [], "classes": [], "imports": [], "calls": [],
+            "function_bodies": {}, "class_bodies": {},
+            "globals": ["GLOBAL_X"], "global_bodies": {"GLOBAL_X": "GLOBAL_X = 5"},
+            "fields": [], "field_info": {},
+        }
+        result = mcp_server._precompute_file_triples(
+            "config.py", extracted, ":commit/abc123", {}, segment_index=None,
+        )
+        assert len(result["global_entries"]) == 1
+        ident, name, triples = result["global_entries"][0]
+        assert ident == mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
+        assert name == "GLOBAL_X"
+        assert f"[{ident} :entity-type :type/variable]" in triples
+        assert f"[{ident} :introduced-by :commit/abc123]" in triples
+
+    def test_field_entries_shape_disambiguates_by_class(self):
+        import mcp_server
+        extracted = {
+            "functions": [], "classes": ["Foo"], "imports": [], "calls": [],
+            "function_bodies": {}, "class_bodies": {"Foo": "class Foo: ..."},
+            "globals": [], "global_bodies": {},
+            "fields": [("staticField", "Foo", True)],
+            "field_info": {"staticField": {"class": "Foo", "static": True, "body": "staticField = 1"}},
+        }
+        result = mcp_server._precompute_file_triples(
+            "models.py", extracted, ":commit/abc123", {}, segment_index=None,
+        )
+        assert len(result["field_entries"]) == 1
+        ident, name, triples = result["field_entries"][0]
+        expected_ident = mcp_server._code_ident("field", "models.py", "Foo.staticField")
+        assert ident == expected_ident
+        assert f"[{ident} :entity-type :type/field]" in triples
+        assert f"[{ident} :static true]" in triples
+        class_ident = mcp_server._code_ident("class", "models.py", "Foo")
+        assert f"[{ident} :class {class_ident}]" in triples
+
+
+class TestBuildCodeTriplesGlobalsAndFields:
+    def test_new_global_writes_full_triples(self):
+        import mcp_server
+        extracted = {"functions": [], "classes": [], "imports": [], "calls": [],
+                     "function_bodies": {}, "class_bodies": {},
+                     "globals": ["GLOBAL_X"], "global_bodies": {"GLOBAL_X": "GLOBAL_X = 5"},
+                     "fields": [], "field_info": {}}
+        precomputed = mcp_server._precompute_file_triples("config.py", extracted, ":commit/c1", {})
+        entity_valid_from, entity_descriptions, file_entities = {}, {}, {}
+        triples = mcp_server._build_code_triples(
+            "config.py", extracted, "2024-01-01T00:00:00Z", entity_valid_from,
+            entity_descriptions, file_entities, ":commit/c1", precomputed,
+        )
+        ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
+        assert any(f"{ident} :entity-type :type/variable" in t for t in triples)
+        assert ident in entity_valid_from
+
+    def test_preexisting_global_only_gets_modified_in(self):
+        import mcp_server
+        extracted = {"functions": [], "classes": [], "imports": [], "calls": [],
+                     "function_bodies": {}, "class_bodies": {},
+                     "globals": ["GLOBAL_X"], "global_bodies": {"GLOBAL_X": "GLOBAL_X = 6"},
+                     "fields": [], "field_info": {}}
+        precomputed = mcp_server._precompute_file_triples("config.py", extracted, ":commit/c2", {})
+        ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
+        module_ident = mcp_server._code_ident("module", "config.py")
+        # Module must already be known too, otherwise _build_code_triples treats
+        # it as newly introduced and emits module_candidate_triples alongside
+        # the global's :modified-in line, breaking the strict equality below.
+        entity_valid_from = {
+            module_ident: "2024-01-01T00:00:00Z",
+            ident: "2024-01-01T00:00:00Z",
+        }
+        entity_descriptions = {module_ident: "config.py", ident: "GLOBAL_X"}
+        file_entities = {"config.py": [module_ident, ident]}
+        triples = mcp_server._build_code_triples(
+            "config.py", extracted, "2024-01-02T00:00:00Z", entity_valid_from,
+            entity_descriptions, file_entities, ":commit/c2", precomputed,
+        )
+        # Both the already-known module and the already-known global only get
+        # a :modified-in edge — none of the candidate (:entity-type, :ident, …)
+        # triples are re-asserted.
+        assert triples == [
+            f"[{module_ident} :modified-in :commit/c2]",
+            f"[{ident} :modified-in :commit/c2]",
+        ]
+
+
 class TestPreloadKnownDeps:
     def test_reloads_open_depends_on_edge(self, mock_minigraf_db, tmp_path):
         mock_class, db_instance = mock_minigraf_db

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2065,6 +2065,23 @@ class TestRustGoCGlobalsAndFields:
         info = {n: (c, s) for n, c, s in result["fields"]}
         assert info["ASSOC_CONST"] == ("Foo", True)
 
+    def test_rust_generic_impl_const_owning_class_strips_type_params(self):
+        # For `impl<T> Foo<T> { ... }`, the impl_item's `type` field is a
+        # generic_type node whose text is "Foo<T>", not a bare
+        # type_identifier -- verified against the real installed
+        # tree-sitter-rust grammar. The owning_class recorded for an
+        # associated const must be the clean base name "Foo" (matching
+        # what struct_item's `name` field produces for the same struct
+        # elsewhere), not "Foo<T>", or the field's :class edge orphans
+        # itself from the struct's actual registered class ident.
+        import mcp_server
+        source = b"struct Foo<T> {\n    val: T,\n}\nimpl<T> Foo<T> {\n    const CAP: usize = 16;\n}\n"
+        tree = self._rust_parser().parse(source)
+        result = mcp_server._extract_rust_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["CAP"] == ("Foo", True)
+        assert result["field_info"]["CAP"]["class"] == "Foo"
+
     def test_rust_pub_visibility_does_not_break_extraction(self):
         # `pub` is a visibility_modifier CHILD of static_item/struct_item/
         # field_declaration/const_item (verified against the real installed

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2206,6 +2206,14 @@ class TestGitHelpers:
         content = mcp_server._git_file_content(str(git_repo), first_hash, "auth.py")
         assert b"def login" in content
 
+    def test_git_blob_content_returns_raw_bytes(self, git_repo):
+        import mcp_server
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        entries = mcp_server._git_diff_tree_raw(str(git_repo), commits[0][0])
+        _, _, _, _, new_sha, _ = entries[0][:6]
+        content = mcp_server._git_blob_content(str(git_repo), new_sha)
+        assert b"def login" in content
+
 
 class TestGitDiffTreeRaw:
     def test_regular_file_add(self, git_repo):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1839,6 +1839,7 @@ class TestExtractFromSource:
         assert result == {
             "functions": [], "classes": [], "imports": [], "calls": [],
             "function_bodies": {}, "class_bodies": {},
+            "globals": [], "global_bodies": {}, "fields": [], "field_info": {},
         }
 
     def test_extracts_function_bodies(self):
@@ -1854,6 +1855,35 @@ class TestExtractFromSource:
         result = mcp_server._extract_from_source(source, self._python_parser(), "models.py")
         assert "User" in result["class_bodies"]
         assert "def ok" in result["class_bodies"]["User"]
+
+
+class TestExtractGlobalsAndFields:
+    def _python_parser(self):
+        import tree_sitter_python
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_python.language()))
+
+    def test_unsupported_language_returns_empty(self):
+        import mcp_server
+        result = mcp_server._extract_globals_and_fields(None, "nonexistent_lang")
+        assert result == {"globals": [], "global_bodies": {}, "fields": [], "field_info": {}}
+
+    def test_dispatches_to_registered_language_extractor(self):
+        import mcp_server
+        sentinel = {"globals": ["X"], "global_bodies": {"X": "X = 1"}, "fields": [], "field_info": {}}
+        mcp_server._GLOBAL_FIELD_EXTRACTORS["_test_lang"] = lambda root: sentinel
+        try:
+            result = mcp_server._extract_globals_and_fields("fake_root", "_test_lang")
+            assert result == sentinel
+        finally:
+            del mcp_server._GLOBAL_FIELD_EXTRACTORS["_test_lang"]
+
+    def test_extract_from_source_merges_globals_and_fields(self):
+        import mcp_server
+        source = b"def foo(): pass"
+        result = mcp_server._extract_from_source(source, self._python_parser(), "x.py")
+        assert result["globals"] == []
+        assert result["fields"] == []
 
 
 class TestMatchCandidatePair:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2383,6 +2383,81 @@ class TestCppGlobalsAndFields:
         assert "method" not in names
 
 
+class TestRubyGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_ruby
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_ruby.language()))
+
+    def test_global_variable_and_constant_are_globals(self):
+        import mcp_server
+        source = b"$global_var = 5\nCONST_VAR = 10\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_ruby_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"$global_var", "CONST_VAR"}
+
+    def test_class_variable_is_static_instance_variable_in_initialize_is_not(self):
+        import mcp_server
+        source = b"class Foo\n  @@class_var = 1\n  def initialize\n    @instance_var = 2\n  end\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_ruby_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["@@class_var"] == ("Foo", True)
+        assert info["@instance_var"] == ("Foo", False)
+
+    def test_multi_assignment_globals_captures_all_names(self):
+        # `$a, $b = 1, 2` wraps the left side in a left_assignment_list
+        # node instead of exposing a bare global_variable/constant
+        # directly under field:left -- verified empirically against the
+        # real installed tree-sitter-ruby grammar. Same lesson as the
+        # multi-declarator gaps found in Go/C/Java/C++: must unwrap
+        # left_assignment_list to avoid silently dropping every name but
+        # the first.
+        import mcp_server
+        source = b"$a, $b = 1, 2\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_ruby_globals_and_fields(tree.root_node)
+        assert set(result["globals"]) == {"$a", "$b"}
+
+    def test_multi_assignment_class_and_instance_variables_captures_all_names(self):
+        import mcp_server
+        source = b"class Foo\n  @@a, @@b = 1, 2\n  def initialize\n    @x, @y = 1, 2\n  end\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_ruby_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["@@a"] == ("Foo", True)
+        assert info["@@b"] == ("Foo", True)
+        assert info["@x"] == ("Foo", False)
+        assert info["@y"] == ("Foo", False)
+
+    def test_attr_accessor_call_not_captured_as_field(self):
+        # attr_accessor/attr_reader/attr_writer are ordinary method calls
+        # (node type `call`) in the grammar, not assignments -- verified
+        # empirically. Out of scope for this task (which only looks at
+        # `@x = ...` inside initialize); they must not be misclassified
+        # as fields.
+        import mcp_server
+        source = b"class Foo\n  attr_accessor :bar\n  def initialize\n    @baz = 1\n  end\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_ruby_globals_and_fields(tree.root_node)
+        names = [n for n, _, _ in result["fields"]]
+        assert "bar" not in names
+        assert names == ["@baz"]
+
+    def test_module_is_not_treated_as_class(self):
+        # `module Foo ... end` parses as a `module` node, distinct from
+        # `class` -- verified empirically. The brief scopes this
+        # extractor to `class` specifically, so module bodies (which can
+        # also hold constants/class variables) must not be walked into
+        # for field extraction.
+        import mcp_server
+        source = b"module Baz\n  @@mod_var = 1\n  CONST_IN_MOD = 5\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_ruby_globals_and_fields(tree.root_node)
+        assert result["fields"] == []
+        assert result["globals"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6991,14 +6991,18 @@ class TestRunIngestionBitemporalClose:
 
         assert any(old_module_ident in t for t in close_triples_seen), \
             "Old module entities must still be closed when file is renamed"
-        assert any(f"{old_module_ident} :renamed-to {new_module_ident}" in t for t in close_triples_seen), \
-            "Old module's close triples must include :renamed-to pointing at the new ident"
+        # :renamed-to is an open-ended fact (Fix 1): it must be transacted, NOT
+        # folded into the old module's closed valid window via _ingest_close.
+        assert not any(":renamed-to" in t for t in close_triples_seen), \
+            "Old module's close triples must NOT carry :renamed-to (it is open-ended)"
 
         transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
         assert new_fn_ident in transact_calls, \
             "New module's entities must still be created after file is renamed"
         assert f"{new_module_ident} :renamed-from {old_module_ident}" in transact_calls, \
             "New module's open triples must include :renamed-from pointing at the old ident"
+        assert f"{old_module_ident} :renamed-to {new_module_ident}" in transact_calls, \
+            "Old module's :renamed-to must be transacted open-ended, not closed"
 
     @pytest.mark.asyncio
     async def test_in_file_function_rename_links_via_rename_edges(
@@ -7033,9 +7037,18 @@ class TestRunIngestionBitemporalClose:
         old_fn_ident = mcp_server._code_ident("function", "auth.py", "oldName")
         new_fn_ident = mcp_server._code_ident("function", "auth.py", "newName")
 
-        assert any(f"{old_fn_ident} :renamed-to {new_fn_ident}" in t for t in close_triples_seen)
+        # Fix 1: :renamed-to is transacted open-ended, not folded into a close.
+        assert not any(":renamed-to" in t for t in close_triples_seen)
         transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
         assert f"{new_fn_ident} :renamed-from {old_fn_ident}" in transact_calls
+        assert f"{old_fn_ident} :renamed-to {new_fn_ident}" in transact_calls
+        # Fix 4: the old ident must be closed exactly ONCE (rename loop only), not
+        # also as a plain removal — count distinct close batches carrying its :ident.
+        old_ident_close_count = sum(
+            1 for t in close_triples_seen if f"{old_fn_ident} :ident" in t
+        )
+        assert old_ident_close_count == 1, \
+            f"same-file rename should close old ident once, got {old_ident_close_count}"
 
     @pytest.mark.asyncio
     async def test_global_rename_links_via_rename_edges_end_to_end(
@@ -7076,9 +7089,17 @@ class TestRunIngestionBitemporalClose:
         old_ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_X")
         new_ident = mcp_server._code_ident("variable", "config.py", "GLOBAL_Y")
 
-        assert any(f"{old_ident} :renamed-to {new_ident}" in t for t in close_triples_seen)
+        # Fix 1: :renamed-to open-ended via transact, not in the close window.
+        assert not any(":renamed-to" in t for t in close_triples_seen)
         transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
         assert f"{new_ident} :renamed-from {old_ident}" in transact_calls
+        assert f"{old_ident} :renamed-to {new_ident}" in transact_calls
+        # Fix 4: the renamed old global is closed once (rename loop), not twice.
+        old_ident_close_count = sum(
+            1 for t in close_triples_seen if f"{old_ident} :ident" in t
+        )
+        assert old_ident_close_count == 1, \
+            f"same-file global rename should close old ident once, got {old_ident_close_count}"
 
     @pytest.mark.asyncio
     async def test_rename_to_unsupported_ext_closes_old_entities(
@@ -7179,6 +7200,248 @@ class TestRunIngestionBitemporalClose:
         # The new .py path is still ingested normally.
         assert new_fn_ident in transact_calls, \
             "The new .py file's entities must still be created as a plain add"
+
+    @pytest.mark.asyncio
+    async def test_renamed_to_is_open_ended_against_real_graph(self, tmp_path):
+        """Fix 1, verified end-to-end against the REAL minigraf backend (no
+        MiniGrafDb mock, no _ingest_close monkeypatch) — this is the un-mocked
+        query test the review required to close the blind spot that let the
+        :renamed-to valid-window bug ship.
+
+        The essence of Fix 1 is the *valid-time window* of the emitted Datalog:
+        :renamed-to is a brand-new fact that becomes true at the rename commit
+        and must stay true forever after, so it must be transacted OPEN-ENDED
+        (`{:valid-from <rename-commit>}`, no :valid-to), NOT folded into the old
+        entity's closed window via _ingest_close (`retract` + re-transact with
+        `:valid-to`). We assert exactly that by capturing the real Datalog
+        commands executed against the live DB (a pass-through spy that still
+        forwards every call to the real backend and lets ingestion persist),
+        then also query the real graph to confirm both rename directions
+        resolve.
+
+        NOTE on the "as-of before the rename" check the review also asked for:
+        the installed minigraf 1.2.1 does not honour the `:valid-from` /
+        `:valid-to` options passed to `transact` on this code path — every fact
+        is stamped with wall-clock now and `:valid-at "<iso>"` reads cannot
+        observe a historical window (empirically verified). A point-in-time
+        "renamed-to not visible before the rename" query is therefore not
+        expressible against this build, which is *why* the whole suite mocks
+        the DB. We instead assert the equivalent invariant on the real backend:
+        the :renamed-to fact's `:valid-from` equals the RENAME commit's
+        timestamp (so it is introduced at the rename, not before) and it is
+        never emitted with a `:valid-to`.
+        """
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_auth.py").write_text("def login(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "old_auth.py", "new_auth.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename auth"], cwd=repo, check=True, capture_output=True)
+
+        rename_commit_ts = mcp_server._git_commits(str(repo), None)[1][1]
+
+        # Real backend: real MiniGrafDb, real execute, real persistence.
+        mcp_server._db = None
+        mcp_server._graph_path = None
+        mcp_server._ingest_progress = self._make_progress()
+        mcp_server.open_db(str(repo / "memory.graph"))
+
+        real_execute = mcp_server._db_execute
+        executed_cmds = []
+
+        def spy(db, datalog):
+            executed_cmds.append(datalog)
+            return real_execute(db, datalog)
+
+        mcp_server._db_execute = spy
+        try:
+            await mcp_server._run_ingestion(str(repo), "HEAD")
+        finally:
+            mcp_server._db_execute = real_execute
+
+        old_module = mcp_server._code_ident("module", "old_auth.py")
+        new_module = mcp_server._code_ident("module", "new_auth.py")
+        renamed_to_triple = f"{old_module} :renamed-to {new_module}"
+
+        cmds_with_renamed_to = [c for c in executed_cmds if renamed_to_triple in c]
+        assert cmds_with_renamed_to, ":renamed-to must be emitted against the real DB"
+        # It must NEVER be closed: no retract of it, and no transact carrying it
+        # may set a :valid-to (that would make it a bounded historical fact).
+        for c in cmds_with_renamed_to:
+            assert not c.strip().startswith("(retract"), \
+                ":renamed-to must not be retracted (it is open-ended, not closed)"
+            assert ":valid-to" not in c, \
+                ":renamed-to must be transacted open-ended, never with a :valid-to"
+        # At least one open-ended transact introduces it at the RENAME commit.
+        open_transacts = [
+            c for c in cmds_with_renamed_to
+            if c.strip().startswith("(transact") and f':valid-from "{rename_commit_ts}"' in c
+        ]
+        assert open_transacts, \
+            ":renamed-to must be transacted open-ended with :valid-from = rename commit ts"
+
+        # By contrast, the old module's own identity IS still closed (retract).
+        assert any(
+            c.strip().startswith("(retract") and f"{old_module} :ident" in c
+            for c in executed_cmds
+        ), "Old module's :ident must still be closed (retracted) on rename"
+
+        # Query the real graph: both rename directions resolve after ingestion.
+        db = mcp_server.get_db()
+        rt = json.loads(real_execute(db, f"(query [:find ?x :where [{old_module} :renamed-to ?x]])")).get("results", [])
+        rf = json.loads(real_execute(db, f"(query [:find ?x :where [{new_module} :renamed-from ?x]])")).get("results", [])
+        assert rt == [[new_module]], f"forward :renamed-to must resolve to new module, got {rt}"
+        assert rf == [[old_module]], f"reverse :renamed-from must resolve to old module, got {rf}"
+
+        mcp_server._db = None  # release the real file lock for subsequent tests
+
+    @pytest.mark.asyncio
+    async def test_unchanged_global_and_field_survive_unrelated_edit(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """Fix 2: an unchanged module global and class field must NOT be closed
+        when a later commit only edits an unrelated function body. Pre-fix,
+        current_extracted_idents omitted globals/fields, so every still-present
+        global/field looked 'removed' on any M commit and was wrongly closed."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "x.py").write_text(
+            "GLOBAL_CONF = 1234567890123\n\nclass C:\n    field_a = 1\n\ndef f():\n    return 1\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        # Second commit changes only f()'s body — global and field are untouched.
+        (repo / "x.py").write_text(
+            "GLOBAL_CONF = 1234567890123\n\nclass C:\n    field_a = 1\n\ndef f():\n    return 2\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "edit f body"], cwd=repo, check=True, capture_output=True)
+
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        gvar_ident = mcp_server._code_ident("variable", "x.py", "GLOBAL_CONF")
+        field_ident = mcp_server._code_ident("field", "x.py", "C.field_a")
+        assert not any(gvar_ident in t for t in close_triples_seen), \
+            "Unchanged global must NOT be closed on an unrelated function edit"
+        assert not any(field_ident in t for t in close_triples_seen), \
+            "Unchanged field must NOT be closed on an unrelated function edit"
+
+    @pytest.mark.asyncio
+    async def test_file_rename_closes_unmatched_child_and_dependency(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """Fix 3: when a file is renamed, child entities the matcher could not
+        confirm a continuity edge for (e.g. short/ambiguous bodies) and the old
+        path's :depends-on edges must still be closed as plain removals under
+        the OLD path. Pre-fix only the old module was closed, leaking unmatched
+        children and dependency edges open forever alongside the new file's."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "dep.py").write_text("def helper():\n    return 1\n")
+        # go() has a body below _MIN_MATCH_BODY_LEN, so the matcher leaves it
+        # unmatched — the case Fix 3 must still close under the old path.
+        (repo / "main.py").write_text("import dep\n\ndef go():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "main.py", "app.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename main to app"], cwd=repo, check=True, capture_output=True)
+
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        old_go = mcp_server._code_ident("function", "main.py", "go")
+        old_module = mcp_server._code_ident("module", "main.py")
+        dep_module = mcp_server._code_ident("module", "dep.py")
+
+        # Unmatched old child closed as a PLAIN removal (no :renamed-to linkage).
+        assert any(f"{old_go} :ident" in t for t in close_triples_seen), \
+            "Unmatched old child function must be closed under the old path"
+        assert not any("renamed-to" in t and old_go in t for t in close_triples_seen), \
+            "Unmatched child has no continuity edge — must not get a :renamed-to"
+        # Old path's surviving dependency edge is closed too.
+        assert any(
+            f"{old_module} :depends-on {dep_module}" in t for t in close_triples_seen
+        ), "Old path's :depends-on edge must be closed on file rename"
+        # The new file is still ingested.
+        transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
+        assert mcp_server._code_ident("module", "app.py") + " :entity-type" in transact_calls, \
+            "New renamed file's module must still be created"
+
+    @pytest.mark.asyncio
+    async def test_same_file_rename_closes_old_ident_exactly_once(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        """Fix 4: an in-place rename must close the old ident exactly once (via
+        the renamed_pairs loop, with :renamed-to linkage) — not also a second
+        time as a plain removal from the M-status removal detector."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def oldName(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def newName(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename fn"], cwd=repo, check=True, capture_output=True)
+
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        old_fn = mcp_server._code_ident("function", "auth.py", "oldName")
+        close_count = sum(1 for t in close_triples_seen if f"{old_fn} :ident" in t)
+        assert close_count == 1, \
+            f"same-file rename must close old ident exactly once, got {close_count}"
+        new_fn = mcp_server._code_ident("function", "auth.py", "newName")
+        assert any(f"{old_fn} :renamed-to {new_fn}" in t for t in
+                   [c for call in db_instance.execute.call_args_list for c in [str(call)]]), \
+            "the single close path must be the rename path (with :renamed-to linkage)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1836,7 +1836,24 @@ class TestExtractFromSource:
         import mcp_server
         # Passing None as parser triggers AttributeError → except block returns empty dict
         result = mcp_server._extract_from_source(b"def foo(): pass", None, "x.py")
-        assert result == {"functions": [], "classes": [], "imports": [], "calls": []}
+        assert result == {
+            "functions": [], "classes": [], "imports": [], "calls": [],
+            "function_bodies": {}, "class_bodies": {},
+        }
+
+    def test_extracts_function_bodies(self):
+        import mcp_server
+        source = b"def login(user):\n    return user.ok\n"
+        result = mcp_server._extract_from_source(source, self._python_parser(), "auth.py")
+        assert "login" in result["function_bodies"]
+        assert "return user.ok" in result["function_bodies"]["login"]
+
+    def test_extracts_class_bodies(self):
+        import mcp_server
+        source = b"class User:\n    def ok(self):\n        return True\n"
+        result = mcp_server._extract_from_source(source, self._python_parser(), "models.py")
+        assert "User" in result["class_bodies"]
+        assert "def ok" in result["class_bodies"]["User"]
 
 
 class TestExtractFromSourceCFamily:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -775,6 +775,56 @@ class TestMemoryPrepareTurn:
         # Should contain a UTC timestamp like 2026-05-02T15:44:52.184Z
         assert any(re.search(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z', c) for c in calls)
 
+    def test_contains_filter_actually_matches_against_real_graph(self, tmp_path):
+        """Real (non-mocked) backend regression test for the bare `(contains? ...)`
+        clause bug: without the enclosing brackets, `[(contains? ?v "...")]`
+        parses as a rule-invocation of a non-existent rule and silently
+        contributes zero bindings — the targeted query returns empty with no
+        error, indistinguishable at the Python level from "no match found".
+        A mock never catches this because it never parses the Datalog string.
+
+        Asserting only on the heuristic's overall return value is not enough:
+        when the targeted contains? query comes back empty, the function
+        falls back to an UNFILTERED broad scan (mcp_server.py ~4357-4367)
+        that would still surface this fact regardless of whether the
+        targeted filter itself works — that fallback path masked this exact
+        bug from an end-to-end assertion during manual verification. So this
+        spies on _db_execute to confirm the TARGETED contains? query itself
+        returns the matching row, isolating the code path the bug lives in.
+        """
+        import mcp_server
+        mcp_server.open_db(str(tmp_path / "real.graph"))
+        db = mcp_server.get_db()
+        mcp_server._db_execute(
+            db,
+            '(transact {:valid-from "2024-01-01T00:00:00Z"} '
+            '[[:decision/db :entity-type :type/decision] '
+            '[:decision/db :ident ":decision/db"] '
+            '[:decision/db :description "we use postgresql for storage"]])',
+        )
+
+        real_execute = mcp_server._db_execute
+        contains_results = []
+
+        def spy(db_arg, datalog):
+            raw = real_execute(db_arg, datalog)
+            if "contains?" in datalog and "postgresql" in datalog:
+                contains_results.append(json.loads(raw).get("results", []))
+            return raw
+
+        mcp_server._db_execute = spy
+        try:
+            mcp_server._handle_memory_prepare_turn_heuristic(
+                "what database are we using, postgresql or mysql?"
+            )
+        finally:
+            mcp_server._db_execute = real_execute
+
+        assert contains_results, "the targeted contains? query must have been issued"
+        assert any(
+            any("postgresql" in str(v) for v in row) for rows in contains_results for row in rows
+        ), "the bracketed contains? filter must itself find the matching row, not just the broad-scan fallback"
+
 
 class TestHeuristicExtraction:
     def test_extracts_decision_language(self):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3077,6 +3077,83 @@ class TestHaskellGlobalsAndFields:
         assert result["fields"] == []
 
 
+class TestLuaGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_lua
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_lua.language()))
+
+    def test_true_global_assignment(self):
+        import mcp_server
+        tree = self._parser().parse(b"globalX = 5\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_local_declaration_not_captured(self):
+        import mcp_server
+        tree = self._parser().parse(b"local localY = 10\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+    def test_table_field_assignment_not_captured(self):
+        import mcp_server
+        tree = self._parser().parse(b"Foo = {}\nFoo.staticField = 1\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert result["globals"] == ["Foo"]
+        assert result["fields"] == []
+
+    def test_multiple_assignment_captures_all_names(self):
+        # `a, b = 1, 2` puts multiple identifier children under
+        # variable_list, each exposed via field:name -- verified
+        # empirically. child_by_field_name (singular) would silently
+        # return only the first ("a"), matching the multi-assignment gap
+        # that showed up in every other language in this plan (Ruby,
+        # Kotlin, Swift, Scala) -- children_by_field_name (plural) is
+        # required to capture all of them.
+        import mcp_server
+        tree = self._parser().parse(b"a, b = 1, 2\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert "a" in result["globals"]
+        assert "b" in result["globals"]
+
+    def test_mixed_identifier_and_table_field_in_multi_assignment(self):
+        # `a, Foo.x = 1, 2` mixes a plain identifier with a
+        # dot_index_expression in the same variable_list -- verified
+        # empirically. Only the plain identifier is a true global; the
+        # table-field write must still be excluded.
+        import mcp_server
+        tree = self._parser().parse(b"a, Foo.x = 1, 2\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert result["globals"] == ["a"]
+
+    def test_local_function_not_captured_as_global(self):
+        # `local function foo() ... end` parses as a function_declaration
+        # node (with a "local" child), never an assignment_statement --
+        # verified empirically -- so it cannot be misidentified as a
+        # global variable assignment. Functions are handled separately
+        # by _LANG_NODE_TYPES["lua"]["functions"].
+        import mcp_server
+        tree = self._parser().parse(b"local function foo() end\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+    def test_top_level_function_not_captured_as_global(self):
+        # `function foo() ... end` (no `local`) is also a
+        # function_declaration node, not an assignment_statement --
+        # verified empirically -- so it must not be captured here either.
+        import mcp_server
+        tree = self._parser().parse(b"function foo() end\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+    def test_no_globals_or_fields_when_absent(self):
+        import mcp_server
+        tree = self._parser().parse(b"function foo() end\n")
+        result = mcp_server._extract_lua_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+        assert result["fields"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2288,6 +2288,101 @@ class TestJavaCSharpGlobalsAndFields:
         assert result["globals"] == []
 
 
+class TestCppGlobalsAndFields:
+    def _cpp_parser(self):
+        import tree_sitter_cpp
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_cpp.language()))
+
+    def test_top_level_declaration_is_global(self):
+        import mcp_server
+        tree = self._cpp_parser().parse(b"int global_x = 5;\n")
+        result = mcp_server._extract_cpp_globals_and_fields(tree.root_node)
+        assert "global_x" in result["globals"]
+
+    def test_static_and_instance_class_fields(self):
+        import mcp_server
+        source = b"class Foo {\npublic:\n    static int staticField;\n    int instanceField;\n};\n"
+        tree = self._cpp_parser().parse(source)
+        result = mcp_server._extract_cpp_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_struct_fields_same_shape_as_class(self):
+        # struct_specifier and class_specifier expose field:body /
+        # field_declaration_list identically -- verified empirically
+        # against the real installed tree-sitter-cpp grammar. Structs
+        # default to public visibility but the AST shape for extracting
+        # fields is the same either way.
+        import mcp_server
+        source = b"struct Bar {\n    int a;\n    static float f;\n};\n"
+        tree = self._cpp_parser().parse(source)
+        result = mcp_server._extract_cpp_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["a"] == ("Bar", False)
+        assert info["f"] == ("Bar", True)
+
+    def test_multiple_access_specifier_sections_do_not_affect_extraction(self):
+        # A class with several public:/private:/public: sections in
+        # sequence -- access_specifier nodes are just siblings in the
+        # field_declaration_list body and must not disrupt iteration over
+        # the field_declaration members that follow them.
+        import mcp_server
+        source = (
+            b"class Foo {\n"
+            b"public:\n"
+            b"    int pub1;\n"
+            b"private:\n"
+            b"    static int priv1;\n"
+            b"public:\n"
+            b"    int pub2;\n"
+            b"};\n"
+        )
+        tree = self._cpp_parser().parse(source)
+        result = mcp_server._extract_cpp_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["pub1"] == ("Foo", False)
+        assert info["priv1"] == ("Foo", True)
+        assert info["pub2"] == ("Foo", False)
+
+    def test_multi_declarator_global_captures_all_names(self):
+        # `int a, b;` at file scope puts more than one node under the
+        # `declarator` field of a single declaration -- child_by_field_name
+        # (singular) only returns the first, silently dropping `b`.
+        # Verified empirically against the real installed tree-sitter-cpp
+        # grammar (same lesson as C/Java's multi-declarator statement);
+        # children_by_field_name (plural) must be used instead.
+        import mcp_server
+        source = b"int a, b;\n"
+        tree = self._cpp_parser().parse(source)
+        result = mcp_server._extract_cpp_globals_and_fields(tree.root_node)
+        assert "a" in result["globals"]
+        assert "b" in result["globals"]
+
+    def test_multi_declarator_field_captures_all_names(self):
+        # Same multi-declarator gap as globals, but for class/struct
+        # fields: `int x, y;` inside a field_declaration_list.
+        import mcp_server
+        source = b"class Foo {\npublic:\n    int x, y;\n};\n"
+        tree = self._cpp_parser().parse(source)
+        result = mcp_server._extract_cpp_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["x"] == ("Foo", False)
+        assert info["y"] == ("Foo", False)
+
+    def test_method_declaration_not_captured_as_field(self):
+        # A method's declarator is a function_declarator wrapping a
+        # field_identifier, not a bare field_identifier -- must not be
+        # misclassified as a field.
+        import mcp_server
+        source = b"class Foo {\npublic:\n    void method();\n};\n"
+        tree = self._cpp_parser().parse(source)
+        result = mcp_server._extract_cpp_globals_and_fields(tree.root_node)
+        names = [n for n, _, _ in result["fields"]]
+        assert "method" not in names
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5424,6 +5424,152 @@ class TestPrecomputeGlobalsAndFields:
         assert f"[{ident} :class {class_ident}]" in triples
 
 
+class TestFieldClassContainment:
+    """Fields owned by a real (extracted) class get BOTH module- and
+    class-containment plus a :class edge; fields whose reported owner is not a
+    real extracted class fall back to module-only containment with no dangling
+    :class or class-contains edge (issues.md P2 findings)."""
+
+    def _parser(self, module_name, lang_key):
+        import mcp_server
+        import tree_sitter
+        import importlib
+        grammar_mod = importlib.import_module(module_name)
+        mcp_server._grammar_cache.clear()
+        real_lang = tree_sitter.Language(grammar_mod.language())
+        real_parser = tree_sitter.Parser(real_lang)
+        mcp_server._grammar_cache[lang_key] = real_parser
+        return real_parser
+
+    def test_real_class_field_gets_both_contains_and_class_edge(self):
+        import mcp_server
+        extracted = {
+            "functions": [], "classes": ["Foo"], "imports": [], "calls": [],
+            "globals": [], "fields": [("bar", "Foo", True)],
+        }
+        result = mcp_server._precompute_file_triples(
+            "models.py", extracted, ":commit/c1", {}, segment_index=None,
+        )
+        field_ident = mcp_server._code_ident("field", "models.py", "Foo.bar")
+        module_ident = mcp_server._code_ident("module", "models.py")
+        class_ident = mcp_server._code_ident("class", "models.py", "Foo")
+        _, _, triples = result["field_entries"][0]
+        assert f"[{module_ident} :contains {field_ident}]" in triples
+        assert f"[{class_ident} :contains {field_ident}]" in triples
+        assert f"[{field_ident} :class {class_ident}]" in triples
+        assert result["field_class_map"] == {field_ident: class_ident}
+
+    def test_field_with_no_extracted_owner_class_is_module_only(self):
+        import mcp_server
+        # owner "Ghost" is NOT in classes -> no :class, no class-contains edge.
+        extracted = {
+            "functions": [], "classes": [], "imports": [], "calls": [],
+            "globals": [], "fields": [("attr", "Ghost", True)],
+        }
+        result = mcp_server._precompute_file_triples(
+            "x.py", extracted, ":commit/c1", {}, segment_index=None,
+        )
+        field_ident = mcp_server._code_ident("field", "x.py", "Ghost.attr")
+        module_ident = mcp_server._code_ident("module", "x.py")
+        class_ident = mcp_server._code_ident("class", "x.py", "Ghost")
+        _, _, triples = result["field_entries"][0]
+        assert f"[{module_ident} :contains {field_ident}]" in triples
+        assert all(":class " not in t for t in triples)
+        assert f"[{class_ident} :contains {field_ident}]" not in triples
+        assert result["field_class_map"] == {}
+
+    def test_elixir_module_attribute_falls_back_to_module_only(self):
+        import mcp_server
+        parser = self._parser("tree_sitter_elixir", "elixir")
+        extracted = mcp_server._extract_from_source(
+            b"defmodule Foo do\n  @attr 1\nend\n", parser, "foo.ex",
+        )
+        # Confirm the reproduction from issues.md: field extracted, no class.
+        assert extracted["fields"] == [("attr", "Foo", True)]
+        assert extracted["classes"] == []
+        result = mcp_server._precompute_file_triples(
+            "foo.ex", extracted, ":commit/c1", {}, segment_index=None,
+        )
+        field_ident = mcp_server._code_ident("field", "foo.ex", "Foo.attr")
+        module_ident = mcp_server._code_ident("module", "foo.ex")
+        class_ident = mcp_server._code_ident("class", "foo.ex", "Foo")
+        _, _, triples = result["field_entries"][0]
+        assert f"[{module_ident} :contains {field_ident}]" in triples
+        assert all(":class " not in t for t in triples)
+        assert f"[{class_ident} :contains {field_ident}]" not in triples
+        assert result["field_class_map"] == {}
+
+    def test_haskell_newtype_field_falls_back_to_module_only(self):
+        import mcp_server
+        parser = self._parser("tree_sitter_haskell", "haskell")
+        extracted = mcp_server._extract_from_source(
+            b"newtype Foo = Foo { unFoo :: Int }\n", parser, "foo.hs",
+        )
+        assert extracted["fields"] == [("unFoo", "Foo", False)]
+        assert extracted["classes"] == []
+        result = mcp_server._precompute_file_triples(
+            "foo.hs", extracted, ":commit/c1", {}, segment_index=None,
+        )
+        field_ident = mcp_server._code_ident("field", "foo.hs", "Foo.unFoo")
+        module_ident = mcp_server._code_ident("module", "foo.hs")
+        class_ident = mcp_server._code_ident("class", "foo.hs", "Foo")
+        _, _, triples = result["field_entries"][0]
+        assert f"[{module_ident} :contains {field_ident}]" in triples
+        assert all(":class " not in t for t in triples)
+        assert f"[{class_ident} :contains {field_ident}]" not in triples
+        assert result["field_class_map"] == {}
+
+    def test_build_code_triples_populates_field_class_ident(self):
+        import mcp_server
+        extracted = {
+            "functions": [], "classes": ["Foo"], "imports": [], "calls": [],
+            "globals": [], "fields": [("bar", "Foo", True)],
+        }
+        precomputed = mcp_server._precompute_file_triples("models.py", extracted, ":commit/c1", {})
+        field_class_ident = {}
+        mcp_server._build_code_triples(
+            "models.py", extracted, "2024-01-01T00:00:00Z", {}, {}, {}, ":commit/c1",
+            precomputed, field_class_ident,
+        )
+        field_ident = mcp_server._code_ident("field", "models.py", "Foo.bar")
+        class_ident = mcp_server._code_ident("class", "models.py", "Foo")
+        assert field_class_ident == {field_ident: class_ident}
+
+    def test_build_code_triples_omits_field_class_ident_for_dangling_owner(self):
+        import mcp_server
+        extracted = {
+            "functions": [], "classes": [], "imports": [], "calls": [],
+            "globals": [], "fields": [("attr", "Ghost", True)],
+        }
+        precomputed = mcp_server._precompute_file_triples("x.py", extracted, ":commit/c1", {})
+        field_class_ident = {}
+        mcp_server._build_code_triples(
+            "x.py", extracted, "2024-01-01T00:00:00Z", {}, {}, {}, ":commit/c1",
+            precomputed, field_class_ident,
+        )
+        assert field_class_ident == {}
+
+    def test_close_triples_retracts_extra_class_contains_edge(self):
+        import mcp_server
+        field_ident = mcp_server._code_ident("field", "models.py", "Foo.bar")
+        module_ident = mcp_server._code_ident("module", "models.py")
+        class_ident = mcp_server._code_ident("class", "models.py", "Foo")
+        triples = mcp_server._build_close_triples(
+            field_ident, "Foo.bar", module_ident, class_ident,
+        )
+        assert f"[{module_ident} :contains {field_ident}]" in triples
+        assert f"[{class_ident} :contains {field_ident}]" in triples
+
+    def test_close_triples_ignores_none_extra_parent(self):
+        import mcp_server
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        module_ident = mcp_server._code_ident("module", "auth.py")
+        triples = mcp_server._build_close_triples(fn_ident, "login", module_ident, None)
+        # Only the module-contains edge, no phantom extra :contains.
+        contains = [t for t in triples if ":contains" in t]
+        assert contains == [f"[{module_ident} :contains {fn_ident}]"]
+
+
 class TestBuildCodeTriplesGlobalsAndFields:
     def test_new_global_writes_full_triples(self):
         import mcp_server
@@ -8547,3 +8693,82 @@ def test_schema_has_variable_and_field_types():
     field_optional = mcp_server.MINIGRAF_SCHEMA["field"]["optional"]
     assert field_optional[":static"] is bool
     assert field_optional[":class"] is str
+
+
+class TestFieldClassContainmentE2E:
+    """Real-backend (non-mocked) end-to-end test: a class field is queryable via
+    the class's :contains edge in the live graph, and that edge is closed when
+    the field is removed (issues.md P2: "add a graph-level test asserting a
+    class's :contains set includes its fields" + close-logic verification)."""
+
+    def _init_repo(self, repo):
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _commit(self, repo, msg):
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True)
+
+    def _query(self, path, q):
+        from minigraf import MiniGrafDb
+        db = MiniGrafDb.open(path)
+        try:
+            return json.loads(db.execute(q)).get("results", [])
+        finally:
+            del db
+
+    def test_class_contains_field_is_queryable_and_closed_on_removal(self, tmp_path, monkeypatch):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+
+        # Commit 1: a class with a field.
+        (repo / "models.py").write_text("class Account:\n    balance = 0\n")
+        self._commit(repo, "add Account")
+
+        graph_path = str(tmp_path / "e2e.graph")
+        monkeypatch.setenv("MINIGRAF_GRAPH_PATH", graph_path)
+        mcp_server._db = None
+        mcp_server._graph_path = ""
+
+        asyncio.run(mcp_server._run_ingestion(str(repo), "HEAD"))
+        mcp_server._db = None
+
+        class_ident = mcp_server._code_ident("class", "models.py", "Account")
+        field_ident = mcp_server._code_ident("field", "models.py", "Account.balance")
+
+        # The class :contains set includes its field (structural graph traversal).
+        contains = self._query(
+            graph_path, f"(query [:find ?f :where [{class_ident} :contains ?f]])"
+        )
+        contained = {row[0] for row in contains}
+        assert field_ident in contained, f"expected {field_ident} in class :contains {contained}"
+
+        # Commit 2: remove the field (replace with a method) so it is a removal.
+        (repo / "models.py").write_text("class Account:\n    def deposit(self):\n        pass\n")
+        self._commit(repo, "drop balance field")
+
+        mcp_server._db = None
+        mcp_server._graph_path = ""
+        asyncio.run(mcp_server._run_ingestion(str(repo), "HEAD"))
+        mcp_server._db = None
+
+        # The class-contains edge to the removed field is CLOSED at current time.
+        contains_after = self._query(
+            graph_path, f"(query [:find ?f :where [{class_ident} :contains ?f]])"
+        )
+        contained_after = {row[0] for row in contains_after}
+        assert field_ident not in contained_after, (
+            f"class-contains edge to removed field leaked open: {contained_after}"
+        )
+
+        # And the module-contains edge to the field is closed too (no half-close).
+        module_ident = mcp_server._code_ident("module", "models.py")
+        mod_contains_after = {
+            row[0] for row in self._query(
+                graph_path, f"(query [:find ?f :where [{module_ident} :contains ?f]])"
+            )
+        }
+        assert field_ident not in mod_contains_after

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1957,7 +1957,13 @@ class TestMatchRenamedEntities:
         removed = {"function": [("foo", old)]}
         added = {"function": [("bar", new)]}
         matches = mcp_server._match_renamed_entities(removed, added)
-        assert matches == [("function", "foo", "bar")]
+        # 5-tuples now: (category, old_name, old_node, new_name, new_node) —
+        # project down to the name-only shape and check node identity separately.
+        assert len(matches) == 1
+        category, old_name, old_node, new_name, new_node = matches[0]
+        assert (category, old_name, new_name) == ("function", "foo", "bar")
+        assert old_node is old
+        assert new_node is new
         assert removed["function"] == []
         assert added["function"] == []
 
@@ -1971,8 +1977,9 @@ class TestMatchRenamedEntities:
         removed = {"function": [("a", old_a), ("b", old_b)]}
         added = {"function": [("a1", new_a1), ("b1", new_b1)]}
         matches = mcp_server._match_renamed_entities(removed, added)
-        assert ("function", "a", "a1") in matches
-        assert ("function", "b", "b1") in matches
+        projected = [(category, old_name, new_name) for category, old_name, _, new_name, _ in matches]
+        assert ("function", "a", "a1") in projected
+        assert ("function", "b", "b1") in projected
         assert len(matches) == 2
 
     def test_ambiguous_duplicate_bodies_not_matched(self):
@@ -2006,6 +2013,19 @@ class TestMatchRenamedEntities:
         added = {"function": [], "class": [("bar", new)]}
         matches = mcp_server._match_renamed_entities(removed, added)
         assert matches == []
+
+
+class TestCollectEntityNodes:
+    def test_collects_function_and_class_nodes_by_name(self):
+        import mcp_server
+        parser = mcp_server._get_parser("test.py")
+        source = b"def foo():\n    pass\n\nclass Bar:\n    pass\n"
+        tree = parser.parse(source)
+        result = mcp_server._collect_entity_nodes(tree.root_node, "python")
+        assert "foo" in result["function"]
+        assert result["function"]["foo"].type == "function_definition"
+        assert "Bar" in result["class"]
+        assert result["class"]["Bar"].type == "class_definition"
 
 
 class TestExtractFromSourceCFamily:
@@ -2793,7 +2813,7 @@ class TestExtractCommit:
         commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
         first_hash = commits[0][0]
 
-        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), first_hash)
+        results, gitlink_changes, gitmodules_map, _renamed_pairs = mcp_server._extract_commit(str(git_repo), first_hash)
 
         assert len(results) == 1
         status, file_path, extracted, precomputed, old_path = results[0]
@@ -2812,7 +2832,7 @@ class TestExtractCommit:
         commits = mcp_server._git_commits(str(git_repo_with_deletion), watermark_hash=None)
         delete_hash = commits[-1][0]
 
-        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo_with_deletion), delete_hash)
+        results, gitlink_changes, gitmodules_map, _renamed_pairs = mcp_server._extract_commit(str(git_repo_with_deletion), delete_hash)
 
         d_entries = [r for r in results if r[0] == "D"]
         assert len(d_entries) == 1
@@ -2824,7 +2844,7 @@ class TestExtractCommit:
             mcp_server, "_git_diff_tree_raw",
             lambda repo, commit: [("A", "000000", "100644", "0" * 40, "a" * 40, "notes.txt", "", None)],
         )
-        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), "deadbeef")
+        results, gitlink_changes, gitmodules_map, _renamed_pairs = mcp_server._extract_commit(str(git_repo), "deadbeef")
         assert results == []
 
     def test_content_fetch_failure_is_omitted_not_raised(self, git_repo, monkeypatch):
@@ -2838,7 +2858,7 @@ class TestExtractCommit:
             raise mcp_server.MiniGrafError("simulated git-show failure")
 
         monkeypatch.setattr(mcp_server, "_git_file_content", boom)
-        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), "deadbeef")
+        results, gitlink_changes, gitmodules_map, _renamed_pairs = mcp_server._extract_commit(str(git_repo), "deadbeef")
         assert results == []
 
     def test_gitlink_add_is_reported_separately_from_file_results(self, tmp_path):
@@ -2870,7 +2890,7 @@ class TestExtractCommit:
         _subprocess.run(["git", "commit", "-m", "add submodule"], cwd=repo, check=True, capture_output=True)
 
         commits = mcp_server._git_commits(str(repo), watermark_hash=None)
-        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(repo), commits[0][0])
+        results, gitlink_changes, gitmodules_map, _renamed_pairs = mcp_server._extract_commit(str(repo), commits[0][0])
 
         # Neither the gitlink path (vendor/lib) nor .gitmodules itself has a
         # resolvable extension (_EXT_TO_LANG has no entry for either), so
@@ -2895,7 +2915,7 @@ class TestExtractCommit:
             original_init(self, *args, **kwargs)
 
         monkeypatch.setattr(mcp_server._SegmentSuffixIndex, "__init__", counting_init)
-        results, _, _ = mcp_server._extract_commit(str(git_repo_with_deps), commits[0][0])
+        results, _, _, _ = mcp_server._extract_commit(str(git_repo_with_deps), commits[0][0])
 
         assert len(results) == 2  # mod_a.py (imports mod_b) and mod_b.py both added here
         assert build_count == 1
@@ -2913,7 +2933,7 @@ class TestExtractCommit:
         _subprocess.run(["git", "commit", "-m", "add vendored lib"], cwd=repo, check=True, capture_output=True)
 
         commits = mcp_server._git_commits(str(repo), watermark_hash=None)
-        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(
+        results, gitlink_changes, gitmodules_map, _renamed_pairs = mcp_server._extract_commit(
             str(repo), commits[0][0], ["vendor/"]
         )
         assert results == []
@@ -2922,7 +2942,7 @@ class TestExtractCommit:
         import mcp_server
         commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
         first_hash = commits[0][0]
-        results, gitlink_changes, gitmodules_map = mcp_server._extract_commit(str(git_repo), first_hash)
+        results, gitlink_changes, gitmodules_map, _renamed_pairs = mcp_server._extract_commit(str(git_repo), first_hash)
         assert len(results) == 1
         assert results[0][1] == "auth.py"
 
@@ -2957,6 +2977,27 @@ class TestExtractCommitRename:
         status, file_path, extracted, precomputed, old_path = results[0]
         assert status == "A"
         assert old_path == ""
+
+    def test_cross_file_move_produces_renamed_pair(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "fileA.py").write_text(
+            "def stayHere(x):\n    return x + 1\n\ndef moveMe(x):\n    return x * 2 + 7\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "fileA.py").write_text("def stayHere(x):\n    return x + 1\n")
+        (repo / "fileB.py").write_text("def moveMe(x):\n    return x * 2 + 7\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "move function"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        assert ("function", "fileA.py", "moveMe", "fileB.py", "moveMe") in renamed_pairs
 
 
 class TestIngestionWrites:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2183,6 +2183,111 @@ class TestRustGoCGlobalsAndFields:
         assert info["b"] == ("Foo", False)
 
 
+class TestJavaCSharpGlobalsAndFields:
+    def _java_parser(self):
+        import tree_sitter_java
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_java.language()))
+
+    def _csharp_parser(self):
+        import tree_sitter_c_sharp
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_c_sharp.language()))
+
+    def test_java_static_and_instance_fields(self):
+        import mcp_server
+        source = b"public class Foo {\n    static int staticField = 1;\n    int instanceField = 2;\n}\n"
+        tree = self._java_parser().parse(source)
+        result = mcp_server._extract_java_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+        assert result["globals"] == []
+
+    def test_csharp_static_and_instance_fields(self):
+        import mcp_server
+        source = b"public class Foo {\n    static int staticField = 1;\n    int instanceField = 2;\n}\n"
+        tree = self._csharp_parser().parse(source)
+        result = mcp_server._extract_csharp_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+        assert result["globals"] == []
+
+    def test_java_multi_declarator_field_captures_all_names(self):
+        # `int a, b;` puts more than one node under the `declarator` field
+        # of a single field_declaration -- child_by_field_name (singular)
+        # only returns the first, silently dropping `b`. Verified
+        # empirically against the real installed tree-sitter-java grammar
+        # (same lesson as Go's multi-name struct field and C's
+        # multi-declarator statement); children_by_field_name (plural)
+        # must be used instead.
+        import mcp_server
+        source = b"public class Foo {\n    int a, b = 3;\n}\n"
+        tree = self._java_parser().parse(source)
+        result = mcp_server._extract_java_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["a"] == ("Foo", False)
+        assert info["b"] == ("Foo", False)
+
+    def test_csharp_multi_declarator_field_captures_all_names(self):
+        # Unlike Java, C#'s field_declaration wraps a single
+        # variable_declaration child whose variable_declarator children
+        # (for `int a, b;`) are all plain positional children -- iterating
+        # var_decl.children already captures all of them. This test locks
+        # in that a multi-name field isn't silently dropped.
+        import mcp_server
+        source = b"public class Foo {\n    int a, b = 3;\n}\n"
+        tree = self._csharp_parser().parse(source)
+        result = mcp_server._extract_csharp_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["a"] == ("Foo", False)
+        assert info["b"] == ("Foo", False)
+
+    def test_java_nested_class_fields_captured(self):
+        # walk() recurses into every node (not just direct root children)
+        # to find nested class_declarations, since a nested/inner class is
+        # a real, valid Java construct. This locks in that its fields are
+        # attributed to the inner class's own name, not the outer one, and
+        # that the method body sibling isn't mistakenly walked for fields.
+        import mcp_server
+        source = (
+            b"public class Outer {\n"
+            b"    class Inner {\n"
+            b"        static int innerStatic = 5;\n"
+            b"    }\n"
+            b"    void m() {\n"
+            b"        int local = 1;\n"
+            b"    }\n"
+            b"}\n"
+        )
+        tree = self._java_parser().parse(source)
+        result = mcp_server._extract_java_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["innerStatic"] == ("Inner", True)
+        assert "local" not in info
+        assert result["globals"] == []
+
+    def test_csharp_nested_class_fields_captured(self):
+        import mcp_server
+        source = (
+            b"public class Outer {\n"
+            b"    class Inner {\n"
+            b"        static int innerStatic = 5;\n"
+            b"    }\n"
+            b"    void M() {\n"
+            b"        int local = 1;\n"
+            b"    }\n"
+            b"}\n"
+        )
+        tree = self._csharp_parser().parse(source)
+        result = mcp_server._extract_csharp_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["innerStatic"] == ("Inner", True)
+        assert "local" not in info
+        assert result["globals"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2458,6 +2458,109 @@ class TestRubyGlobalsAndFields:
         assert result["globals"] == []
 
 
+class TestPhpGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_php
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_php.language_php()))
+
+    def test_top_level_variable_is_global(self):
+        import mcp_server
+        source = b"<?php\n$globalVar = 5;\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_php_globals_and_fields(tree.root_node)
+        assert "$globalVar" in result["globals"]
+
+    def test_static_and_instance_properties(self):
+        import mcp_server
+        source = b"<?php\nclass Foo {\n    public static $staticField = 1;\n    public $instanceField = 2;\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_php_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["$staticField"] == ("Foo", True)
+        assert info["$instanceField"] == ("Foo", False)
+
+    def test_multi_property_declaration_captures_all_names(self):
+        # `public static $a = 1, $b = 2;` -- a single property_declaration
+        # containing multiple property_element children -- verified
+        # empirically against the real installed tree-sitter-php grammar.
+        # This is the PHP analog of the recurring multi-declarator gap
+        # (Go/Java/C++), but here the brief's plain iteration over every
+        # property_element child already handles it correctly.
+        import mcp_server
+        source = b"<?php\nclass Foo {\n    public static $a = 1, $b = 2;\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_php_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["$a"] == ("Foo", True)
+        assert info["$b"] == ("Foo", True)
+
+    def test_typed_property_still_captured(self):
+        # PHP 7.4+ typed properties (`public int $x = 5;`) add a
+        # primitive_type/named_type child to property_declaration but
+        # keep the same property_element shape -- verified empirically.
+        import mcp_server
+        source = b"<?php\nclass Foo {\n    public int $x = 5;\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_php_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["$x"] == ("Foo", False)
+
+    def test_semicolon_style_namespace_globals_still_captured(self):
+        # `namespace App;` (semicolon style) does not wrap subsequent
+        # statements -- they remain direct children of `program` --
+        # verified empirically. No special-casing needed for this form.
+        import mcp_server
+        source = b"<?php\nnamespace App;\n$x = 5;\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_php_globals_and_fields(tree.root_node)
+        assert "$x" in result["globals"]
+
+    def test_block_style_namespace_globals_and_classes_captured(self):
+        # `namespace App { ... }` (block style) wraps its statements in
+        # a compound_statement exposed via field:body on
+        # namespace_definition -- verified empirically against the real
+        # installed tree-sitter-php grammar. Same shape-changing-wrapper
+        # lesson as JS's export_statement: without unwrapping, every
+        # global/class inside a block-style namespace is silently
+        # dropped, and PHP namespaces are extremely common in real code.
+        import mcp_server
+        source = (
+            b"<?php\nnamespace App {\n"
+            b"    $x = 5;\n"
+            b"    class Foo {\n        public $y = 1;\n    }\n"
+            b"}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_php_globals_and_fields(tree.root_node)
+        assert "$x" in result["globals"]
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["$y"] == ("Foo", False)
+
+    def test_promoted_constructor_property_captured_as_instance_field(self):
+        # PHP 8+ constructor property promotion
+        # (`public function __construct(public int $x) {}`) produces a
+        # property_promotion_parameter node inside the constructor's
+        # formal_parameters -- NOT a property_declaration under the
+        # class body -- verified empirically. The brief's code as
+        # written only scans property_declaration nodes in the class
+        # body, so promoted properties would be silently missed without
+        # this extra handling. Promoted properties cannot carry a
+        # `static` modifier in real PHP (verified: adding one produces
+        # a parse ERROR node), so they are always instance fields.
+        import mcp_server
+        source = (
+            b"<?php\nclass Foo {\n"
+            b"    public function __construct(public int $x, private string $y = \"z\") {}\n"
+            b"}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_php_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["$x"] == ("Foo", False)
+        assert info["$y"] == ("Foo", False)
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2658,6 +2658,125 @@ class TestKotlinGlobalsAndFields:
         assert result["fields"] == []
 
 
+class TestSwiftGlobalsAndFields:
+    def _parser(self):
+        import tree_sitter_swift
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_swift.language()))
+
+    def test_top_level_let_is_global(self):
+        import mcp_server
+        tree = self._parser().parse(b"let globalX = 5\n")
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        assert "globalX" in result["globals"]
+
+    def test_static_and_instance_properties(self):
+        import mcp_server
+        source = b"class Foo {\n    static var staticField = 1\n    var instanceField = 2\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["staticField"] == ("Foo", True)
+        assert info["instanceField"] == ("Foo", False)
+
+    def test_top_level_multi_binding_let_captures_all_names(self):
+        # `let a = 1, b = 2` binds multiple names in one
+        # property_declaration, each its own `field:name` -- verified
+        # empirically against the real installed tree-sitter-swift
+        # grammar. Same multi-declarator lesson as every prior language
+        # in this plan: every name must be extracted, not just the
+        # first.
+        import mcp_server
+        tree = self._parser().parse(b"let a = 1, b = 2\n")
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        assert "a" in result["globals"]
+        assert "b" in result["globals"]
+
+    def test_class_multi_binding_property_captures_all_names(self):
+        import mcp_server
+        source = b"class Foo {\n    let a = 1, b = 2\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["a"] == ("Foo", False)
+        assert info["b"] == ("Foo", False)
+
+    def test_struct_and_enum_properties_extracted(self):
+        # struct and enum declarations share the class_declaration node
+        # type with class (distinguished only by declaration_kind), and
+        # enum's body node is a differently-typed enum_class_body --
+        # both verified empirically to work via child_by_field_name
+        # ("body"), which is keyed by field name, not node type.
+        import mcp_server
+        source = (
+            b"struct Bar {\n    var structField = 5\n}\n"
+            b"enum E {\n    static let enumField = 1\n}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["structField"] == ("Bar", False)
+        assert info["enumField"] == ("E", True)
+
+    def test_tuple_destructuring_produces_no_globals(self):
+        # `let (x, y) = (1, 2)` wraps names in a pattern whose nested
+        # per-name patterns expose no bound_identifier field -- verified
+        # empirically -- so it is safely skipped rather than crashing
+        # or misattributing a name.
+        import mcp_server
+        tree = self._parser().parse(b"let (x, y) = (1, 2)\n")
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+
+    def test_extension_properties_attributed_to_extended_type(self):
+        # extension Foo { ... } shares the class_declaration node type;
+        # its `name` field is a user_type wrapping Foo's
+        # type_identifier, and .text on it still resolves to plain
+        # "Foo" -- verified empirically -- so extension properties are
+        # picked up rather than silently dropped or misattributed.
+        import mcp_server
+        source = b"extension Foo {\n    var extField = 3\n    static var extStatic = 4\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["extField"] == ("Foo", False)
+        assert info["extStatic"] == ("Foo", True)
+
+    def test_init_only_class_has_no_fields(self):
+        # Swift has no primary-constructor property shorthand: a class
+        # with only an `init` method and no property_declaration
+        # produces zero fields -- verified empirically.
+        import mcp_server
+        source = b"class Foo {\n    init() { self.x = 1 }\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        assert result["fields"] == []
+
+    def test_nested_class_not_recursed_into(self):
+        import mcp_server
+        source = (
+            b"class Outer {\n"
+            b"    class Inner {\n"
+            b"        var innerField = 3\n"
+            b"    }\n"
+            b"    var outerField = 4\n"
+            b"}\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["outerField"] == ("Outer", False)
+        assert "innerField" not in info
+
+    def test_no_globals_or_fields_when_absent(self):
+        import mcp_server
+        source = b"func main() {\n    print(\"hi\")\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._extract_swift_globals_and_fields(tree.root_node)
+        assert result["globals"] == []
+        assert result["fields"] == []
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5059,6 +5059,43 @@ class TestRunIngestionBitemporalClose:
         assert f"{new_module_ident} :renamed-from {old_module_ident}" in transact_calls, \
             "New module's open triples must include :renamed-from pointing at the old ident"
 
+    @pytest.mark.asyncio
+    async def test_in_file_function_rename_links_via_rename_edges(
+        self, mock_minigraf_db, tmp_path, monkeypatch
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def oldName(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def newName(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename fn"], cwd=repo, check=True, capture_output=True)
+
+        mock_class, db_instance = mock_minigraf_db
+        db_instance.execute.return_value = json.dumps({"results": []})
+        import mcp_server
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+
+        close_triples_seen = []
+        monkeypatch.setattr(
+            mcp_server, "_ingest_close",
+            lambda db, triples, orig_ts, commit_ts, reason: close_triples_seen.extend(triples),
+        )
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        old_fn_ident = mcp_server._code_ident("function", "auth.py", "oldName")
+        new_fn_ident = mcp_server._code_ident("function", "auth.py", "newName")
+
+        assert any(f"{old_fn_ident} :renamed-to {new_fn_ident}" in t for t in close_triples_seen)
+        transact_calls = " ".join(str(c) for c in db_instance.execute.call_args_list)
+        assert f"{new_fn_ident} :renamed-from {old_fn_ident}" in transact_calls
+
 
 # ---------------------------------------------------------------------------
 # Fixtures for bi-temporal :depends-on integration tests

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1979,6 +1979,52 @@ class TestJsFamilyGlobalsAndFields:
         result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
         assert result["globals"] == []
 
+    def test_export_const_captured_as_global(self):
+        import mcp_server
+        tree = self._js_parser().parse(b"export const GLOBAL_X = 5;\n")
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        assert "GLOBAL_X" in result["globals"]
+        assert result["global_bodies"]["GLOBAL_X"].startswith("export const")
+
+    def test_export_let_captured_as_global(self):
+        import mcp_server
+        tree = self._js_parser().parse(b"export let GLOBAL_Y = 5;\n")
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        assert "GLOBAL_Y" in result["globals"]
+        assert result["global_bodies"]["GLOBAL_Y"].startswith("export let")
+
+    def test_export_class_captures_fields(self):
+        import mcp_server
+        source = b"export class Foo { static a = 1; b = 2; }\n"
+        tree = self._js_parser().parse(source)
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["a"] == ("Foo", True)
+        assert info["b"] == ("Foo", False)
+
+    def test_export_default_class_captures_fields(self):
+        import mcp_server
+        source = b"export default class Bar { c = 3; }\n"
+        tree = self._js_parser().parse(source)
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["c"] == ("Bar", False)
+
+    def test_export_const_and_class_together(self):
+        import mcp_server
+        source = (
+            b"export const X = 5;\n"
+            b"export class Foo { static a = 1; b = 2; }\n"
+            b"export default class Bar { c = 3; }\n"
+        )
+        tree = self._js_parser().parse(source)
+        result = mcp_server._extract_js_family_globals_and_fields(tree.root_node)
+        assert "X" in result["globals"]
+        info = {n: (c, s) for n, c, s in result["fields"]}
+        assert info["a"] == ("Foo", True)
+        assert info["b"] == ("Foo", False)
+        assert info["c"] == ("Bar", False)
+
 
 class TestMatchCandidatePair:
     def _parse(self, source: str):


### PR DESCRIPTION
## Summary

Implements bi-temporal rename/move tracking for git ingestion, plus the global/field/static extraction issue #113 asked for (folded in as a prerequisite — the rename matcher needs entity categories to track renames for).

- **File/module renames** — detected via git's own `-M`, with raw-diff parsing and status-`R` extraction handling.
- **Function/class/global/field renames** — detected via a custom AST-lockstep matcher tolerant of local-variable renames (below git's own diff granularity — e.g. a function renamed within an unchanged file, or moved unchanged into a different file).
- **Global/field/static extraction** — two new entity types, `:type/variable` and `:type/field`, across all 16-17 currently-supported languages, via new scope-aware per-language extractors (not a naive full-tree walk, which would misclassify every local variable as a global).
- All renamed entities get `:renamed-from`/`:renamed-to` schema attributes linking old and new idents, layered on the existing bi-temporal close/open machinery.

Design spec: `docs/superpowers/specs/2026-07-14-git-ingestion-rename-tracking-design.md`
Implementation plan (29 tasks): `docs/superpowers/plans/2026-07-14-git-ingestion-rename-tracking.md`

## Review process

Built via 29 sequential, individually-reviewed implementation tasks, then put through two rounds of independent whole-branch review plus a final pass, which together found and fixed 17 issues before merge — including:

- A **critical false-positive** in the rename matcher for the field category (wrong renames could get confirmed).
- A **project-wide, pre-existing bug** (not introduced by this branch, discovered while verifying it): every valid-time-bounded `transact` call in `mcp_server.py` had its Datalog arguments in the wrong order per minigraf's own grammar, silently making bi-temporal closes no-ops since the project's inception. Fixed across all 8 affected call sites. Filed [#133](https://github.com/project-minigraf/temporal_reasoning/issues/133) for the broader mock-vs-real-backend testing gap that let this hide for so long, and [#134](https://github.com/project-minigraf/temporal_reasoning/issues/134) for a related pre-existing gap.
- A **critical lifecycle bug** found by the final whole-branch review: closed entities' bookkeeping was never purged from in-memory state, causing ghost entities and phantom historical-window corruption when a file path is reused after a rename or delete.
- Several `-M`/matcher edge cases (renaming into an unsupported/ignored path leaking entities forever; matcher O(n³) cost on large commits; an unguarded RecursionError that could abort a whole ingestion run) and per-language extraction gaps (JS/TS `export` wrapping, Go struct-field access, Rust generic-impl linkage, PHP namespaces, and more — each empirically verified against the real installed grammar, not assumed).

Full incident-by-incident writeup in this branch's `.superpowers/sdd/progress.md` ledger.

## Test plan

- [x] Full suite passes: `pytest tests/test_mcp_server.py -q` → 548 passed, 0 failed
- [x] Every fix has a dedicated regression test; bi-temporal correctness fixes are verified against a real (non-mocked) minigraf backend, not just call-argument mocks
- [x] SKILL.md updated for the new entity types and rename-tracking attributes

Fixes #111
Fixes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118SWGgEdQo5LVZzgvb9dm1