### PR TITLE
Fix #183: no length/size validation on LLM/agent-extracted fact values

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -111,7 +111,7 @@ Canonical ident form: lowercase, hyphens only — `:decision/redis` not `:decisi
 Allowed entity types: `:decision/`, `:preference/`, `:constraint/`, `:dependency/`, `:module/`, `:function/`, `:class/`, `:variable/`, `:field/` (code structure — auto-ingested); `:commit/`, `:tag/`, `:ingestion/` are system-only (written by `minigraf_ingest_git`), do not write to them directly
 Required attribute on all types: `:description`
 Optional attributes: `:rationale`, `:date`, `:alias`
-String-valued attributes are capped at 4096 characters (override via `MINIGRAF_MAX_FACT_VALUE_LENGTH`); a longer value is a schema violation and the whole fact is rejected — summarize before storing, don't paste large blocks of raw text.
+String-valued attributes are capped at 4096 characters (override via `MINIGRAF_MAX_FACT_VALUE_LENGTH`); a longer value is a schema violation and the whole `minigraf_transact` call is rejected — summarize before storing, don't paste large blocks of raw text.
 
 Run `minigraf_audit` periodically or after a session with heavy writes to detect and retract any schema violations.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,6 +111,7 @@ Canonical ident form: lowercase, hyphens only — `:decision/redis` not `:decisi
 Allowed entity types: `:decision/`, `:preference/`, `:constraint/`, `:dependency/`, `:module/`, `:function/`, `:class/`, `:variable/`, `:field/` (code structure — auto-ingested); `:commit/`, `:tag/`, `:ingestion/` are system-only (written by `minigraf_ingest_git`), do not write to them directly
 Required attribute on all types: `:description`
 Optional attributes: `:rationale`, `:date`, `:alias`
+String-valued attributes are capped at 4096 characters (override via `MINIGRAF_MAX_FACT_VALUE_LENGTH`); a longer value is a schema violation and the whole fact is rejected — summarize before storing, don't paste large blocks of raw text.
 
 Run `minigraf_audit` periodically or after a session with heavy writes to detect and retract any schema violations.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4483,6 +4483,11 @@ def _last_run_write(db: Any, commit_hash: str, run_at: str, total_ingested: int,
 # They are invisible to schema validation and filtered from attr_facts in minigraf_audit.
 _SYSTEM_ATTRS: frozenset = frozenset({":entity-type", ":ident"})
 
+# Maximum length (characters) for a string-valued fact attribute. Bounds how much
+# raw text (e.g. LLM/agent-extracted conversation content) can be written into the
+# graph and the FTS5 fact index in a single fact.
+_MAX_FACT_VALUE_LENGTH = int(os.environ.get("MINIGRAF_MAX_FACT_VALUE_LENGTH", "4096"))
+
 MINIGRAF_SCHEMA: Dict[str, Dict[str, Dict[str, type]]] = {
     "decision": {
         "required": {":description": str},
@@ -4617,6 +4622,15 @@ def _validate_facts(facts: List[Dict[str, Any]]) -> List[str]:
                 violations.append(
                     f"entity '{entity}' attribute '{attr}' has wrong type "
                     f"(expected {optional[attr].__name__}, got {type(value).__name__})"
+                )
+
+        # Bound string-valued attributes so a single fact can't inject an
+        # arbitrarily large value into the graph and FTS5 index.
+        for attr, value in attrs.items():
+            if isinstance(value, str) and len(value) > _MAX_FACT_VALUE_LENGTH:
+                violations.append(
+                    f"entity '{entity}' attribute '{attr}' value exceeds maximum "
+                    f"length ({len(value)} > {_MAX_FACT_VALUE_LENGTH} characters)"
                 )
 
         # Closed-world: unknown attributes are violations.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2075,6 +2075,33 @@ class TestValidateFacts:
                       "attribute": ":description", "value": "test"}]
             assert mcp_server._validate_facts(facts) == [], f"Failed for {etype}"
 
+    def test_oversized_string_value_rejected(self):
+        import mcp_server
+        facts = [{"entity": ":decision/redis", "entity_type": "decision",
+                  "attribute": ":description",
+                  "value": "x" * (mcp_server._MAX_FACT_VALUE_LENGTH + 1)}]
+        violations = mcp_server._validate_facts(facts)
+        assert len(violations) == 1
+        assert "length" in violations[0].lower() or "size" in violations[0].lower()
+
+    def test_value_at_max_length_is_accepted(self):
+        import mcp_server
+        facts = [{"entity": ":decision/redis", "entity_type": "decision",
+                  "attribute": ":description",
+                  "value": "x" * mcp_server._MAX_FACT_VALUE_LENGTH}]
+        assert mcp_server._validate_facts(facts) == []
+
+    def test_oversized_optional_attribute_rejected(self):
+        import mcp_server
+        facts = [{"entity": ":decision/redis", "entity_type": "decision",
+                  "attribute": ":description", "value": "use Redis"},
+                 {"entity": ":decision/redis", "entity_type": "decision",
+                  "attribute": ":rationale",
+                  "value": "x" * (mcp_server._MAX_FACT_VALUE_LENGTH + 1)}]
+        violations = mcp_server._validate_facts(facts)
+        assert len(violations) == 1
+        assert ":rationale" in violations[0]
+
 
 class TestHeuristicNormalization:
     def test_ident_uses_canonical_slug(self):
@@ -2138,6 +2165,19 @@ class TestTransactExtractedFactsSchema:
             '(query [:find ?d :where [:service/auth :description ?d]])'
         ))
         assert auth["results"] == []
+
+    def test_oversized_value_is_skipped(self, real_db):
+        import mcp_server
+        facts = [{"entity": ":decision/redis", "entity_type": "decision",
+                  "attribute": ":description",
+                  "value": "x" * (mcp_server._MAX_FACT_VALUE_LENGTH + 1)}]
+        stored = mcp_server._transact_extracted_facts(facts)
+
+        assert stored == 0
+        queried = json.loads(real_db.execute(
+            '(query [:find ?d :where [:decision/redis :description ?d]])'
+        ))
+        assert queried["results"] == []
 
     def test_transact_extracted_facts_does_not_drop_sibling_optional_attributes(self, real_db):
         """Regression test for a real bug: _transact_extracted_facts used to
@@ -2290,6 +2330,21 @@ class TestMinigrafTransactSchema:
             '(query [:find ?d :where [:decision/redis :description ?d]])'
         ))
         assert queried["results"] == [["use Redis"]]
+
+    def test_rejects_oversized_value(self, real_db):
+        import mcp_server
+        big_value = "x" * (mcp_server._MAX_FACT_VALUE_LENGTH + 1)
+        result = mcp_server.handle_minigraf_transact(
+            f'[[:decision/redis :description "{big_value}"]]',
+            reason="test"
+        )
+
+        assert result["ok"] is False
+        assert "schema" in result["error"].lower() or "violation" in result["error"].lower()
+        queried = json.loads(real_db.execute(
+            '(query [:find ?d :where [:decision/redis :description ?d]])'
+        ))
+        assert queried["results"] == []
 
     def test_keyword_only_transact_bypasses_schema_validation(self, real_db):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2501,6 +2501,28 @@ class TestMinigrafAudit:
         assert "retracted" in result
         assert "violations" in result
 
+    def test_oversized_value_is_flagged_and_retracted(self, real_db):
+        """#183 audit-side coverage: an oversized :description written directly
+        (bypassing minigraf_transact's own _validate_facts guard) is caught and
+        retracted by minigraf_audit's shared _validate_facts call."""
+        import mcp_server
+        big_value = "x" * (mcp_server._MAX_FACT_VALUE_LENGTH + 1)
+        real_db.execute(
+            '(transact {} [[:decision/redis :entity-type :type/decision] '
+            '[:decision/redis :ident ":decision/redis"] '
+            f'[:decision/redis :description "{big_value}"]])'
+        )
+
+        result = mcp_server.handle_minigraf_audit()
+
+        assert result["ok"] is True
+        assert result["retracted"] == 1
+        assert len(result["violations"]) == 1
+        remaining = json.loads(real_db.execute(
+            '(query [:find ?d :where [:decision/redis :description ?d]])'
+        ))
+        assert remaining["results"] == []
+
     def test_audit_retract_removes_from_fact_index_by_keyword_ident(self, real_db):
         """The Datalog retract uses #uuid literals (audit's own design,
         so it can retract without a keyword-to-UUID lookup), but the entity


### PR DESCRIPTION
## Summary
- Adds `_MAX_FACT_VALUE_LENGTH` (default 4096 chars, override via `MINIGRAF_MAX_FACT_VALUE_LENGTH`) and a length check in `_validate_facts`, closing the trust boundary described in #183: a single LLM/agent-extracted fact could previously inject an arbitrarily large value into both the graph and the persisted FTS5 fact index.
- Covers all three call sites that already route through `_validate_facts`: the public `minigraf_transact` tool, `_transact_extracted_facts` (LLM/agent extraction), and `minigraf_audit`'s per-entity re-validation.
- SKILL.md documents the cap and env var override.

Fixes #183

## Test plan
- [x] TDD: new tests watched RED (`AttributeError: no attribute '_MAX_FACT_VALUE_LENGTH'`) before implementing
- [x] Boundary tests: value at max length accepted, one over rejected
- [x] Real-backend regression tests for all three call paths (`_validate_facts` unit-level, `_transact_extracted_facts`, `handle_minigraf_transact`, `minigraf_audit`)
- [x] Independent code-review subagent dispatched before merge — "Ready to merge: Yes"; two Minor findings (audit-path test gap, SKILL.md wording precision) addressed in a follow-up commit per this project's fix-before-merge norm
- [x] Full suite: 639 passed, no regressions
- [x] `ruff`/`black`: identical pre-existing findings, nothing new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL