### PR TITLE
fix: dedup fact_index inserts on exact 5-tuple match

### DIFF
--- a/docs/superpowers/specs/2026-07-17-persisted-fact-index-design.md
+++ b/docs/superpowers/specs/2026-07-17-persisted-fact-index-design.md
@@ -140,7 +140,15 @@ today's one-document-per-fact-row `FactIndex`.
 ### Write path — the choke point
 
 Every write to the graph must also update the index, incrementally, so the
-index never drifts and never needs a rescan under normal operation. A fully
+index never drifts and never needs a rescan under normal operation.
+**Correction (#152):** this "never drifts" claim was inaccurate as originally
+implemented — `insert_facts` was a plain `INSERT` with no dedup guard, so
+re-transacting an already-current fact through this same choke point (e.g.
+`_watermark_update`'s per-commit `:entity-type`/`:ident`/`:description`
+triples) appended a duplicate row every time. Fixed by making `insert_facts`
+conditional on a companion `facts_dedup` table keyed on the exact
+`(entity, attribute, value, valid_from, valid_to)` 5-tuple — see
+`fact_index.insert_facts`'s docstring. A fully
 exhaustive pass — every `_db_execute(db, ...)` call site in the file, not
 filtered by any same-line pattern (an earlier, quote-agnostic-but-still-
 same-line-anchored grep pass missed calls where the Datalog string is built

--- a/fact_index.py
+++ b/fact_index.py
@@ -75,6 +75,18 @@ def ensure_schema(con: sqlite3.Connection) -> None:
     transaction early and reintroduce the non-atomicity race rebuild_index's
     retry loop exists to prevent. rebuild_index() inlines both schema
     statements instead (_SCHEMA_SQL, _META_SCHEMA_SQL).
+
+    Code-review note on #152's facts_dedup addition: against an existing v2
+    index file (pre-dating facts_dedup), this function creates facts_dedup
+    empty (IF NOT EXISTS) but does NOT bump schema_version (INSERT OR IGNORE
+    is a no-op once the key exists) and does NOT backfill facts_dedup from
+    facts_fts's existing rows. A write against such a file before its next
+    read-triggered rebuild_index() (see needs_backfill(), whose only caller
+    that acts on a True result is the read-path handle_memory_prepare_turn)
+    can therefore append one more duplicate for a key that was already
+    duplicated pre-fix -- bounded, not the original unbounded-growth bug,
+    and self-healing once a read path triggers a real rebuild, but not
+    something open_writer()/ensure_schema() close on their own.
     """
     con.execute(_SCHEMA_SQL)
     con.execute(_META_SCHEMA_SQL)
@@ -209,12 +221,27 @@ def delete_facts(
     """Delete matching CURRENT rows from facts_fts (valid_to IS NULL only).
     Does not commit -- see insert_facts. Historical rows for the same
     (entity, attribute, value) from an earlier lifecycle are never touched
-    by a retract -- only the live, open-ended assertion is removed."""
+    by a retract -- only the live, open-ended assertion is removed.
+
+    Also clears the matching facts_dedup row(s) (valid_to = '', the same
+    normalized-NULL sentinel insert_facts writes) -- code-review finding on
+    #152: leaving a stale facts_dedup row after a retract would make a later
+    insert_facts call for the exact same (entity, attribute, value,
+    valid_from) silently no-op, since the dedup guard can't distinguish
+    "already indexed and still live" from "was indexed once, since
+    retracted." Deliberately not scoped to a specific valid_from, matching
+    facts_fts's own DELETE above -- delete_facts doesn't know which
+    valid_from the now-deleted current row had either."""
     if not triples:
         return
     con.executemany(
         "DELETE FROM facts_fts WHERE entity = ? AND attribute = ? AND value = ? "
         "AND valid_to IS NULL",
+        [(e, a, v) for e, a, v, _vf, _vt in triples],
+    )
+    con.executemany(
+        "DELETE FROM facts_dedup WHERE entity = ? AND attribute = ? AND value = ? "
+        "AND valid_to = ''",
         [(e, a, v) for e, a, v, _vf, _vt in triples],
     )
 

--- a/fact_index.py
+++ b/fact_index.py
@@ -26,7 +26,21 @@ _SCHEMA_SQL = (
     "tokenize='unicode61')"
 )
 _META_SCHEMA_SQL = "CREATE TABLE IF NOT EXISTS index_meta (key TEXT PRIMARY KEY, value TEXT)"
-_SCHEMA_VERSION = "2"
+# A real (non-virtual) companion table, not part of facts_fts itself -- FTS5
+# virtual tables support neither UNIQUE constraints nor upserts, so exact-row
+# dedup for insert_facts (see #152) needs a B-tree-indexed table to check
+# against instead of an O(n) scan over facts_fts. entity/attribute/value/
+# valid_from/valid_to together are the dedup key; valid_from and valid_to are
+# COALESCEd to '' on write because SQL's default UNIQUE semantics treat NULL
+# as never equal to itself, which would otherwise let every current fact
+# (valid_to=None) dodge the constraint entirely.
+_DEDUP_SCHEMA_SQL = (
+    "CREATE TABLE IF NOT EXISTS facts_dedup ("
+    "entity TEXT NOT NULL, attribute TEXT NOT NULL, value TEXT NOT NULL, "
+    "valid_from TEXT NOT NULL, valid_to TEXT NOT NULL, "
+    "UNIQUE(entity, attribute, value, valid_from, valid_to))"
+)
+_SCHEMA_VERSION = "3"
 
 
 def index_path_for(graph_path: str) -> str:
@@ -64,6 +78,7 @@ def ensure_schema(con: sqlite3.Connection) -> None:
     """
     con.execute(_SCHEMA_SQL)
     con.execute(_META_SCHEMA_SQL)
+    con.execute(_DEDUP_SCHEMA_SQL)
     con.execute(
         "INSERT OR IGNORE INTO index_meta (key, value) VALUES ('schema_version', ?)",
         (_SCHEMA_VERSION,),
@@ -144,18 +159,47 @@ def insert_facts(
     con: sqlite3.Connection,
     triples: Sequence[Tuple[str, str, str, Optional[str], Optional[str]]],
 ) -> None:
-    """Insert rows into facts_fts. Does not commit -- caller controls the
-    transaction boundary (immediate for single-fact writes, batched per
-    ingestion-commit for git ingestion). Each row is
-    (entity, attribute, value, valid_from, valid_to); valid_to=None means a
-    current (open-ended) fact, a real ISO timestamp means historical."""
+    """Insert rows into facts_fts, skipping any exact (entity, attribute,
+    value, valid_from, valid_to) 5-tuple that's already indexed (#152).
+    Does not commit -- caller controls the transaction boundary (immediate
+    for single-fact writes, batched per ingestion-commit for git ingestion).
+    Each row is (entity, attribute, value, valid_from, valid_to);
+    valid_to=None means a current (open-ended) fact, a real ISO timestamp
+    means historical.
+
+    Minigraf's own graph is idempotent under re-transacting an identical
+    fact with the same validity window -- no new graph fact is created --
+    but this used to be a plain INSERT with no corresponding guard, so
+    re-transacting an already-current fact (e.g. _watermark_update's
+    :entity-type/:ident/:description triples, re-asserted on every ingested
+    commit) appended a fresh duplicate row on every call. facts_dedup (a
+    real B-tree-indexed table facts_fts itself can't provide, being an FTS5
+    virtual table with no UNIQUE/upsert support) makes each row's write
+    conditional on genuinely not having been written before, one row at a
+    time so INSERT OR IGNORE's per-statement rowcount reliably says whether
+    that exact row was new (executemany's rowcount is not per-row reliable
+    across sqlite3 driver versions). A distinct valid_from for the same
+    (entity, attribute, value) is deliberately NOT deduped -- it's a
+    genuinely distinct fact, mirroring minigraf's own graph semantics."""
     if not triples:
         return
-    con.executemany(
-        "INSERT INTO facts_fts (entity, attribute, value, valid_from, valid_to) "
-        "VALUES (?, ?, ?, ?, ?)",
-        triples,
-    )
+    for entity, attribute, value, valid_from, valid_to in triples:
+        cur = con.execute(
+            "INSERT OR IGNORE INTO facts_dedup "
+            "(entity, attribute, value, valid_from, valid_to) VALUES (?, ?, ?, ?, ?)",
+            (
+                entity, attribute, value,
+                valid_from if valid_from is not None else "",
+                valid_to if valid_to is not None else "",
+            ),
+        )
+        if cur.rowcount == 0:
+            continue
+        con.execute(
+            "INSERT INTO facts_fts (entity, attribute, value, valid_from, valid_to) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (entity, attribute, value, valid_from, valid_to),
+        )
 
 
 def delete_facts(
@@ -295,8 +339,16 @@ def rebuild_index(
             # substrings currently checked).
             con.execute("DROP TABLE IF EXISTS facts_fts")
             con.execute("DROP TABLE IF EXISTS index_meta")
+            # facts_dedup must be dropped and recreated in lockstep with
+            # facts_fts, not just left alone -- insert_facts's dedup guard
+            # keys off facts_dedup, so a stale row surviving from a PRIOR
+            # rebuild would make it wrongly skip inserting that same fact
+            # into the just-emptied facts_fts below (#152 regression test:
+            # test_rebuild_index_resets_dedup_state_across_rebuilds).
+            con.execute("DROP TABLE IF EXISTS facts_dedup")
             con.execute(_SCHEMA_SQL)  # NOT ensure_schema() -- see its docstring
             con.execute(_META_SCHEMA_SQL)
+            con.execute(_DEDUP_SCHEMA_SQL)
             insert_facts(con, facts)
             con.execute(
                 "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('schema_version', ?)",

--- a/tests/test_fact_index.py
+++ b/tests/test_fact_index.py
@@ -51,7 +51,7 @@ def test_open_writer_stamps_schema_version_but_not_backfilled(tmp_path):
         version = con.execute(
             "SELECT value FROM index_meta WHERE key = 'schema_version'"
         ).fetchone()
-        assert version == ("2",)
+        assert version == ("3",)
         backfilled = con.execute(
             "SELECT value FROM index_meta WHERE key = 'backfilled'"
         ).fetchone()
@@ -105,6 +105,110 @@ def test_delete_facts_only_deletes_current_rows(tmp_path):
         fact_index.close_writer(con)
 
 
+# ---------------------------------------------------------------------------
+# #152 -- insert_facts must be idempotent on an exact (entity, attribute,
+# value, valid_from, valid_to) match, not a plain unconditional INSERT.
+# ---------------------------------------------------------------------------
+
+
+def test_insert_facts_is_idempotent_for_current_fact(tmp_path):
+    """Re-transacting the same already-current fact (e.g. _watermark_update's
+    :entity-type/:ident/:description triples, re-asserted on every ingested
+    commit) must not append a second facts_fts row for it."""
+    path = str(tmp_path / "t.fts.sqlite3")
+    con = fact_index.open_writer(path)
+    try:
+        triple = (":decision/x", ":description", "hello", "2026-01-01T00:00:00.000Z", None)
+        fact_index.insert_facts(con, [triple])
+        con.commit()
+        fact_index.insert_facts(con, [triple])
+        con.commit()
+        rows = con.execute("SELECT * FROM facts_fts WHERE entity = ':decision/x'").fetchall()
+        assert len(rows) == 1
+    finally:
+        fact_index.close_writer(con)
+
+
+def test_insert_facts_is_idempotent_for_historical_fact(tmp_path):
+    """The same dedup guard applies to a historical (valid_to set) row."""
+    path = str(tmp_path / "t.fts.sqlite3")
+    con = fact_index.open_writer(path)
+    try:
+        triple = (
+            ":module/foo", ":description", "the foo module",
+            "2024-01-01T00:00:00.000Z", "2024-06-01T00:00:00.000Z",
+        )
+        fact_index.insert_facts(con, [triple])
+        con.commit()
+        fact_index.insert_facts(con, [triple])
+        con.commit()
+        rows = con.execute("SELECT * FROM facts_fts WHERE entity = ':module/foo'").fetchall()
+        assert len(rows) == 1
+    finally:
+        fact_index.close_writer(con)
+
+
+def test_insert_facts_is_idempotent_with_null_valid_from(tmp_path):
+    """valid_from=None is a real input shape used elsewhere in this suite
+    (and by rebuild_index callers) -- the dedup key must handle it, not just
+    the more common non-null valid_from case."""
+    path = str(tmp_path / "t.fts.sqlite3")
+    con = fact_index.open_writer(path)
+    try:
+        triple = (":decision/x", ":description", "hello", None, None)
+        fact_index.insert_facts(con, [triple])
+        con.commit()
+        fact_index.insert_facts(con, [triple])
+        con.commit()
+        rows = con.execute("SELECT * FROM facts_fts WHERE entity = ':decision/x'").fetchall()
+        assert len(rows) == 1
+    finally:
+        fact_index.close_writer(con)
+
+
+def test_insert_facts_keeps_distinct_valid_from_as_separate_rows(tmp_path):
+    """Dedup is scoped to the exact 5-tuple only -- the same (entity,
+    attribute, value) re-asserted with a genuinely different valid_from is a
+    distinct fact (mirrors minigraf's own graph semantics, confirmed
+    directly: re-transacting with a different valid_from is NOT idempotent
+    at the graph level either) and must not be collapsed."""
+    path = str(tmp_path / "t.fts.sqlite3")
+    con = fact_index.open_writer(path)
+    try:
+        fact_index.insert_facts(con, [(":tag/v1", ":name", "v1", "2026-01-01T00:00:00.000Z", None)])
+        con.commit()
+        fact_index.insert_facts(con, [(":tag/v1", ":name", "v1", "2026-02-01T00:00:00.000Z", None)])
+        con.commit()
+        rows = con.execute("SELECT valid_from FROM facts_fts WHERE entity = ':tag/v1'").fetchall()
+        assert len(rows) == 2
+    finally:
+        fact_index.close_writer(con)
+
+
+def test_insert_facts_dedup_persists_across_writer_reopen(tmp_path):
+    """The dedup guard must survive a close/reopen of the writer connection
+    -- the real-world case is separate ingestion runs, each opening a fresh
+    connection to the same on-disk index file."""
+    path = str(tmp_path / "t.fts.sqlite3")
+    triple = (":ingestion/watermark", ":ident", ":ingestion/watermark", "2026-01-01T00:00:00.000Z", None)
+    con1 = fact_index.open_writer(path)
+    fact_index.insert_facts(con1, [triple])
+    fact_index.close_writer(con1)
+
+    con2 = fact_index.open_writer(path)
+    fact_index.insert_facts(con2, [triple])
+    fact_index.close_writer(con2)
+
+    con3 = fact_index.open_reader(path)
+    try:
+        rows = con3.execute(
+            "SELECT * FROM facts_fts WHERE entity = ':ingestion/watermark'"
+        ).fetchall()
+        assert len(rows) == 1
+    finally:
+        con3.close()
+
+
 def test_rebuild_index_stamps_backfilled_sentinel(tmp_path):
     path = str(tmp_path / "t.fts.sqlite3")
     fact_index.rebuild_index(path, [(":decision/x", ":description", "hello", None, None)])
@@ -151,6 +255,27 @@ def test_needs_backfill_true_for_v1_index_file_no_meta_table(tmp_path):
     con.execute(
         "CREATE VIRTUAL TABLE facts_fts USING fts5(entity, attribute, value, tokenize='unicode61')"
     )
+    con.commit()
+    con.close()
+    assert fact_index.needs_backfill(path) is True
+
+
+def test_needs_backfill_true_for_pre_dedup_schema_v2_file(tmp_path):
+    """A schema-v2 index file (backfilled, but predating facts_dedup / #152)
+    must be flagged for rebuild -- schema_version mismatch is what forces
+    the rebuild that creates facts_dedup and repopulates it, rather than an
+    old writer connection silently reusing a v2 file that lacks the table
+    insert_facts' dedup guard now depends on."""
+    import sqlite3 as _sqlite3
+    path = str(tmp_path / "t.fts.sqlite3")
+    con = _sqlite3.connect(path)
+    con.execute(
+        "CREATE VIRTUAL TABLE facts_fts USING fts5(entity, attribute, value, "
+        "valid_from UNINDEXED, valid_to UNINDEXED, tokenize='unicode61')"
+    )
+    con.execute("CREATE TABLE index_meta (key TEXT PRIMARY KEY, value TEXT)")
+    con.execute("INSERT INTO index_meta (key, value) VALUES ('schema_version', '2')")
+    con.execute("INSERT INTO index_meta (key, value) VALUES ('backfilled', '1')")
     con.commit()
     con.close()
     assert fact_index.needs_backfill(path) is True
@@ -431,6 +556,25 @@ def test_rebuild_index_replaces_existing_data(tmp_path):
     finally:
         con.close()
     assert rows == [(":decision/new",)]
+
+
+def test_rebuild_index_resets_dedup_state_across_rebuilds(tmp_path):
+    """A rebuild must clear whatever dedup bookkeeping insert_facts uses --
+    otherwise a second rebuild reinserting the exact same fact (identical
+    5-tuple, e.g. re-running a full backfill against an unchanged graph)
+    would see it as "already indexed" from the first rebuild's dedup state
+    and skip inserting it into the freshly emptied facts_fts, leaving the
+    index with zero rows for a fact that's actually present."""
+    path = str(tmp_path / "t.fts.sqlite3")
+    triple = (":decision/x", ":description", "hello world", None, None)
+    fact_index.rebuild_index(path, [triple])
+    fact_index.rebuild_index(path, [triple])
+    con = fact_index.open_reader(path)
+    try:
+        rows = con.execute("SELECT entity FROM facts_fts").fetchall()
+    finally:
+        con.close()
+    assert rows == [(":decision/x",)]
 
 
 def test_rebuild_index_empty_facts(tmp_path):

--- a/tests/test_fact_index.py
+++ b/tests/test_fact_index.py
@@ -209,6 +209,32 @@ def test_insert_facts_dedup_persists_across_writer_reopen(tmp_path):
         con3.close()
 
 
+def test_insert_facts_after_delete_is_not_silently_swallowed(tmp_path):
+    """Code-review finding on #152: delete_facts must also clear the
+    matching facts_dedup row, not just the facts_fts row -- otherwise a
+    retract followed by a re-assert that happens to reuse the exact same
+    valid_from (a general-purpose possibility via handle_minigraf_transact/
+    handle_minigraf_retract, even if today's specific retract-then-reassert
+    callers in mcp_server.py don't hit it) would see insert_facts treat the
+    row as "already indexed" from the now-deleted assertion and silently
+    skip re-inserting it -- the fact stays live in the graph but vanishes
+    from the index forever, until the next full rebuild_index()."""
+    path = str(tmp_path / "t.fts.sqlite3")
+    con = fact_index.open_writer(path)
+    try:
+        triple = (":decision/x", ":description", "hello", "2026-01-01T00:00:00.000Z", None)
+        fact_index.insert_facts(con, [triple])
+        con.commit()
+        fact_index.delete_facts(con, [triple])
+        con.commit()
+        fact_index.insert_facts(con, [triple])
+        con.commit()
+        rows = con.execute("SELECT * FROM facts_fts WHERE entity = ':decision/x'").fetchall()
+        assert len(rows) == 1
+    finally:
+        fact_index.close_writer(con)
+
+
 def test_rebuild_index_stamps_backfilled_sentinel(tmp_path):
     path = str(tmp_path / "t.fts.sqlite3")
     fact_index.rebuild_index(path, [(":decision/x", ":description", "hello", None, None)])


### PR DESCRIPTION
## Summary

- `fact_index.insert_facts()` was a plain `INSERT` with no idempotency guard against `facts_fts`, so re-transacting an already-current fact through the `_transact` choke point (e.g. `_watermark_update`'s per-commit `:entity-type`/`:ident`/`:description` triples, not retract-paired the way `:hash` is) appended a duplicate row every time — confirmed directly reproducible, inflating FTS5's `bm25()` corpus stats and crowding bounded `top_n` results.
- Adds a real (non-virtual) `facts_dedup` companion table with a `UNIQUE` constraint on `(entity, attribute, value, valid_from, valid_to)` — FTS5 virtual tables can't enforce constraints/upserts directly — and makes `insert_facts` conditional on genuinely not having written that exact row before. `NULL` valid_from/valid_to are normalized to `''` for the dedup key since SQL's default `UNIQUE` treats `NULL != NULL`.
- `_SCHEMA_VERSION` bumped 2→3 so `needs_backfill()` flags existing v2 index files for a full `rebuild_index()`, which now drops+recreates `facts_dedup` alongside `facts_fts`/`index_meta` in the same atomic transaction (a stale dedup table surviving a rebuild would otherwise suppress a legitimately fresh insert into the just-emptied `facts_fts`).
- `delete_facts` now also clears the matching `facts_dedup` row (code-review finding) — otherwise a retract followed by a re-assert reusing the exact same `valid_from` would be silently swallowed by the dedup guard forever.

## Scope note

Deliberately does **not** touch `_ingest_tags` (mcp_server.py), which re-transacts every tag on every ingestion run using a fresh `run_ts_iso` as `valid_from`. That's a distinct, more severe **graph-level** bug (confirmed via direct reproduction against the real `minigraf` library: re-transacting the same `(entity, attribute, value)` with a different `valid_from` creates a genuine second live fact in the graph itself, not just index drift) — filed separately as #156, since an index-layer dedup fix can't and shouldn't collapse facts that minigraf itself treats as distinct.

## Test plan

- [x] `pytest tests/test_fact_index.py -v` — 50 passed (7 new tests added for #152, 1 more added after code review for the `delete_facts` gap, 1 schema-version-mismatch regression test)
- [x] `pytest tests/test_mcp_server.py -k "FactIndex or Watermark or IngestTags or Dedup"` — 22 passed
- [x] Full `pytest tests/test_mcp_server.py` run compared against master via a separate checkout — identical pre-existing failure set (tree-sitter language-parser tests + one MCP-sampling test that needs live LLM access), confirmed not caused by this change
- [x] Dispatched an independent code-review subagent against the diff; addressed its one Important finding (`delete_facts`/`facts_dedup` gap) with a fix + regression test, documented the other (schema-version bump is read-path-triggered, not automatic on next write) in `ensure_schema`'s docstring

Fixes #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU