### PR TITLE
fix: pin git ingestion to a configurable branch instead of HEAD

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -268,7 +268,7 @@ minigraf_ingest_status()
 # → {"ok": true, "status": "idle", ...}
 
 # Step 2: start only if idle
-minigraf_ingest_git(repo_path="/path/to/repo", branch="HEAD")
+minigraf_ingest_git(repo_path="/path/to/repo")
 # → {"ok": true, "job_id": "git-ingest", "message": "Ingestion started for /path/to/repo"}
 
 # If already running:
@@ -280,7 +280,9 @@ minigraf_ingest_git(repo_path="/path/to/repo", branch="HEAD")
 
 Once started, inform the user that ingestion is running in the background and move on — do not poll or wait for completion.
 
-Auto-started at MCP server startup — the server creates a background asyncio task that calls `_run_ingestion(cwd, "HEAD")` immediately. Set `MINIGRAF_NO_AUTO_INGEST=1` to suppress this (useful in eval sandboxes). Incremental: reads the `:ingestion/watermark` entity to determine the last ingested commit, then only processes new commits.
+Auto-started at MCP server startup — the server creates a background asyncio task that ingests the resolved default branch immediately. Set `MINIGRAF_NO_AUTO_INGEST=1` to suppress this (useful in eval sandboxes). Incremental: reads the `:ingestion/watermark` entity to determine the last ingested commit, then only processes new commits.
+
+By default, `minigraf_ingest_git` (and the auto-start above) resolve which branch to walk instead of blindly following whatever ref is checked out: `MINIGRAF_GIT_BRANCH` wins if set, otherwise the repo's `main` or `master` branch is auto-detected, falling back to `HEAD` only if neither exists. Pass an explicit `branch` argument to override both — useful for on-demand ingestion of a feature branch without disturbing the pinned default.
 
 Vendored/third-party/generated paths are skipped for AST extraction by default (`3rdParty/`, `third_party/`, `vendor/`, `node_modules/`, `dist/`, `build/`, `*.min.js`, `*.map`) — no per-file entities are created for them, and any in-repo import resolving into an ignored path is tagged `:type/external-dependency` instead of an internal module dependency. Extend the ignore list with `MINIGRAF_INGEST_IGNORE` (comma-separated globs/prefixes, e.g. `MINIGRAF_INGEST_IGNORE=generated/,*.pb.go`) and/or a repo-local `.temporalignore` file (one pattern per line, `#` comments allowed) — both add to the defaults, they don't replace them. Ignore config is resolved once when ingestion starts and applies uniformly across all historical commits; it does not retroactively remove entities from a graph that was already ingested before the ignore list was added.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3477,6 +3477,29 @@ def _code_ident(entity_type: str, file_path: str, name: Optional[str] = None) ->
 # ---------------------------------------------------------------------------
 
 
+def _default_git_branch(repo_path: str) -> str:
+    """Resolve the branch to ingest when the caller didn't pass one explicitly.
+
+    MINIGRAF_GIT_BRANCH (matching the other MINIGRAF_* ingestion env vars)
+    takes precedence, trusted as-is with no existence check. Otherwise
+    auto-detect the repo's actual default branch by trying main then master,
+    so ingestion tracks a stable target instead of silently following
+    whatever ref happens to be checked out (#130). Only falls back to "HEAD"
+    if neither exists.
+    """
+    env_branch = os.environ.get("MINIGRAF_GIT_BRANCH")
+    if env_branch:
+        return env_branch
+    for candidate in ("main", "master"):
+        result = _subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", candidate],
+            cwd=repo_path, capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            return candidate
+    return "HEAD"
+
+
 def _git_commits(
     repo_path: str,
     watermark_hash: Optional[str],
@@ -6315,7 +6338,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
 
 async def handle_minigraf_ingest_git(
     repo_path: Optional[str] = None,
-    branch: str = "HEAD",
+    branch: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Start background git ingestion. Returns immediately."""
     global _ingest_task, _ingest_progress
@@ -6351,7 +6374,7 @@ async def handle_minigraf_ingest_git(
         "status": "starting", "processed": 0, "total": 0, "prior_ingested": 0,
         "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
     }
-    _ingest_task = asyncio.create_task(_run_ingestion(repo, branch))
+    _ingest_task = asyncio.create_task(_run_ingestion(repo, branch or _default_git_branch(repo)))
     return {"ok": True, "job_id": "git-ingest", "message": f"Ingestion started for {repo}"}
 
 
@@ -6608,7 +6631,11 @@ _TOOLS: List[Tool] = [
                 },
                 "branch": {
                     "type": "string",
-                    "description": "Branch or ref to walk. Defaults to HEAD.",
+                    "description": (
+                        "Branch or ref to walk. Defaults to MINIGRAF_GIT_BRANCH if "
+                        "set, otherwise auto-detects the repo's main/master branch, "
+                        "falling back to HEAD only if neither exists."
+                    ),
                 },
             },
             "required": [],
@@ -6688,7 +6715,7 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
         if name == "minigraf_ingest_git":
             result = await handle_minigraf_ingest_git(
                 repo_path=arguments.get("repo_path"),
-                branch=arguments.get("branch", "HEAD"),
+                branch=arguments.get("branch"),
             )
             return [TextContent(type="text", text=json.dumps(result))]
 
@@ -6746,7 +6773,8 @@ async def main() -> None:
             _ingest_progress["owner_pid"] = holder_pid
         else:
             _ingest_progress["status"] = "starting"
-            _ingest_task = asyncio.create_task(_run_ingestion(str(Path.cwd()), "HEAD"))
+            cwd = str(Path.cwd())
+            _ingest_task = asyncio.create_task(_run_ingestion(cwd, _default_git_branch(cwd)))
 
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4064,6 +4064,45 @@ class TestGitHelpers:
         assert b"def login" in content
 
 
+class TestDefaultGitBranch:
+    def _init_repo_with_branch(self, tmp_path, branch_name):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init", "-b", branch_name], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "f.py").write_text("x = 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def test_env_var_takes_precedence_over_auto_detect(self, tmp_path, monkeypatch):
+        import mcp_server
+        repo = self._init_repo_with_branch(tmp_path, "main")
+        monkeypatch.setenv("MINIGRAF_GIT_BRANCH", "release")
+        # "release" doesn't even exist as a branch here -- the env var is
+        # trusted as-is, not validated against the repo.
+        assert mcp_server._default_git_branch(str(repo)) == "release"
+
+    def test_auto_detects_main_when_present(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.delenv("MINIGRAF_GIT_BRANCH", raising=False)
+        repo = self._init_repo_with_branch(tmp_path, "main")
+        assert mcp_server._default_git_branch(str(repo)) == "main"
+
+    def test_auto_detects_master_when_no_main(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.delenv("MINIGRAF_GIT_BRANCH", raising=False)
+        repo = self._init_repo_with_branch(tmp_path, "master")
+        assert mcp_server._default_git_branch(str(repo)) == "master"
+
+    def test_falls_back_to_head_when_neither_main_nor_master_exist(self, tmp_path, monkeypatch):
+        import mcp_server
+        monkeypatch.delenv("MINIGRAF_GIT_BRANCH", raising=False)
+        repo = self._init_repo_with_branch(tmp_path, "trunk")
+        assert mcp_server._default_git_branch(str(repo)) == "HEAD"
+
+
 class TestGitDiffTreeRaw:
     def test_regular_file_add(self, git_repo):
         import mcp_server
@@ -6069,6 +6108,60 @@ class TestRunIngestion:
         assert mcp_server._ingest_progress["status"] == "starting"
 
     @pytest.mark.asyncio
+    async def test_ingest_git_resolves_branch_via_default_when_not_specified(
+        self, mock_minigraf_db, git_repo, monkeypatch
+    ):
+        """#130: omitting `branch` must resolve through _default_git_branch,
+        not hardcode "HEAD"."""
+        import mcp_server
+        monkeypatch.setattr(mcp_server, "_live_lock_holder_pid", lambda path: None)
+        monkeypatch.setattr(mcp_server, "_default_git_branch", lambda repo_path: "resolved-branch")
+        captured = {}
+
+        async def fake_run_ingestion(repo_path, branch):
+            captured["branch"] = branch
+
+        monkeypatch.setattr(mcp_server, "_run_ingestion", fake_run_ingestion)
+        mcp_server._ingest_task = None
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+            "current_commit": "", "error": None, "owner_pid": None,
+        }
+        result = await mcp_server.handle_minigraf_ingest_git(repo_path=str(git_repo))
+        await mcp_server._ingest_task
+        assert result["ok"] is True
+        assert captured["branch"] == "resolved-branch"
+
+    @pytest.mark.asyncio
+    async def test_ingest_git_explicit_branch_overrides_default(
+        self, mock_minigraf_db, git_repo, monkeypatch
+    ):
+        """An explicit `branch` argument must win over _default_git_branch,
+        which shouldn't even be consulted in that case."""
+        import mcp_server
+        monkeypatch.setattr(mcp_server, "_live_lock_holder_pid", lambda path: None)
+
+        def unexpected_call(repo_path):
+            raise AssertionError("_default_git_branch should not be called when branch is explicit")
+
+        monkeypatch.setattr(mcp_server, "_default_git_branch", unexpected_call)
+        captured = {}
+
+        async def fake_run_ingestion(repo_path, branch):
+            captured["branch"] = branch
+
+        monkeypatch.setattr(mcp_server, "_run_ingestion", fake_run_ingestion)
+        mcp_server._ingest_task = None
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+            "current_commit": "", "error": None, "owner_pid": None,
+        }
+        result = await mcp_server.handle_minigraf_ingest_git(repo_path=str(git_repo), branch="feature-x")
+        await mcp_server._ingest_task
+        assert result["ok"] is True
+        assert captured["branch"] == "feature-x"
+
+    @pytest.mark.asyncio
     async def test_processed_seeded_from_prior_ingested(self, mock_minigraf_db, git_repo, monkeypatch):
         """processed starts at the true persisted commit count and increments
         cumulatively — regression test for #85 (seeding must not rely on the
@@ -6593,6 +6686,54 @@ class TestMainAutoIngestLockCheck:
 
         assert mcp_server._ingest_task is not None
         assert mcp_server._ingest_progress["status"] == "starting"
+
+        mcp_server._shutdown_requested.set()
+        await asyncio.wait_for(main_task, timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_auto_ingest_resolves_branch_via_default_git_branch(self, monkeypatch, tmp_path):
+        """#130: auto-start at server boot must resolve the branch through
+        _default_git_branch instead of hardcoding "HEAD"."""
+        import mcp_server
+
+        monkeypatch.setenv("MINIGRAF_GRAPH_PATH", str(tmp_path / "t.graph"))
+        monkeypatch.setattr(mcp_server, "_live_lock_holder_pid", lambda path: None)
+        monkeypatch.setattr(mcp_server, "_default_git_branch", lambda repo_path: "resolved-default")
+
+        captured = {}
+
+        async def fake_run_ingestion(repo_path, branch):
+            captured["branch"] = branch
+            done, _ = await asyncio.wait(
+                {
+                    asyncio.create_task(mcp_server._shutdown_requested.wait()),
+                    asyncio.create_task(asyncio.Event().wait()),
+                },
+                return_when=asyncio.FIRST_COMPLETED
+            )
+
+        monkeypatch.setattr(mcp_server, "_run_ingestion", fake_run_ingestion)
+        mcp_server._shutdown_requested = asyncio.Event()
+        mcp_server._ingest_task = None
+
+        @contextlib.asynccontextmanager
+        async def fake_stdio_server():
+            yield (object(), object())
+
+        monkeypatch.setattr(mcp_server, "stdio_server", fake_stdio_server)
+
+        run_started = asyncio.Event()
+
+        async def fake_run(read_stream, write_stream, init_opts):
+            run_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(mcp_server.server, "run", fake_run)
+
+        main_task = asyncio.create_task(mcp_server.main())
+        await run_started.wait()
+
+        assert captured["branch"] == "resolved-default"
 
         mcp_server._shutdown_requested.set()
         await asyncio.wait_for(main_task, timeout=2)


### PR DESCRIPTION
## Summary
- Every git-ingestion entry point (`handle_minigraf_ingest_git`'s default, the MCP tool dispatch default, and the server's auto-start call) defaulted `branch` to the literal string `"HEAD"`, so the graph's view of "the codebase" silently followed whatever ref was checked out when ingestion happened to fire, with no record of which branch a given pass actually walked.
- Adds `_default_git_branch(repo_path)`: `MINIGRAF_GIT_BRANCH` env var wins if set (matches the existing `MINIGRAF_*` naming convention), otherwise auto-detects the repo's `main`/`master` branch via `git rev-parse --verify --quiet`, falling back to `HEAD` only if neither exists.
- Explicit `branch` arguments to `minigraf_ingest_git` still override both, unchanged — only the *default* (nothing passed) resolves through the new helper.
- Updated the tool's `inputSchema` description and SKILL.md to document the new default-resolution behavior and `MINIGRAF_GIT_BRANCH`.

Fixes #130.

## Test plan
- [x] New `TestDefaultGitBranch` unit tests (env var precedence, main auto-detect, master auto-detect, HEAD fallback when neither exists) — written first, watched fail with `AttributeError` before implementing.
- [x] New `handle_minigraf_ingest_git` tests: resolves branch via `_default_git_branch` when omitted; explicit `branch` argument overrides it without even calling the helper.
- [x] New `main()` auto-start test: confirms the auto-start call resolves branch via `_default_git_branch` instead of hardcoding `"HEAD"`.
- [x] Full suite: `101 failed, 442 passed, 39 skipped` — identical failure count/set to the pre-existing baseline (missing tree-sitter grammars for cpp/ruby/php/kotlin/swift/scala/haskell/lua/elixir in this sandbox), confirming no regressions.

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU