### PR TITLE
docs(roadmap): downgrade Phase 5 to feature-complete, add Phase 5.5 Ingestion Hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,4 +262,5 @@ See [`evals/benchmark.md`](evals/benchmark.md) for full results and per-eval bre
 - **Phase 3** — MCP server, per-turn auto-memory hooks ✓
 - **Phase 4** — Entity normalization, schema-aware extraction, minigraf_audit ✓
 - **Phase 5** — Code structure ingestion from git history, minigraf_ingest_git ✓
+- **Phase 5.5** — Ingestion hardening: rename tracking, vendored-path ignore, async startup, persisted on-disk retrieval index ✓ (see [ROADMAP.md](ROADMAP.md) for at-scale re-validation status)
 - **Phase 6** — Observability and trust for automatic memory (planned)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,7 +44,7 @@
 | `minigraf_audit` | 7th MCP tool; audits all entities against schema, retracts violators (bi-temporal — history preserved) | Complete ✓ |
 | Entity Resolution section | `SKILL.md` updated with resolution guidance and `minigraf_audit` instructions | Complete ✓ |
 
-## Phase 5 (Complete ✓) — Code Structure Evolution from Git History
+## Phase 5 (Feature-complete; production-hardening shipped, not yet re-validated at reported production scale) — Code Structure Evolution from Git History
 
 Extend the bi-temporal graph to store code structure extracted from git history, enabling temporal queries over how a codebase evolved and why. Ingested structural entities resolve against the canonical schema from Phase 4. Phase 6 observability will add confidence tagging on top of the ingested edges.
 
@@ -63,6 +63,18 @@ This project adds value where git structurally cannot help:
 **Cross-layer joins.** There is no way to ask git: "list all dependency changes that happened after the decision to switch databases." The decision lives in agent memory; the structural change lives in git; they are in separate systems with no shared query surface. In the graph, both are datoms and a single Datalog join connects them.
 
 The graph is built *from* git but answers queries git cannot express. Value scales with history length, structural complexity, and frequency of cross-cutting or cross-layer queries.
+
+### Validated positioning
+
+A competitive scan (mem0, Zep/Graphiti, Cognee, Letta, the MCP reference memory
+server) done while investigating #119 confirmed this niche is real and
+unoccupied: the nearest neighbor, Zep/Graphiti, is bi-temporal but relies on LLM
+extraction, an opaque hybrid-search API, no Datalog, and no code-structure
+ingestion. The deterministic, bi-temporal, Datalog-queryable structural model of
+a codebase — not conversational-memory parity with mem0/Zep/Letta — is this
+project's differentiator, and the roadmap should keep leaning into it. The
+problem #119 raised was never that this positioning was wrong, only that Phase 5
+overstated how production-ready the feature occupying it was; see Phase 5.5.
 
 ### Ingestion
 
@@ -84,6 +96,50 @@ The graph is built *from* git but answers queries git cannot express. Value scal
 - Agent-facing query patterns (fewshots / skill prompts) for common insights: circular dependency detection, high-churn modules, blast radius of a proposed change
 - Cross-layer queries that join code structure edges with agent decision datoms in the same graph — e.g., "show dependency changes that occurred after the database migration decision"
 - Natural-language question templates mapped to Datalog patterns so agents can ask structural questions without writing raw Datalog
+
+## Phase 5.5 (Complete ✓) — Ingestion Hardening
+
+A full-scale ingestion run against a real repo (ArangoDB, 52,948 HEAD commits)
+surfaced that Phase 5 was feature-complete but not production-viable: ingestion sat
+at ~100% CPU for 4+ hours and reached only ~21,134 / 52,948 commits before being
+stopped, with the graph reaching ~3.8 GB / ~460k entities, most of it vendored
+third-party code. Filed as #119, which named four blocking problems directly
+(#103, #111, #115, #116) and, in the same write-up, flagged two further
+retrieval-path gaps (#117, #118) that made the roadmap's BM25 backlog note
+inaccurate — folded into the same table below since all six belong to the same
+production-viability story:
+
+| Issue | Problem | Fix |
+|---|---|---|
+| #103 | Synchronous startup work blocks the MCP handshake on large graphs | Offloaded `_run_ingestion`'s startup preload phase to a worker thread (`run_in_executor`) |
+| #111 (+#113) | Renames/moves not tracked — identity is path-derived, so history fractures into duplicate disconnected entities; also, fields/static members/globals were never extracted as entities at all | Rename/move tracking added (entity identity survives path changes); field/static-member/global-variable extraction added to the AST pass |
+| #115 | Vendored/3rd-party subtrees (V8, ICU, boost, node_modules) ingested as first-class entities, bloating the graph and drowning retrieval in noise | Path-ignore config for git ingestion |
+| #116 | AST extraction ran on a GIL-bound thread pool — a single mega-commit could peg CPU for hours and make the MCP server unresponsive | Moved extraction off the GIL-bound thread pool |
+| #117 | `rank-bm25` optional-extra absence silently degrades hook-side retrieval to an ~82s/7GB path | First promoted `rank-bm25` to a core dependency; superseded days later when #118's persisted index shipped and the in-memory BM25 path (`FactIndex`/`IndexCache`, `rank-bm25` itself) was deleted outright as unreachable (#148) |
+| #118 | In-memory BM25 index is a per-process singleton; the `UserPromptSubmit` hook is a fresh short-lived process every turn, so retrieval was always cold and returned nothing | Persisted, mmap-able on-disk SQLite FTS5 index (`fact_index.py`), bi-temporal, shared across processes — the in-memory BM25 path this replaced no longer exists in the codebase |
+
+Fixing these surfaced further correctness bugs in the same area, tracked and
+resolved in the same hardening pass rather than deferred: #146 (Datalog injection
+via unescaped string interpolation), #153 (agent-strategy extraction losing its
+keyword ident), #152 (fact-index duplicate rows on idempotent re-writes), #156
+(`_ingest_tags` creating genuine graph-level duplicate facts, not just index
+drift), #147 (eager startup backfill needed, plus a DB-lock leak the review for
+it caught), #150 (batched index-writer commit failures needed the same
+fault-isolation per-triple writes already had), #149 (numeric-valued triples
+silently skipped during index auto-derivation), #148 (dead heuristic-fallback
+code removed once #117/#118 made it unreachable), #151 (installer needed to
+refresh a stale editable-install module mapping after the `fact_index` module was
+added).
+
+**Validation status:** #120 added `evals/at_scale/`, a repeatable in-process
+benchmark tier measuring both git-ingestion performance and query
+correctness+latency against real repo history (see `evals/at_scale/benchmark.md`).
+Its current baseline is this repo's own history — 498 commits ingested in 78.87s —
+which validates the harness and confirms no regressions, but is roughly two orders
+of magnitude smaller than the 52,948-commit run that motivated this issue.
+Re-running the benchmark against a comparably large real-world repo is the
+natural next step to independently confirm production-viability at that scale;
+it has not been done as of this update.
 
 ## Phase 6 — Observability and Trust for Automatic Memory
 
@@ -118,7 +174,7 @@ For a local single-user developer tool (the current Phase 5 target), stored data
 - `minigraf_ingest_docs` (experiment) — ingest plain text/markdown files from git history using the existing heuristic/llm/agent extraction strategies, with commit timestamps as `:valid-from`. Enables backdated decision entities from committed ADRs and design docs. Risk: duplication against conversation-extracted entities; quality depends on extraction strategy. Spec before building.
 - WASM bindings (browser + edge) — no spec or concrete driver yet
 - Mobile embedding — no spec or concrete driver yet
-- **Embedding-based disambiguation** — add only when at least two of: (a) entity volume exceeds prompt injection limits, (b) cross-session resolution fails on canonical lookup, (c) free-text search is explicitly requested. Sub-points (a) and (c) are addressed by the BM25 index (`FactIndex` / `IndexCache`, `rank-bm25`, in-memory). The remaining open question is (b): cross-session resolution failures where the user references an entity by description rather than ident (e.g. "Redis cache" → `:decision/redis`) — BM25 keyword overlap does not handle this; it would require semantic embedding. Add embedding support only if (b) becomes a demonstrated pain point. Preferred shape remains an embedded co-located index (`sqlite-vec` or `lancedb`), not a separate service.
+- **Embedding-based disambiguation** — add only when at least two of: (a) entity volume exceeds prompt injection limits, (b) cross-session resolution fails on canonical lookup, (c) free-text search is explicitly requested. Sub-points (a) and (c) were assumed to already be addressed by an in-memory BM25 index (`FactIndex` / `IndexCache`, `rank-bm25`) — #118 invalidated that for the primary deployment surface: the index lived in a per-process module-level singleton, but the `UserPromptSubmit` hook is a fresh short-lived process every turn, so the cache was always cold and `handle_memory_prepare_turn` returned empty. A persisted, mmap-able on-disk index is therefore a **prerequisite** for hook-side retrieval to function at all, not an optional embedding add-on — shipped via #118's SQLite FTS5 index (`fact_index.py`), which replaced the in-memory BM25 path (`FactIndex`/`IndexCache`, `rank-bm25`) entirely rather than sitting alongside it; see Phase 5.5. The remaining open question is (b): cross-session resolution failures where the user references an entity by description rather than ident (e.g. "Redis cache" → `:decision/redis`) — BM25 keyword overlap does not handle this; it would require semantic embedding. Add embedding support only if (b) becomes a demonstrated pain point. Preferred shape remains an embedded co-located index (`sqlite-vec` or `lancedb`), not a separate service.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #119. Docs-only, no code changes.

- Downgrades `ROADMAP.md`'s Phase 5 heading from "Complete ✓" to "feature-complete; production-hardening shipped, not yet re-validated at reported production scale."
- Adds a new **Phase 5.5 — Ingestion Hardening** section documenting the four blocking bugs #119 named directly (#103, #111/#113, #115, #116), the two retrieval-path gaps it also flagged (#117, #118), and the further hardening bugs their fixes surfaced along the way (#146, #153, #152, #156, #147, #150, #149, #148, #151) — all confirmed closed/merged.
- Corrects the Backlog's "Embedding-based disambiguation" note, which wrongly assumed an in-memory BM25 index already handled retrieval — it never worked in the hook's short-lived-process model (cold per-process singleton), and has since been replaced entirely by #118's persisted on-disk FTS5 index (the `rank-bm25` dependency and `FactIndex`/`IndexCache` no longer exist in the codebase — verified via `git log -S`).
- Adds a short "Validated positioning" note per #119's optional third suggestion (competitive scan vs. mem0/Zep/Graphiti/Cognee/Letta).
- Syncs `README.md`'s Phases checklist with a Phase 5.5 line, deferring to `ROADMAP.md` for at-scale validation status.

Deliberately does **not** claim production-viability at the reported 52,948-commit scale has been re-validated — only that the named bugs are fixed, and that a much smaller (498-commit) benchmark exists via #120's `evals/at_scale/` tier. Re-running that benchmark against a comparably large repo is flagged as the natural next step, not yet done.

An independent review pass (dispatched before opening this PR, per project convention) caught two real inaccuracies before push, both fixed:
- The #117 table row originally claimed `rank-bm25` was "promoted to a core dependency" as current state — true only transiently; it was deleted outright days later when #118 superseded it (confirmed via `git log -S rank-bm25`).
- The #111/#113 row omitted that #113 was field/static-member/global-variable extraction, not just rename tracking (the two were bundled in one PR/merge commit but are materially different capabilities).

## Test plan

- [x] Docs-only change; no runtime surface to exercise.
- [x] All 17 cited issue numbers verified `CLOSED` via `gh issue view`.
- [x] Benchmark numbers (498 commits, 78.87s) cross-checked against `evals/at_scale/benchmark.md`.
- [x] Each "Fix" description in the new table spot-checked against actual code/git history, not just trusted from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)