### PR TITLE
Fix #177: #uuid/#inst-tagged facts silently dropped from the fact index

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3042,9 +3042,25 @@ def handle_minigraf_query(datalog: str) -> Dict[str, Any]:
         return {"ok": False, "error": str(e)}
 
 
+_TAGGED_LITERAL = r'#(?:uuid|inst)\s+"[^"\\]*"'
 _FACTS_TRIPLE_PATTERN = re.compile(
-    r'\[(\:[^\s\]]+)\s+(\:[^\s\]]+)\s+("(?:[^"\\]|\\.)*"|\:[^\s\]]+|-?\d+(?:\.\d+)?)\]'
+    r'\[(\:[^\s\]]+|' + _TAGGED_LITERAL + r')\s+(\:[^\s\]]+)\s+'
+    r'("(?:[^"\\]|\\.)*"|\:[^\s\]]+|-?\d+(?:\.\d+)?|' + _TAGGED_LITERAL + r')\]'
 )
+_TAGGED_LITERAL_PATTERN = re.compile(r'#(?:uuid|inst)\s+"([^"\\]*)"')
+
+
+def _unwrap_facts_block_token(raw: str) -> str:
+    """Strip quoting/tagging from a captured entity or value token: a quoted
+    string loses its quotes, a #uuid/#inst "..." literal loses the tag and
+    keeps the raw UUID/timestamp text, anything else (keyword, number) is
+    kept as-is."""
+    if raw.startswith('"'):
+        return raw[1:-1]
+    m = _TAGGED_LITERAL_PATTERN.match(raw)
+    if m:
+        return m.group(1)
+    return raw
 
 
 def _parse_facts_block(facts_str: str) -> List[Tuple[str, str, str]]:
@@ -3055,15 +3071,23 @@ def _parse_facts_block(facts_str: str) -> List[Tuple[str, str, str]]:
     capture keyword-valued and bare-numeric-valued triples, which schema
     validation intentionally skips but the index must not). Value is
     unquoted for string-valued triples, kept as-is (a keyword, number, or
-    entity reference) otherwise. #uuid/#inst-tagged values still aren't
-    captured -- pass index_triples explicitly if one of those needs to be
-    searchable.
+    entity reference) otherwise. #uuid/#inst-tagged entity references and
+    values are also captured, with the tag stripped and the raw UUID/
+    timestamp text kept as the indexed entity/value (#177) -- this is not
+    a keyword ident, so entity identity in the index can fragment across a
+    keyword-tagged create and a later #uuid-tagged update of the same
+    graph entity; pass index_triples explicitly (see handle_minigraf_audit)
+    when a resolved keyword ident is available and identity consistency
+    matters more than a mechanical capture.
     """
     triples = []
     for m in _FACTS_TRIPLE_PATTERN.finditer(facts_str):
         entity, attribute, raw_value = m.groups()
-        value = raw_value[1:-1] if raw_value.startswith('"') else raw_value
-        triples.append((entity, attribute, value))
+        triples.append((
+            _unwrap_facts_block_token(entity),
+            attribute,
+            _unwrap_facts_block_token(raw_value),
+        ))
     return triples
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -746,6 +746,29 @@ class TestMinigrafTransact:
         results = fact_index.query_facts(index_path, "redis caching", top_n=10, boost=2.0, historical_discount=1.0)
         assert any(r[0] == ":decision/use-redis" for r in results)
 
+    def test_transact_uuid_tagged_entity_is_indexed(self, real_db):
+        """#177: a caller who only has a raw UUID entity ref (e.g. from a prior
+        minigraf_query result that didn't bind through an :ident) must still get
+        indexed, not silently dropped."""
+        import mcp_server
+        import fact_index
+        mcp_server.handle_minigraf_transact(
+            '[[:decision/x :description "hello"]]', reason="test"
+        )
+        queried = mcp_server.handle_minigraf_query(
+            '[:find ?e :where [?e :description "hello"]]'
+        )
+        entity_uuid = queried["results"][0][0]
+
+        result = mcp_server.handle_minigraf_transact(
+            f'[[#uuid "{entity_uuid}" :status "reviewed"]]', reason="test2"
+        )
+        assert result["ok"] is True
+
+        index_path = fact_index.index_path_for(mcp_server._graph_path)
+        results = fact_index.query_facts(index_path, "reviewed", top_n=10, boost=2.0, historical_discount=1.0)
+        assert any(r[1] == ":status" and r[2] == "reviewed" for r in results)
+
 
 class TestMinigrafRetract:
     def test_requires_reason(self, real_db):
@@ -833,6 +856,33 @@ class TestParseFactsBlock:
         assert result == [
             (":decision/x", ":offset", "-3"),
             (":decision/x", ":score", "1.5"),
+        ]
+
+    def test_uuid_tagged_entity_triple(self):
+        import mcp_server
+        result = mcp_server._parse_facts_block(
+            '[#uuid "b14d54ed-41b3-5675-a334-26f9fbcba5fe" :status "reviewed"]'
+        )
+        assert result == [
+            ("b14d54ed-41b3-5675-a334-26f9fbcba5fe", ":status", "reviewed"),
+        ]
+
+    def test_uuid_tagged_value_triple(self):
+        import mcp_server
+        result = mcp_server._parse_facts_block(
+            '[:decision/x :resolves-to #uuid "b14d54ed-41b3-5675-a334-26f9fbcba5fe"]'
+        )
+        assert result == [
+            (":decision/x", ":resolves-to", "b14d54ed-41b3-5675-a334-26f9fbcba5fe"),
+        ]
+
+    def test_inst_tagged_value_triple(self):
+        import mcp_server
+        result = mcp_server._parse_facts_block(
+            '[:decision/x :created-at #inst "2026-01-01T00:00:00.000Z"]'
+        )
+        assert result == [
+            (":decision/x", ":created-at", "2026-01-01T00:00:00.000Z"),
         ]
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -809,6 +809,31 @@ class TestMinigrafRetract:
         results = fact_index.query_facts(index_path, "redis caching", top_n=10, boost=2.0, historical_discount=1.0)
         assert results == []
 
+    def test_retract_uuid_tagged_entity_removes_from_fact_index(self, real_db):
+        """#177 retract-side mirror: a #uuid-tagged retract must remove the
+        row _transact indexed under the same raw UUID entity string."""
+        import mcp_server
+        import fact_index
+        mcp_server.handle_minigraf_transact(
+            '[[:decision/x :description "hello"]]', reason="test"
+        )
+        queried = mcp_server.handle_minigraf_query(
+            '[:find ?e :where [?e :description "hello"]]'
+        )
+        entity_uuid = queried["results"][0][0]
+        mcp_server.handle_minigraf_transact(
+            f'[[#uuid "{entity_uuid}" :status "reviewed"]]', reason="test2"
+        )
+
+        result = mcp_server.handle_minigraf_retract(
+            f'[[#uuid "{entity_uuid}" :status "reviewed"]]', reason="cleanup"
+        )
+        assert result["ok"] is True
+
+        index_path = fact_index.index_path_for(mcp_server._graph_path)
+        results = fact_index.query_facts(index_path, "reviewed", top_n=10, boost=2.0, historical_discount=1.0)
+        assert results == []
+
 
 class TestParseFactsBlock:
     def test_single_string_valued_triple(self):
@@ -883,6 +908,20 @@ class TestParseFactsBlock:
         )
         assert result == [
             (":decision/x", ":created-at", "2026-01-01T00:00:00.000Z"),
+        ]
+
+    def test_uuid_tagged_entity_and_value_in_same_triple(self):
+        import mcp_server
+        result = mcp_server._parse_facts_block(
+            '[#uuid "b14d54ed-41b3-5675-a334-26f9fbcba5fe" :resolves-to '
+            '#uuid "c25e65fe-52c4-6786-b445-37f0fcba6f6f"]'
+        )
+        assert result == [
+            (
+                "b14d54ed-41b3-5675-a334-26f9fbcba5fe",
+                ":resolves-to",
+                "c25e65fe-52c4-6786-b445-37f0fcba6f6f",
+            ),
         ]
 
 


### PR DESCRIPTION
## Summary
- `_FACTS_TRIPLE_PATTERN` required a colon-prefixed keyword entity, so any triple using a `#uuid`-tagged entity reference (exactly what `minigraf_query` returns whenever a query doesn't bind through an `:ident`) matched nothing — the fact wrote to the graph fine but silently vanished from the fact index, with no error.
- Extends the regex to also capture `#uuid "..."`/`#inst "..."`-tagged entity references and values, unwrapping the tag and keeping the raw UUID/timestamp text as the indexed entity/value — same regex-extension approach #149 used for bare numerics, applied to the tagged-literal shape #149 explicitly left uncaptured.
- Deliberately did not resolve `#uuid` entities to a canonical `:ident` (the issue's alternative suggestion): ordinary `minigraf_transact` facts never write a separate `:ident`, so a resolver would almost always fall back to the raw UUID anyway while adding a DB round-trip per transact. The resulting tradeoff (a `#uuid`-tagged fact is indexed under the raw UUID string, not matching a sibling keyword-entity fact about the same graph entity, so it misses the BM25 memory-fact boost) is documented in `_parse_facts_block`'s docstring and filed separately as #194, out of scope here.

Independent code review (dispatched before push) found no Critical/Important blocking issues; two coverage gaps it flagged (a `#uuid` literal as both entity and value in one triple, and the retract-side path) were both confirmed already-working and added as regression tests before merge.

## Test plan
- [x] New unit tests in `TestParseFactsBlock` for `#uuid`-tagged entity, `#uuid`-tagged value, `#inst`-tagged value, and `#uuid` as both entity and value in one triple
- [x] Real-backend regression test (`TestMinigrafTransact::test_transact_uuid_tagged_entity_is_indexed`) reproducing the issue's exact repro against `handle_minigraf_transact`/`handle_minigraf_query`
- [x] Real-backend regression test (`TestMinigrafRetract::test_retract_uuid_tagged_entity_removes_from_fact_index`) covering the retract-side mirror
- [x] Targeted suite (`ParseFactsBlock`/`TransactRetract`/`MinigrafTransact`/`MinigrafRetract`/`MinigrafAudit`): 36 passed
- [x] Full suite: identical pre-existing 102-failure baseline (confirmed via `git stash`, missing tree-sitter grammar packages, unrelated), no regressions
- [x] `ruff check`: clean; `black --check`: identical pre-existing findings before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL