### PR TITLE
fix: make rank-bm25 a core dependency and bound the heuristic fallback (#117)

### DIFF
--- a/install.py
+++ b/install.py
@@ -313,15 +313,15 @@ def setup_mcp_json(target_dir: str) -> bool:
     - Creates the file if absent.
     - Merges into existing content if present (other servers are preserved).
     - Always updates MINIGRAF_GRAPH_PATH to reflect the target project path.
-    - Uses `uvx temporal-reasoning[git-ingestion,bm25]` so the published PyPI
+    - Uses `uvx temporal-reasoning[git-ingestion]` so the published PyPI
       package is invoked directly — no local venv path baked in. `[git-ingestion]`
       is required so uvx's ephemeral venv actually has the tree-sitter
       packages code-structure extraction depends on (see issue #93 — a bare
       `uvx temporal-reasoning` resolves none of them, silently disabling
-      code-structure extraction). `[bm25]` is required so rank-bm25 is present
-      and handle_memory_prepare_turn can use the cached, indexed BM25 path
-      instead of permanently falling back to the unindexed, O(graph-size)
-      heuristic scan on every turn (see issue #96).
+      code-structure extraction). rank-bm25 is a core (non-optional) dependency
+      so handle_memory_prepare_turn always has the cached, indexed BM25 path
+      available instead of falling back to the unindexed, O(graph-size)
+      heuristic scan on every turn (see issues #96, #117).
     - Only MINIGRAF_GRAPH_PATH is set here; ANTHROPIC_API_KEY and
       MINIGRAF_EXTRACTION_STRATEGY belong in .claude/settings.local.json so
       they are available to hook subprocesses as well as the MCP server.
@@ -343,7 +343,7 @@ def setup_mcp_json(target_dir: str) -> bool:
     existing.setdefault("mcpServers", {})["temporal-reasoning"] = {
         "type": "stdio",
         "command": "uvx",
-        "args": ["temporal-reasoning[git-ingestion,bm25]"],
+        "args": ["temporal-reasoning[git-ingestion]"],
         "env": {
             "MINIGRAF_GRAPH_PATH": graph_path,
         },
@@ -359,7 +359,7 @@ def setup_mcp_json(target_dir: str) -> bool:
 
     verb = "Updated" if file_existed else "Created"
     print(f"✓ {verb} {mcp_json_path}")
-    print(f"    command = uvx temporal-reasoning[git-ingestion,bm25]")
+    print(f"    command = uvx temporal-reasoning[git-ingestion]")
     print(f"    MINIGRAF_GRAPH_PATH = {graph_path}")
     return True
 
@@ -569,7 +569,7 @@ def _build_plugin_stub() -> str:
                 "temporal-reasoning": {
                     "type": "stdio",
                     "command": "uvx",
-                    "args": ["temporal-reasoning[git-ingestion,bm25]"],
+                    "args": ["temporal-reasoning[git-ingestion]"],
                 },
             },
         }, f, indent=2)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4356,6 +4356,12 @@ def _build_query_clauses(user_message: str) -> str:
 
 _MEMORY_PREFIXES = (":decision/", ":preference/", ":constraint/", ":dependency/")
 
+# Entity-type names (without the ":type/" prefix) for the same memory-fact
+# categories as _MEMORY_PREFIXES — used to scope the heuristic fallback's
+# broad scan (see _handle_memory_prepare_turn_heuristic) to just the facts
+# a user records via memory_finalize_turn, not the entire code graph.
+_MEMORY_ENTITY_TYPES = tuple(p.strip(":/") for p in _MEMORY_PREFIXES)
+
 
 def _tokenize(text: str) -> List[str]:
     """Split text on non-alphanumeric chars, lowercase, filter empties.
@@ -4512,16 +4518,30 @@ def _handle_memory_prepare_turn_heuristic(user_message: str) -> str:
             continue
 
     if not collected:
-        # Broad fallback scan — still respect temporal clause
-        try:
-            raw = _db_execute(
-                db, f"(query [:find ?e ?a ?v {temporal_clauses} :where [?e ?a ?v]])"
-            )
-            data = json.loads(raw)
-            all_results = data.get("results", [])
-            collected = all_results[:scan_limit]
-        except (MiniGrafError, json.JSONDecodeError):
-            pass
+        # Broad fallback scan — bounded to memory-fact entity types (decision/
+        # preference/constraint/dependency) rather than the whole graph. An
+        # unscoped [?e ?a ?v] scan pulls every code-structure and commit fact
+        # git ingestion has ever added too — on a real repo that dwarfs the
+        # handful of manually recorded memory facts and was the source of an
+        # 80s/7GB blowup on a 21k-commit graph (issue #117).
+        for entity_type in _MEMORY_ENTITY_TYPES:
+            if len(collected) >= scan_limit:
+                break
+            try:
+                raw = _db_execute(
+                    db,
+                    f"(query [:find ?e ?a ?v {temporal_clauses} "
+                    f":where [?e :entity-type :type/{entity_type}] [?e ?a ?v]])",
+                )
+                data = json.loads(raw)
+                for row in data.get("results", []):
+                    key = tuple(row)
+                    if key not in seen:
+                        seen.add(key)
+                        collected.append(row)
+            except (MiniGrafError, json.JSONDecodeError):
+                continue
+        collected = collected[:scan_limit]
 
     if not collected:
         return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,13 @@ classifiers = [
 dependencies = [
     "minigraf>=1.2.1",
     "mcp>=1.27.0",
+    "rank-bm25",
 ]
 
 [project.scripts]
 temporal-reasoning = "mcp_server:run"
 
 [project.optional-dependencies]
-bm25 = ["rank-bm25"]
 git-ingestion = [
     "tree-sitter>=0.22.0",
     "tree-sitter-rust", "tree-sitter-python", "tree-sitter-javascript",
@@ -48,7 +48,6 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "black>=25.11.0",
     "ruff>=0.15.12",
-    "rank-bm25",
 ]
 
 [tool.setuptools]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -64,22 +64,22 @@ class TestCheckMcpServerImportable:
 
 
 class TestSetupMcpJson:
-    def test_uses_git_ingestion_and_bm25_extras(self, tmp_path):
+    def test_uses_git_ingestion_extra(self, tmp_path):
         install.setup_mcp_json(str(tmp_path))
         with open(tmp_path / ".mcp.json") as f:
             config = json.load(f)
         args = config["mcpServers"]["temporal-reasoning"]["args"]
-        assert args == ["temporal-reasoning[git-ingestion,bm25]"]
+        assert args == ["temporal-reasoning[git-ingestion]"]
 
 
 class TestBuildPluginStub:
-    def test_stub_mcp_json_uses_git_ingestion_and_bm25_extras(self, tmp_path, monkeypatch):
+    def test_stub_mcp_json_uses_git_ingestion_extra(self, tmp_path, monkeypatch):
         monkeypatch.setattr(install.os.path, "expanduser", lambda p: str(tmp_path))
         stub_dir = install._build_plugin_stub()
         with open(install.os.path.join(stub_dir, ".mcp.json")) as f:
             config = json.load(f)
         args = config["mcpServers"]["temporal-reasoning"]["args"]
-        assert args == ["temporal-reasoning[git-ingestion,bm25]"]
+        assert args == ["temporal-reasoning[git-ingestion]"]
 
 
 class TestSyncLists:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -35,7 +35,7 @@ except ImportError:
 
 requires_bm25 = pytest.mark.skipif(
     not _HAS_RANK_BM25,
-    reason="rank_bm25 not installed (pip install -e .[bm25] or .[dev])",
+    reason="rank_bm25 not installed — it is a core dependency (pip install -e .)",
 )
 
 
@@ -838,6 +838,47 @@ class TestMemoryPrepareTurn:
         result = mcp_server._handle_memory_prepare_turn_heuristic("tell me about our framework")
 
         assert "Redis" in result
+
+    def test_broad_scan_excludes_non_memory_entity_types(self, real_db):
+        """The broad-scan fallback must not surface code-structure facts (e.g.
+        git-ingested modules) — on a real repo those dwarf the handful of
+        manually recorded memory facts and turned the fallback into an
+        unbounded full-graph scan (issue #117: 80s/7GB on a 21k-commit graph).
+        It must stay scoped to memory entity types (decision/preference/
+        constraint/dependency) even when nothing targeted matched.
+        """
+        import mcp_server
+        real_db.execute(
+            '(transact {} [[:module/auth-py :entity-type :type/module] '
+            '[:module/auth-py :ident ":module/auth-py"] '
+            '[:module/auth-py :description "authentication helper module"]])'
+        )
+        real_db.execute(
+            '(transact {} [[:decision/redis :entity-type :type/decision] '
+            '[:decision/redis :ident ":decision/redis"] '
+            '[:decision/redis :description "use Redis for caching"]])'
+        )
+
+        result = mcp_server._handle_memory_prepare_turn_heuristic("tell me about our framework")
+
+        assert "Redis" in result
+        assert "auth-py" not in result
+        assert "authentication helper" not in result
+
+    def test_broad_scan_scopes_query_by_entity_type(self, real_db):
+        """The fallback's broad scan must restrict :where to memory entity
+        types instead of running an unscoped [?e ?a ?v] scan over every
+        triple in the graph.
+        """
+        import mcp_server
+
+        with execute_spy() as calls:
+            mcp_server._handle_memory_prepare_turn_heuristic("tell me about our framework")
+
+        broad_scan_calls = [
+            c for c in calls if "contains?" not in c and ":where [?e ?a ?v]" in c
+        ]
+        assert not broad_scan_calls, f"found unscoped broad scan: {broad_scan_calls}"
 
     def test_respects_scan_limit_env_var(self, real_db, monkeypatch):
         import mcp_server


### PR DESCRIPTION
## Summary
- Fixes #117 — `rank-bm25` was an optional extra, so a hook wired to a venv installed without `[bm25]` silently fell back to an unbounded, unindexed full-graph scan (measured 81.8s / ~7GB RSS on a 21k-commit graph vs 1.45s / 67MB with rank_bm25 present).
- Moves `rank-bm25` into `pyproject.toml`'s core `dependencies`, dropping the `[bm25]` extra everywhere it was referenced (`install.py`'s `.mcp.json`/plugin-stub generation, their tests).
- Bounds the heuristic fallback's broad scan (`_handle_memory_prepare_turn_heuristic`) to memory-fact entity types (`:type/decision`, `:type/preference`, `:type/constraint`, `:type/dependency`) instead of an unscoped `[?e ?a ?v]` scan over every triple — so even a degraded environment (rank_bm25 somehow still missing) can't blow up on git-ingested code-structure/commit facts, which dominate a real graph.

Matches the issue's own "ideally 1 + 3" recommendation (core dependency + bounded fallback); fix 2 (a loud warning for the optional-extra case) is moot since the dependency is no longer optional.

## Test plan
- [x] TDD: added failing tests first (`test_broad_scan_excludes_non_memory_entity_types`, `test_broad_scan_scopes_query_by_entity_type`), watched them fail for the expected reason, then implemented the fix.
- [x] Updated `test_install.py`'s two `[git-ingestion,bm25]` assertions to `[git-ingestion]`.
- [x] Full suite: 601 passed (599 baseline + 2 net new tests), confirmed via `git stash` diff that the baseline is unchanged and pre-existing stderr noise (`[IndexCache] rebuild failed`) predates this change.
- [x] `ruff`/`black` — confirmed identical pre-existing findings before and after this diff (no new lint issues introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU