### PR TITLE
Fix #189: unreadable commit anywhere in the range aborted the entire ingestion run

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7,6 +7,7 @@ Sole interface to the minigraf .graph file via the MiniGrafDb Python binding.
 """
 import asyncio
 import concurrent.futures
+import concurrent.futures.process
 import configparser
 import contextlib
 import datetime
@@ -6316,7 +6317,32 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                     # ingestion run — including the many existing tests that drive
                     # _run_ingestion through a real ProcessPoolExecutor worker — would
                     # otherwise fail with "too many values to unpack".
-                    extracted_files, gitlink_changes, gitmodules_map, renamed_pairs = await fut
+                    try:
+                        extracted_files, gitlink_changes, gitmodules_map, renamed_pairs = await fut
+                    except concurrent.futures.process.BrokenProcessPool:
+                        # The whole worker pool died (OOM kill, native segfault) --
+                        # every other pending future in the sliding window is
+                        # equally poisoned, so this is not isolable to one commit
+                        # (see this function's docstring). Propagate to the outer
+                        # handler as before.
+                        raise
+                    except Exception as e:
+                        # Ordinary extraction failure (bad git ref, unreadable
+                        # blob, unsupported syntax) -- isolate it to this one
+                        # commit instead of aborting the whole run, matching this
+                        # function's own documented "fail only the one commit"
+                        # contract and the per-file try/except _extract_commit
+                        # already uses one level down for content-fetch failures.
+                        print(
+                            f"[_run_ingestion] skipping unreadable commit {commit_hash} "
+                            f"({subject!r}): {e}",
+                            file=sys.stderr,
+                        )
+                        submit_next()
+                        _ingest_progress["current_commit"] = commit_hash
+                        _ingest_progress["processed"] += 1
+                        await asyncio.sleep(0)  # yield to event loop
+                        continue
                     submit_next()
 
                     last_hash = commit_hash

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -6729,6 +6729,22 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                         await loop.run_in_executor(write_executor, _db_checkpoint, db)
                         await loop.run_in_executor(write_executor, _commit_index_writer_safe, index_con)
 
+                    except Exception as e:
+                        # Ordinary per-commit write failure (malformed EDN, a
+                        # transient constraint violation, ...) -- isolate it to
+                        # this one commit rather than aborting every commit
+                        # still pending, matching this function's own
+                        # documented "fail only the one commit" contract and
+                        # the extraction-phase isolation above. Opening the DB
+                        # itself (_ensure_db_async, just above this try) is
+                        # deliberately NOT covered here -- that failure is
+                        # unrecoverable for every remaining commit too, so it
+                        # still propagates to the outer handler.
+                        print(
+                            f"[_run_ingestion] skipping commit {commit_hash} "
+                            f"({subject!r}): write failed: {e}",
+                            file=sys.stderr,
+                        )
                     finally:
                         _db = None  # release file lock between commits
                         db = None   # drop local reference too — see note above

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7429,6 +7429,46 @@ class TestRunIngestionCommitFaultIsolation:
         subjects = {r[2] for r in results if r[1] == ":subject"}
         assert "add models" in subjects
 
+    @pytest.mark.asyncio
+    async def test_write_phase_failure_for_one_commit_is_skipped_not_fatal(
+        self, real_db, git_repo, monkeypatch, capsys
+    ):
+        """The issue's own suggested fix asked to wrap "the whole per-commit
+        body," not just the extraction await -- a failure in the DB-writing
+        section (e.g. _watermark_update raising) must be isolated the same
+        way as an extraction failure, not just abort the whole run because
+        it happens to occur past the extraction step."""
+        import mcp_server
+        import fact_index
+
+        real_watermark_update = mcp_server._watermark_update
+        calls = []
+
+        def failing_once_watermark_update(db, commit_hash, commit_ts_iso, reason, index_con=None):
+            calls.append(commit_hash)
+            if len(calls) == 1:
+                raise RuntimeError("simulated write failure")
+            return real_watermark_update(db, commit_hash, commit_ts_iso, reason, index_con)
+
+        monkeypatch.setattr(mcp_server, "_watermark_update", failing_once_watermark_update)
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0,
+            "current_commit": "", "error": None,
+        }
+        await mcp_server._run_ingestion(str(git_repo), "HEAD")
+
+        assert mcp_server._ingest_progress["status"] == "complete"
+        assert mcp_server._ingest_progress["processed"] == 2  # git_repo's 2 real commits
+        assert "write failed" in capsys.readouterr().err
+
+        # Second commit (models.py) still got ingested despite the first
+        # commit's write-phase failure -- proves isolation, not just that
+        # the run avoided "error" status.
+        index_path = fact_index.index_path_for(mcp_server._graph_path)
+        results = fact_index.query_facts(index_path, "models", top_n=50, boost=2.0, historical_discount=1.0)
+        subjects = {r[2] for r in results if r[1] == ":subject"}
+        assert "add models" in subjects
+
 
 class TestRunIngestionBatchedIndexWrites:
     @pytest.mark.asyncio

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7361,6 +7361,75 @@ class TestRunIngestion:
         assert mcp_server._ingest_progress["processed"] == 21717  # 21715 + 2 commits
 
 
+class TestRunIngestionCommitFaultIsolation:
+    """#189: an ordinary extraction failure for a single commit (bad git
+    ref, unreadable blob, unsupported syntax) must fail only that one
+    commit, not the whole run -- _run_ingestion's own docstring already
+    claims this contract ("Ordinary exceptions ... are unaffected and still
+    fail only the one commit as before"), but the `await fut` in the main
+    pipeline loop had no try/except around it, so any exception raised
+    inside _extract_commit (running in a worker process) propagated all the
+    way to the outer `except Exception` handler and flipped the whole run
+    to status "error", leaving every commit after the bad one unprocessed."""
+
+    @pytest.mark.asyncio
+    async def test_unreadable_commit_is_skipped_not_fatal(self, real_db, git_repo, monkeypatch, capsys):
+        import mcp_server
+
+        real_git_commits = mcp_server._git_commits
+
+        def poisoned_git_commits(repo_path, watermark_hash, branch="HEAD"):
+            # Inject a commit hash that was never actually created in this
+            # repo -- git diff-tree on it fails exactly like a
+            # shallow-clone-missing-object or a repo mutated concurrently
+            # with a long-running ingestion (force-push / `git gc --prune`).
+            commits = real_git_commits(repo_path, watermark_hash, branch)
+            poisoned = commits[:1] + [("deadbeef" * 5, "2026-01-01T00:00:00Z", "x@x.com", "POISONED")] + commits[1:]
+            return poisoned
+
+        monkeypatch.setattr(mcp_server, "_git_commits", poisoned_git_commits)
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0,
+            "current_commit": "", "error": None,
+        }
+        await mcp_server._run_ingestion(str(git_repo), "HEAD")
+
+        assert mcp_server._ingest_progress["status"] == "complete"
+        # 2 real commits from git_repo + 1 skipped poisoned commit
+        assert mcp_server._ingest_progress["processed"] == 3
+        assert "deadbeef" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_commits_after_the_bad_one_are_still_ingested(self, real_db, git_repo, monkeypatch):
+        import mcp_server
+        import fact_index
+
+        real_git_commits = mcp_server._git_commits
+
+        def poisoned_git_commits(repo_path, watermark_hash, branch="HEAD"):
+            commits = real_git_commits(repo_path, watermark_hash, branch)
+            poisoned = [commits[0], ("deadbeef" * 5, "2026-01-01T00:00:00Z", "x@x.com", "POISONED")] + commits[1:]
+            return poisoned
+
+        monkeypatch.setattr(mcp_server, "_git_commits", poisoned_git_commits)
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0,
+            "current_commit": "", "error": None,
+        }
+        await mcp_server._run_ingestion(str(git_repo), "HEAD")
+
+        # git_repo's second (post-poison) commit adds models.py -- proves
+        # ingestion continued past the bad commit instead of aborting. Read
+        # via the persisted fact index (not the in-memory graph db directly)
+        # since real_db's MiniGrafDb.open() patch hands back a brand-new
+        # isolated store on every reopen -- _run_ingestion reopens the db
+        # between commits, so only index/DB-external assertions survive.
+        index_path = fact_index.index_path_for(mcp_server._graph_path)
+        results = fact_index.query_facts(index_path, "models", top_n=50, boost=2.0, historical_discount=1.0)
+        subjects = {r[2] for r in results if r[1] == ":subject"}
+        assert "add models" in subjects
+
+
 class TestRunIngestionBatchedIndexWrites:
     @pytest.mark.asyncio
     async def test_ingestion_commits_index_once_per_commit_not_per_triple(self, real_db, git_repo, monkeypatch):


### PR DESCRIPTION
## Summary
- `_run_ingestion`'s main pipeline loop had an unguarded `await fut` for per-commit extraction — any exception from `_extract_commit` (bad git ref, unreadable blob, a repo mutated concurrently with ingestion) propagated to the outer handler and aborted the *entire remaining* commit range, contradicting the function's own docstring ("Ordinary exceptions ... fail only the one commit").
- Wraps the extraction await: `BrokenProcessPool` still propagates (whole pool is dead, not isolable), any other exception logs to stderr, counts the commit as processed without adding facts, and continues.
- Independent code review (dispatched per this project's standing practice) caught that the issue's own suggested fix asked for "the whole per-commit body," not just extraction — widened the fix to also isolate DB-write-phase failures (`_watermark_update`, `_db_checkpoint`, etc.) the same way, while still letting a DB-*open* failure (`_ensure_db_async`) abort the whole run, matching the issue's "genuinely unrecoverable" carve-out.

## Test plan
- [x] New `TestRunIngestionCommitFaultIsolation` (3 tests) against a real `ProcessPoolExecutor` and real git repo, following the issue's own repro technique (only `_git_commits` patched to inject one bogus commit hash mid-range)
- [x] Full suite: 603 passed, identical pre-existing 102-failure baseline (missing tree-sitter grammars in this sandbox) confirmed via `git stash`
- [x] `ruff`/`black`: identical pre-existing findings, nothing new

Fixes #189

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL