### PR TITLE
fix: link unresolved-import stubs to their submodule via :resolves-to

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -321,7 +321,7 @@ potentially stale watermark.
 
 ### Git-Ingested Data Schema
 
-`minigraf_ingest_git` writes the following entity types. All relationship attributes (`:parent`, `:introduced-by`, `:modified-in`, `:contains`, `:depends-on`, `:tagged-commit`) are stored as keyword entity references — they bypass string-value schema validation by design and are directly traversable in queries.
+`minigraf_ingest_git` writes the following entity types. All relationship attributes (`:parent`, `:introduced-by`, `:modified-in`, `:contains`, `:depends-on`, `:tagged-commit`, `:resolves-to`) are stored as keyword entity references — they bypass string-value schema validation by design and are directly traversable in queries.
 
 **Ident slugging:** non-alphanumeric characters in paths and names are replaced with hyphens and consecutive hyphens collapsed. Examples: `src/auth.py` → `:module/src-auth-py`; function `login` in `src/auth.py` → `:function/src-auth-py-login`.
 
@@ -418,6 +418,7 @@ Ident: `:module/<slugified-path-or-import-name>` (shares the module ident namesp
 | `:submodule-name` / `:submodule-url` | from `.gitmodules`, when parseable (submodules only) |
 | `:introduced-by` (keyword ref) | commit that first introduced this dependency |
 | `:modified-in` (keyword ref) | one edge per commit that bumped a submodule's pinned commit |
+| `:resolves-to` (keyword ref, unresolved-import placeholders only) | points to the real submodule entity when this placeholder's import path falls under a known `.gitmodules`/gitlink path — bridges the two ident schemes (`_canonical_ident` from the raw import specifier vs. `_code_ident` from the submodule's declared path), which otherwise never produce the same ident string even once both entities exist. Set regardless of which one was ingested first. |
 
 Vendored-in-tree code checked in as regular files (not a git submodule) is parsed as ordinary `:type/module`/`:function`/`:class` entities like any first-party code — only real gitlinks (mode `160000`) and genuinely-unresolved imports get the external marker.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3287,6 +3287,34 @@ def _segments_end_with(full_segments: List[str], candidate_segments: List[str]) 
     return full_segments[-len(candidate_segments):] == candidate_segments
 
 
+def _dep_import_segments(import_name: str) -> List[str]:
+    """Split a dependency-edge import specifier into path segments.
+
+    Mirrors _resolve_module_import's tier-3 splitting rule exactly (slash if
+    present, else dot) so a submodule path prefix match (see
+    _submodule_path_matches_import, #112) uses the same segmentation the
+    resolver itself would have used.
+    """
+    return import_name.split("/") if "/" in import_name else import_name.split(".")
+
+
+def _submodule_path_matches_import(submodule_path: str, import_name: str) -> bool:
+    """True if a dependency-edge import specifier falls under a submodule's path.
+
+    Used to link an unresolved-import stub ident (computed via
+    _canonical_ident from the raw import specifier) to a submodule entity
+    (computed via _code_ident from its .gitmodules/gitlink path) — the two
+    are never the same ident string, so #112's fix connects them with an
+    explicit :resolves-to edge whenever the submodule's path is a whole-segment
+    prefix of the import's own segments.
+    """
+    submodule_segments = _path_segments(submodule_path)
+    import_segments = _dep_import_segments(import_name)
+    if not submodule_segments or len(submodule_segments) > len(import_segments):
+        return False
+    return import_segments[:len(submodule_segments)] == submodule_segments
+
+
 class _SegmentSuffixIndex:
     """Reverse index over file_entities' path segments, bucketed by last segment.
 
@@ -5137,19 +5165,25 @@ def _preload_known_entities(db: Any, repo_path: str) -> tuple:
     entity_descriptions) just works for submodules without new parallel state.
     Unresolved-import placeholders (no :path) are not reloaded by this query —
     nothing in this codebase ever closes one, so the gap is harmless; see the
-    design spec's Section 2.
+    design spec's Section 2. (submodule_paths below deliberately reuses this
+    same :path-bearing external-dependency row set — see its own docstring.)
 
     Pre-seeding from `git ls-files` ensures that _resolve_module_import can
     find any module file even when processing early commits — before those files
     have been introduced in the chronological commit walk.
 
-    Returns (entity_valid_from, entity_descriptions, file_entities).
+    Returns (entity_valid_from, entity_descriptions, file_entities, submodule_paths).
     entity_valid_from maps ident → git commit timestamp of first introduction.
     entity_descriptions maps ident → human-readable name (function/class/file).
+    submodule_paths maps external-dependency (submodule) ident → its :path,
+    used by the gitlink "add"/stub-creation linking in #112's fix to tell a
+    real submodule ident apart from an unresolved-import stub ident (which
+    never has a :path).
     """
     entity_valid_from: Dict[str, str] = {}
     entity_descriptions: Dict[str, str] = {}
     file_entities: Dict[str, List[str]] = {}
+    submodule_paths: Dict[str, str] = {}
 
     # Pre-seed file_entities with all files currently in the repo
     try:
@@ -5183,10 +5217,44 @@ def _preload_known_entities(db: Any, repo_path: str) -> tuple:
                 file_entities.setdefault(path, [])
                 if ident not in file_entities[path]:
                     file_entities[path].append(ident)
+                if entity_type == "external-dependency":
+                    submodule_paths[ident] = path
         except Exception:
             pass
 
-    return entity_valid_from, entity_descriptions, file_entities
+    return entity_valid_from, entity_descriptions, file_entities, submodule_paths
+
+
+def _preload_unresolved_dep_idents(db: Any, submodule_paths: Dict[str, str]) -> Dict[str, str]:
+    """Reload ident -> import_name for every unresolved-import stub (#112).
+
+    _preload_known_entities' external-dependency branch requires a :path fact,
+    which only real submodule entities have — unresolved-import stubs (see
+    _run_ingestion's dep-edge handling) never get one, so they're invisible to
+    that query. This runs the same :entity-type match WITHOUT the :path
+    requirement, then subtracts submodule_paths' idents (already known
+    submodules) to get exactly the stub idents, restart-safe.
+
+    Needed so a submodule added in a later, separate ingestion run can still
+    find and link any stub created in an earlier run (see the gitlink "add"
+    handling in _run_ingestion) — without this, only same-run stubs would
+    ever get linked.
+    """
+    unresolved: Dict[str, str] = {}
+    try:
+        raw = _db_execute(
+            db,
+            "(query [:find ?ident ?desc :where "
+            "[?e :entity-type :type/external-dependency] "
+            "[?e :ident ?ident] "
+            "[?e :description ?desc]])",
+        )
+        for ident, desc in json.loads(raw).get("results", []):
+            if ident not in submodule_paths:
+                unresolved[ident] = desc
+    except Exception:
+        pass
+    return unresolved
 
 
 def _preload_field_class_idents(db: Any) -> Dict[str, str]:
@@ -5360,15 +5428,16 @@ def _load_ingestion_preload_state(repo_path: str) -> tuple:
     db = _db if _db is not None else _open_db_at_with_extended_retry(_graph_path or _get_graph_path())
     watermark = _watermark_query(db)
     prior_ingested = _count_commit_entities(db)
-    entity_valid_from, entity_descriptions, file_entities = _preload_known_entities(db, repo_path)
+    entity_valid_from, entity_descriptions, file_entities, submodule_paths = _preload_known_entities(db, repo_path)
     file_deps, dep_valid_from = _preload_known_deps(db, file_entities)
     pinned_commit_state = _preload_pinned_commits(db)
     field_class_ident = _preload_field_class_idents(db)
     field_static_ident = _preload_field_static_idents(db)
+    unresolved_dep_idents = _preload_unresolved_dep_idents(db, submodule_paths)
     return (
         watermark, prior_ingested, entity_valid_from, entity_descriptions,
         file_entities, file_deps, dep_valid_from, pinned_commit_state,
-        field_class_ident, field_static_ident,
+        field_class_ident, field_static_ident, submodule_paths, unresolved_dep_idents,
     )
 
 
@@ -5714,7 +5783,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
             (
                 watermark, prior_ingested, entity_valid_from, entity_descriptions,
                 file_entities, file_deps, dep_valid_from, pinned_commit_state,
-                field_class_ident, field_static_ident,
+                field_class_ident, field_static_ident, submodule_paths, unresolved_dep_idents,
             ) = await loop.run_in_executor(preload_executor, _load_ingestion_preload_state, repo_path)
         # minigraf exposes no explicit close(): the file lock is only released once
         # every reference to the handle is gone — the worker thread's own `db`
@@ -5986,6 +6055,14 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                             ])
                                             entity_valid_from[dep_ident] = commit_ts_iso
                                             entity_descriptions[dep_ident] = import_name
+                                            unresolved_dep_idents[dep_ident] = import_name
+                                            # #112: an already-known submodule may be the real
+                                            # target this unresolvable import was reaching for
+                                            # (submodule directories are never in file_entities,
+                                            # so any import into one always falls through here).
+                                            for sub_ident, sub_path in submodule_paths.items():
+                                                if _submodule_path_matches_import(sub_path, import_name):
+                                                    add_triples.append(f"[{dep_ident} :resolves-to {sub_ident}]")
                                 previous_deps = file_deps.get(file_path, set())
                                 for dep_ident in current_deps - previous_deps:
                                     dep_add_triples.append(f"[{module_ident} :depends-on {dep_ident}]")
@@ -6105,6 +6182,15 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                 entity_valid_from[ext_ident] = commit_ts_iso
                                 entity_descriptions[ext_ident] = description
                                 pinned_commit_state[ext_ident] = (sha, commit_ts_iso)
+                                submodule_paths[ext_ident] = path
+                                # #112: link any pre-existing unresolved-import stub whose
+                                # import path reaches into this submodule — the ordering in
+                                # the issue's own repro (stub created before the submodule
+                                # was ever added), which the per-import check above can't
+                                # catch since the submodule wasn't known yet at that time.
+                                for stub_ident, import_name in unresolved_dep_idents.items():
+                                    if _submodule_path_matches_import(path, import_name):
+                                        add_triples.append(f"[{stub_ident} :resolves-to {ext_ident}]")
                             elif kind == "bump":
                                 old_sha, orig_ts = pinned_commit_state.get(ext_ident, (None, commit_ts_iso))
                                 if old_sha is not None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5234,7 +5234,7 @@ class TestIngestionWrites:
             "results": [[":function/auth-py-login", "auth.py", "login", "2025-01-15T10:00:00Z"]]
         })
         db = mcp_server.get_db()
-        entity_valid_from, entity_descriptions, file_entities = (
+        entity_valid_from, entity_descriptions, file_entities, submodule_paths = (
             mcp_server._preload_known_entities(db, str(git_repo))
         )
         assert entity_valid_from.get(":function/auth-py-login") == "2025-01-15T10:00:00Z"
@@ -5691,11 +5691,14 @@ class TestPreloadExternalDependencies:
         mcp_server.open_db(str(tmp_path / "memory.graph"))
         db = mcp_server.get_db()
 
-        entity_valid_from, entity_descriptions, file_entities = mcp_server._preload_known_entities(db, str(tmp_path))
+        entity_valid_from, entity_descriptions, file_entities, submodule_paths = (
+            mcp_server._preload_known_entities(db, str(tmp_path))
+        )
 
         assert ":module/vendor-lib" in entity_valid_from
         assert entity_descriptions[":module/vendor-lib"] == "lib"
         assert "vendor/lib" in file_entities
+        assert submodule_paths[":module/vendor-lib"] == "vendor/lib"
 
     def test_preload_pinned_commits_reloads_current_sha(self, mock_minigraf_db, tmp_path):
         mock_class, db_instance = mock_minigraf_db
@@ -6871,7 +6874,7 @@ class TestIndexCacheInvalidation:
         mcp_server.open_db(str(tmp_path / "t.graph"))
         monkeypatch.setattr(mcp_server, "_git_commits", lambda *a, **k: [])
         monkeypatch.setattr(mcp_server, "_watermark_query", lambda db: None)
-        monkeypatch.setattr(mcp_server, "_preload_known_entities", lambda *a, **k: ({}, {}, {}))
+        monkeypatch.setattr(mcp_server, "_preload_known_entities", lambda *a, **k: ({}, {}, {}, {}))
         monkeypatch.setattr(mcp_server, "_ingest_tags", lambda *a, **k: None)
         monkeypatch.setattr(mcp_server, "_last_run_write", lambda *a, **k: None)
         with patch.object(mcp_server._index_cache, "invalidate") as mock_inv:
@@ -8614,6 +8617,119 @@ class TestRunIngestionGitlinks:
             "removed submodule's :entity-type must be closed (issue #137)"
         assert count(":path", '"vendor/lib"') == 0, \
             "removed submodule's :path must be closed (issue #137)"
+
+        mcp_server._db = None  # release the real file lock for subsequent tests
+
+
+class TestSubmoduleDependencyLinking:
+    """Issue #112: a dependency-edge stub created from an unresolvable
+    include path (e.g. #include "vendor/libX/api.h") and the submodule's own
+    entity (from .gitmodules / gitlink mode 160000) are computed via two
+    different ident schemes — _canonical_ident("module", import_name) for the
+    stub vs. _code_ident("module", path) for the submodule — so they land as
+    permanently disconnected idents even once both exist. A :resolves-to edge
+    from the stub to the submodule must connect them.
+
+    Verified against the REAL minigraf backend (no mock), since the fix reads
+    back existing external-dependency rows via a DB query at gitlink-add time.
+    """
+
+    def _make_progress(self):
+        return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
+
+    def _add_submodule_commit(self, repo, path="vendor/libX", name="libX", url="https://example.com/libX.git"):
+        sub = repo.parent / f"{repo.name}-sub"
+        _subprocess.run(["git", "init", "-q", str(sub)], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "config", "user.email", "t@t.com"], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "config", "user.name", "T"], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "commit", "--allow-empty", "-m", "e"], check=True, capture_output=True)
+        sub_hash = _subprocess.run(
+            ["git", "-C", str(sub), "rev-parse", "HEAD"], check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        (repo / ".gitmodules").write_text(f'[submodule "{name}"]\n\tpath = {path}\n\turl = {url}\n')
+        _subprocess.run(
+            ["git", "update-index", "--add", "--cacheinfo", f"160000,{sub_hash},{path}"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(["git", "add", ".gitmodules"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add submodule"], cwd=repo, check=True, capture_output=True)
+        return sub_hash
+
+    @pytest.mark.asyncio
+    async def test_preexisting_stub_links_to_submodule_added_later(self, tmp_path):
+        """Issue #112's exact repro order: the unresolvable include is ingested
+        first (no submodule exists yet), then the real submodule is added and
+        ingested incrementally. The stub from step one must end up with a
+        :resolves-to edge to the submodule entity from step two."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "consumer.py").write_text("import vendor.libX.api\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add consumer"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server._db = None
+        mcp_server._graph_path = None
+        mcp_server._ingest_progress = self._make_progress()
+        mcp_server.open_db(str(repo / "memory.graph"))
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        self._add_submodule_commit(repo)
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        db = mcp_server.get_db()
+        real_execute = mcp_server._db_execute
+
+        def rows(query):
+            raw = real_execute(db, query)
+            return json.loads(raw).get("results", [])
+
+        stub_ident = mcp_server._canonical_ident("module", "vendor.libX.api")
+        submodule_ident = mcp_server._code_ident("module", "vendor/libX")
+        assert rows(f"(query [:find ?v :where [{stub_ident} :resolves-to ?v]])") == [[submodule_ident]], \
+            "unresolved-include stub must gain a :resolves-to edge to the submodule entity (issue #112)"
+
+        mcp_server._db = None  # release the real file lock for subsequent tests
+
+    @pytest.mark.asyncio
+    async def test_stub_created_after_submodule_links_immediately(self, tmp_path):
+        """Reverse ordering: the submodule already exists, then a later commit
+        adds an include reaching under it. Since submodule directories are
+        never walked as tracked files, this import can never resolve — the fix
+        must link the new stub the moment it's created, not just at the next
+        gitlink event."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        self._add_submodule_commit(repo)
+
+        (repo / "consumer.py").write_text("import vendor.libX.api\n")
+        _subprocess.run(["git", "add", "consumer.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add consumer"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server._db = None
+        mcp_server._graph_path = None
+        mcp_server._ingest_progress = self._make_progress()
+        mcp_server.open_db(str(repo / "memory.graph"))
+        await mcp_server._run_ingestion(str(repo), "HEAD")
+
+        db = mcp_server.get_db()
+        real_execute = mcp_server._db_execute
+
+        def rows(query):
+            raw = real_execute(db, query)
+            return json.loads(raw).get("results", [])
+
+        stub_ident = mcp_server._canonical_ident("module", "vendor.libX.api")
+        submodule_ident = mcp_server._code_ident("module", "vendor/libX")
+        assert rows(f"(query [:find ?v :where [{stub_ident} :resolves-to ?v]])") == [[submodule_ident]], \
+            "stub created after the submodule already exists must link immediately (issue #112)"
 
         mcp_server._db = None  # release the real file lock for subsequent tests
 


### PR DESCRIPTION
## Summary
- Fixes #112: dependency-edge stubs created from an unresolvable include (e.g. `#include "vendor/libX/api.h"`) and the submodule entity they actually point at (from `.gitmodules`/gitlink) were computed via two different ident schemes — `_canonical_ident` from the raw import specifier vs. `_code_ident` from the submodule's declared path — so they never shared an ident and stayed permanently disconnected, regardless of ingestion order.
- Adds a `:resolves-to` edge from the stub ident to the submodule ident whenever the submodule's path is a whole-segment prefix of the stub's import path (new `_submodule_path_matches_import` helper).
- Handles both orderings from the issue: linked immediately at stub-creation time when the submodule is already known, and linked at gitlink "add" time by scanning pre-existing stubs when the stub predates the submodule (the issue's own repro order).
- Restart-safe: extends `_preload_known_entities` to also return `submodule_paths` (idents that have a `:path`, i.e. real submodules) and adds `_preload_unresolved_dep_idents` to reload pure stub idents (no `:path`) via a DB query, so linking works across incremental/resumed ingestion runs, not just within one process.
- Documents the new `:resolves-to` edge in SKILL.md's `:type/external-dependency` section.

## Test plan
- [x] Two new real-backend regression tests in `TestSubmoduleDependencyLinking` (mirrors #137's `..._against_real_graph` pattern): one for the issue's exact repro order (stub before submodule), one for the reverse order (submodule before stub) — both verify a `:resolves-to` edge query on the real minigraf backend.
- [x] Watched both fail (RED) before the fix, confirmed for the right reason (missing edge, not a setup error).
- [x] Full suite (`pytest tests/`) run before and after: identical failing-test set (101 pre-existing failures, all from tree-sitter grammars not installed in this sandbox — cpp/ruby/php/kotlin/swift/scala/haskell/lua/elixir), no new regressions; 3 existing unit tests updated for `_preload_known_entities`'s new 4-tuple return shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU