### PR TITLE
fix: detect and refresh stale editable-install module mapping

### DIFF
--- a/install.py
+++ b/install.py
@@ -19,6 +19,8 @@ Usage:
 import sys
 import subprocess
 import os
+import re
+import tempfile
 import importlib.util
 from datetime import datetime, timezone
 
@@ -214,6 +216,78 @@ def check_mcp_server_importable():
         return True
     stderr = result.stderr.decode(errors="replace").strip()
     print(f"✗ Cannot import mcp_server: {stderr}")
+    return False
+
+
+def _pyproject_py_modules() -> list:
+    """Parse the `py-modules` list from pyproject.toml's [tool.setuptools] table.
+
+    Regex parse rather than a TOML library dependency — the value is always a
+    flat array of quoted strings, matching this project's other lightweight
+    config-parsing (e.g. _plugin_version).
+    """
+    path = os.path.join(REPO_DIR, "pyproject.toml")
+    try:
+        with open(path) as f:
+            content = f.read()
+    except IOError:
+        return []
+    match = re.search(r"py-modules\s*=\s*\[([^\]]*)\]", content)
+    if not match:
+        return []
+    return re.findall(r'"([^"]+)"', match.group(1))
+
+
+def _editable_install_present() -> bool:
+    """Return True if the venv already has an editable install of this package."""
+    result = subprocess.run(
+        [VENV_PYTHON, "-m", "pip", "show", "temporal-reasoning"],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def check_editable_install_current() -> bool:
+    """Verify an existing editable install resolves every top-level module
+    declared in pyproject.toml from outside REPO_DIR, refreshing it if not.
+
+    setuptools' editable-install finder bakes a module-name -> path MAPPING at
+    `pip install -e .` time. Pulling changes that add a new top-level module
+    (e.g. fact_index, added by #118) doesn't update an already-baked mapping —
+    the module then only resolves when the importing process's cwd happens to
+    be REPO_DIR, which is why mcp_server and the hooks (which add REPO_DIR to
+    sys.path themselves) are unaffected but any other out-of-repo entry point
+    would silently break (see issue #151). Skipped entirely if no editable
+    install exists yet — this only heals drift in installs that already
+    opted in, it doesn't create one.
+    """
+    if not _editable_install_present():
+        print("✓ No editable install of temporal-reasoning found — nothing to check")
+        return True
+
+    modules = _pyproject_py_modules()
+    if not modules:
+        print("✓ No py-modules declared — nothing to check")
+        return True
+
+    def _probe() -> bool:
+        result = subprocess.run(
+            [VENV_PYTHON, "-c", "; ".join(f"import {m}" for m in modules)],
+            capture_output=True,
+            cwd=tempfile.gettempdir(),
+        )
+        return result.returncode == 0
+
+    if _probe():
+        print(f"✓ Editable install up to date ({', '.join(modules)})")
+        return True
+
+    print("  Editable install predates a new top-level module — refreshing...")
+    if _venv_pip_install("-e", REPO_DIR, timeout=120) and _probe():
+        print("✓ Editable install refreshed")
+        return True
+
+    print("✗ Could not refresh editable install — re-run `pip install -e .` in the venv manually")
     return False
 
 
@@ -746,6 +820,7 @@ def main(target_dir: str = "", harness: str = "claude-code") -> None:
         ("mcp package", check_mcp_package),
         ("tree-sitter language packages", check_tree_sitter_packages),
         ("MCP server", check_mcp_server_importable),
+        ("editable install freshness", check_editable_install_current),
     ]
 
     results = []

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -63,6 +63,58 @@ class TestCheckMcpServerImportable:
             assert install.check_mcp_server_importable() is False
 
 
+class TestPyprojectPyModules:
+    def test_parses_declared_modules(self):
+        modules = install._pyproject_py_modules()
+        assert "fact_index" in modules
+        assert "mcp_server" in modules
+
+    def test_returns_empty_list_when_file_missing(self, monkeypatch):
+        monkeypatch.setattr(install, "REPO_DIR", "/nonexistent/path/xyz")
+        assert install._pyproject_py_modules() == []
+
+
+class TestCheckEditableInstallCurrent:
+    def test_returns_true_when_no_editable_install_present(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)  # pip show: not installed
+            assert install.check_editable_install_current() is True
+        assert mock_run.call_count == 1
+
+    def test_returns_true_when_editable_install_resolves_all_modules(self, monkeypatch):
+        monkeypatch.setattr(install, "_pyproject_py_modules", lambda: ["fact_index"])
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0),  # pip show: present
+                MagicMock(returncode=0),  # import probe: resolves fine
+            ]
+            assert install.check_editable_install_current() is True
+        assert mock_run.call_count == 2
+
+    def test_refreshes_and_succeeds_when_mapping_has_drifted(self, monkeypatch):
+        monkeypatch.setattr(install, "_pyproject_py_modules", lambda: ["fact_index"])
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0),  # pip show: present
+                MagicMock(returncode=1),  # import probe: drifted (stale MAPPING)
+                MagicMock(returncode=0),  # pip install -e .: succeeds
+                MagicMock(returncode=0),  # import probe again: now resolves
+            ]
+            assert install.check_editable_install_current() is True
+        assert mock_run.call_count == 4
+
+    def test_returns_false_when_refresh_does_not_fix_it(self, monkeypatch):
+        monkeypatch.setattr(install, "_pyproject_py_modules", lambda: ["fact_index"])
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0),  # pip show: present
+                MagicMock(returncode=1),  # import probe: drifted
+                MagicMock(returncode=0),  # pip install -e .: succeeds
+                MagicMock(returncode=1),  # import probe again: still broken
+            ]
+            assert install.check_editable_install_current() is False
+
+
 class TestSetupMcpJson:
     def test_uses_git_ingestion_extra(self, tmp_path):
         install.setup_mcp_json(str(tmp_path))
@@ -176,6 +228,7 @@ class TestMainHarnessGating:
         monkeypatch.setattr(install, "check_mcp_package", lambda: True)
         monkeypatch.setattr(install, "check_tree_sitter_packages", lambda: True)
         monkeypatch.setattr(install, "check_mcp_server_importable", lambda: True)
+        monkeypatch.setattr(install, "check_editable_install_current", lambda: True)
 
     def test_non_claude_harness_skips_claude_specific_setup(self, monkeypatch, tmp_path):
         self._patch_common(monkeypatch)


### PR DESCRIPTION
## Summary
- Fixes #151: `install.py` now detects when the venv's editable-install finder mapping predates a newly added top-level module (the class of drift that would leave `import fact_index` unresolved outside `REPO_DIR` after a bare `git pull`, per #118's final review) and automatically re-runs `pip install -e .` to heal it.
- Only acts when an editable install of `temporal-reasoning` already exists in the venv — it heals drift, it doesn't create an opt-in that wasn't there before.
- Verified live against this repo's own venv: `import fact_index` failed from `/tmp` before the fix, and resolved correctly after `check_editable_install_current()` ran.

## Test plan
- [x] `pytest tests/test_install.py -v` — 35/35 pass, including 4 new tests covering: no editable install present, already up to date, drift detected + refreshed successfully, drift detected + refresh doesn't fix it
- [x] `pytest tests/` — full suite, 691/691 pass
- [x] `ruff check install.py tests/test_install.py` — no new findings (confirmed identical 6 pre-existing findings on master via `git stash`)
- [x] Manual end-to-end repro: demonstrated the actual drift on this dev machine's venv (missing `fact_index` from `MAPPING`), ran the new check, confirmed the import now resolves from outside the repo directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU