### PR TITLE
feat(install): require an explicit --harness and install only that harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Temporal Reasoning provides persistent bi-temporal graph memory for AI coding ag
 ## Quick Start
 
 ```bash
-# Install dependencies and sync skill
-python install.py
+# Install dependencies and sync skill (--harness is required: claude-code, opencode, or codex)
+python install.py --harness claude-code
 
 # Use in code
 from minigraf import query, transact

--- a/README.md
+++ b/README.md
@@ -92,23 +92,33 @@ query("[:find ?name :where [:project/db :name ?name]]")
 
 ## Install
 
+`install.py` requires an explicit `--harness` so it only touches the files for the agent you're setting up: `claude-code`, `opencode`, or `codex`.
+
 ```bash
 git clone https://github.com/project-minigraf/temporal_reasoning
 cd /your/project
-python /path/to/temporal_reasoning/install.py
+python /path/to/temporal_reasoning/install.py --harness claude-code
 ```
 
-Run `install.py` from your project root. It creates a virtualenv, installs dependencies, and writes `.mcp.json` and `.claude/settings*.json` into your project directory. That's it.
+Run `install.py` from your project root. It creates a virtualenv, installs dependencies, and — for `--harness claude-code` — writes `.mcp.json` and `.claude/settings*.json` into your project directory. That's it.
 
 **Optional — LLM extraction strategy:** `install.py` defaults to heuristic (regex) extraction, which requires no API key. To use LLM-based extraction, set `MINIGRAF_EXTRACTION_STRATEGY=llm` and `ANTHROPIC_API_KEY=<your key>` in `.claude/settings.local.json` after running the script.
 
 ### OpenCode
 
 ```bash
-python /path/to/temporal_reasoning/install.py
+python /path/to/temporal_reasoning/install.py --harness opencode
 ```
 
-This also syncs the skill into `.opencode/skills/temporal-reasoning`.
+This syncs the skill into `.opencode/skills/temporal-reasoning`. OpenCode's MCP + hook wiring is manual — merge `hooks/opencode.json` into your OpenCode config (see the file for details; auto-memory hooks don't fire in OpenCode, so the agent calls `memory_prepare_turn`/`memory_finalize_turn` explicitly per `SKILL.md`).
+
+### Codex CLI
+
+```bash
+python /path/to/temporal_reasoning/install.py --harness codex
+```
+
+This syncs the skill into `.codex/skills/temporal-reasoning`. Codex's MCP + hook wiring is manual — merge `hooks/codex.toml` into your `config.toml`.
 
 ## Quick Start
 

--- a/install.py
+++ b/install.py
@@ -3,10 +3,17 @@
 Installation script for temporal-reasoning skill.
 Installs minigraf and mcp Python packages, syncs skill files, provides next steps.
 
+--harness is required and selects exactly one target; only that harness's
+skill directory (and, for claude-code, Claude Code's config files) is
+created or updated. Supported values: claude-code, opencode, codex.
+
 Usage:
-    python install.py          # Full install
-    python install.py --check  # Just check dependencies
-    python install.py --force  # Force reinstall even if recent
+    python install.py --harness claude-code            # Full install for Claude Code
+    python install.py --harness opencode                # Sync skill files for OpenCode
+    python install.py --harness codex                   # Sync skill files for Codex CLI
+    python install.py --harness claude-code --check      # Just check dependencies
+    python install.py --harness claude-code --force      # Force reinstall even if recent
+    python install.py --harness claude-code --target DIR # Install into a specific project directory
 """
 
 import sys
@@ -34,11 +41,42 @@ PLUGIN_VERSION = _plugin_version()
 
 FILES_TO_SYNC = ["SKILL.md", "mcp_server.py", "skill.json"]
 DIRS_TO_SYNC = ["tools", "hooks"]
-SKILL_DIRS = [
-    os.path.join(".codex", "skills", "temporal-reasoning"),
-    os.path.join(".opencode", "skills", "temporal-reasoning"),
-    os.path.join("skills", "temporal-reasoning"),
-]
+SUPPORTED_HARNESSES = ("claude-code", "opencode", "codex")
+HARNESS_SKILL_DIRS = {
+    "codex": os.path.join(".codex", "skills", "temporal-reasoning"),
+    "opencode": os.path.join(".opencode", "skills", "temporal-reasoning"),
+    "claude-code": os.path.join("skills", "temporal-reasoning"),
+}
+_MANUAL_CONFIG_TEMPLATE = {
+    "opencode": os.path.join("hooks", "opencode.json"),
+    "codex": os.path.join("hooks", "codex.toml"),
+}
+_HARNESS_FLAG_VALUE_ARGS = ("--harness", "--target")
+
+
+def _resolve_harness(argv):
+    """Parse and validate the required --harness argument from *argv*.
+
+    Returns the harness string on success. On a missing or invalid value,
+    prints actionable usage text and returns None — callers must treat None
+    as "stop before writing any files."
+    """
+    if "--harness" not in argv:
+        print("✗ --harness is required.")
+        print(f"  Supported harnesses: {', '.join(SUPPORTED_HARNESSES)}")
+        print(f"  Usage: python install.py --harness <{'|'.join(SUPPORTED_HARNESSES)}>")
+        return None
+    idx = argv.index("--harness")
+    if idx + 1 >= len(argv):
+        print("✗ --harness requires a value.")
+        print(f"  Supported harnesses: {', '.join(SUPPORTED_HARNESSES)}")
+        return None
+    value = argv[idx + 1]
+    if value not in SUPPORTED_HARNESSES:
+        print(f"✗ Unknown harness {value!r}.")
+        print(f"  Supported harnesses: {', '.join(SUPPORTED_HARNESSES)}")
+        return None
+    return value
 
 
 def ensure_venv() -> bool:
@@ -187,25 +225,24 @@ def _write_last_update() -> None:
         f.write(datetime.now(timezone.utc).isoformat())
 
 
-def _sync_files(target_dir: str) -> None:
+def _sync_files(target_dir: str, harness: str) -> None:
     import shutil
-    for rel_dir in SKILL_DIRS:
-        dest_dir = os.path.join(target_dir, rel_dir)
-        os.makedirs(dest_dir, exist_ok=True)
-        for fname in FILES_TO_SYNC:
-            src = os.path.join(REPO_DIR, fname)
-            if os.path.exists(src):
-                shutil.copy2(src, os.path.join(dest_dir, fname))
-        for dname in DIRS_TO_SYNC:
-            src_dir = os.path.join(REPO_DIR, dname)
-            if os.path.isdir(src_dir):
-                shutil.copytree(src_dir, os.path.join(dest_dir, dname), dirs_exist_ok=True)
+    rel_dir = HARNESS_SKILL_DIRS[harness]
+    dest_dir = os.path.join(target_dir, rel_dir)
+    os.makedirs(dest_dir, exist_ok=True)
+    for fname in FILES_TO_SYNC:
+        src = os.path.join(REPO_DIR, fname)
+        if os.path.exists(src):
+            shutil.copy2(src, os.path.join(dest_dir, fname))
+    for dname in DIRS_TO_SYNC:
+        src_dir = os.path.join(REPO_DIR, dname)
+        if os.path.isdir(src_dir):
+            shutil.copytree(src_dir, os.path.join(dest_dir, dname), dirs_exist_ok=True)
     synced = ", ".join(FILES_TO_SYNC + DIRS_TO_SYNC)
-    dirs = ", ".join(SKILL_DIRS)
-    print(f"✓ Synced [{synced}] → [{dirs}]")
+    print(f"✓ Synced [{synced}] → [{rel_dir}]")
 
 
-def update_skill(target_dir: str) -> bool:
+def update_skill(target_dir: str, harness: str) -> bool:
     """Pull from GitHub and sync skill files to target_dir."""
     print("Checking for skill updates...")
     try:
@@ -220,7 +257,7 @@ def update_skill(target_dir: str) -> bool:
         _write_last_update()
         if result.stdout.strip() and "Already up to date" not in result.stdout:
             print("Pulling latest from GitHub...")
-        _sync_files(target_dir)
+        _sync_files(target_dir, harness)
         print("✓ Skill up-to-date")
         return True
     except subprocess.CalledProcessError:
@@ -235,12 +272,21 @@ def update_skill(target_dir: str) -> bool:
 
 
 def _get_target_dir() -> str:
-    if "--target" in sys.argv:
-        idx = sys.argv.index("--target")
-        if idx + 1 < len(sys.argv):
-            return os.path.abspath(sys.argv[idx + 1])
-    # Accept a bare positional path argument (e.g. `python install.py /path/to/project`)
-    for arg in sys.argv[1:]:
+    argv = sys.argv[1:]
+    if "--target" in argv:
+        idx = argv.index("--target")
+        if idx + 1 < len(argv):
+            return os.path.abspath(argv[idx + 1])
+    # Accept a bare positional path argument (e.g. `python install.py /path/to/project`),
+    # skipping over recognized flags and the values that belong to them.
+    skip_next = False
+    for arg in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in _HARNESS_FLAG_VALUE_ARGS:
+            skip_next = True
+            continue
         if not arg.startswith("-"):
             return os.path.abspath(arg)
     return os.getcwd()
@@ -662,7 +708,7 @@ def register_plugin_with_claude() -> bool:
     return True
 
 
-def main(target_dir: str = "") -> None:
+def main(target_dir: str = "", harness: str = "claude-code") -> None:
     print("=" * 50)
     print("Temporal Reasoning Skill Setup")
     print("=" * 50)
@@ -694,6 +740,18 @@ def main(target_dir: str = "") -> None:
         results.append(check_func())
         print()
 
+    if harness != "claude-code":
+        ok = all(results)
+        print("=" * 50)
+        print("✓ Setup complete!" if ok else "✗ Setup incomplete — fix errors above")
+        print("=" * 50)
+        print()
+        print(f"Skill files synced to your {harness} skill directory.")
+        print(f"Manual MCP + hook configuration required — see {_MANUAL_CONFIG_TEMPLATE[harness]} for a template.")
+        if not ok:
+            sys.exit(1)
+        return
+
     print("Configuring .mcp.json...")
     mcp_ok = setup_mcp_json(target_dir)
     print()
@@ -717,11 +775,6 @@ def main(target_dir: str = "") -> None:
         print()
         print("Replace any 'your-api-key-here' placeholders in:")
         print("  .claude/settings.local.json    — hooks + Claude Code env (ANTHROPIC_API_KEY)")
-        print()
-        print("Other agents (manual config — see hooks/ for templates):")
-        print("    hooks/codex.toml    — Codex CLI")
-        print("    hooks/hermes.yaml   — Hermes")
-        print("    hooks/opencode.json — OpenCode")
     else:
         print("=" * 50)
         print("✗ Setup incomplete — fix errors above")
@@ -730,14 +783,22 @@ def main(target_dir: str = "") -> None:
 
 
 if __name__ == "__main__":
+    if "-h" in sys.argv or "--help" in sys.argv:
+        print(__doc__)
+        sys.exit(0)
+
+    harness = _resolve_harness(sys.argv[1:])
+    if harness is None:
+        sys.exit(2)
+
     target_dir = _get_target_dir()
     force = "--force" in sys.argv
     if target_dir != REPO_DIR:
         print(f"Installing into: {target_dir}")
 
     if force or should_update():
-        update_skill(target_dir)
+        update_skill(target_dir, harness)
     else:
-        _sync_files(target_dir)
+        _sync_files(target_dir, harness)
 
-    main(target_dir)
+    main(target_dir, harness)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -91,3 +91,109 @@ class TestSyncLists:
 
     def test_hooks_in_dirs_to_sync(self):
         assert "hooks" in install.DIRS_TO_SYNC
+
+
+class TestResolveHarness:
+    def test_missing_harness_returns_none(self):
+        assert install._resolve_harness([]) is None
+
+    def test_missing_harness_value_returns_none(self):
+        assert install._resolve_harness(["--harness"]) is None
+
+    def test_invalid_harness_value_returns_none(self):
+        assert install._resolve_harness(["--harness", "vim"]) is None
+
+    def test_valid_claude_code_harness(self):
+        assert install._resolve_harness(["--harness", "claude-code"]) == "claude-code"
+
+    def test_valid_opencode_harness(self):
+        assert install._resolve_harness(["--harness", "opencode"]) == "opencode"
+
+    def test_valid_codex_harness(self):
+        assert install._resolve_harness(["--harness", "codex"]) == "codex"
+
+    def test_harness_value_alongside_other_flags(self):
+        argv = ["--target", "/some/path", "--harness", "codex", "--force"]
+        assert install._resolve_harness(argv) == "codex"
+
+
+class TestGetTargetDir:
+    def test_harness_value_not_mistaken_for_target_dir(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["install.py", "--harness", "codex"])
+        assert install._get_target_dir() == install.os.getcwd()
+
+    def test_explicit_target_still_works_with_harness(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys, "argv",
+            ["install.py", "--harness", "opencode", "--target", str(tmp_path)],
+        )
+        assert install._get_target_dir() == install.os.path.abspath(str(tmp_path))
+
+    def test_bare_positional_path_still_works_with_harness(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys, "argv",
+            ["install.py", "--harness", "claude-code", str(tmp_path)],
+        )
+        assert install._get_target_dir() == install.os.path.abspath(str(tmp_path))
+
+
+class TestSyncFilesHarnessScoping:
+    @pytest.mark.parametrize("harness,expected_dir,other_dirs", [
+        ("claude-code", "skills/temporal-reasoning",
+         [".codex/skills/temporal-reasoning", ".opencode/skills/temporal-reasoning"]),
+        ("opencode", ".opencode/skills/temporal-reasoning",
+         [".codex/skills/temporal-reasoning", "skills/temporal-reasoning"]),
+        ("codex", ".codex/skills/temporal-reasoning",
+         [".opencode/skills/temporal-reasoning", "skills/temporal-reasoning"]),
+    ])
+    def test_only_selected_harness_dir_is_written(self, tmp_path, harness, expected_dir, other_dirs):
+        install._sync_files(str(tmp_path), harness)
+        assert (tmp_path / expected_dir / "SKILL.md").exists()
+        for other in other_dirs:
+            assert not (tmp_path / other).exists()
+
+
+class TestMainHarnessGating:
+    def _patch_common(self, monkeypatch):
+        monkeypatch.setattr(install, "ensure_venv", lambda: True)
+        monkeypatch.setattr(install, "check_python_version", lambda: True)
+        monkeypatch.setattr(install, "check_minigraf_package", lambda: True)
+        monkeypatch.setattr(install, "check_mcp_package", lambda: True)
+        monkeypatch.setattr(install, "check_tree_sitter_packages", lambda: True)
+        monkeypatch.setattr(install, "check_mcp_server_importable", lambda: True)
+
+    def test_non_claude_harness_skips_claude_specific_setup(self, monkeypatch, tmp_path):
+        self._patch_common(monkeypatch)
+        mcp_json = MagicMock(return_value=True)
+        settings_json = MagicMock(return_value=True)
+        settings_local = MagicMock(return_value=True)
+        register = MagicMock(return_value=True)
+        monkeypatch.setattr(install, "setup_mcp_json", mcp_json)
+        monkeypatch.setattr(install, "setup_claude_settings_json", settings_json)
+        monkeypatch.setattr(install, "setup_claude_settings", settings_local)
+        monkeypatch.setattr(install, "register_plugin_with_claude", register)
+
+        install.main(str(tmp_path), "opencode")
+
+        mcp_json.assert_not_called()
+        settings_json.assert_not_called()
+        settings_local.assert_not_called()
+        register.assert_not_called()
+
+    def test_claude_code_harness_runs_claude_specific_setup(self, monkeypatch, tmp_path):
+        self._patch_common(monkeypatch)
+        mcp_json = MagicMock(return_value=True)
+        settings_json = MagicMock(return_value=True)
+        settings_local = MagicMock(return_value=True)
+        register = MagicMock(return_value=True)
+        monkeypatch.setattr(install, "setup_mcp_json", mcp_json)
+        monkeypatch.setattr(install, "setup_claude_settings_json", settings_json)
+        monkeypatch.setattr(install, "setup_claude_settings", settings_local)
+        monkeypatch.setattr(install, "register_plugin_with_claude", register)
+
+        install.main(str(tmp_path), "claude-code")
+
+        mcp_json.assert_called_once_with(str(tmp_path))
+        settings_json.assert_called_once_with(str(tmp_path))
+        settings_local.assert_called_once_with(str(tmp_path))
+        register.assert_called_once()


### PR DESCRIPTION
## Summary
- `--harness` is now a required `install.py` argument (`claude-code`, `opencode`, or `codex`, aligned with `skill.json`'s `environments`). Missing/unknown values fail fast with actionable usage text, before any file is written.
- `SKILL_DIRS` (a flat list synced unconditionally) is replaced with `HARNESS_SKILL_DIRS`, a per-harness mapping — a run now only creates/updates the selected harness's skill directory.
- Claude Code's config automation (`.mcp.json`, `.claude/settings*.json`, plugin registration with the local Claude Code install) now runs only for `--harness claude-code`. `opencode`/`codex` installs sync skill files only and point at their existing manual `hooks/opencode.json` / `hooks/codex.toml` templates.
- Fixed a latent bug in `_get_target_dir()`'s positional-path fallback: without this fix, `--harness codex` (or any future flag value) would have been misread as the target directory since the loop only special-cased `--target`.
- `--help`/`-h` now prints the (updated) module docstring documenting the required flag and its keywords.

## Test plan
- [x] New unit tests: `TestResolveHarness` (missing/missing-value/invalid/valid × 3), `TestGetTargetDir` (harness value not swallowed as target, `--target` and positional-path compatibility), `TestSyncFilesHarnessScoping` (parametrized over all 3 harnesses — each writes only its own dir), `TestMainHarnessGating` (claude-code runs the 4 Claude-specific setup calls; opencode does not)
- [x] Full suite: `pytest -q` → 597 passed
- [x] Manual: bare `python install.py` and `--harness vim` both exit 2 with usage text and write nothing; `--harness opencode --target <dir>` creates only `.opencode/skills/temporal-reasoning`; `--harness claude-code --target <dir>` still does the full install (`.claude/`, `.mcp.json`, `skills/temporal-reasoning`)
- [x] Docs synced: README.md install section (per-harness commands + manual-config pointers), CLAUDE.md Quick Start

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU