### PR TITLE
Fix cross-layer ground-truth entries to use a genuine single-query join (#120)

### DIFF
--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -7,8 +7,12 @@ The "cross-layer" ground-truth category (entries 5-6) is a genuine single-query
 graph-level join: it binds the seeded decision's own `:db/valid-from` as an output
 variable via minigraf's `:db/valid-from`/`:db/valid-to` pseudo-attributes, then
 filters structural facts by comparing each one's own `:db/valid-from` against it
-in the same query (`[(< ?fvf ?dvf)]` / `[(> ?fvf ?dvf)]`). Removing the seed makes
-either query return nothing, since `?dvf` could never bind. This capability exists
+in the same query (`[(< ?fvf ?dvf)]` / `[(> ?fvf ?dvf)]`). If the seed decision
+fact were silently missing, `?dvf` would never bind and `count-distinct` over the
+resulting empty join returns `0`, not an error -- entry 5's own expected answer is
+already `0`, so it can't distinguish a working join from a silently broken one on
+its own; entry 6 (expects `12`, degrades to `0` if the join breaks) is the one
+that actually proves the join fired. Run both together. This capability exists
 in minigraf and is already used internally by `mcp_server.py` (`_preload_known_deps`,
 `_rebuild_index_from_graph`), but is not yet documented in `SKILL.md` — see #165.
 An earlier version of this note incorrectly claimed no such mechanism existed and
@@ -63,3 +67,14 @@ that was wrong and has been corrected here.
 | 4 | dependency-impact | PASS | 14.1ms | 6.1ms |
 | 5 | cross-layer | PASS | 571.3ms | 6.0ms |
 | 6 | cross-layer | PASS | 551.7ms | 2.9ms |
+
+## Query Correctness Run — 20260719T184747Z
+
+| ID | Category | Result | minigraf latency | baseline latency |
+|---|---|---|---|---|
+| 1 | point-in-time | PASS | 6.8ms | 3.1ms |
+| 2 | delta | SKIPPED (manual diff) | 0.0ms | 0.0ms |
+| 3 | regression-tracing | PASS | 1.8ms | 8.0ms |
+| 4 | dependency-impact | PASS | 14.5ms | 5.3ms |
+| 5 | cross-layer | PASS | 568.4ms | 6.2ms |
+| 6 | cross-layer | PASS | 549.6ms | 2.9ms |

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -3,13 +3,17 @@
 See issue #120 and `docs/superpowers/specs/2026-07-19-at-scale-benchmark-design.md`.
 Observational only -- no pass/fail thresholds.
 
-The "cross-layer" ground-truth category (entries 5-6) demonstrates the two-query
-valid-time-bracket pattern SKILL.md documents for decision-correlation — not a
-single graph-level join. minigraf's current Datalog grammar has no documented way
-to bind a fact's own `:valid-from` as an output variable or compare it numerically
-within one query, so an agent must know the decision's timestamp out-of-band
-(exactly as the seeded fixture does) and issue two `:valid-at`-bounded queries, one
-on each side of it.
+The "cross-layer" ground-truth category (entries 5-6) is a genuine single-query
+graph-level join: it binds the seeded decision's own `:db/valid-from` as an output
+variable via minigraf's `:db/valid-from`/`:db/valid-to` pseudo-attributes, then
+filters structural facts by comparing each one's own `:db/valid-from` against it
+in the same query (`[(< ?fvf ?dvf)]` / `[(> ?fvf ?dvf)]`). Removing the seed makes
+either query return nothing, since `?dvf` could never bind. This capability exists
+in minigraf and is already used internally by `mcp_server.py` (`_preload_known_deps`,
+`_rebuild_index_from_graph`), but is not yet documented in `SKILL.md` — see #165.
+An earlier version of this note incorrectly claimed no such mechanism existed and
+shipped entries 5-6 as a weaker two-query valid-time-bracket workaround instead;
+that was wrong and has been corrected here.
 
 ## Ingestion Run — 20260719T074053Z
 
@@ -48,3 +52,14 @@ on each side of it.
 | 4 | dependency-impact | PASS | 14.1ms | 5.6ms |
 | 5 | cross-layer | PASS | 9.4ms | 6.8ms |
 | 6 | cross-layer | PASS | 9.4ms | 3.1ms |
+
+## Query Correctness Run — 20260719T183705Z
+
+| ID | Category | Result | minigraf latency | baseline latency |
+|---|---|---|---|---|
+| 1 | point-in-time | PASS | 6.8ms | 3.1ms |
+| 2 | delta | SKIPPED (manual diff) | 0.0ms | 0.0ms |
+| 3 | regression-tracing | PASS | 1.8ms | 6.9ms |
+| 4 | dependency-impact | PASS | 14.1ms | 6.1ms |
+| 5 | cross-layer | PASS | 571.3ms | 6.0ms |
+| 6 | cross-layer | PASS | 551.7ms | 2.9ms |

--- a/evals/at_scale/query_ground_truth.json
+++ b/evals/at_scale/query_ground_truth.json
@@ -38,10 +38,10 @@
     {
       "id": 5,
       "category": "cross-layer",
-      "question": "Genuine single-query cross-layer join: how many fact_index.py :type/function entities were introduced BEFORE the :decision/persisted-fact-index decision's own :db/valid-from (a synthetic decision seeded at 2026-07-17T04:00:00Z, before fact_index.py existed)? The query binds the decision's :db/valid-from as an output variable and filters structural facts by comparing each one's own :db/valid-from against it -- removing the seed makes the query return nothing, since ?dvf could never bind.",
+      "question": "Genuine single-query cross-layer join: how many fact_index.py :type/function entities were introduced BEFORE the :decision/persisted-fact-index decision's own :db/valid-from (a synthetic decision seeded at 2026-07-17T04:00:00Z, before fact_index.py existed)? The query binds the decision's :db/valid-from as an output variable and filters structural facts by comparing each one's own :db/valid-from against it. Note: this entry's own expected answer (0) is not discriminating on its own -- if the seed were silently missing, ?dvf would never bind and count-distinct over the resulting empty join would ALSO return 0, not an error. Entry 6 (12 vs. a silent-failure 0) is the one that actually proves the join fired; run both together.",
       "seed": "[[:decision/persisted-fact-index :entity-type :type/decision] [:decision/persisted-fact-index :description \"Persist the fact index as a SQLite FTS5 table instead of an in-memory index\"]]",
       "seed_valid_from": "2026-07-17T04:00:00Z",
-      "seed_note": "Synthetic -- no agent-authored decision datom naturally exists tied to this repo's real history. Seeded explicitly so this question is answerable; not a claim the correlation is organically real. See design doc's 'Cross-layer question caveat'.",
+      "seed_note": "Synthetic -- no agent-authored decision datom naturally exists tied to this repo's real history. Seeded explicitly so this question is answerable; not a claim the correlation is organically real. See design doc's 'Cross-layer question caveat'. Entry 6 has no seed of its own -- it depends on this entry running first in the same run_query_benchmark.py session so the decision fact already exists in the graph; the two entries are order-dependent, not independently runnable.",
       "datalog": "[:find (count-distinct ?fn) :any-valid-time :where [:decision/persisted-fact-index :db/valid-from ?dvf] [?fn :entity-type :type/function] [?fn :file \"fact_index.py\"] [?fn :db/valid-from ?fvf] [(< ?fvf ?dvf)]]",
       "expected": [[0]],
       "baseline_cmd": "git log --oneline --diff-filter=A -- fact_index.py"
@@ -49,7 +49,7 @@
     {
       "id": 6,
       "category": "cross-layer",
-      "question": "The complementary half of entry 5's single-query join: how many fact_index.py :type/function entities were introduced AFTER the same decision's :db/valid-from? Same query shape as entry 5 with the comparison direction flipped ([(> ?fvf ?dvf)] instead of [(< ?fvf ?dvf)]) -- genuinely joins against :decision/persisted-fact-index in one query, not two separate :valid-at-bounded queries diffed externally.",
+      "question": "The complementary half of entry 5's single-query join: how many fact_index.py :type/function entities were introduced AFTER the same decision's :db/valid-from? Same query shape as entry 5 with the comparison direction flipped ([(> ?fvf ?dvf)] instead of [(< ?fvf ?dvf)]) -- genuinely joins against :decision/persisted-fact-index in one query, not two separate :valid-at-bounded queries diffed externally. This is the entry with real discriminating power: if the seed (transacted by entry 5, which must run first) were silently missing, ?dvf would never bind and this query would return 0 instead of the expected 12 -- unlike entry 5, whose own expected value is already 0.",
       "datalog": "[:find (count-distinct ?fn) :any-valid-time :where [:decision/persisted-fact-index :db/valid-from ?dvf] [?fn :entity-type :type/function] [?fn :file \"fact_index.py\"] [?fn :db/valid-from ?fvf] [(> ?fvf ?dvf)]]",
       "expected": [[12]],
       "baseline_cmd": "git show 3f30610f49a4:fact_index.py | grep -c '^def '"

--- a/evals/at_scale/query_ground_truth.json
+++ b/evals/at_scale/query_ground_truth.json
@@ -38,22 +38,21 @@
     {
       "id": 5,
       "category": "cross-layer",
-      "question": "(before, query 1 of 2) Demonstrates SKILL.md's documented two-query valid-time-bracket pattern for cross-layer decision correlation: an agent first learns a decision's :valid-from out-of-band (here, a synthetic decision seeded at 2026-07-17T04:00:00Z, before fact_index.py existed), then uses that timestamp as the :valid-at bound for a structure query. This is the 'before' half -- it does not join against the decision fact itself; minigraf's Datalog grammar has no documented way to bind a fact's own :valid-from as an output variable within a query. How many :type/function entities exist for fact_index.py at that valid-time?",
+      "question": "Genuine single-query cross-layer join: how many fact_index.py :type/function entities were introduced BEFORE the :decision/persisted-fact-index decision's own :db/valid-from (a synthetic decision seeded at 2026-07-17T04:00:00Z, before fact_index.py existed)? The query binds the decision's :db/valid-from as an output variable and filters structural facts by comparing each one's own :db/valid-from against it -- removing the seed makes the query return nothing, since ?dvf could never bind.",
       "seed": "[[:decision/persisted-fact-index :entity-type :type/decision] [:decision/persisted-fact-index :description \"Persist the fact index as a SQLite FTS5 table instead of an in-memory index\"]]",
       "seed_valid_from": "2026-07-17T04:00:00Z",
       "seed_note": "Synthetic -- no agent-authored decision datom naturally exists tied to this repo's real history. Seeded explicitly so this question is answerable; not a claim the correlation is organically real. See design doc's 'Cross-layer question caveat'.",
-      "datalog": "[:find ?fn :valid-at \"2026-07-17T04:00:00Z\" :where [?fn :entity-type :type/function] [?fn :file \"fact_index.py\"]]",
-      "expected": [],
+      "datalog": "[:find (count-distinct ?fn) :any-valid-time :where [:decision/persisted-fact-index :db/valid-from ?dvf] [?fn :entity-type :type/function] [?fn :file \"fact_index.py\"] [?fn :db/valid-from ?fvf] [(< ?fvf ?dvf)]]",
+      "expected": [[0]],
       "baseline_cmd": "git log --oneline --diff-filter=A -- fact_index.py"
     },
     {
       "id": 6,
       "category": "cross-layer",
-      "question": "(after, query 2 of 2) The second half of the two-query valid-time-bracket pattern (see entry 5): using the same synthetic decision's :valid-from as an externally-known boundary, how many :type/function entities exist for fact_index.py at the pinned commit's valid-time (2026-07-17T06:34:00Z, after the decision's valid-from)? Like entry 5, this query does not reference the decision fact directly.",
-      "datalog": "[:find (count ?fn) :valid-at \"2026-07-17T06:34:00Z\" :where [?fn :entity-type :type/function] [?fn :file \"fact_index.py\"]]",
+      "question": "The complementary half of entry 5's single-query join: how many fact_index.py :type/function entities were introduced AFTER the same decision's :db/valid-from? Same query shape as entry 5 with the comparison direction flipped ([(> ?fvf ?dvf)] instead of [(< ?fvf ?dvf)]) -- genuinely joins against :decision/persisted-fact-index in one query, not two separate :valid-at-bounded queries diffed externally.",
+      "datalog": "[:find (count-distinct ?fn) :any-valid-time :where [:decision/persisted-fact-index :db/valid-from ?dvf] [?fn :entity-type :type/function] [?fn :file \"fact_index.py\"] [?fn :db/valid-from ?fvf] [(> ?fvf ?dvf)]]",
       "expected": [[12]],
-      "baseline_cmd": "git show 3f30610f49a4:fact_index.py | grep -c '^def '",
-      "limitation": "This demonstrates the two-query valid-time-bracket pattern SKILL.md documents for cross-layer decision correlation, not a single graph-level join spanning both the decision and the structural facts. minigraf's current Datalog grammar has no documented way to bind a fact's own :valid-from as a queryable output variable or compare it numerically within one query, so an agent must know the decision's timestamp out-of-band (exactly as the seeded fixture does) and issue two :valid-at-bounded queries, one on each side of it."
+      "baseline_cmd": "git show 3f30610f49a4:fact_index.py | grep -c '^def '"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #164 (merged). The "cross-layer" ground-truth entries (5-6) in `evals/at_scale/query_ground_truth.json` seeded a synthetic decision fact but never actually queried it — the "correlation" was two independent `:valid-at`-bounded point queries whose timestamps happened to bracket the decision, chosen externally, not derived from the graph. That was shipped based on an incorrect belief that minigraf has no way to bind a fact's own `:valid-from` as a queryable output variable.

That belief was wrong: minigraf supports exactly this via `:db/valid-from`/`:db/valid-to` pseudo-attributes — `mcp_server.py` already relies on it internally (`_preload_known_deps`, `_rebuild_index_from_graph`) — it's just undocumented in `SKILL.md` (filed separately as #165).

This PR replaces entries 5/6 with a genuine single-query join: `[:decision/persisted-fact-index :db/valid-from ?dvf]` binds the decision's own timestamp, then `[?fn :db/valid-from ?fvf] [(< ?fvf ?dvf)]` / `[(> ?fvf ?dvf)]` filters structural facts by comparing against it in the same query.

An independent review then caught a second, subtler issue in the first version of this fix: the claim "removing the seed makes the query return nothing" was itself false (`count-distinct` over an empty join returns `0`, not an error) — fixed in a follow-up commit that corrects the wording and clarifies which entry (6, not 5) actually has discriminating power.

## Verification

- Both queries independently verified against this repo's real, correctly-pinned ingestion graph (443 commits through `3f30610f49a4`) via a real script file, not `-c`/heredoc (which breaks this codebase's `ProcessPoolExecutor`-based ingestion) — confirmed `before: [[0]]`, `after: [[12]]`, matching what's shipped.
- Independent code review re-derived the core claim from source (`mcp_server.py`) and re-ran the real benchmark itself, reproducing the same results.
- 715/715 tests pass; real query benchmark re-run against this repo, all 5 scored entries PASS.

## Related

- #165 — SKILL.md doc gap for `:db/valid-from`/`:db/valid-to`, filed separately.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU