### PR TITLE
Fix #176: checkpoint failure after successful transact/retract reported ok:False

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -775,6 +775,8 @@ All functions return `{"ok": bool, ...}`. Common errors:
 - `as_of requires :as-of clause` — include `:as-of N` in query
 - `reason is required for all writes` — provide non-empty reason
 
+`minigraf_transact`/`minigraf_retract` may return `{"ok": true, ..., "warning": "..."}` if the write itself succeeded but a subsequent internal checkpoint failed (e.g. a disk/permissions error). The fact is durably written — do not retry, since a retry uses a fresh timestamp and creates a duplicate.
+
 If an error persists after checking syntax and installation, use `minigraf_report_issue` to file a structured bug report with the failing query and error message:
 
 ```python

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3007,6 +3007,25 @@ def _db_checkpoint(db: Any) -> None:
         db.checkpoint()
 
 
+def _checkpoint_after_write(db: Any, tool_name: str, result: Dict[str, Any]) -> None:
+    """Checkpoint after a transact/retract that has already applied its graph
+    and fact-index write. A checkpoint failure here must not flip an
+    already-successful write's result to ok:False (#176) -- the caller would
+    reasonably retry, and a retry uses a fresh valid_from, which creates a
+    genuine duplicate live datom rather than a no-op (per #156's finding that
+    minigraf only treats an identical (entity, attribute, value, valid_from)
+    tuple as idempotent). Mutates result in place, adding a "warning" key
+    when the checkpoint fails and the write itself succeeded.
+    """
+    try:
+        _db_checkpoint(db)
+        _update_mtime()
+    except MiniGrafError as e:
+        print(f"[{tool_name}] checkpoint failed after successful write: {e}", file=sys.stderr)
+        if result.get("ok"):
+            result["warning"] = f"checkpoint failed after write succeeded: {e}"
+
+
 # ---------------------------------------------------------------------------
 # Result parsing
 # ---------------------------------------------------------------------------
@@ -3256,14 +3275,13 @@ def handle_minigraf_transact(facts: str, reason: str) -> Dict[str, Any]:
     db = get_db()
     try:
         raw = _transact(db, facts, _now_utc_ms())
-        _db_checkpoint(db)
-        _update_mtime()
-        result = _parse_tx_result(raw)
-        if result["ok"]:
-            result["reason"] = reason
-        return result
     except MiniGrafError as e:
         return {"ok": False, "error": str(e)}
+    result = _parse_tx_result(raw)
+    if result["ok"]:
+        result["reason"] = reason
+    _checkpoint_after_write(db, "minigraf_transact", result)
+    return result
 
 
 def handle_minigraf_retract(facts: str, reason: str) -> Dict[str, Any]:
@@ -3274,14 +3292,13 @@ def handle_minigraf_retract(facts: str, reason: str) -> Dict[str, Any]:
     db = get_db()
     try:
         raw = _retract(db, facts)
-        _db_checkpoint(db)
-        _update_mtime()
-        result = _parse_tx_result(raw)
-        if result["ok"]:
-            result["reason"] = reason
-        return result
     except MiniGrafError as e:
         return {"ok": False, "error": str(e)}
+    result = _parse_tx_result(raw)
+    if result["ok"]:
+        result["reason"] = reason
+    _checkpoint_after_write(db, "minigraf_retract", result)
+    return result
 
 
 def handle_minigraf_rule(rule: str) -> Dict[str, Any]:
@@ -3416,11 +3433,23 @@ def handle_minigraf_audit(as_of: Optional[int] = None) -> Dict[str, Any]:
                             (kw_ident, a, v) for a, v in attr_rows if isinstance(v, str)
                         ]
                         _retract(db, retract_facts, index_triples=index_triples)
-                        _db_checkpoint(db)
-                        _update_mtime()
+                    except Exception as e:
+                        print(f"[minigraf_audit] retract failed for {kw_ident}: {e}", file=sys.stderr)
+                    else:
+                        # The retract (graph + fact index) already applied above --
+                        # count it regardless of whether the checkpoint that follows
+                        # succeeds (#176), and never let a checkpoint failure raise
+                        # out of this loop and abort the rest of the audit.
                         retracted += 1
-                    except Exception:
-                        pass
+                        try:
+                            _db_checkpoint(db)
+                            _update_mtime()
+                        except Exception as e:
+                            print(
+                                f"[minigraf_audit] checkpoint failed after retracting "
+                                f"{kw_ident}: {e}",
+                                file=sys.stderr,
+                            )
 
     return {
         "ok": True,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -769,6 +769,45 @@ class TestMinigrafTransact:
         results = fact_index.query_facts(index_path, "reviewed", top_n=10, boost=2.0, historical_discount=1.0)
         assert any(r[1] == ":status" and r[2] == "reviewed" for r in results)
 
+    def test_checkpoint_failure_after_successful_write_still_reports_ok(self, tmp_path, monkeypatch):
+        """#176: the graph write (and fact-index write) already happened by
+        the time _db_checkpoint runs -- a checkpoint-only failure must not be
+        reported as ok:False, since a caller retrying on a false failure uses
+        a fresh valid_from and creates a real duplicate live datom (per
+        #156's finding that differing valid_from isn't idempotent at the
+        graph level). Manufactures a real permission failure (chmod the
+        containing directory read-only, so minigraf's WAL-deletion step
+        during checkpoint fails for real) rather than faking the exception."""
+        import mcp_server
+        graph_path = str(tmp_path / "t.graph")
+        mcp_server._db = None
+        mcp_server._graph_path = graph_path
+        mcp_server.open_db(graph_path)
+
+        real_checkpoint = mcp_server._db_checkpoint
+
+        def failing_checkpoint(db):
+            os.chmod(tmp_path, 0o555)
+            try:
+                real_checkpoint(db)
+            finally:
+                os.chmod(tmp_path, 0o755)
+
+        monkeypatch.setattr(mcp_server, "_db_checkpoint", failing_checkpoint)
+
+        result = mcp_server.handle_minigraf_transact(
+            '[[:decision/y :description "should-persist"]]', reason="test"
+        )
+
+        assert result["ok"] is True
+        assert "warning" in result
+
+        monkeypatch.setattr(mcp_server, "_db_checkpoint", real_checkpoint)
+        queried = mcp_server.handle_minigraf_query(
+            '[:find ?d :where [:decision/y :description ?d]]'
+        )
+        assert queried["results"] == [["should-persist"]]
+
 
 class TestMinigrafRetract:
     def test_requires_reason(self, real_db):
@@ -833,6 +872,43 @@ class TestMinigrafRetract:
         index_path = fact_index.index_path_for(mcp_server._graph_path)
         results = fact_index.query_facts(index_path, "reviewed", top_n=10, boost=2.0, historical_discount=1.0)
         assert results == []
+
+    def test_checkpoint_failure_after_successful_write_still_reports_ok(self, tmp_path, monkeypatch):
+        """#176 retract-side mirror: the retract itself already happened by
+        the time _db_checkpoint runs, so a checkpoint-only failure must not
+        be reported as ok:False."""
+        import mcp_server
+        graph_path = str(tmp_path / "t.graph")
+        mcp_server._db = None
+        mcp_server._graph_path = graph_path
+        mcp_server.open_db(graph_path)
+        mcp_server.handle_minigraf_transact(
+            '[[:decision/old :description "deprecated"]]', reason="setup"
+        )
+
+        real_checkpoint = mcp_server._db_checkpoint
+
+        def failing_checkpoint(db):
+            os.chmod(tmp_path, 0o555)
+            try:
+                real_checkpoint(db)
+            finally:
+                os.chmod(tmp_path, 0o755)
+
+        monkeypatch.setattr(mcp_server, "_db_checkpoint", failing_checkpoint)
+
+        result = mcp_server.handle_minigraf_retract(
+            '[[:decision/old :description "deprecated"]]', reason="gone"
+        )
+
+        assert result["ok"] is True
+        assert "warning" in result
+
+        monkeypatch.setattr(mcp_server, "_db_checkpoint", real_checkpoint)
+        queried = mcp_server.handle_minigraf_query(
+            '[:find ?d :where [:decision/old :description ?d]]'
+        )
+        assert queried["results"] == []
 
 
 class TestParseFactsBlock:
@@ -2281,6 +2357,43 @@ class TestMinigrafAudit:
         index_path = fact_index.index_path_for(mcp_server._graph_path)
         results = fact_index.query_facts(index_path, "decision bad", top_n=10, boost=2.0, historical_discount=1.0)
         assert not any(r[0] == ":decision/bad" for r in results)
+
+    def test_checkpoint_failure_after_retract_still_counts_and_persists(self, tmp_path, monkeypatch):
+        """#176 audit-side mirror: the per-entity retract (graph + fact
+        index) already happened by the time _db_checkpoint runs inside the
+        audit loop -- a checkpoint-only failure must not silently under-count
+        `retracted`, since the retraction is already durably applied."""
+        import mcp_server
+        graph_path = str(tmp_path / "t.graph")
+        mcp_server._db = None
+        mcp_server._graph_path = graph_path
+        mcp_server.open_db(graph_path)
+        mcp_server.handle_minigraf_transact(
+            '[[:decision/bad :entity-type :type/decision] '
+            '[:decision/bad :ident ":decision/bad"]]',
+            reason="setup",
+        )
+
+        real_checkpoint = mcp_server._db_checkpoint
+
+        def failing_checkpoint(db):
+            os.chmod(tmp_path, 0o555)
+            try:
+                real_checkpoint(db)
+            finally:
+                os.chmod(tmp_path, 0o755)
+
+        monkeypatch.setattr(mcp_server, "_db_checkpoint", failing_checkpoint)
+
+        result = mcp_server.handle_minigraf_audit()
+
+        assert result["retracted"] == 1
+
+        monkeypatch.setattr(mcp_server, "_db_checkpoint", real_checkpoint)
+        queried = mcp_server.handle_minigraf_query(
+            '[:find ?e :where [?e :entity-type :type/decision]]'
+        )
+        assert queried["results"] == []
 
 
 class TestPhase5Schema:


### PR DESCRIPTION
## Summary
- `handle_minigraf_transact`/`handle_minigraf_retract` wrapped the write (`_transact`/`_retract`, which already durably applies the graph + fact-index write) and the subsequent `_db_checkpoint` in one `except MiniGrafError` block, so a checkpoint-only failure (e.g. disk/permissions) was reported as `ok: False` even though the write had already succeeded — inviting a retry that creates a real duplicate live datom (differing `valid_from`, per #156).
- New `_checkpoint_after_write` helper separates "did the write fail" from "did the checkpoint fail after a successful write": the latter now logs to stderr and adds a non-fatal `"warning"` field to an otherwise-successful result instead of flipping `ok` to `False`.
- `handle_minigraf_audit`'s per-entity retract loop gets the same treatment: a checkpoint failure after a successful retract no longer silently under-counts `retracted` (previously swallowed by a bare `except Exception: pass` with zero logging).
- `SKILL.md` documents the new optional `"warning"` field and tells callers not to retry on it.

## Test plan
- [x] 3 new tests manufacture a *real* checkpoint failure (chmod the containing directory read-only during checkpoint, matching the issue's own repro) — watched RED against pre-fix code, GREEN after the fix
- [x] Full `tests/` suite: 606 passed (603 baseline + 3 net new), identical pre-existing 102-failure baseline (missing tree-sitter grammars, unrelated) confirmed via `git stash` diff
- [x] `ruff check`/`black --check`: identical findings before/after, nothing new
- [x] Independent code-review subagent: no Critical/Important findings, "Ready to merge: Yes"

Fixes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL