### PR TITLE
Fix #182: backdating hints silently dropped on format deviation or calendar-invalid dates

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5011,7 +5011,11 @@ def _transact_extracted_facts(facts: List[Dict[str, str]], valid_from: Optional[
                 triples = f'[{entity} {attribute} "{escaped_value}"]'
             _transact(db, "[" + triples + "]", now_z)
             stored += 1
-        except MiniGrafError:
+        except MiniGrafError as e:
+            print(
+                f"[_transact_extracted_facts] dropped fact for {entity} {attribute}: {e}",
+                file=sys.stderr,
+            )
             continue
     if stored:
         _db_checkpoint(db)
@@ -5156,20 +5160,52 @@ def _call_llm(model: str, prompt: str) -> str:
         return message.content[0].text
 
 
-def _parse_valid_at_hint(raw: str):
-    """Extract optional '; valid-at: YYYY-MM-DD' comment from model output.
+_VALID_AT_LINE_RE = re.compile(r"^;\s*valid-at:\s*", re.IGNORECASE)
 
-    Returns (valid_at, cleaned_datalog) where valid_at defaults to the current
-    UTC ms timestamp if no hint is present.
+# Tried in order; each is a full-string match (no unconverted trailing data),
+# so "2024-03-15T10:00:00Z" only matches the datetime formats, not the plain
+# date one. %z accepts a bare "Z" suffix as UTC since Python 3.7.
+_VALID_AT_DATE_FORMATS = (
+    "%Y-%m-%d",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+def _parse_valid_at_hint(raw: str):
+    """Extract optional '; valid-at: <date>' comment from model output.
+
+    Accepts 'YYYY-MM-DD' (zero-padded or not) and full ISO 8601 datetimes,
+    normalizing any of them down to a plain 'YYYY-MM-DD' date. Returns
+    (valid_at, cleaned_datalog) where valid_at defaults to the current UTC
+    ms timestamp if no hint line is present. If a hint line is present but
+    its date is unparseable or calendar-invalid (e.g. "2024-13-45"), the
+    line is still stripped from the returned datalog and valid_at defaults
+    to now, but a warning is printed to stderr so that default is
+    distinguishable from "no hint given".
     """
     valid_at = _now_utc_ms()
     kept = []
     for line in raw.splitlines():
         stripped = line.strip()
-        if stripped.startswith("; valid-at:"):
-            date_str = stripped[len("; valid-at:"):].strip()
-            if re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
-                valid_at = date_str
+        match = _VALID_AT_LINE_RE.match(stripped)
+        if match:
+            date_str = stripped[match.end():].strip()
+            parsed = None
+            for fmt in _VALID_AT_DATE_FORMATS:
+                try:
+                    parsed = datetime.datetime.strptime(date_str, fmt)
+                    break
+                except ValueError:
+                    continue
+            if parsed is not None:
+                valid_at = parsed.strftime("%Y-%m-%d")
+            else:
+                print(
+                    f"[valid-at] unparseable date hint {date_str!r}; "
+                    "defaulting valid-at to now",
+                    file=sys.stderr,
+                )
         else:
             kept.append(line)
     return valid_at, "\n".join(kept).strip()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1939,6 +1939,51 @@ class TestParseValidAtHint:
         valid_at, datalog = mcp_server._parse_valid_at_hint(raw)
         assert valid_at == "2025-06-30"
 
+    def test_accepts_non_zero_padded_date(self):
+        """#182: '2024-3-15' (no zero-padding) is a plausible LLM output and
+        must not silently fall back to now."""
+        import mcp_server
+        raw = '; valid-at: 2024-3-15\n[[:e :a "v"]]'
+        valid_at, datalog = mcp_server._parse_valid_at_hint(raw)
+        assert valid_at == "2024-03-15"
+
+    def test_accepts_full_iso_datetime_and_normalizes_to_date(self):
+        """#182: a full ISO-8601 datetime hint is normalized down to a date."""
+        import mcp_server
+        raw = '; valid-at: 2024-03-15T10:00:00Z\n[[:e :a "v"]]'
+        valid_at, datalog = mcp_server._parse_valid_at_hint(raw)
+        assert valid_at == "2024-03-15"
+
+    def test_accepts_hint_line_with_no_space_after_semicolon(self):
+        """#182: ';valid-at: ...' (no space after ';') must still be
+        recognized as a hint line and stripped from the returned datalog,
+        not left in place to corrupt it."""
+        import mcp_server
+        raw = ';valid-at: 2024-03-15\n[[:e :a "v"]]'
+        valid_at, datalog = mcp_server._parse_valid_at_hint(raw)
+        assert valid_at == "2024-03-15"
+        assert "valid-at" not in datalog
+        assert datalog == '[[:e :a "v"]]'
+
+    def test_calendar_invalid_date_falls_back_to_now_with_warning(self, capsys):
+        """#182: a regex-plausible but calendar-invalid date (month 13) must
+        not be passed through unvalidated -- it previously reached _transact
+        and caused the whole fact to be silently dropped downstream."""
+        import re
+        import mcp_server
+        raw = '; valid-at: 2024-13-45\n[[:e :a "v"]]'
+        valid_at, datalog = mcp_server._parse_valid_at_hint(raw)
+        assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z", valid_at)
+        assert "unparseable date hint" in capsys.readouterr().err
+
+    def test_unparseable_hint_warns_on_stderr(self, capsys):
+        """#182: an unparseable hint must be distinguishable from no hint at
+        all, via a warning printed to stderr."""
+        import mcp_server
+        raw = '; valid-at: not-a-date\n[[:e :a "v"]]'
+        mcp_server._parse_valid_at_hint(raw)
+        assert "unparseable date hint" in capsys.readouterr().err
+
 
 class TestCanonicalIdent:
     def test_lowercases_value(self):
@@ -2119,6 +2164,24 @@ class TestTransactExtractedFactsSchema:
         attrs = {a: v for a, v in result["results"]}
         assert attrs[":description"] == "use Redis"
         assert attrs[":alias"] == "in-memory store, key-value cache"
+
+    def test_minigraf_error_at_transact_time_logs_warning(self, real_db, capsys):
+        """#182: a fact that passes schema validation but is rejected by
+        minigraf itself at transact time (e.g. a calendar-invalid
+        :valid-from date) must not be silently swallowed -- it should be
+        distinguishable on stderr from "the extraction strategy found
+        nothing"."""
+        import mcp_server
+        facts = [{"entity": ":decision/redis", "entity_type": "decision",
+                  "attribute": ":description", "value": "use Redis"}]
+        stored = mcp_server._transact_extracted_facts(facts, valid_from="2024-13-45")
+
+        assert stored == 0
+        queried = json.loads(real_db.execute(
+            '(query [:find ?d :where [:decision/redis :description ?d]])'
+        ))
+        assert queried["results"] == []
+        assert "dropped fact for :decision/redis" in capsys.readouterr().err
 
     def test_entity_missing_description_entirely_is_still_rejected(self, real_db):
         """Confirms the per-entity-group fix doesn't loosen validation: an


### PR DESCRIPTION
## Summary
- `_parse_valid_at_hint` matched only a strict zero-padded `YYYY-MM-DD` regex with no fallback — any format deviation (missing zero-padding, full ISO datetime, no space after `;`) silently defaulted `valid_at` to now, defeating the bi-temporal-backdating feature with zero signal.
- A regex-matching but calendar-invalid date (e.g. `2024-13-45`) passed through unvalidated, reached `_transact`, and raised `MiniGrafError`, which `_transact_extracted_facts`'s per-fact `except MiniGrafError: continue` swallowed — dropping the whole fact silently.
- Now parses with `datetime.strptime` across a small ordered set of accepted formats, normalizing to `YYYY-MM-DD` and naturally rejecting calendar-invalid dates before they reach `_transact`. Prints a stderr warning both when a hint is present but unparseable, and when `_transact_extracted_facts` drops a fact due to `MiniGrafError` — so neither failure mode is indistinguishable from "nothing found."

Fixes #182.

## Test plan
- [x] `pytest tests/test_mcp_server.py -k "ValidAt or ExtractedFacts or LlmStrategy or AgentStrategy"` — 41 passed
- [x] Reproduced all 6 cases from the issue directly against `_parse_valid_at_hint`; confirmed each now behaves correctly
- [x] Reproduced the calendar-invalid `MiniGrafError` against a real in-memory `MiniGrafDb`
- [x] Added regression tests for: non-zero-padded dates, full ISO datetime normalization, missing space after `;`, calendar-invalid dates, unparseable-hint stderr warning, and transact-time `MiniGrafError` stderr warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL