### PR TITLE
Fix #187: stop _watermark_update from duplicating constant facts per commit

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4221,7 +4221,10 @@ def _watermark_update(db: Any, commit_hash: str, commit_ts_iso: str, reason: str
     written exactly once rather than accumulating a duplicate per commit
     (minigraf is not idempotent at the graph level for re-transacting the same
     (entity, attribute, value) under a different valid-from -- see #156). :hash
-    always changes, so it keeps its unconditional retract-then-reassert.
+    always changes, so it keeps its unconditional retract-then-reassert. Does
+    NOT retroactively collapse duplicates a pre-fix run already created -- a
+    duplicate row whose value trivially matches desired is left alone, same
+    bounded/self-healing-by-omission scoping as _ingest_tags' own #156 fix.
     """
     current_raw = _db_execute(db, "(query [:find ?a ?v :where [:ingestion/watermark ?a ?v]])")
     current: Dict[str, str] = dict(json.loads(current_raw).get("results", []))

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4212,19 +4212,45 @@ def _count_commit_entities(db: Any) -> int:
 
 
 def _watermark_update(db: Any, commit_hash: str, commit_ts_iso: str, reason: str, index_con: Optional[Any] = None) -> None:
-    """Record the last successfully ingested commit hash in the graph."""
-    existing = _watermark_query(db)
-    if existing:
-        _retract(db, f'[[:ingestion/watermark :hash "{existing}"]]', index_con=index_con)
-    _transact(
-        db,
-        f'[[:ingestion/watermark :entity-type :type/ingestion] '
-        f'[:ingestion/watermark :ident ":ingestion/watermark"] '
-        f'[:ingestion/watermark :description "git ingestion watermark"] '
-        f'[:ingestion/watermark :hash "{commit_hash}"]]',
-        commit_ts_iso,
-        index_con=index_con,
-    )
+    """Record the last successfully ingested commit hash in the graph.
+
+    Called once per COMMIT (not once per run) inside _run_ingestion's main loop.
+    :entity-type/:ident/:description are constant and never change after the
+    first call -- diffed against the entity's current live values first, and
+    only retracted+re-transacted when the value actually changed, so they are
+    written exactly once rather than accumulating a duplicate per commit
+    (minigraf is not idempotent at the graph level for re-transacting the same
+    (entity, attribute, value) under a different valid-from -- see #156). :hash
+    always changes, so it keeps its unconditional retract-then-reassert.
+    """
+    current_raw = _db_execute(db, "(query [:find ?a ?v :where [:ingestion/watermark ?a ?v]])")
+    current: Dict[str, str] = dict(json.loads(current_raw).get("results", []))
+
+    def _edn(attr: str, value: str) -> str:
+        return value if attr == ":entity-type" else f'"{_edn_escape(value)}"'
+
+    constants = {
+        ":entity-type": ":type/ingestion",
+        ":ident": ":ingestion/watermark",
+        ":description": "git ingestion watermark",
+    }
+
+    to_retract: List[str] = []
+    to_transact: List[str] = []
+    for attr, value in constants.items():
+        if current.get(attr) == value:
+            continue  # already correct -- skip to avoid creating a duplicate live fact (#156)
+        if attr in current:
+            to_retract.append(f"[:ingestion/watermark {attr} {_edn(attr, current[attr])}]")
+        to_transact.append(f"[:ingestion/watermark {attr} {_edn(attr, value)}]")
+
+    if ":hash" in current:
+        to_retract.append(f"[:ingestion/watermark :hash {_edn(':hash', current[':hash'])}]")
+    to_transact.append(f"[:ingestion/watermark :hash {_edn(':hash', commit_hash)}]")
+
+    if to_retract:
+        _retract(db, "[" + " ".join(to_retract) + "]", index_con=index_con)
+    _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
 
 
 def _last_run_write(db: Any, commit_hash: str, run_at: str, total_ingested: int, index_con: Optional[Any] = None) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1031,6 +1031,46 @@ class TestIngestTagsGraphLevelIdempotency:
         assert json.loads(raw)["results"] == [["v1.1.0"]]
 
 
+class TestWatermarkUpdateGraphLevelIdempotency:
+    """#187: same failure shape as #156 (TestIngestTagsGraphLevelIdempotency), but in
+    _watermark_update -- called once per COMMIT rather than once per run. Only :hash
+    was ever retracted before reassertion; :entity-type/:ident/:description are
+    constant values that never change after the first call, but were unconditionally
+    re-transacted under a fresh valid-from on every commit, each creating a second
+    genuinely live duplicate fact (minigraf is not idempotent at the graph level for
+    that -- see #156)."""
+
+    def test_constant_attrs_not_duplicated_across_commits(self, real_db):
+        import mcp_server
+        mcp_server._watermark_update(real_db, "hash1", "2026-01-01T00:00:00.000Z", "commit 1")
+        mcp_server._watermark_update(real_db, "hash2", "2026-01-02T00:00:00.000Z", "commit 2")
+        mcp_server._watermark_update(real_db, "hash3", "2026-01-03T00:00:00.000Z", "commit 3")
+        raw = mcp_server._db_execute(
+            real_db, "(query [:find ?a ?v :where [:ingestion/watermark ?a ?v]])"
+        )
+        results = json.loads(raw)["results"]
+        assert len(results) == 4  # :entity-type, :ident, :description, :hash -- one each
+
+    def test_second_commit_skips_rewriting_unchanged_constant_attrs(self, real_db):
+        import mcp_server
+        mcp_server._watermark_update(real_db, "hash1", "2026-01-01T00:00:00.000Z", "commit 1")
+        with execute_spy() as calls:
+            mcp_server._watermark_update(real_db, "hash2", "2026-01-02T00:00:00.000Z", "commit 2")
+        writes = [c for c in calls if c.startswith("(transact") or c.startswith("(retract")]
+        # Only :hash's retract+reassert should fire -- nothing for the unchanged constants.
+        assert len(writes) == 2
+        assert not any(":entity-type" in c or ":ident" in c or ":description" in c for c in writes)
+
+    def test_hash_still_updates_to_single_live_fact(self, real_db):
+        import mcp_server
+        mcp_server._watermark_update(real_db, "hash1", "2026-01-01T00:00:00.000Z", "commit 1")
+        mcp_server._watermark_update(real_db, "hash2", "2026-01-02T00:00:00.000Z", "commit 2")
+        raw = mcp_server._db_execute(
+            real_db, "(query [:find ?v :where [:ingestion/watermark :hash ?v]])"
+        )
+        assert json.loads(raw)["results"] == [["hash2"]]
+
+
 class TestMinigrafReportIssue:
     def test_delegates_to_report_issue(self, real_db):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1070,6 +1070,21 @@ class TestWatermarkUpdateGraphLevelIdempotency:
         )
         assert json.loads(raw)["results"] == [["hash2"]]
 
+    def test_changed_constant_value_retracts_stale_and_keeps_single_live_fact(self, real_db):
+        import mcp_server
+        mcp_server._watermark_update(real_db, "hash1", "2026-01-01T00:00:00.000Z", "commit 1")
+        mcp_server._retract(real_db, '[[:ingestion/watermark :description "git ingestion watermark"]]')
+        mcp_server._transact(
+            real_db,
+            '[[:ingestion/watermark :description "stale description"]]',
+            "2026-01-02T00:00:00.000Z",
+        )
+        mcp_server._watermark_update(real_db, "hash2", "2026-01-03T00:00:00.000Z", "commit 2")
+        raw = mcp_server._db_execute(
+            real_db, "(query [:find ?v :where [:ingestion/watermark :description ?v]])"
+        )
+        assert json.loads(raw)["results"] == [["git ingestion watermark"]]
+
 
 class TestMinigrafReportIssue:
     def test_delegates_to_report_issue(self, real_db):


### PR DESCRIPTION
## Summary
- `_watermark_update` fires once per commit inside `_run_ingestion`'s main loop, and unconditionally re-transacted `:entity-type`/`:ident`/`:description` under a fresh `valid_from` on every call even though those values never change after the first call — minigraf isn't idempotent for re-transacting the same `(entity, attribute, value)` under a different `valid_from`, so each call created a second genuinely live duplicate fact (same root cause #156 fixed for `_ingest_tags`, but firing per-commit rather than per-run — ~1200 duplicates already present on this repo's own 400+-commit history).
- Fix diffs against the entity's current live values first and only retracts+re-transacts an attribute whose value actually changed, mirroring `_ingest_tags`' post-#156 idiom exactly (including its `_edn` keyword-vs-string helper pattern). `:hash` keeps its unconditional retract-then-reassert since it always changes — matches issue #187's own suggested fix precisely.
- Docstring documents the same bounded/self-healing-by-omission scope as `_ingest_tags`: does not retroactively collapse duplicates a pre-fix run already created.

Fixes #187.

## Test plan
- [x] TDD: new `TestWatermarkUpdateGraphLevelIdempotency` class, watched RED against pre-fix code (10 live facts instead of 4; unconditional rewrite of unchanged constants), then GREEN after the fix.
- [x] Independent code-review subagent dispatched before push — Important finding (missing no-retroactive-cleanup doc parity) and Minor finding (missing changed-value-branch test) both addressed in a follow-up commit.
- [x] Full suite: no regressions vs. the pre-existing 102-failure baseline (confirmed via `git stash` diff — missing tree-sitter grammar packages in this sandbox, unrelated to this change).
- [x] `ruff`/`black`: identical pre-existing findings before/after, nothing new introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)