### PR TITLE
Fix #181: embedded double-quote in an extracted value silently dropped the whole fact

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3944,6 +3944,14 @@ def _edn_escape(s: str) -> str:
     return s.replace("\\", "\\\\").replace('"', '\\"')
 
 
+_EDN_ESCAPE_SEQUENCE = re.compile(r'\\(.)')
+
+
+def _edn_unescape(s: str) -> str:
+    """Reverse _edn_escape: \\\" -> \" and \\\\ -> \\ in a captured EDN string body."""
+    return _EDN_ESCAPE_SEQUENCE.sub(lambda m: m.group(1), s)
+
+
 def _git_file_content(repo_path: str, commit_hash: str, file_path: str) -> bytes:
     """Return raw bytes of a file at the given commit."""
     result = _subprocess.run(
@@ -4629,16 +4637,16 @@ def _parse_transact_facts(facts_str: str) -> List[Dict[str, Any]]:
     like :type/decision are skipped — they are internal type tags, not
     user-authored facts subject to schema validation.
     """
-    pattern = r'\[(\:[^\s\]]+)\s+(\:[^\s\]]+)\s+"([^"]+)"\]'
+    pattern = r'\[(\:[^\s\]]+)\s+(\:[^\s\]]+)\s+"((?:[^"\\]|\\.)+)"\]'
     result = []
     for match in re.finditer(pattern, facts_str):
-        entity, attribute, value = match.groups()
+        entity, attribute, raw_value = match.groups()
         entity_type = entity.split("/")[0].lstrip(":") if "/" in entity else ""
         result.append({
             "entity": entity,
             "entity_type": entity_type,
             "attribute": attribute,
-            "value": value,
+            "value": _edn_unescape(raw_value),
         })
     return result
 
@@ -5029,6 +5037,9 @@ Canonical ident form: lowercase, hyphens only — :decision/redis not :decision/
 Use these attributes: :description (required), :rationale (optional), :date (optional), :alias (optional).
 No other attributes are valid.
 
+IMPORTANT — quoting: if a value itself contains a double-quote character, escape it as \\" so
+it doesn't end the string literal early — e.g. :description "she called it \\"the fix\\"".
+
 IMPORTANT — entity resolution: if a reference matches an existing canonical ident or alias above,
 reuse that exact ident. Only mint a new ident if the entity is genuinely new.
 
@@ -5206,6 +5217,9 @@ Canonical ident form: lowercase, hyphens only — :decision/redis not :decision/
 {canonical_entities_section}
 Use these attributes: :description (required), :rationale (optional), :date (optional), :alias (optional).
 No other attributes are valid. If an entity matches an existing ident or alias, reuse it exactly.
+
+If a value itself contains a double-quote character, escape it as \\" so it doesn't end the
+string literal early — e.g. :description "she called it \\"the fix\\"".
 
 For each newly-minted entity, also emit an :alias fact with 2-5 comma-separated
 alternative terms or broader concepts someone might use to refer to it later —

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1686,6 +1686,16 @@ class TestAliasEnrichment:
         assert "alias" in mcp_server._AGENT_SAMPLING_PROMPT.lower()
         assert "synonym" in mcp_server._AGENT_SAMPLING_PROMPT.lower() or "alternative term" in mcp_server._AGENT_SAMPLING_PROMPT.lower()
 
+    def test_llm_extraction_prompt_instructs_quote_escaping(self):
+        """#181: an unescaped embedded quote in an extracted value truncates
+        the Datalog string literal, silently dropping the whole fact."""
+        import mcp_server
+        assert '\\"' in mcp_server._LLM_EXTRACTION_PROMPT
+
+    def test_agent_sampling_prompt_instructs_quote_escaping(self):
+        import mcp_server
+        assert '\\"' in mcp_server._AGENT_SAMPLING_PROMPT
+
 
 class TestConversationalMemoryFactIndex:
     def test_transact_extracted_facts_indexes(self, real_db):
@@ -1734,6 +1744,27 @@ class TestConversationalMemoryFactIndex:
         index_path = fact_index.index_path_for(mcp_server._graph_path)
         results = fact_index.query_facts(index_path, "redis", top_n=10, boost=2.0, historical_discount=1.0)
         assert any(r[0] == ":decision/x" for r in results)
+
+    def test_agent_extract_and_transact_preserves_embedded_quote(self, real_db, monkeypatch):
+        """#181: a sampled fact whose value contains an embedded double-quote
+        (a realistic shape -- the model quoting a phrase verbatim) must not be
+        silently dropped by _parse_transact_facts on the way to
+        _transact_extracted_facts."""
+        import mcp_server
+        import asyncio as _asyncio
+
+        async def fake_request(conversation_delta, canonical_section):
+            return r'[[:decision/x :description "he said \"hello\" to me"]]'
+
+        monkeypatch.setattr(mcp_server, "_request_agent_memory_block_async", fake_request)
+        monkeypatch.setattr(mcp_server, "_query_canonical_entities", lambda: "")
+        result = _asyncio.run(mcp_server._agent_extract_and_transact("greeting"))
+        assert result["ok"] is True
+        assert result["stored_count"] == 1
+        queried = json.loads(real_db.execute(
+            '(query [:find ?d :where [:decision/x :description ?d]])'
+        ))
+        assert queried["results"] == [['he said "hello" to me']]
 
 
 class TestMcpToolWiring:
@@ -2146,6 +2177,31 @@ class TestParseTransactFacts:
         assert len(facts) == 1
         assert facts[0]["entity_type"] == "service"
         assert facts[0]["entity"] == ":service/auth"
+
+    def test_handles_embedded_escaped_quote_in_value(self):
+        import mcp_server
+        facts = mcp_server._parse_transact_facts(
+            r'[[:decision/x :description "he said \"hello\" to me"]]'
+        )
+        assert len(facts) == 1
+        assert facts[0]["value"] == 'he said "hello" to me'
+
+    def test_handles_embedded_escaped_backslash_in_value(self):
+        import mcp_server
+        facts = mcp_server._parse_transact_facts(
+            r'[[:decision/x :description "path is C:\\temp"]]'
+        )
+        assert len(facts) == 1
+        assert facts[0]["value"] == r"path is C:\temp"
+
+    def test_does_not_drop_later_triples_after_quoted_value(self):
+        import mcp_server
+        facts = mcp_server._parse_transact_facts(
+            r'[[:decision/x :description "he said \"hi\""]'
+            r' [:decision/x :rationale "fast"]]'
+        )
+        assert len(facts) == 2
+        assert facts[1]["value"] == "fast"
 
 
 class TestMinigrafTransactSchema:


### PR DESCRIPTION
## Summary

- `_parse_transact_facts`'s value regex (`"([^"]+)"`) had no support for an escaped/embedded double quote — a value like `he said \"hello\" to me` from an LLM/agent-extracted fact matched up to the first literal `"` and required `]` immediately after, so the whole fact was silently dropped with zero facts returned (indistinguishable from "nothing worth storing").
- Extended the regex to be escape-aware (`(?:[^"\\]|\\.)+`), mirroring the already-fixed sibling `_FACTS_TRIPLE_PATTERN` (from #149/#177), and added `_edn_unescape` to reverse `_edn_escape` on the captured value so `_transact_extracted_facts`'s later re-escape on write doesn't double-escape it.
- Added a quoting instruction to both extraction prompts (`_LLM_EXTRACTION_PROMPT`, `_AGENT_SAMPLING_PROMPT`) telling the model to escape embedded quotes, per the issue's suggested fix — defense in depth, though the regex fix is what actually makes correctness independent of model compliance.

Fixes #181.

Filed #198 as a follow-up (found during review): the sibling index-side parser `_unwrap_facts_block_token` has the same unescape gap, degrading FTS index text quality for quoted values — lower severity, no data loss, out of scope for this PR.

## Test plan

- [x] New unit tests in `TestParseTransactFacts`: embedded escaped quote, embedded escaped backslash, doesn't drop a later triple after a quoted value — all watched RED before the regex fix.
- [x] New end-to-end real-backend test `test_agent_extract_and_transact_preserves_embedded_quote` in `TestConversationalMemoryFactIndex`: exercises `_agent_extract_and_transact` → `_parse_transact_facts` → `_transact_extracted_facts` → graph write → read-back, confirming the embedded quote survives the full round trip.
- [x] New prompt-content smoke tests confirming both extraction prompts instruct quote-escaping.
- [x] Existing #146 regression test (`test_transact_extracted_facts_escapes_quotes_in_value`, injection-protection) still passes unchanged.
- [x] Full suite: identical pre-existing 102-failure baseline before/after (missing tree-sitter grammars in this sandbox, confirmed via `git stash`), 612 passed (606 baseline + 6 net new).
- [x] `ruff`/`black`: identical pre-existing findings before/after, nothing new introduced.
- [x] Independent code-review subagent dispatched before this PR — no Critical/Important findings, verified the regex has no catastrophic-backtracking risk and `_edn_unescape` correctly handles the escaped-backslash-before-quote ordering trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL