### PR TITLE
Add nightly at-scale benchmark CI job, reporting only runtime errors (#120)

### DIFF
--- a/.github/workflows/at-scale-benchmark-nightly.yml
+++ b/.github/workflows/at-scale-benchmark-nightly.yml
@@ -1,0 +1,52 @@
+name: At-Scale Benchmark (nightly)
+
+# Runs the at-scale code-graph benchmark tier (evals/at_scale/, issue #120) against
+# this repo's own history every night. Purpose: catch runtime failures in the
+# ingestion/query-benchmark harness itself (crashes, hangs, broken assumptions as
+# this repo's real history grows) -- not benchmark-number regressions. The tier is
+# deliberately observational (see evals/at_scale/benchmark.md), so this workflow
+# does not gate on or compare any metric; it only fails if either script exits
+# non-zero. A failed scheduled run notifies via GitHub's own default workflow
+# failure notifications -- no extra alerting is wired up here.
+
+on:
+  schedule:
+    - cron: "0 3 * * *"  # 03:00 UTC daily
+  workflow_dispatch: {}  # allows manual runs to verify the workflow itself
+
+permissions:
+  contents: read
+
+jobs:
+  at-scale-benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository (full history)
+        uses: actions/checkout@v4
+        with:
+          # Both benchmarks need real git history: the ingestion benchmark walks
+          # this repo's full commit log, and the query benchmark ingests through
+          # a pinned historical commit (evals/at_scale/query_ground_truth.json's
+          # pinned_commit) that a shallow (depth-1) clone would not even contain.
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,git-ingestion]"
+
+      - name: Add project to PYTHONPATH
+        run: echo "PYTHONPATH=${{ github.workspace }}" >> $GITHUB_ENV
+
+      - name: Run ingestion benchmark
+        run: python -m evals.at_scale.run_ingestion_benchmark --repo-path . --branch HEAD
+
+      - name: Run query-correctness benchmark
+        if: always()
+        run: python -m evals.at_scale.run_query_benchmark --repo-path .

--- a/evals/at_scale/run_ingestion_benchmark.py
+++ b/evals/at_scale/run_ingestion_benchmark.py
@@ -142,7 +142,12 @@ async def run_ingestion_benchmark(
     return result
 
 
-def main() -> None:
+def _exit_code(metrics: dict[str, Any]) -> int:
+    """Return 1 if ingestion ended in an error state, else 0."""
+    return 1 if metrics.get("final_status") == "error" else 0
+
+
+def main() -> int:
     parser = argparse.ArgumentParser(description="Run the at-scale ingestion benchmark (#120).")
     parser.add_argument("--repo-path", default=".")
     parser.add_argument("--branch", default=None)
@@ -168,7 +173,8 @@ def main() -> None:
     print(json.dumps(metrics, indent=2))
     print(f"\nWrote {json_path}")
     print(f"Appended to {report_path}")
+    return _exit_code(metrics)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/evals/at_scale/run_query_benchmark.py
+++ b/evals/at_scale/run_query_benchmark.py
@@ -89,7 +89,16 @@ async def run_query_benchmark(
     return results
 
 
-def main() -> None:
+def _exit_code(results: list[dict[str, Any]]) -> int:
+    """Return 1 if any scored entry failed (passed is False), else 0.
+
+    Unscored entries (passed is None, e.g. manual-diff-only delta entries)
+    never affect the exit code -- only an explicit False does.
+    """
+    return 1 if any(r.get("passed") is False for r in results) else 0
+
+
+def main() -> int:
     parser = argparse.ArgumentParser(description="Run the at-scale query benchmark (#120).")
     parser.add_argument("--repo-path", default=".")
     parser.add_argument(
@@ -111,7 +120,8 @@ def main() -> None:
     append_query_report(results, report_path)
     print(json.dumps(results, indent=2))
     print(f"\nAppended to {report_path}")
+    return _exit_code(results)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_at_scale_ingestion_benchmark.py
+++ b/tests/test_at_scale_ingestion_benchmark.py
@@ -3,7 +3,18 @@ import subprocess as _subprocess
 
 import pytest
 
-from evals.at_scale.run_ingestion_benchmark import run_ingestion_benchmark
+from evals.at_scale.run_ingestion_benchmark import _exit_code, run_ingestion_benchmark
+
+
+class TestExitCode:
+    def test_zero_when_status_complete(self):
+        assert _exit_code({"final_status": "complete"}) == 0
+
+    def test_nonzero_when_status_error(self):
+        assert _exit_code({"final_status": "error"}) == 1
+
+    def test_zero_when_status_missing(self):
+        assert _exit_code({}) == 0
 
 
 @pytest.fixture

--- a/tests/test_at_scale_query_benchmark.py
+++ b/tests/test_at_scale_query_benchmark.py
@@ -4,7 +4,27 @@ import subprocess as _subprocess
 
 import pytest
 
-from evals.at_scale.run_query_benchmark import run_query_benchmark
+from evals.at_scale.run_query_benchmark import _exit_code, run_query_benchmark
+
+
+class TestExitCode:
+    def test_zero_when_all_scored_entries_pass(self):
+        results = [
+            {"id": 1, "passed": True},
+            {"id": 2, "passed": None},
+            {"id": 3, "passed": True},
+        ]
+        assert _exit_code(results) == 0
+
+    def test_nonzero_when_any_entry_fails(self):
+        results = [
+            {"id": 1, "passed": True},
+            {"id": 2, "passed": False},
+        ]
+        assert _exit_code(results) == 1
+
+    def test_zero_for_empty_results(self):
+        assert _exit_code([]) == 0
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

New `.github/workflows/at-scale-benchmark-nightly.yml` runs both `evals/at_scale/` benchmark scripts against this repo's own history at 03:00 UTC daily. Purpose is narrowly liveness monitoring — did ingestion or the query benchmark crash or hang, as this repo's real history keeps growing — not benchmark-number regression gating, consistent with the at-scale tier's own "observational only" design (`docs/superpowers/specs/2026-07-19-at-scale-benchmark-design.md`).

Uses `fetch-depth: 0` since both scripts need full git history — the query benchmark ingests through a pinned historical commit (`3f30610f49a4`, from #118, well behind `HEAD`) that a shallow clone wouldn't even contain. No Python version matrix (cross-version compat is already covered by `pytest.yml` on every push/PR), no auto-commit of results (stays ephemeral per run, matching the tier's no-CI-gate design choice), no custom alerting (GitHub's own scheduled-workflow-failure notification is the signal).

## A real bug this surfaced

Code review caught that neither script's `main()` actually reflected an internal failure in its process exit code — `run_query_benchmark.py` never checked per-entry `passed` results, and `run_ingestion_benchmark.py` never checked for `final_status == "error"` (`mcp_server._run_ingestion` intentionally swallows its own exceptions for server-resilience reasons that don't carry over to a CI script). Without this fix, the workflow's entire premise — fail on real errors — would have silently not worked; a broken benchmark would show green.

Fixed by adding a small, pure, directly-unit-tested `_exit_code()` helper to each script and wiring both `main()`s through `sys.exit()`. TDD throughout (6 new tests, watched RED before implementing). Re-review independently traced `mcp_server.py`'s `_ingest_progress["status"]` state machine and confirmed `"error"` is a complete failure signal for this script's execution path (the alternate terminal state `"stopped"` is unreachable here — it only arises from the persistent server's own signal-handling path, which this script never invokes).

## Test plan

- [x] 721/721 tests pass (`pytest tests/`)
- [x] Locally validated the exact CI invocation pattern (`PYTHONPATH=. python -m evals.at_scale.run_ingestion_benchmark ...`) end-to-end against this real repo
- [x] Independently reviewed twice (initial + re-review after the exit-code fix), both clean
- [ ] Not yet verified against real GitHub Actions infrastructure — `workflow_dispatch` is enabled so it can be triggered manually to confirm before waiting for the first scheduled run

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016tSwKVtvYtNfnm1a19B3LU