### PR TITLE
Fix #178: _clear_stale_lock could delete a different, live process's lock file

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2813,12 +2813,28 @@ def _pid_is_alive(pid: int) -> bool:
 def _clear_stale_lock(path: str, holder_pid: int) -> bool:
     """Remove path's lock file if its recorded holder process is no longer alive.
 
+    holder_pid is extracted from an earlier lock-contention error (at time
+    T0); by the time this runs (T1), the lock file may have already changed
+    hands to a different, live, legitimate holder. Re-reads the lock file's
+    *current* contents immediately before deleting and only proceeds if it
+    still names holder_pid, to avoid stripping a live holder of its lock
+    protection (#178). This narrows but does not eliminate the underlying
+    TOCTOU race -- a gap remains between this re-check and the os.remove.
+
     Returns True if a stale lock was removed.
     """
     if _pid_is_alive(holder_pid):
         return False  # holder still alive (or we lack permission to tell — leave it)
+    lock_path = path + ".lock"
     try:
-        os.remove(path + ".lock")
+        with open(lock_path) as f:
+            current_holder = f.read().strip()
+    except OSError:
+        return False  # no lock file (already cleared by someone else)
+    if current_holder != str(holder_pid):
+        return False  # reclaimed by a different holder since T0 — not ours to clear
+    try:
+        os.remove(lock_path)
         return True
     except OSError:
         return False

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2810,6 +2810,18 @@ def _pid_is_alive(pid: int) -> bool:
     return True
 
 
+def _read_lock_holder_raw(path: str) -> Optional[str]:
+    """Read path's lock file and return its raw, unparsed contents, or None
+    if the lock file doesn't exist. Shared by _clear_stale_lock and
+    _live_lock_holder_pid, whose parsing/validation needs diverge past this
+    point (#106, #178)."""
+    try:
+        with open(path + ".lock") as f:
+            return f.read().strip()
+    except OSError:
+        return None  # no lock file
+
+
 def _clear_stale_lock(path: str, holder_pid: int) -> bool:
     """Remove path's lock file if its recorded holder process is no longer alive.
 
@@ -2825,16 +2837,13 @@ def _clear_stale_lock(path: str, holder_pid: int) -> bool:
     """
     if _pid_is_alive(holder_pid):
         return False  # holder still alive (or we lack permission to tell — leave it)
-    lock_path = path + ".lock"
-    try:
-        with open(lock_path) as f:
-            current_holder = f.read().strip()
-    except OSError:
+    current_holder = _read_lock_holder_raw(path)
+    if current_holder is None:
         return False  # no lock file (already cleared by someone else)
     if current_holder != str(holder_pid):
         return False  # reclaimed by a different holder since T0 — not ours to clear
     try:
-        os.remove(lock_path)
+        os.remove(path + ".lock")
         return True
     except OSError:
         return False
@@ -2854,10 +2863,8 @@ def _live_lock_holder_pid(path: str) -> Optional[int]:
     logic (_try_open_with_self_heal, _ensure_db_async) still runs as the
     fallback if the race is lost anyway.
     """
-    try:
-        with open(path + ".lock") as f:
-            holder = f.read().strip()
-    except OSError:
+    holder = _read_lock_holder_raw(path)
+    if holder is None:
         return None  # no lock file
     if not holder.isdigit():
         return None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -359,6 +359,66 @@ class TestGetDbLockRetry:
         )
 
 
+class TestClearStaleLockReverifiesCurrentHolder:
+    """Regression tests for #178: _clear_stale_lock must re-read the lock
+    file's *current* contents immediately before deleting it, and only
+    delete if it still names the PID it was asked to clear. Without this,
+    a lock file that changed hands between the original failed open (T0,
+    when holder_pid was extracted from the error) and this call (T1) would
+    be deleted out from under a new, live, legitimate holder just because
+    the *original* holder_pid happened to be dead."""
+
+    def test_does_not_delete_lock_now_held_by_a_different_live_process(self, tmp_path):
+        import mcp_server
+        graph_path = str(tmp_path / "t.graph")
+        lock_path = graph_path + ".lock"
+
+        with _hold_lock_subprocess(graph_path, exit_immediately=True) as dead_pid:
+            pass  # holder opened, printed its PID, and is confirmed reaped/dead
+
+        # Simulate a new, live, legitimate holder having since acquired the
+        # lock at this same path (our own real PID stands in for "a
+        # different, live process").
+        new_holder_pid = os.getpid()
+        with open(lock_path, "w") as f:
+            f.write(str(new_holder_pid))
+
+        # Called with the stale holder_pid extracted from the earlier (T0)
+        # error, which is genuinely dead -- but the lock file no longer
+        # names that PID.
+        assert mcp_server._clear_stale_lock(graph_path, dead_pid) is False
+        assert os.path.exists(lock_path)
+        with open(lock_path) as f:
+            assert f.read().strip() == str(new_holder_pid)
+
+    def test_still_deletes_lock_that_still_names_the_dead_holder(self, tmp_path):
+        """Same-shape regression guard as the existing
+        test_self_heals_stale_lock_from_dead_pid, kept here alongside the
+        new re-verification test so the two behaviors (delete when still
+        stale, don't delete when reclaimed) are visible side by side."""
+        import mcp_server
+        graph_path = str(tmp_path / "t.graph")
+        lock_path = graph_path + ".lock"
+
+        with _hold_lock_subprocess(graph_path, exit_immediately=True) as dead_pid:
+            pass
+
+        with open(lock_path, "w") as f:
+            f.write(str(dead_pid))
+
+        assert mcp_server._clear_stale_lock(graph_path, dead_pid) is True
+        assert not os.path.exists(lock_path)
+
+    def test_missing_lock_file_returns_false(self, tmp_path):
+        """Another race shape: something else already removed the lock file
+        between the failed open and this call. No file to re-verify against
+        -- nothing to delete, must not raise."""
+        import mcp_server
+        graph_path = str(tmp_path / "t.graph")
+
+        assert mcp_server._clear_stale_lock(graph_path, 999999) is False
+
+
 class TestTryOpenWithSelfHealReuse:
     """Regression test for #107: minigraf_ingest_status incorrectly reported
     "Database is locked by another process" while minigraf_ingest_git was


### PR DESCRIPTION
## Summary
- `_clear_stale_lock(path, holder_pid)` extracts `holder_pid` from a lock-contention error at time T0, then deletes whatever `.lock` file currently exists at `path` if that PID is dead — without ever re-checking the file still names `holder_pid` at the later instant T1 it actually runs
- Between T0 and T1 the original holder could die and a different, live, legitimate process could acquire a fresh lock at that path; the old code would delete that live holder's lock file out from under it (classic lock-file TOCTOU), risking concurrent writers on the same graph file
- Now re-reads the lock file's current contents immediately before deleting and only proceeds if it still names `holder_pid`
- Follow-up commit extracts a shared `_read_lock_holder_raw` helper (review finding) so `_clear_stale_lock` and `_live_lock_holder_pid` don't duplicate the same read-lock-file logic

Fixes #178

## Test plan
- [x] New `TestClearStaleLockReverifiesCurrentHolder` class (3 tests): reclaimed-by-live-process is not deleted, still-stale lock is still deleted (regression guard), missing lock file returns False without raising
- [x] Watched the reclaimed-lock test fail against pre-fix code, pass after
- [x] Full suite green (768 passed) after the fix and after the refactor commit; `ruff`/`black` findings identical to baseline (nothing new introduced)
- [x] Independent code-review subagent dispatched before opening this PR — verdict "Yes, ready to merge"; its one Important (non-blocking) suggestion (dedupe lock-file-read logic) applied in the follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL