### PR TITLE
Fix #173: _extract_call_name silently returns no calls for Java, Kotlin, Swift, PHP, and Haskell

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -640,7 +640,54 @@ def _extract_import_name(node, lang_name: str) -> List[str]:
 
 
 def _extract_call_name(node, lang_name: str) -> Optional[str]:
-    """Extract the function name from a call node (best-effort, identifiers only)."""
+    """Extract the function name from a call node (best-effort, identifiers only).
+
+    The callee's field name and node type are not universal across grammars:
+      - JS/TS/Rust/C/C++/Go/C#/Scala: field "function", type "identifier" (default case below).
+      - Java (method_invocation): callee field is named "name", not "function".
+      - Kotlin/Swift (call_expression): no field name at all — callee is the
+        first named child (an identifier/simple_identifier).
+      - PHP (function_call_expression): field is "function" but the node type
+        there is "name", not "identifier".
+      - Haskell (apply): field is "function" but the node type is "variable",
+        and calls with 2+ arguments curry into nested apply nodes
+        (`f x y` -> apply(function=apply(function=variable f, argument=x), argument=y)),
+        so the callee sits at the bottom of the leftward "function"-field chain.
+    """
+    if lang_name == "java":
+        fn = node.child_by_field_name("name")
+        if fn and fn.type == "identifier":
+            return fn.text.decode("utf-8")
+        return None
+    if lang_name in ("kotlin", "swift"):
+        children = node.named_children
+        if children and children[0].type in ("identifier", "simple_identifier"):
+            return children[0].text.decode("utf-8")
+        return None
+    if lang_name == "php":
+        fn = node.child_by_field_name("function")
+        if fn and fn.type == "name":
+            return fn.text.decode("utf-8")
+        return None
+    if lang_name == "haskell":
+        # A curried call `f x y` nests as apply(function=apply(function=variable
+        # f, argument=x), argument=y) -- _walk_ast visits every "apply" node in
+        # that chain, so without this check each inner link would independently
+        # walk back down to the same innermost callee, reporting one call as
+        # many. Only the outermost apply (the one NOT itself sitting in a
+        # parent apply's "function" field) should emit.
+        parent = node.parent
+        if parent is not None and parent.type == "apply" and parent.child_by_field_name("function") == node:
+            return None
+        current = node
+        while current.type == "apply":
+            fn = current.child_by_field_name("function")
+            if fn is None:
+                return None
+            if fn.type == "variable":
+                return fn.text.decode("utf-8")
+            current = fn
+        return None
     fn = node.child_by_field_name("function")
     if fn and fn.type == "identifier":
         return fn.text.decode("utf-8")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11755,6 +11755,88 @@ class TestExtractImportName:
         assert "github.com/user/pkg" in result
 
 
+class TestExtractCallName:
+    """Unit tests for _extract_call_name — regression coverage for #173, where
+    the callee's field name / node type convention (field "function", type
+    "identifier") assumed by the default branch does not hold for Java,
+    Kotlin, Swift, PHP, or Haskell."""
+
+    def test_default_convention_still_works(self, tmp_path):
+        """Go's call_expression matches the generic field="function"/type="identifier"
+        convention this helper falls back to for every language without a
+        dedicated branch — must keep working unchanged."""
+        pytest.importorskip("tree_sitter_go")
+        import mcp_server
+        source = b"func bar() { doStuff(1, 2) }"
+        node = _parse_import_node("go", source, "call_expression", tmp_path)
+        assert mcp_server._extract_call_name(node, "go") == "doStuff"
+
+    def test_java_method_invocation(self, tmp_path):
+        pytest.importorskip("tree_sitter_java")
+        import mcp_server
+        source = b"class Foo { void bar() { doStuff(1, 2); } }"
+        node = _parse_import_node("java", source, "method_invocation", tmp_path)
+        assert mcp_server._extract_call_name(node, "java") == "doStuff"
+
+    def test_kotlin_call_expression_has_no_field_name(self, tmp_path):
+        pytest.importorskip("tree_sitter_kotlin")
+        import mcp_server
+        source = b"fun bar() { doStuff(1, 2) }"
+        node = _parse_import_node("kotlin", source, "call_expression", tmp_path)
+        assert mcp_server._extract_call_name(node, "kotlin") == "doStuff"
+
+    def test_swift_call_expression_has_no_field_name(self, tmp_path):
+        pytest.importorskip("tree_sitter_swift")
+        import mcp_server
+        source = b"func bar() { doStuff(1, 2) }"
+        node = _parse_import_node("swift", source, "call_expression", tmp_path)
+        assert mcp_server._extract_call_name(node, "swift") == "doStuff"
+
+    def test_php_function_call_expression_callee_type_is_name(self, tmp_path):
+        pytest.importorskip("tree_sitter_php")
+        import mcp_server
+        source = b"<?php\nfunction bar() { doStuff(1, 2); }"
+        node = _parse_import_node("php", source, "function_call_expression", tmp_path)
+        assert mcp_server._extract_call_name(node, "php") == "doStuff"
+
+    def test_haskell_single_arg_apply(self, tmp_path):
+        pytest.importorskip("tree_sitter_haskell")
+        import mcp_server
+        source = b"main = doStuff 1"
+        node = _parse_import_node("haskell", source, "apply", tmp_path)
+        assert mcp_server._extract_call_name(node, "haskell") == "doStuff"
+
+    def test_haskell_curried_multi_arg_apply_via_walk_ast_no_duplicates(self, tmp_path):
+        """A curried call `doStuff 1 2` nests as two "apply" nodes sharing the
+        same innermost callee. _walk_ast visits both (both match the "calls"
+        node type), so the inner one must suppress itself or the single call
+        site is reported twice."""
+        pytest.importorskip("tree_sitter_haskell")
+        import mcp_server
+        source = b"main = doStuff 1 2"
+        tmp_file = tmp_path / "test.hs"
+        tmp_file.write_bytes(source)
+        parser = mcp_server._get_parser(str(tmp_file))
+        tree = parser.parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "haskell")
+        assert results["calls"] == ["doStuff"]
+
+    def test_haskell_separately_nested_call_still_counted(self, tmp_path):
+        """A genuinely separate call passed as an argument (not a curry link
+        of the same call) must still be extracted independently."""
+        pytest.importorskip("tree_sitter_haskell")
+        import mcp_server
+        source = b"main = doStuff (helper 1) 2"
+        tmp_file = tmp_path / "test.hs"
+        tmp_file.write_bytes(source)
+        parser = mcp_server._get_parser(str(tmp_file))
+        tree = parser.parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "haskell")
+        assert sorted(results["calls"]) == ["doStuff", "helper"]
+
+
 def test_schema_has_renamed_from_and_to_on_code_entities():
     import mcp_server
     for entity_type in ("module", "function", "class", "variable", "field"):


### PR DESCRIPTION
## Summary
- \`_extract_call_name\` hardcoded one grammar convention (callee at field `"function"`, node type `"identifier"`) that only holds for JS/TS/Rust/C/C++/Go/C#/Scala. Java, Kotlin, Swift, PHP, and Haskell each break it in a different way, so `:calls` extraction silently returned `[]` for all five languages regardless of how many calls the source contained.
- Added per-language handling mirroring the existing precedent (`_c_family_function_name` as a dedicated helper, `_extract_import_name`'s per-language `elif` chain):
  - **Java** (`method_invocation`): callee field is `"name"`, not `"function"`.
  - **Kotlin/Swift** (`call_expression`): no field name — callee is the first named child.
  - **PHP** (`function_call_expression`): field is `"function"` (correct) but node type is `"name"`, not `"identifier"`.
  - **Haskell** (`apply`): field is `"function"` (correct) but node type is `"variable"`; multi-arg calls curry into nested `apply` nodes, so the fix walks down the `"function"`-field chain to the innermost callee, and suppresses inner curry links (which `_walk_ast` also visits) so one call site isn't reported twice.
- Verified each language's exact AST shape directly against the installed tree-sitter grammar before writing the fix (matches the repro data in the issue).

## Test plan
- [x] Added `TestExtractCallName` (8 new tests): one per fixed language, a default-convention regression check (Go), a Haskell single-arg case, a Haskell curried multi-arg case (asserts no duplicate), and a Haskell separately-nested-call case (asserts the genuinely distinct callee is still counted).
- [x] Full suite: `python -m pytest tests/test_mcp_server.py` — 652 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL