### PR TITLE
fix: close submodule entity's :entity-type/:path on gitlink removal

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3793,6 +3793,7 @@ def _build_close_triples(
     extra_contains_parent: Optional[str] = None,
     *,
     close_entity_type: bool = False,
+    entity_type_kw: Optional[str] = None,
     file_value: Optional[str] = None,
     is_static: Optional[bool] = None,
 ) -> List[str]:
@@ -3822,7 +3823,14 @@ def _build_close_triples(
     (submodule) idents that reuse the "module" ident prefix but were never
     actually asserted as :type/module — deriving :entity-type from the ident
     prefix there would transact a false fact, so only call sites that KNOW
-    they're closing a real module/function/class/variable/field pass these.
+    they're closing a real module/function/class/variable/field pass
+    close_entity_type=True.
+
+    entity_type_kw is the escape hatch for exactly that submodule case (#137):
+    an explicit ":type/xxx" keyword to close instead of deriving one from the
+    ident prefix, for callers whose ident prefix does NOT match their real
+    :entity-type. Takes precedence over close_entity_type when both are given
+    (they shouldn't be — pass one or the other).
     """
     triples = [
         f'[{ident} :ident "{_edn_escape(ident)}"]',
@@ -3837,7 +3845,9 @@ def _build_close_triples(
     ):
         triples.append(f"[{extra_contains_parent} :contains {ident}]")
         triples.append(f"[{ident} :class {extra_contains_parent}]")
-    if close_entity_type:
+    if entity_type_kw is not None:
+        triples.append(f"[{ident} :entity-type {entity_type_kw}]")
+    elif close_entity_type:
         entity_type = ident.split("/", 1)[0].lstrip(":")
         triples.append(f"[{ident} :entity-type :type/{entity_type}]")
     if file_value is not None:
@@ -6108,7 +6118,11 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                 orig_ts = entity_valid_from.get(ext_ident, commit_ts_iso)
                                 desc = entity_descriptions.get(ext_ident, "")
                                 close_items.append(
-                                    (_build_close_triples(ext_ident, desc, ext_ident), orig_ts)
+                                    (_build_close_triples(
+                                        ext_ident, desc, ext_ident,
+                                        entity_type_kw=":type/external-dependency",
+                                        file_value=path,
+                                    ), orig_ts)
                                 )
                                 # Submodule removed: purge lifecycle state so a later
                                 # re-add at the same path is treated as genuinely new.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8569,6 +8569,54 @@ class TestRunIngestionGitlinks:
         ident = mcp_server._code_ident("module", "vendor/lib")
         assert any(f'[{ident} :ident "{ident}"]' in t for t in close_triples_seen)
 
+    @pytest.mark.asyncio
+    async def test_submodule_removal_closes_entity_type_and_path_against_real_graph(self, tmp_path):
+        """Issue #137: a removed submodule's :entity-type/:path must be closed
+        too, not just :ident/:description (the pre-existing behavior verified
+        by test_submodule_removal_closes_entity above via a mock). Pre-fix,
+        [?e :entity-type :type/external-dependency] and [?e :path ?p] queries
+        without an :ident join still returned the removed submodule forever,
+        the same class of bug as #134 (see PR #136) but for the gitlink
+        "remove" close site, which #136 deliberately left unfixed since
+        deriving :entity-type from the ident's "module" prefix there would
+        have transacted a false :type/module fact.
+
+        Verified against the REAL minigraf backend, counting rows before/after
+        removal (no mock — this is exactly the un-mocked query check #134's
+        fix required).
+        """
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        self._add_submodule_commit(repo)
+        _subprocess.run(["git", "rm", "-f", "vendor/lib"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "remove submodule"], cwd=repo, check=True, capture_output=True)
+
+        # Real backend: real MiniGrafDb, real execute, real persistence.
+        mcp_server._db = None
+        mcp_server._graph_path = None
+        mcp_server._ingest_progress = self._make_progress()
+        mcp_server.open_db(str(repo / "memory.graph"))
+
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        db = mcp_server.get_db()
+        real_execute = mcp_server._db_execute
+
+        def count(attr, value):
+            raw = real_execute(db, f"(query [:find ?e :where [?e {attr} {value}]])")
+            return len(json.loads(raw).get("results", []))
+
+        assert count(":entity-type", ":type/external-dependency") == 0, \
+            "removed submodule's :entity-type must be closed (issue #137)"
+        assert count(":path", '"vendor/lib"') == 0, \
+            "removed submodule's :path must be closed (issue #137)"
+
+        mcp_server._db = None  # release the real file lock for subsequent tests
+
 
 # ---------------------------------------------------------------------------
 # Helpers for TestExtractImportName


### PR DESCRIPTION
## Summary
- Follow-up to #134 / PR #136: the gitlink "remove" close site was deliberately left out of that fix because it couldn't safely use `close_entity_type=True` — the submodule ident reuses the `"module"` prefix (`_code_ident("module", path)`) but its real `:entity-type` is `:type/external-dependency`, so deriving from the prefix there would transact a false `:type/module` fact.
- Adds an `entity_type_kw: Optional[str] = None` param to `_build_close_triples` — an explicit keyword that takes precedence over the prefix-derived `close_entity_type` path, for exactly this "ident prefix lies about the real type" case.
- Wires `entity_type_kw=":type/external-dependency"` and `file_value=path` into the gitlink "remove" call site only; the 5 existing `close_entity_type=True` call sites from #136 are untouched.

Fixes #137

## Test plan
- [x] New regression test `test_submodule_removal_closes_entity_type_and_path_against_real_graph`, run against the real minigraf backend, confirmed to fail before the fix and pass after
- [x] Full suite: 386 passed (excluding tests failing on master due to pre-existing missing tree-sitter grammar packages in this environment, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU