### PR TITLE
Fix #185: capture merge-commit content dropped by plain diff-tree

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3711,7 +3711,19 @@ def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
     Supersedes running diff-tree a second time just to detect gitlinks:
     --raw already carries file mode (needed to spot submodule paths, mode
     160000) in the same subprocess invocation _extract_commit already makes.
+
+    Merge commits (#185): plain `git diff-tree --raw` (no -m/-c/--cc) is
+    documented git behavior to emit NOTHING for a commit with more than one
+    parent, even when real content was authored at the merge point itself
+    (most commonly, manual conflict-resolution edits). Ordinary clean merges
+    don't need special handling here -- every underlying change is already
+    reachable via the individual non-merge commits `_git_commits`' plain
+    `git log` walk visits regardless -- so this branches to
+    _git_diff_tree_combined_raw only for actual merge commits, leaving the
+    single-parent (overwhelmingly common) path above untouched.
     """
+    if len(_git_parent_hashes(repo_path, commit_hash)) > 1:
+        return _git_diff_tree_combined_raw(repo_path, commit_hash)
     result = _subprocess.run(
         ["git", "diff-tree", "--no-commit-id", "-r", "-M", "--raw", "--root", commit_hash],
         cwd=repo_path, capture_output=True, text=True, check=True,
@@ -3734,6 +3746,67 @@ def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
         else:
             old_path, path = "", rest
         entries.append((status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity))
+    return entries
+
+
+def _git_diff_tree_combined_raw(repo_path: str, commit_hash: str) -> List[tuple]:
+    """Combined-diff (`--cc`) raw parse, used only for merge commits (#185).
+
+    `--cc`'s combined-diff format already restricts its output to paths whose
+    content differs from EVERY parent -- exactly the "genuinely authored at
+    the merge point" set this exists to recover. A file that matches at
+    least one parent unchanged never appears here, which is what keeps this
+    safe for the common "both sides touched different files" clean-merge
+    case (reports nothing) and the "both sides touched the same file in
+    non-overlapping, auto-merged hunks" case (reports the file, since its
+    merged content differs from both individual parents, same as a manual
+    conflict resolution would).
+
+    Combined raw lines carry one leading ':' and one mode/sha per parent
+    (plus one more of each for the merge result itself), e.g. for an
+    ordinary 2-parent merge:
+    "::100644 100644 100644 <sha1> <sha2> <sha_new> MM\tpath". Rename/copy
+    detection doesn't apply in combined-diff mode, so there is always
+    exactly one tab-separated path field -- old_path is always "" and
+    similarity is always None, matching _git_diff_tree_raw's non-rename rows.
+
+    status is derived from the mode columns rather than the trailing status
+    letters (which are one char per parent, e.g. "MM", and don't collapse
+    cleanly to _git_diff_tree_raw's single-char contract): new_mode all
+    zeros means "D"; every old_mode all zeros means "A" (the path exists in
+    none of the parents); otherwise "M". old_mode/old_sha are taken from the
+    first parent only -- combined diff has no single unambiguous "old" side
+    for a merge, and the exact old-side content only feeds this codebase's
+    best-effort rename-matching heuristic (_extract_commit's
+    old_entity_nodes), not the fact-extraction this issue is about.
+    """
+    result = _subprocess.run(
+        ["git", "diff-tree", "--cc", "--no-commit-id", "-r", "--raw", "--root", commit_hash],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    entries = []
+    for line in result.stdout.strip().splitlines():
+        if not line.startswith(":"):
+            continue
+        meta, sep, path = line.partition("\t")
+        if not sep:
+            continue
+        n_parents = len(meta) - len(meta.lstrip(":"))
+        fields = meta[n_parents:].split(" ")
+        if len(fields) != 2 * n_parents + 3:
+            continue
+        old_modes = fields[:n_parents]
+        new_mode = fields[n_parents]
+        old_shas = fields[n_parents + 1: 2 * n_parents + 1]
+        new_sha = fields[2 * n_parents + 1]
+        zero_mode = "0" * len(new_mode)
+        if new_mode == zero_mode:
+            status = "D"
+        elif all(m == zero_mode for m in old_modes):
+            status = "A"
+        else:
+            status = "M"
+        entries.append((status, old_modes[0], new_mode, old_shas[0], new_sha, path, "", None))
     return entries
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3718,12 +3718,18 @@ def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
     (most commonly, manual conflict-resolution edits). Ordinary clean merges
     don't need special handling here -- every underlying change is already
     reachable via the individual non-merge commits `_git_commits`' plain
-    `git log` walk visits regardless -- so this branches to
-    _git_diff_tree_combined_raw only for actual merge commits, leaving the
-    single-parent (overwhelmingly common) path above untouched.
+    `git log` walk visits regardless.
+
+    Rather than checking parent count up front (an extra `git log -1`
+    subprocess call on every single commit, working against this function's
+    single-subprocess-call design goal for the overwhelmingly common
+    single-parent case), the plain diff-tree call always runs first; a
+    parent-count check (and the _git_diff_tree_combined_raw fallback it
+    guards) only happens on the rare path where it comes back empty -- which
+    is exactly the signal ("root or single-parent commit truly touched
+    nothing" vs. "this is a merge commit, plain diff-tree always returns
+    nothing regardless of content") this needs to distinguish.
     """
-    if len(_git_parent_hashes(repo_path, commit_hash)) > 1:
-        return _git_diff_tree_combined_raw(repo_path, commit_hash)
     result = _subprocess.run(
         ["git", "diff-tree", "--no-commit-id", "-r", "-M", "--raw", "--root", commit_hash],
         cwd=repo_path, capture_output=True, text=True, check=True,
@@ -3746,6 +3752,8 @@ def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
         else:
             old_path, path = "", rest
         entries.append((status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity))
+    if not entries and len(_git_parent_hashes(repo_path, commit_hash)) > 1:
+        return _git_diff_tree_combined_raw(repo_path, commit_hash)
     return entries
 
 
@@ -3779,6 +3787,17 @@ def _git_diff_tree_combined_raw(repo_path: str, commit_hash: str) -> List[tuple]
     for a merge, and the exact old-side content only feeds this codebase's
     best-effort rename-matching heuristic (_extract_commit's
     old_entity_nodes), not the fact-extraction this issue is about.
+
+    Known residual gap (verified, not yet fixed -- see #185's follow-up):
+    --cc only reports a path when it differs from EVERY parent, so content
+    that exists on exactly one parent's side and is discarded entirely at
+    the merge (final tree matches the OTHER parent, which never had it)
+    never appears here either -- e.g. a submodule added on a feature branch
+    but dropped while resolving the merge leaves its `:pinned-commit` fact
+    open forever, since neither plain diff-tree nor --cc ever reports the
+    removal. Distinct root cause from the content-authored-at-merge case
+    this function fixes (that content is genuinely new; this content is
+    genuinely gone), so deliberately out of scope here.
     """
     result = _subprocess.run(
         ["git", "diff-tree", "--cc", "--no-commit-id", "-r", "--raw", "--root", commit_hash],

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4708,6 +4708,101 @@ class TestGitDiffTreeRaw:
         assert statuses == {"A", "D"}
 
 
+class TestGitDiffTreeRawMergeCommits:
+    """See #185: plain `git diff-tree --raw` (no -m/-c/--cc) always emits
+    nothing for a merge commit -- this is documented git behavior. Content
+    authored genuinely at the merge point (e.g. manual conflict-resolution
+    edits) was silently and permanently dropped as a result.
+    """
+
+    def _init_repo(self, repo):
+        repo.mkdir()
+        _subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def test_merge_commit_with_conflict_resolution_content_is_captured(self, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        self._init_repo(repo)
+
+        (repo / "langs.py").write_text("LANGS = {\n    'python': 1,\n}\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "-b", "feature"], cwd=repo, check=True, capture_output=True)
+        (repo / "langs.py").write_text("LANGS = {\n    'python': 1,\n    'rust': 2,\n}\n")
+        _subprocess.run(["git", "commit", "-am", "add rust"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+        (repo / "langs.py").write_text("LANGS = {\n    'python': 1,\n    'go': 3,\n}\n")
+        _subprocess.run(["git", "commit", "-am", "add go"], cwd=repo, check=True, capture_output=True)
+
+        merge_result = _subprocess.run(
+            ["git", "merge", "feature", "--no-ff", "-m", "merge feature"],
+            cwd=repo, capture_output=True, text=True,
+        )
+        assert merge_result.returncode != 0, "expected a real conflict on the shared lines"
+
+        # Hand-resolve with content present in NEITHER parent (kotlin) --
+        # this is the "genuinely authored at the merge point" case #185 is about.
+        (repo / "langs.py").write_text(
+            "LANGS = {\n    'python': 1,\n    'rust': 2,\n    'go': 3,\n    'kotlin': 4,\n}\n"
+        )
+        _subprocess.run(["git", "add", "langs.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "--no-edit"], cwd=repo, check=True, capture_output=True)
+
+        merge_hash = _subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert len(mcp_server._git_parent_hashes(str(repo), merge_hash)) == 2
+
+        entries = mcp_server._git_diff_tree_raw(str(repo), merge_hash)
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
+        assert path == "langs.py"
+        assert status == "M"
+        assert old_path == ""
+        content = mcp_server._git_blob_content(str(repo), new_sha)
+        assert b"kotlin" in content
+
+    def test_clean_non_conflicting_merge_reports_no_entries(self, tmp_path):
+        """Each side touches its own file only -- every changed byte is already
+        reachable via the individual non-merge commits `_git_commits` walks, so
+        the merge commit itself should contribute nothing new."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        self._init_repo(repo)
+
+        (repo / "base.py").write_text("x = 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "-b", "feature"], cwd=repo, check=True, capture_output=True)
+        (repo / "feature_only.py").write_text("y = 2\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add feature file"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+        (repo / "main_only.py").write_text("z = 3\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add main file"], cwd=repo, check=True, capture_output=True)
+
+        merge_result = _subprocess.run(
+            ["git", "merge", "feature", "--no-ff", "-m", "merge feature"],
+            cwd=repo, capture_output=True, text=True,
+        )
+        assert merge_result.returncode == 0, "expected a clean, non-conflicting merge"
+
+        merge_hash = _subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert len(mcp_server._git_parent_hashes(str(repo), merge_hash)) == 2
+
+        entries = mcp_server._git_diff_tree_raw(str(repo), merge_hash)
+        assert entries == []
+
+
 class TestIsIgnoredPath:
     def test_directory_pattern_matches_nested_path(self):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4802,6 +4802,28 @@ class TestGitDiffTreeRawMergeCommits:
         entries = mcp_server._git_diff_tree_raw(str(repo), merge_hash)
         assert entries == []
 
+    def test_single_parent_commit_pays_no_extra_parent_hash_lookup(self, git_repo, monkeypatch):
+        """The merge-commit branch must not cost the (overwhelming) common
+        single-parent case an extra subprocess call -- _git_parent_hashes
+        should only be consulted when the plain diff-tree call itself came
+        back empty, not unconditionally up front."""
+        import mcp_server
+
+        base_run = mcp_server._subprocess.run
+        call_count = {"n": 0}
+
+        def counting_run(cmd, *args, **kwargs):
+            if cmd[:2] == ["git", "log"] and "--format=%P" in cmd:
+                call_count["n"] += 1
+            return base_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(mcp_server._subprocess, "run", counting_run)
+
+        commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)
+        mcp_server._git_diff_tree_raw(str(git_repo), commits[0][0])
+
+        assert call_count["n"] == 0, "expected zero _git_parent_hashes calls for an ordinary non-empty commit"
+
 
 class TestIsIgnoredPath:
     def test_directory_pattern_matches_nested_path(self):
@@ -5087,6 +5109,54 @@ class TestParseGitmodules:
 
 
 class TestExtractCommit:
+    def test_merge_commit_conflict_resolution_content_produces_facts(self, tmp_path):
+        """See #185: a plain diff-tree call sees nothing at all for a merge
+        commit, so before the fix this returned zero results even though a
+        real function was introduced only at the merge point."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "m.py").write_text("def base():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "-b", "feature"], cwd=repo, check=True, capture_output=True)
+        (repo / "m.py").write_text("def base():\n    pass\n\ndef from_feature():\n    pass\n")
+        _subprocess.run(["git", "commit", "-am", "feature adds fn"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+        (repo / "m.py").write_text("def base():\n    pass\n\ndef from_main():\n    pass\n")
+        _subprocess.run(["git", "commit", "-am", "main adds fn"], cwd=repo, check=True, capture_output=True)
+
+        merge_result = _subprocess.run(
+            ["git", "merge", "feature", "--no-ff", "-m", "merge feature"],
+            cwd=repo, capture_output=True, text=True,
+        )
+        assert merge_result.returncode != 0, "expected a real conflict on the shared file"
+
+        (repo / "m.py").write_text(
+            "def base():\n    pass\n\ndef from_main():\n    pass\n\n"
+            "def from_feature():\n    pass\n\ndef merge_authored():\n    pass\n"
+        )
+        _subprocess.run(["git", "add", "m.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "--no-edit"], cwd=repo, check=True, capture_output=True)
+
+        merge_hash = _subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        results, gitlink_changes, gitmodules_map, _renamed_pairs = mcp_server._extract_commit(str(repo), merge_hash)
+
+        assert len(results) == 1
+        status, file_path, extracted, precomputed, old_path = results[0]
+        assert status == "M"
+        assert file_path == "m.py"
+        assert "merge_authored" in extracted["functions"]
+
     def test_added_file_returns_extracted_dict(self, git_repo):
         import mcp_server
         commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)


### PR DESCRIPTION
## Summary

- Plain `git diff-tree --raw` (no `-m`/`-c`/`--cc`) is documented git behavior to emit nothing for a merge commit, so `_extract_commit` silently and permanently dropped content genuinely authored at a merge point (e.g. manual conflict-resolution edits) — no error, no retry path, watermark still advances.
- `_git_diff_tree_raw` now falls back to a new `_git_diff_tree_combined_raw` (parsing `--cc`'s combined-diff raw format) only when the plain diff-tree call comes back empty *and* the commit has more than one parent — zero extra subprocess calls for the common single-parent case, matching the issue's own stated efficiency goal.
- Verified against this repo's own cited repro commit (`22cdf15`): `_extract_commit` now correctly extracts 84/220 functions from `mcp_server.py`/`tests/test_mcp_server.py` at that merge commit, where it previously returned nothing.
- Independent review caught a distinct, narrower blind spot (content discarded entirely at a merge, matching only one parent) — verified real via a submodule repro, documented in the new function's docstring as out of scope, and filed separately as #191 per this repo's established narrow-scoping precedent.

## Test plan

- [x] New `TestGitDiffTreeRawMergeCommits` (real conflict-resolution content captured; clean non-conflicting merge still reports nothing; no extra subprocess call on the common path) — all TDD, watched RED against pre-fix code first
- [x] New `TestExtractCommit::test_merge_commit_conflict_resolution_content_produces_facts` — end-to-end fact extraction, also watched RED
- [x] Full suite: 729 passed, 0 failed (venv with full tree-sitter grammar set)
- [x] `ruff`/`black`: identical pre-existing findings before/after (confirmed via checkout diff), nothing new introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)