### PR TITLE
fix: extend _parse_facts_block regex to capture numeric-valued triples

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3043,7 +3043,7 @@ def handle_minigraf_query(datalog: str) -> Dict[str, Any]:
 
 
 _FACTS_TRIPLE_PATTERN = re.compile(
-    r'\[(\:[^\s\]]+)\s+(\:[^\s\]]+)\s+("(?:[^"\\]|\\.)*"|\:[^\s\]]+)\]'
+    r'\[(\:[^\s\]]+)\s+(\:[^\s\]]+)\s+("(?:[^"\\]|\\.)*"|\:[^\s\]]+|-?\d+(?:\.\d+)?)\]'
 )
 
 
@@ -3052,9 +3052,12 @@ def _parse_facts_block(facts_str: str) -> List[Tuple[str, str, str]]:
     block or a single triple string -- scans for all matches rather than
     requiring a strict split, so it works on both shapes uniformly (mirrors
     _parse_transact_facts' existing regex-scan approach, extended to also
-    capture keyword-valued triples, which schema validation intentionally
-    skips but the index must not). Value is unquoted for string-valued
-    triples, kept as-is (a keyword or entity reference) otherwise.
+    capture keyword-valued and bare-numeric-valued triples, which schema
+    validation intentionally skips but the index must not). Value is
+    unquoted for string-valued triples, kept as-is (a keyword, number, or
+    entity reference) otherwise. #uuid/#inst-tagged values still aren't
+    captured -- pass index_triples explicitly if one of those needs to be
+    searchable.
     """
     triples = []
     for m in _FACTS_TRIPLE_PATTERN.finditer(facts_str):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -816,6 +816,25 @@ class TestParseFactsBlock:
         import mcp_server
         assert mcp_server._parse_facts_block("[]") == []
 
+    def test_numeric_valued_triple(self):
+        import mcp_server
+        result = mcp_server._parse_facts_block(
+            "[:ingestion/last-run-at :total-ingested 42]"
+        )
+        assert result == [(":ingestion/last-run-at", ":total-ingested", "42")]
+
+    def test_negative_and_float_valued_triples(self):
+        import mcp_server
+        block = (
+            "[[:decision/x :offset -3] "
+            "[:decision/x :score 1.5]]"
+        )
+        result = mcp_server._parse_facts_block(block)
+        assert result == [
+            (":decision/x", ":offset", "-3"),
+            (":decision/x", ":score", "1.5"),
+        ]
+
 
 class TestTransactRetractChokePoint:
     def test_transact_writes_to_index(self, real_db, tmp_path):


### PR DESCRIPTION
## Summary
- `_FACTS_TRIPLE_PATTERN` (used by `_parse_facts_block`, which `_transact`/`_retract` fall back on when a caller doesn't pass `index_triples` explicitly) only matched quoted-string and keyword values.
- A numeric-valued triple such as `[:ingestion/last-run-at :total-ingested 42]` silently failed to match, so it was dropped from the fact index during auto-derivation.
- Extended the regex's value alternation to also accept bare integers/floats (optionally negative). Updated the docstring to note `#uuid`/`#inst`-tagged values are still not captured by auto-derivation.

Fixes #149.

## Test plan
- [x] Added `test_numeric_valued_triple` and `test_negative_and_float_valued_triples` to `TestParseFactsBlock`, watched them fail (RED) before the regex fix, pass (GREEN) after.
- [x] `python -m pytest tests/test_mcp_server.py -k "ParseFactsBlock or TransactRetract or Index or ParseTransactFacts"` — 57 passed, no regressions.
- [x] Confirmed the ~100 unrelated failures in the full suite (Scala/Haskell/Lua/Elixir globals-and-fields tests) pre-exist on master (reproduced via `git stash`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU