### PR TITLE
fix: isolate fact-index writer faults during git ingestion (#150)

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3098,17 +3098,33 @@ def _index_write(
 
 def _open_index_writer_safe(path: str) -> Optional[Any]:
     """Open the batched fact-index writer connection used by _run_ingestion,
-    never raising (#150). A failure here (disk full, corrupted file,
-    permissions) degrades to per-triple index writes instead of aborting the
-    whole ingestion run: downstream call sites already accept
-    index_con=None and fall back to _index_write's own open+commit+close
-    path, which is independently fault-isolated per call.
+    never raising (#150). Retries lock contention with the same blocking
+    backoff _open_db_at_with_retry uses (_LOCK_RETRY_MAX/_LOCK_RETRY_BASE) --
+    the eager startup backfill (#147) can hold fact_index.rebuild_index()'s
+    write transaction open for a whole historical rescan, and giving up on
+    the first "database is locked" would otherwise silently downgrade this
+    entire ingestion run's fact-index writes to the slow per-triple path for
+    no reason beyond a transient startup race. Only safe off the asyncio
+    event-loop thread (blocking time.sleep) -- always invoked via
+    write_executor, never inline on the loop.
+
+    Any other failure (disk full, corrupted file, permissions) degrades
+    immediately to per-triple index writes instead of aborting the whole
+    ingestion run: downstream call sites already accept index_con=None and
+    fall back to _index_write's own open+commit+close path, which is
+    independently fault-isolated per call.
     """
-    try:
-        return fact_index.open_writer(path)
-    except Exception as e:
-        print(f"[fact_index] open_writer failed: {e}", file=sys.stderr)
-        return None
+    delay = _LOCK_RETRY_BASE
+    for attempt in range(_LOCK_RETRY_MAX):
+        try:
+            return fact_index.open_writer(path)
+        except Exception as e:
+            if not _is_lock_error(e) or attempt == _LOCK_RETRY_MAX - 1:
+                print(f"[fact_index] open_writer failed: {e}", file=sys.stderr)
+                return None
+            time.sleep(delay)
+            delay *= 2
+    return None  # unreachable -- loop above always returns
 
 
 def _commit_index_writer_safe(index_con: Optional[Any]) -> None:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3096,6 +3096,43 @@ def _index_write(
         print(f"[fact_index] {action} failed: {e}", file=sys.stderr)
 
 
+def _open_index_writer_safe(path: str) -> Optional[Any]:
+    """Open the batched fact-index writer connection used by _run_ingestion,
+    never raising (#150). A failure here (disk full, corrupted file,
+    permissions) degrades to per-triple index writes instead of aborting the
+    whole ingestion run: downstream call sites already accept
+    index_con=None and fall back to _index_write's own open+commit+close
+    path, which is independently fault-isolated per call.
+    """
+    try:
+        return fact_index.open_writer(path)
+    except Exception as e:
+        print(f"[fact_index] open_writer failed: {e}", file=sys.stderr)
+        return None
+
+
+def _commit_index_writer_safe(index_con: Optional[Any]) -> None:
+    """Commit the batched fact-index connection, never raising (#150)."""
+    if index_con is None:
+        return
+    try:
+        index_con.commit()
+    except Exception as e:
+        print(f"[fact_index] commit failed: {e}", file=sys.stderr)
+
+
+def _close_index_writer_safe(index_con: Optional[Any]) -> None:
+    """Close the batched fact-index connection, never raising (#150) -- a
+    failure here must not mask an otherwise-successful ingestion run as an
+    error."""
+    if index_con is None:
+        return
+    try:
+        fact_index.close_writer(index_con)
+    except Exception as e:
+        print(f"[fact_index] close_writer failed: {e}", file=sys.stderr)
+
+
 def _transact(
     db: Any,
     datalog_facts: str,
@@ -6055,7 +6092,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
         # and per-triple commits would be dominated by fsync overhead at
         # that scale.
         index_path = fact_index.index_path_for(_graph_path or _get_graph_path())
-        index_con = await loop.run_in_executor(write_executor, fact_index.open_writer, index_path)
+        index_con = await loop.run_in_executor(write_executor, _open_index_writer_safe, index_path)
 
         try:
             # Extraction (git show + tree-sitter parse + triple construction) runs
@@ -6496,7 +6533,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
 
                         await loop.run_in_executor(write_executor, _watermark_update, db, commit_hash, commit_ts_iso, reason, index_con)
                         await loop.run_in_executor(write_executor, _db_checkpoint, db)
-                        await loop.run_in_executor(write_executor, index_con.commit)
+                        await loop.run_in_executor(write_executor, _commit_index_writer_safe, index_con)
 
                     finally:
                         _db = None  # release file lock between commits
@@ -6527,7 +6564,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                 # whole span, undoing this fix's own purpose in its teardown.
                 # Routing it through write_executor keeps the wait off the
                 # event-loop thread, same as every other blocking call above.
-                await loop.run_in_executor(write_executor, fact_index.close_writer, index_con)
+                await loop.run_in_executor(write_executor, _close_index_writer_safe, index_con)
                 await loop.run_in_executor(write_executor, executor.shutdown)
 
             if completed_all:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7006,6 +7006,78 @@ class TestRunIngestionBatchedIndexWrites:
         assert len(commit_calls) == 3
 
 
+class TestRunIngestionIndexFaultIsolation:
+    """#150: the batched fact-index connection's three call sites in
+    _run_ingestion (open_writer, the per-commit commit(), close_writer) must
+    each degrade gracefully like every per-triple _index_write call already
+    does -- a failure there must never abort the whole ingestion run, since
+    "index maintenance never blocks a graph write" is a stated invariant
+    everywhere else in this module (see _index_write's own docstring and
+    TestBookkeepingWritesFactIndex.test_transact_index_write_failure_does_not_raise
+    for the single-write equivalent of this same guarantee)."""
+
+    @pytest.mark.asyncio
+    async def test_open_writer_failure_does_not_abort_ingestion(self, real_db, git_repo, monkeypatch, capsys):
+        import mcp_server
+        import fact_index
+
+        monkeypatch.setattr(fact_index, "open_writer", lambda path: (_ for _ in ()).throw(OSError("disk full")))
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0,
+            "current_commit": "", "error": None,
+        }
+        await mcp_server._run_ingestion(str(git_repo), "HEAD")
+
+        assert mcp_server._ingest_progress["status"] == "complete"
+        assert mcp_server._ingest_progress["processed"] == 2
+        assert "open_writer failed" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_commit_failure_does_not_abort_ingestion(self, real_db, git_repo, monkeypatch, capsys):
+        import mcp_server
+        import fact_index
+
+        original_open_writer = fact_index.open_writer
+
+        class FailingCommitConnection:
+            def __init__(self, con):
+                self._con = con
+            def __getattr__(self, name):
+                return getattr(self._con, name)
+            def commit(self):
+                raise OSError("disk full")
+
+        def failing_commit_open_writer(path):
+            return FailingCommitConnection(original_open_writer(path))
+
+        monkeypatch.setattr(fact_index, "open_writer", failing_commit_open_writer)
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0,
+            "current_commit": "", "error": None,
+        }
+        await mcp_server._run_ingestion(str(git_repo), "HEAD")
+
+        assert mcp_server._ingest_progress["status"] == "complete"
+        assert mcp_server._ingest_progress["processed"] == 2
+        assert "commit failed" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_close_writer_failure_does_not_abort_ingestion(self, real_db, git_repo, monkeypatch, capsys):
+        import mcp_server
+        import fact_index
+
+        monkeypatch.setattr(fact_index, "close_writer", lambda con: (_ for _ in ()).throw(OSError("disk full")))
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0,
+            "current_commit": "", "error": None,
+        }
+        await mcp_server._run_ingestion(str(git_repo), "HEAD")
+
+        assert mcp_server._ingest_progress["status"] == "complete"
+        assert mcp_server._ingest_progress["processed"] == 2
+        assert "close_writer failed" in capsys.readouterr().err
+
+
 class TestRunIngestionParentEdgeFactIndex:
     @pytest.mark.asyncio
     async def test_parent_edge_is_searchable_via_fact_index(self, real_db, git_repo, monkeypatch):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7006,6 +7006,80 @@ class TestRunIngestionBatchedIndexWrites:
         assert len(commit_calls) == 3
 
 
+class TestOpenIndexWriterSafeRetry:
+    """#150 follow-up (code review): a transient "database is locked" from
+    fact_index.open_writer must be retried, not treated as a permanent
+    failure on the first attempt -- the eager startup backfill (#147) can
+    hold rebuild_index()'s write transaction open across this exact race
+    window, and giving up immediately would silently downgrade a whole
+    ingestion run to per-triple index writes for no reason beyond a
+    transient race clearing a moment later."""
+
+    def test_retries_lock_error_then_succeeds(self, tmp_path, monkeypatch):
+        import mcp_server
+        import fact_index
+
+        index_path = str(tmp_path / "test.fts.sqlite3")
+        real_open_writer = fact_index.open_writer
+        call_count = {"n": 0}
+
+        def flaky_open_writer(path):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise sqlite3.OperationalError("database is locked")
+            return real_open_writer(path)
+
+        monkeypatch.setattr(fact_index, "open_writer", flaky_open_writer)
+        sleep_calls = []
+        monkeypatch.setattr(mcp_server.time, "sleep", lambda d: sleep_calls.append(d))
+
+        con = mcp_server._open_index_writer_safe(index_path)
+
+        assert con is not None
+        con.close()
+        assert call_count["n"] == 2
+        assert len(sleep_calls) == 1
+
+    def test_gives_up_after_exhausting_retries_on_persistent_lock_error(self, tmp_path, monkeypatch, capsys):
+        import mcp_server
+        import fact_index
+
+        index_path = str(tmp_path / "test.fts.sqlite3")
+        monkeypatch.setattr(
+            fact_index, "open_writer",
+            lambda path: (_ for _ in ()).throw(sqlite3.OperationalError("database is locked")),
+        )
+        monkeypatch.setattr(mcp_server.time, "sleep", lambda d: None)
+
+        con = mcp_server._open_index_writer_safe(index_path)
+
+        assert con is None
+        assert "open_writer failed" in capsys.readouterr().err
+
+    def test_non_lock_error_is_not_retried(self, tmp_path, monkeypatch, capsys):
+        import mcp_server
+        import fact_index
+
+        index_path = str(tmp_path / "test.fts.sqlite3")
+        call_count = {"n": 0}
+
+        def failing_open_writer(path):
+            call_count["n"] += 1
+            raise OSError("disk full")
+
+        monkeypatch.setattr(fact_index, "open_writer", failing_open_writer)
+
+        def fail_if_called(_delay):
+            raise AssertionError("time.sleep() must not be called for a non-lock error")
+        monkeypatch.setattr(mcp_server.time, "sleep", fail_if_called)
+
+        con = mcp_server._open_index_writer_safe(index_path)
+
+        assert con is None
+        assert call_count["n"] == 1
+        assert "open_writer failed" in capsys.readouterr().err
+
+
 class TestRunIngestionIndexFaultIsolation:
     """#150: the batched fact-index connection's three call sites in
     _run_ingestion (open_writer, the per-commit commit(), close_writer) must


### PR DESCRIPTION
## Summary
- `_run_ingestion`'s batched fact-index connection (`fact_index.open_writer`, the per-commit `index_con.commit()`, `fact_index.close_writer`) was the one write path not following the "index maintenance never blocks a graph write" invariant every per-triple `_index_write` call already enforces — a failure there aborted the whole ingestion run instead of just the index maintenance.
- All three call sites now go through never-raising wrappers (`_open_index_writer_safe`, `_commit_index_writer_safe`, `_close_index_writer_safe`) that log to stderr and fall back to `index_con=None`, which downstream call sites already handle via `_index_write`'s own independently-guarded per-triple open+commit+close path.
- Follow-up from an independent code-review pass: `_open_index_writer_safe` now retries "database is locked" with the same backoff `_open_db_at_with_retry` uses (`_LOCK_RETRY_MAX`/`_LOCK_RETRY_BASE`), since #147's eager startup backfill can hold `rebuild_index()`'s write transaction open across this exact race window — without the retry, a single transient lock hit would permanently downgrade a whole ingestion run to slow per-triple index writes.

Fixes #150.

## Test plan
- [x] 3 new tests in `TestRunIngestionIndexFaultIsolation` (`tests/test_mcp_server.py`), one per call site, each watched RED against pre-fix code (aborted with `status == "error"`) before the fix, GREEN after.
- [x] 3 new tests in `TestOpenIndexWriterSafeRetry` covering: retry-then-succeed on a transient lock error, give-up-and-log after exhausting retries on a persistent lock error, and no-retry-for-non-lock-errors (verified RED against the pre-retry commit via a scratch worktree).
- [x] Full suite: 593 passed (587 baseline + 6 net new), no regressions.
- [x] `ruff`/`black`: identical pre-existing findings before/after (confirmed via `git stash`), nothing new introduced.
- [x] Independent code-review subagent dispatched before pushing; its one Important finding (no retry on `open_writer`, risking a permanent downgrade under #147's startup-backfill contention) fixed inline before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU