### PR TITLE
Fix #186: _last_run_write never retracts previous values

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4286,8 +4286,23 @@ def _total_ingested_query(db: Any) -> int:
     mid-way (e.g. by lock contention) leaves this stale even though further
     commits were durably persisted. Use _count_commit_entities for the true
     current count.
+
+    :any-valid-time is required here (not a design choice) -- valid-from is
+    the run's own timestamp, not real wall-clock time, so a plain query's
+    implicit "as of now" filter can miss facts whose valid-from lands after
+    the real current moment. But :any-valid-time also surfaces already-closed
+    historical rows from prior runs, so the :db/valid-to pseudo-attribute is
+    bound and filtered to the open-fact sentinel to select only the live
+    value -- otherwise, even after _last_run_write's #186 retract-before-
+    reassert fix, this could still nondeterministically return a stale run's
+    value depending on row order.
     """
-    raw = _db_execute(db, "(query [:find ?n :any-valid-time :where [:ingestion/last-run-at :total-ingested ?n]])")
+    raw = _db_execute(
+        db,
+        "(query [:find ?n :any-valid-time "
+        ":where [:ingestion/last-run-at :total-ingested ?n] "
+        "[:ingestion/last-run-at :db/valid-to ?vt] [(= ?vt 9223372036854775807)]])",
+    )
     results = json.loads(raw).get("results", [])
     return int(results[0][0]) if results else 0
 
@@ -4348,19 +4363,58 @@ def _watermark_update(db: Any, commit_hash: str, commit_ts_iso: str, reason: str
     _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
 
 
+_LAST_RUN_KEYWORD_ATTRS = frozenset({":entity-type"})
+_LAST_RUN_NUMERIC_ATTRS = frozenset({":total-ingested"})
+
+
 def _last_run_write(db: Any, commit_hash: str, run_at: str, total_ingested: int, index_con: Optional[Any] = None) -> None:
-    """Record the wall-clock time, final commit hash, and cumulative ingested count."""
-    _transact(
-        db,
-        f'[[:ingestion/last-run-at :entity-type :type/ingestion] '
-        f'[:ingestion/last-run-at :ident ":ingestion/last-run-at"] '
-        f'[:ingestion/last-run-at :description "last ingestion run timestamp"] '
-        f'[:ingestion/last-run-at :last-run-at "{run_at}"] '
-        f'[:ingestion/last-run-at :last-commit "{commit_hash}"] '
-        f'[:ingestion/last-run-at :total-ingested {total_ingested}]]',
-        run_at,
-        index_con=index_con,
-    )
+    """Record the wall-clock time, final commit hash, and cumulative ingested count.
+
+    Same graph-level non-idempotency (#156) as _watermark_update/_ingest_tags:
+    re-transacting the same (entity, attribute, value) under a fresh valid-from
+    creates a second genuinely live duplicate rather than a no-op -- this was
+    unconditionally re-transacting all six attributes on every completed run,
+    so after the second run the singleton :ingestion/last-run-at entity carried
+    multiple live values per attribute, and any-valid-time readers (e.g.
+    handle_minigraf_ingest_status) could pair one run's timestamp with a
+    different run's commit hash (#186). Diffs against the entity's current
+    live values first and only retracts+reasserts attributes that actually
+    changed -- :entity-type/:ident/:description are constant and written once;
+    :last-run-at/:last-commit/:total-ingested change every run and always
+    retract-then-reassert, same as :hash in _watermark_update.
+    """
+    desired: Dict[str, Any] = {
+        ":entity-type": ":type/ingestion",
+        ":ident": ":ingestion/last-run-at",
+        ":description": "last ingestion run timestamp",
+        ":last-run-at": run_at,
+        ":last-commit": commit_hash,
+        ":total-ingested": total_ingested,
+    }
+
+    current_raw = _db_execute(db, "(query [:find ?a ?v :where [:ingestion/last-run-at ?a ?v]])")
+    current: Dict[str, Any] = dict(json.loads(current_raw).get("results", []))
+
+    def _edn(attr: str, value: Any) -> str:
+        if attr in _LAST_RUN_KEYWORD_ATTRS:
+            return value
+        if attr in _LAST_RUN_NUMERIC_ATTRS:
+            return str(value)
+        return f'"{_edn_escape(value)}"'
+
+    to_retract: List[str] = []
+    to_transact: List[str] = []
+    for attr, value in desired.items():
+        if current.get(attr) == value:
+            continue  # already correct -- skip to avoid creating a duplicate live fact (#156)
+        if attr in current:
+            to_retract.append(f"[:ingestion/last-run-at {attr} {_edn(attr, current[attr])}]")
+        to_transact.append(f"[:ingestion/last-run-at {attr} {_edn(attr, value)}]")
+
+    if to_retract:
+        _retract(db, "[" + " ".join(to_retract) + "]", index_con=index_con)
+    if to_transact:
+        _transact(db, "[" + " ".join(to_transact) + "]", run_at, index_con=index_con)
 
 
 # System attributes written by _transact_extracted_facts alongside domain attributes.
@@ -6740,11 +6794,19 @@ def handle_minigraf_ingest_status() -> Dict[str, Any]:
     if _ingest_progress["status"] != "running":
         try:
             db = get_db()
+            # :any-valid-time is needed since valid-from is the run's own
+            # timestamp, not real wall-clock time (see _total_ingested_query),
+            # but it also surfaces already-closed historical rows -- bind and
+            # filter :db/valid-to to the open-fact sentinel on each attribute
+            # so only the current run's own (?t, ?h) pair is returned, not a
+            # cross-product with a different historical run's value (#186).
             raw = _db_execute(
                 db,
                 "(query [:find ?t ?h :any-valid-time "
                 ":where [:ingestion/last-run-at :last-run-at ?t] "
-                "[:ingestion/last-run-at :last-commit ?h]])"
+                "[:ingestion/last-run-at :db/valid-to ?vt1] [(= ?vt1 9223372036854775807)] "
+                "[:ingestion/last-run-at :last-commit ?h] "
+                "[:ingestion/last-run-at :db/valid-to ?vt2] [(= ?vt2 9223372036854775807)]])"
             )
             rows = json.loads(raw).get("results", [])
             if rows:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1086,6 +1086,83 @@ class TestWatermarkUpdateGraphLevelIdempotency:
         assert json.loads(raw)["results"] == [["git ingestion watermark"]]
 
 
+class TestLastRunWriteGraphLevelIdempotency:
+    """#186: same failure shape as #156/#187 (TestIngestTagsGraphLevelIdempotency /
+    TestWatermarkUpdateGraphLevelIdempotency), but in _last_run_write, called once
+    per completed ingestion RUN. It used to unconditionally re-transact all six
+    attributes on every call with no retract-before-reassert at all -- not even
+    :hash's partial protection in _watermark_update -- so after the second
+    completed run the singleton :ingestion/last-run-at entity carried multiple
+    live values per attribute simultaneously."""
+
+    def test_constant_attrs_not_duplicated_across_runs(self, real_db):
+        import mcp_server
+        mcp_server._last_run_write(real_db, "hash1", "2026-01-01T00:00:00.000Z", 10)
+        mcp_server._last_run_write(real_db, "hash2", "2026-01-02T00:00:00.000Z", 25)
+        mcp_server._last_run_write(real_db, "hash3", "2026-01-03T00:00:00.000Z", 40)
+        raw = mcp_server._db_execute(
+            real_db, "(query [:find ?a ?v :where [:ingestion/last-run-at ?a ?v]])"
+        )
+        results = json.loads(raw)["results"]
+        # :entity-type, :ident, :description, :last-run-at, :last-commit,
+        # :total-ingested -- one live value each, not a cross-product of 3 runs.
+        assert len(results) == 6
+
+    def test_second_run_skips_rewriting_unchanged_constant_attrs(self, real_db):
+        import mcp_server
+        mcp_server._last_run_write(real_db, "hash1", "2026-01-01T00:00:00.000Z", 10)
+        with execute_spy() as calls:
+            mcp_server._last_run_write(real_db, "hash2", "2026-01-02T00:00:00.000Z", 25)
+        writes = [c for c in calls if c.startswith("(transact") or c.startswith("(retract")]
+        # Only :last-run-at/:last-commit/:total-ingested's retract+reassert
+        # should fire -- nothing for the unchanged :entity-type/:ident/:description.
+        assert len(writes) == 2
+        assert not any(":entity-type" in c or ":ident" in c or ":description" in c for c in writes)
+
+    def test_last_run_at_and_last_commit_stay_paired_after_third_run(self, real_db):
+        """Direct reproduction of #186: before the fix, :last-run-at and
+        :last-commit each accumulated one live value per run, so an
+        :any-valid-time join across both attributes returned a 3x3
+        cross-product -- rows[0] could pair one run's timestamp with a
+        DIFFERENT run's commit hash. After the fix, only the current run's
+        own pair should be live."""
+        import mcp_server
+        mcp_server._last_run_write(real_db, "hashA_run1", "2026-01-01T00:00:00.000Z", 10)
+        mcp_server._last_run_write(real_db, "hashB_run2", "2026-01-02T00:00:00.000Z", 25)
+        mcp_server._last_run_write(real_db, "hashC_run3_LATEST", "2026-01-03T00:00:00.000Z", 40)
+
+        raw = mcp_server._db_execute(
+            real_db,
+            "(query [:find ?t ?h :any-valid-time "
+            ":where [:ingestion/last-run-at :last-run-at ?t] "
+            "[:ingestion/last-run-at :last-commit ?h]])",
+        )
+        results = json.loads(raw)["results"]
+        assert results == [["2026-01-03T00:00:00.000Z", "hashC_run3_LATEST"]]
+
+    def test_total_ingested_reflects_latest_run_not_first(self, real_db):
+        import mcp_server
+        mcp_server._last_run_write(real_db, "hashA", "2026-01-01T00:00:00.000Z", 10)
+        mcp_server._last_run_write(real_db, "hashB", "2026-01-02T00:00:00.000Z", 25)
+        mcp_server._last_run_write(real_db, "hashC", "2026-01-03T00:00:00.000Z", 40)
+        assert mcp_server._total_ingested_query(real_db) == 40
+
+    def test_changed_constant_value_retracts_stale_and_keeps_single_live_fact(self, real_db):
+        import mcp_server
+        mcp_server._last_run_write(real_db, "hash1", "2026-01-01T00:00:00.000Z", 10)
+        mcp_server._retract(real_db, '[[:ingestion/last-run-at :description "last ingestion run timestamp"]]')
+        mcp_server._transact(
+            real_db,
+            '[[:ingestion/last-run-at :description "stale description"]]',
+            "2026-01-02T00:00:00.000Z",
+        )
+        mcp_server._last_run_write(real_db, "hash2", "2026-01-03T00:00:00.000Z", 25)
+        raw = mcp_server._db_execute(
+            real_db, "(query [:find ?v :where [:ingestion/last-run-at :description ?v]])"
+        )
+        assert json.loads(raw)["results"] == [["last ingestion run timestamp"]]
+
+
 class TestMinigrafReportIssue:
     def test_delegates_to_report_issue(self, real_db):
         import mcp_server
@@ -4459,6 +4536,27 @@ class TestMinigrafIngestStatus:
         }
         result = mcp_server.handle_minigraf_ingest_status()
         assert result["total_ingested"] is None
+
+    def test_last_run_at_and_last_commit_stay_paired_across_multiple_runs(self, real_db):
+        """Regression test for #186: handle_minigraf_ingest_status's
+        :any-valid-time query used to return an arbitrary row from a
+        cross-product of every run's (timestamp, hash) pair -- so a real
+        timestamp could come back paired with a completely different run's
+        commit hash. After the #186 fix, only the latest run's own pair
+        should be reported."""
+        import mcp_server
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0,
+            "current_commit": "", "error": None,
+        }
+        mcp_server._last_run_write(real_db, "hashA_run1", "2026-01-01T00:00:00.000Z", 10)
+        mcp_server._last_run_write(real_db, "hashB_run2", "2026-01-02T00:00:00.000Z", 25)
+        mcp_server._last_run_write(real_db, "hashC_run3_LATEST", "2026-01-03T00:00:00.000Z", 40)
+
+        result = mcp_server.handle_minigraf_ingest_status()
+
+        assert result["last_run_at"] == "2026-01-03T00:00:00.000Z"
+        assert result["last_commit"] == "hashC_run3_LATEST"
 
 
 class TestCodeIdent:


### PR DESCRIPTION
## Summary
- `_last_run_write` unconditionally re-transacted all six attributes on every completed ingestion run with no retract-before-reassert — the same graph-level non-idempotency already fixed for `_ingest_tags` (#156) and `_watermark_update` (#187), but never applied here. After the 2nd completed run, `:ingestion/last-run-at` carried multiple live values per attribute simultaneously, so `handle_minigraf_ingest_status`'s `:any-valid-time` join could pair one run's real timestamp with a *different* run's commit hash.
- Fixed by mirroring the established diff-against-current-live-values pattern: constants (`:entity-type`/`:ident`/`:description`) are written once, `:last-run-at`/`:last-commit`/`:total-ingested` always retract-then-reassert.
- Also hardened `_total_ingested_query` and `handle_minigraf_ingest_status`'s inline query to filter `:db/valid-to` to the open-fact sentinel — `:any-valid-time` surfaces closed historical rows regardless of the write-side fix, so an unfiltered read could still nondeterministically return a stale run's value depending on row order.

## Test plan
- [x] Added `TestLastRunWriteGraphLevelIdempotency` mirroring the existing `#156`/`#187` idempotency test classes, including a direct reproduction of the issue's exact scenario (3 runs → 1 live row per attribute, correctly paired with the latest run, not a 3x3 cross-product).
- [x] Added a regression test on `handle_minigraf_ingest_status` confirming `last_run_at`/`last_commit` stay paired across multiple runs.
- [x] Full suite: `python -m pytest tests/test_mcp_server.py -q` → 609 passed.

Closes #186.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL