### PR TITLE
fix(install): use harness-specific project skill directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,11 @@ __pycache__/
 build/
 *.egg-info/
 
-# OpenCode
+# Harness-local synced skill copies (OpenCode, Codex CLI)
 .opencode/
 .codex
 .codex/
+.agents/
 *.graph
 *.graph.lock
 .mcp.json

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ cd /your/project
 python /path/to/temporal_reasoning/install.py --harness claude-code
 ```
 
-Run `install.py` from your project root. It creates a virtualenv, installs dependencies, and — for `--harness claude-code` — writes `.mcp.json` and `.claude/settings*.json` into your project directory. That's it.
+Run `install.py` from your project root. It creates a virtualenv, installs dependencies, syncs the skill into `.claude/skills/temporal-reasoning` (Claude Code's project-local skill scope), and — for `--harness claude-code` — writes `.mcp.json` and `.claude/settings*.json` into your project directory. That's it.
 
 **Optional — LLM extraction strategy:** `install.py` defaults to heuristic (regex) extraction, which requires no API key. To use LLM-based extraction, set `MINIGRAF_EXTRACTION_STRATEGY=llm` and `ANTHROPIC_API_KEY=<your key>` in `.claude/settings.local.json` after running the script.
 
@@ -118,7 +118,7 @@ This syncs the skill into `.opencode/skills/temporal-reasoning`. OpenCode's MCP 
 python /path/to/temporal_reasoning/install.py --harness codex
 ```
 
-This syncs the skill into `.codex/skills/temporal-reasoning`. Codex's MCP + hook wiring is manual — merge `hooks/codex.toml` into your `config.toml`.
+This syncs the skill into `.agents/skills/temporal-reasoning` — Codex CLI's documented project-local skill scope (it scans `.agents/skills` from the current working directory up to the repository root). Codex's MCP + hook wiring is manual — merge `hooks/codex.toml` into your `config.toml`.
 
 ## Quick Start
 

--- a/install.py
+++ b/install.py
@@ -42,10 +42,22 @@ PLUGIN_VERSION = _plugin_version()
 FILES_TO_SYNC = ["SKILL.md", "mcp_server.py", "skill.json"]
 DIRS_TO_SYNC = ["tools", "hooks"]
 SUPPORTED_HARNESSES = ("claude-code", "opencode", "codex")
+# Per-harness project-local skill directory. Verified against each harness's own
+# docs (2026-07-17), not assumed from prior code:
+#   - claude-code: Claude Code discovers project skills under .claude/skills/
+#     (https://opencode.ai/docs/skills/ independently documents this as the
+#     "Project Claude-compatible" path, corroborating Claude Code's own docs).
+#   - opencode:    .opencode/skills/ is OpenCode's documented project scope
+#     (https://opencode.ai/docs/skills/).
+#   - codex:       Codex CLI scans .agents/skills/ from cwd up to the repo root
+#     — NOT .codex/skills/, which was an unverified assumption in earlier code
+#     (https://developers.openai.com/codex/skills, confirmed 2026-07-17: "Codex
+#     scans .agents/skills in every directory from your current working
+#     directory up to the repository root").
 HARNESS_SKILL_DIRS = {
-    "codex": os.path.join(".codex", "skills", "temporal-reasoning"),
+    "codex": os.path.join(".agents", "skills", "temporal-reasoning"),
     "opencode": os.path.join(".opencode", "skills", "temporal-reasoning"),
-    "claude-code": os.path.join("skills", "temporal-reasoning"),
+    "claude-code": os.path.join(".claude", "skills", "temporal-reasoning"),
 }
 _MANUAL_CONFIG_TEMPLATE = {
     "opencode": os.path.join("hooks", "opencode.json"),

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -139,18 +139,33 @@ class TestGetTargetDir:
 
 class TestSyncFilesHarnessScoping:
     @pytest.mark.parametrize("harness,expected_dir,other_dirs", [
-        ("claude-code", "skills/temporal-reasoning",
-         [".codex/skills/temporal-reasoning", ".opencode/skills/temporal-reasoning"]),
+        ("claude-code", ".claude/skills/temporal-reasoning",
+         [".agents/skills/temporal-reasoning", ".opencode/skills/temporal-reasoning",
+          "skills/temporal-reasoning"]),
         ("opencode", ".opencode/skills/temporal-reasoning",
-         [".codex/skills/temporal-reasoning", "skills/temporal-reasoning"]),
-        ("codex", ".codex/skills/temporal-reasoning",
-         [".opencode/skills/temporal-reasoning", "skills/temporal-reasoning"]),
+         [".agents/skills/temporal-reasoning", ".claude/skills/temporal-reasoning",
+          "skills/temporal-reasoning"]),
+        ("codex", ".agents/skills/temporal-reasoning",
+         [".opencode/skills/temporal-reasoning", ".claude/skills/temporal-reasoning",
+          "skills/temporal-reasoning"]),
     ])
     def test_only_selected_harness_dir_is_written(self, tmp_path, harness, expected_dir, other_dirs):
         install._sync_files(str(tmp_path), harness)
         assert (tmp_path / expected_dir / "SKILL.md").exists()
         for other in other_dirs:
             assert not (tmp_path / other).exists()
+
+    def test_does_not_touch_preexisting_root_skills_dir(self, tmp_path):
+        """Acceptance criterion (#132): a pre-existing root-level skills/ directory
+        must not be overwritten, moved, or deleted by any harness's install."""
+        preexisting = tmp_path / "skills" / "temporal-reasoning" / "SKILL.md"
+        preexisting.parent.mkdir(parents=True)
+        preexisting.write_text("pre-existing sentinel content")
+
+        for harness in install.SUPPORTED_HARNESSES:
+            install._sync_files(str(tmp_path), harness)
+
+        assert preexisting.read_text() == "pre-existing sentinel content"
 
 
 class TestMainHarnessGating:

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,27 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import install
+import uninstall
+
+
+class TestRemoveSkillDirs:
+    def test_removes_every_harness_skill_dir_installed_by_install_py(self, tmp_path):
+        """uninstall.py's SKILL_DIRS is declared "Must match install.py" — verify it
+        actually does, by round-tripping every harness through install._sync_files
+        then uninstall.remove_skill_dirs and checking each is gone (#132 regression:
+        HARNESS_SKILL_DIRS changed but the separate, hand-maintained SKILL_DIRS list
+        in uninstall.py was not updated to match)."""
+        for harness in install.SUPPORTED_HARNESSES:
+            install._sync_files(str(tmp_path), harness)
+
+        for harness in install.SUPPORTED_HARNESSES:
+            installed_dir = tmp_path / install.HARNESS_SKILL_DIRS[harness]
+            assert installed_dir.exists(), f"setup failed for {harness}"
+
+        uninstall.remove_skill_dirs(str(tmp_path))
+
+        for harness in install.SUPPORTED_HARNESSES:
+            installed_dir = tmp_path / install.HARNESS_SKILL_DIRS[harness]
+            assert not installed_dir.exists(), f"{harness} skill dir survived uninstall"

--- a/uninstall.py
+++ b/uninstall.py
@@ -16,13 +16,13 @@ import shutil
 from typing import Callable
 
 REPO_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, REPO_DIR)
+import install
 
-# Must match install.py
-SKILL_DIRS = [
-    os.path.join(".codex", "skills", "temporal-reasoning"),
-    os.path.join(".opencode", "skills", "temporal-reasoning"),
-    os.path.join("skills", "temporal-reasoning"),
-]
+# Sourced from install.py's HARNESS_SKILL_DIRS (not hand-duplicated) so this list
+# can't drift out of sync with the per-harness paths install.py actually writes —
+# a hand-maintained copy here previously went stale when #132 changed those paths.
+SKILL_DIRS = list(install.HARNESS_SKILL_DIRS.values())
 
 PLUGIN_KEY = "temporal-reasoning@temporal-reasoning-local"
 MARKETPLACE_KEY = "temporal-reasoning-local"


### PR DESCRIPTION
## Summary
- Fixes #132: Claude Code installs now write the skill to `.claude/skills/temporal-reasoning` (Claude Code's actual project-local skill discovery location), not the repo-root `skills/temporal-reasoning` used before.
- Codex CLI installs now write to `.agents/skills/temporal-reasoning`, verified against [developers.openai.com/codex/skills](https://developers.openai.com/codex/skills) ("Codex scans .agents/skills in every directory from your current working directory up to the repository root") — the issue explicitly flagged the pre-existing `.codex/skills/temporal-reasoning` mapping as unverified, and it turned out to be wrong.
- OpenCode's `.opencode/skills/temporal-reasoning` was already correct (confirmed against opencode.ai/docs/skills/); left unchanged.
- The installer never writes to or touches a pre-existing root-level `skills/` directory (new regression test covers this).
- Bonus fix found during review: `uninstall.py` had its own hand-maintained `SKILL_DIRS` list (commented "Must match install.py") that went stale against the corrected paths — it silently would have left the new skill locations behind after uninstall. Now sources from `install.HARNESS_SKILL_DIRS` directly so the two files can't drift apart again.

## Test plan
- [x] `tests/test_install.py::TestSyncFilesHarnessScoping` — parametrized per-harness path assertions updated to the verified locations, plus a new test asserting a pre-existing root `skills/` dir survives every harness's install untouched
- [x] `tests/test_uninstall.py` (new) — round-trips every harness through `install._sync_files` then `uninstall.remove_skill_dirs`, asserting each installed dir is actually removed (this is the test that caught the stale-`SKILL_DIRS` bug)
- [x] Full suite: 599 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU