### PR TITLE
fix(mcp): trigger fact-index backfill eagerly at MCP server startup

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4596,7 +4596,16 @@ async def _run_startup_backfill() -> None:
     UserPromptSubmit hook's short-lived, 5-second-timeout-bound process: a
     slow rescan there trips the timeout and retry-storms on every subsequent
     turn instead of ever completing.
+
+    Releases the graph's file lock (_db = None) once done, unconditionally --
+    mirroring call_tool's own finally block -- so the prepare_hook subprocess
+    can still acquire it between turns. Without this, a rebuild triggered
+    here would leave the persistent server process holding the lock open
+    indefinitely (never reset the way a single call_tool invocation is),
+    reproducing this issue's own failure mode -- a hook unable to get the
+    lock in time -- by lock contention instead of a slow rescan.
     """
+    global _db
     path = fact_index.index_path_for(_graph_path or _get_graph_path())
     loop = asyncio.get_running_loop()
     try:
@@ -4606,6 +4615,8 @@ async def _run_startup_backfill() -> None:
                 await loop.run_in_executor(backfill_executor, _rebuild_index_from_graph)
     except Exception as e:
         print(f"[fact_index] startup backfill failed: {e}", file=sys.stderr)
+    finally:
+        _db = None
 
 
 def handle_memory_prepare_turn(user_message: str) -> str:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -101,6 +101,9 @@ _ingest_progress: Dict[str, Any] = {
 }
 _shutdown_requested = asyncio.Event()
 
+# Startup fact-index backfill task (#147)
+_backfill_task: Optional[asyncio.Task] = None
+
 # PID of our immediate supervisor (e.g. `uvx`), recorded at launch. `uvx`
 # does not forward its own death to the spawned server — no signal, no stdin
 # EOF — so a dead supervisor just reparents us (typically to PID 1 or a
@@ -4582,6 +4585,29 @@ def _rebuild_index_from_graph() -> None:
     fact_index.rebuild_index(path, triples)
 
 
+async def _run_startup_backfill() -> None:
+    """Eagerly check-and-run the fact-index backfill from the long-lived
+    server process at startup (#147), mirroring main()'s auto-start-ingestion
+    pattern -- offloaded to a worker thread so the (potentially slow, full
+    graph rescan) work never blocks the stdio handshake.
+
+    Without this, backfill only ever ran lazily inside
+    handle_memory_prepare_turn, which is very often invoked from the
+    UserPromptSubmit hook's short-lived, 5-second-timeout-bound process: a
+    slow rescan there trips the timeout and retry-storms on every subsequent
+    turn instead of ever completing.
+    """
+    path = fact_index.index_path_for(_graph_path or _get_graph_path())
+    loop = asyncio.get_running_loop()
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as backfill_executor:
+            needs = await loop.run_in_executor(backfill_executor, fact_index.needs_backfill, path)
+            if needs:
+                await loop.run_in_executor(backfill_executor, _rebuild_index_from_graph)
+    except Exception as e:
+        print(f"[fact_index] startup backfill failed: {e}", file=sys.stderr)
+
+
 def handle_memory_prepare_turn(user_message: str) -> str:
     """Query the persisted fact index for facts relevant to the user message,
     including labeled historical (retracted/superseded) facts -- the index
@@ -6922,7 +6948,7 @@ async def _orphan_watchdog() -> None:
 
 
 async def main() -> None:
-    global _server_ref, _ingest_task, _ingest_progress, _launch_ppid
+    global _server_ref, _ingest_task, _ingest_progress, _launch_ppid, _backfill_task
     _server_ref = server
     _launch_ppid = os.getppid()
     # Auto-start incremental ingest on server startup so ingestion begins
@@ -6949,6 +6975,13 @@ async def main() -> None:
             _ingest_progress["status"] = "starting"
             cwd = str(Path.cwd())
             _ingest_task = asyncio.create_task(_run_ingestion(cwd, _default_git_branch(cwd)))
+
+        # Eager fact-index backfill (#147): also gated on MINIGRAF_NO_AUTO_INGEST
+        # since it's the same kind of background write to on-disk state that a
+        # deterministic eval sandbox wants to opt out of, alongside ingestion.
+        # Independent of the live-lock-holder check above -- unlike ingestion,
+        # this doesn't race another process for the graph's write lock.
+        _backfill_task = asyncio.create_task(_run_startup_backfill())
 
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):
@@ -6997,6 +7030,11 @@ async def main() -> None:
                 await asyncio.wait_for(_ingest_task, timeout=30)
             except asyncio.TimeoutError:
                 _ingest_task.cancel()
+        if _backfill_task is not None and not _backfill_task.done():
+            try:
+                await asyncio.wait_for(_backfill_task, timeout=30)
+            except asyncio.TimeoutError:
+                _backfill_task.cancel()
 
 
 def run() -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7595,6 +7595,53 @@ class TestMainAutoIngestLockCheck:
         await asyncio.wait_for(main_task, timeout=2)
 
 
+class TestRunStartupBackfillDbLockRelease:
+    @pytest.mark.asyncio
+    async def test_releases_db_lock_after_triggered_rebuild(self, real_db):
+        """Code-review finding on #147: every other _db-touching call site in
+        this file releases the graph's file lock afterward (call_tool's
+        finally, _run_ingestion's per-commit resets) so the prepare_hook
+        subprocess can acquire it between turns. _run_startup_backfill must
+        do the same -- otherwise the persistent server process holds the
+        lock open indefinitely once eager backfill runs once, reproducing
+        this issue's own failure mode (a hook can't get the lock in time) by
+        a different mechanism than the one it fixes."""
+        import mcp_server
+        import fact_index
+        import os
+
+        index_path = fact_index.index_path_for(mcp_server._graph_path)
+        if os.path.exists(index_path):
+            os.remove(index_path)
+
+        assert mcp_server._db is not None  # real_db fixture already opened it
+
+        await mcp_server._run_startup_backfill()
+
+        assert mcp_server._db is None
+
+    @pytest.mark.asyncio
+    async def test_releases_db_lock_even_when_no_rebuild_needed(self, real_db):
+        """Same release discipline must hold on the no-op path (index already
+        backfilled) -- matches call_tool's finally, which resets _db
+        unconditionally after every tool call regardless of whether that
+        specific call touched it."""
+        import mcp_server
+        import fact_index
+
+        # Seed an already-complete index so needs_backfill() is False and
+        # _rebuild_index_from_graph (hence get_db()) is never invoked.
+        index_path = fact_index.index_path_for(mcp_server._graph_path)
+        fact_index.rebuild_index(index_path, [])
+        assert fact_index.needs_backfill(index_path) is False
+
+        assert mcp_server._db is not None  # real_db fixture already opened it
+
+        await mcp_server._run_startup_backfill()
+
+        assert mcp_server._db is None
+
+
 class TestMainStartupBackfill:
     @pytest.mark.asyncio
     async def test_kicks_off_backfill_when_needed(self, monkeypatch, tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7595,6 +7595,170 @@ class TestMainAutoIngestLockCheck:
         await asyncio.wait_for(main_task, timeout=2)
 
 
+class TestMainStartupBackfill:
+    @pytest.mark.asyncio
+    async def test_kicks_off_backfill_when_needed(self, monkeypatch, tmp_path):
+        """#147: main() must eagerly check-and-run the fact-index backfill in
+        a background task at startup, mirroring the auto-start-ingestion
+        pattern, instead of leaving it to the first lazy
+        handle_memory_prepare_turn call -- which can run inside a short-lived,
+        5-second-timeout-bound UserPromptSubmit hook process and retry-storm
+        on a large graph."""
+        import mcp_server
+
+        monkeypatch.setenv("MINIGRAF_GRAPH_PATH", str(tmp_path / "t.graph"))
+        monkeypatch.setattr(mcp_server, "_live_lock_holder_pid", lambda path: None)
+
+        async def fake_run_ingestion(repo_path, branch):
+            await asyncio.wait(
+                {
+                    asyncio.create_task(mcp_server._shutdown_requested.wait()),
+                    asyncio.create_task(asyncio.Event().wait()),
+                },
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+        monkeypatch.setattr(mcp_server, "_run_ingestion", fake_run_ingestion)
+        monkeypatch.setattr(mcp_server.fact_index, "needs_backfill", lambda path: True)
+        rebuild_called = asyncio.Event()
+
+        def fake_rebuild():
+            rebuild_called.set()
+
+        monkeypatch.setattr(mcp_server, "_rebuild_index_from_graph", fake_rebuild)
+        mcp_server._shutdown_requested = asyncio.Event()
+        mcp_server._ingest_task = None
+        mcp_server._backfill_task = None
+
+        @contextlib.asynccontextmanager
+        async def fake_stdio_server():
+            yield (object(), object())
+
+        monkeypatch.setattr(mcp_server, "stdio_server", fake_stdio_server)
+
+        run_started = asyncio.Event()
+
+        async def fake_run(read_stream, write_stream, init_opts):
+            run_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(mcp_server.server, "run", fake_run)
+
+        main_task = asyncio.create_task(mcp_server.main())
+        await run_started.wait()
+
+        assert mcp_server._backfill_task is not None
+        await asyncio.wait_for(rebuild_called.wait(), timeout=2)
+
+        mcp_server._shutdown_requested.set()
+        await asyncio.wait_for(main_task, timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_skips_rebuild_when_already_backfilled(self, monkeypatch, tmp_path):
+        """No unnecessary full rescan when the index is already complete."""
+        import mcp_server
+
+        monkeypatch.setenv("MINIGRAF_GRAPH_PATH", str(tmp_path / "t.graph"))
+        monkeypatch.setattr(mcp_server, "_live_lock_holder_pid", lambda path: None)
+
+        async def fake_run_ingestion(repo_path, branch):
+            await asyncio.wait(
+                {
+                    asyncio.create_task(mcp_server._shutdown_requested.wait()),
+                    asyncio.create_task(asyncio.Event().wait()),
+                },
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+        monkeypatch.setattr(mcp_server, "_run_ingestion", fake_run_ingestion)
+        needs_backfill_checked = asyncio.Event()
+
+        def fake_needs_backfill(path):
+            needs_backfill_checked.set()
+            return False
+
+        monkeypatch.setattr(mcp_server.fact_index, "needs_backfill", fake_needs_backfill)
+        rebuild_called = False
+
+        def fake_rebuild():
+            nonlocal rebuild_called
+            rebuild_called = True
+
+        monkeypatch.setattr(mcp_server, "_rebuild_index_from_graph", fake_rebuild)
+        mcp_server._shutdown_requested = asyncio.Event()
+        mcp_server._ingest_task = None
+        mcp_server._backfill_task = None
+
+        @contextlib.asynccontextmanager
+        async def fake_stdio_server():
+            yield (object(), object())
+
+        monkeypatch.setattr(mcp_server, "stdio_server", fake_stdio_server)
+
+        run_started = asyncio.Event()
+
+        async def fake_run(read_stream, write_stream, init_opts):
+            run_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(mcp_server.server, "run", fake_run)
+
+        main_task = asyncio.create_task(mcp_server.main())
+        await run_started.wait()
+        await asyncio.wait_for(needs_backfill_checked.wait(), timeout=2)
+        await asyncio.wait_for(mcp_server._backfill_task, timeout=2)
+
+        assert rebuild_called is False
+
+        mcp_server._shutdown_requested.set()
+        await asyncio.wait_for(main_task, timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_skips_backfill_when_auto_ingest_disabled(self, monkeypatch, tmp_path):
+        """MINIGRAF_NO_AUTO_INGEST=1 (used by eval sandboxes) must also
+        suppress the eager backfill task, not just ingestion -- both are
+        background writes to on-disk state that a deterministic sandbox
+        wants to opt out of together."""
+        import mcp_server
+
+        monkeypatch.setenv("MINIGRAF_GRAPH_PATH", str(tmp_path / "t.graph"))
+        monkeypatch.setenv("MINIGRAF_NO_AUTO_INGEST", "1")
+        checked = False
+
+        def fake_needs_backfill(path):
+            nonlocal checked
+            checked = True
+            return True
+
+        monkeypatch.setattr(mcp_server.fact_index, "needs_backfill", fake_needs_backfill)
+        mcp_server._shutdown_requested = asyncio.Event()
+        mcp_server._ingest_task = None
+        mcp_server._backfill_task = None
+
+        @contextlib.asynccontextmanager
+        async def fake_stdio_server():
+            yield (object(), object())
+
+        monkeypatch.setattr(mcp_server, "stdio_server", fake_stdio_server)
+
+        run_started = asyncio.Event()
+
+        async def fake_run(read_stream, write_stream, init_opts):
+            run_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(mcp_server.server, "run", fake_run)
+
+        main_task = asyncio.create_task(mcp_server.main())
+        await run_started.wait()
+
+        assert mcp_server._backfill_task is None
+        assert checked is False
+
+        mcp_server._shutdown_requested.set()
+        await asyncio.wait_for(main_task, timeout=2)
+
+
 class TestOrphanWatchdog:
     @pytest.mark.asyncio
     async def test_sets_shutdown_when_ppid_changes(self, monkeypatch):


### PR DESCRIPTION
## Root cause

Fixes #147. The fact-index backfill (a potentially slow full-graph rescan, triggered by `fact_index.needs_backfill()`) previously only ran lazily inside `handle_memory_prepare_turn` — and that call is very often made from the `UserPromptSubmit` hook's short-lived process, which has a 5-second timeout. A slow rescan there trips the timeout, leaving memory retrieval empty and retry-storming the same expensive rescan on every subsequent turn.

## Fix

Added `_run_startup_backfill()`, mirroring the existing auto-start-ingestion pattern already in `main()`: checks `fact_index.needs_backfill()` and, if needed, calls the existing `_rebuild_index_from_graph()`, both offloaded to a dedicated `ThreadPoolExecutor` via `run_in_executor` so the work never blocks the stdio handshake. Wired into `main()` as a new `_backfill_task` (alongside `_ingest_task`), gated on `MINIGRAF_NO_AUTO_INGEST` (same env var ingestion uses, since both are background writes to on-disk state that a deterministic eval sandbox wants to opt out of together), independent of the live-lock-holder ingestion-skip check since backfill doesn't race another process for the graph's *write* lock the way ingestion does. Graceful shutdown teardown extended to await `_backfill_task` (30s timeout, then cancel), mirroring `_ingest_task`.

## Code review fix

An independent review subagent caught a real gap before push: `_run_startup_backfill` never released the graph's file lock (`_db = None`) after a triggered rebuild, unlike every other `_db`-touching call site in this file (`call_tool`'s `finally`, `_run_ingestion`'s per-commit resets). Left unfixed, the persistent server process would hold the lock open indefinitely once eager backfill ran once — reproducing this issue's own failure mode (a hook process can't acquire the lock in time) via lock contention instead of a slow rescan. Fixed by resetting `_db = None` unconditionally after every `_run_startup_backfill` call, mirroring `call_tool`'s `finally` block. TDD: two new tests in `TestRunStartupBackfillDbLockRelease` reproduce the leak (RED) before the fix.

The same review also flagged that eager backfill's `rebuild_index()` transaction can now more reliably overlap with `_run_ingestion`'s `index_con` writes at startup (both start unconditionally together), which could raise `database is locked` on ingestion's side if the rebuild transaction runs past `index_con`'s 5s busy-timeout. This risk pre-dates this PR in rarer form (any `memory_prepare_turn` tool call landing mid-ingestion could already trigger it) and is bounded/self-healing rather than data-loss — it's the same class of gap already tracked by #150 (batched `index_con` writes not fault-isolated), so it's deliberately left for that issue rather than expanding this one's scope.

## Test plan

- [x] New tests in `TestMainStartupBackfill` (backfill kicked off when needed, skipped when already backfilled, skipped when `MINIGRAF_NO_AUTO_INGEST=1`) and `TestRunStartupBackfillDbLockRelease` (lock released after both the rebuild and no-op paths) — all watched RED before implementing, GREEN after.
- [x] Full suite: identical pre-existing 102-failure baseline before/after (confirmed via `git stash`, missing tree-sitter grammars in this sandbox), 536 passed (531 baseline + 5 net new).
- [x] `ruff`/`black`: identical pre-existing findings (4 ruff errors, 2 files need reformatting), nothing new — confirmed new code isn't touched by either tool's diff output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU