### PR TITLE
Fix #170: Elixir functions/modules never extracted — _LANG_NODE_TYPES uses node types that don't exist in the grammar

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -332,6 +332,12 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "calls": set(),
     },
     "elixir": {
+        # Vestigial/unused for functions & classes: defmodule/def/defp all
+        # parse as generic "call" nodes in the real grammar, not as their own
+        # node types, so _walk_ast/_collect_entity_nodes special-case
+        # lang_name == "elixir" entirely and never consult these two sets
+        # (see #170). "imports" is still consulted only indirectly, via the
+        # same elixir-specific branch's fallback to _extract_import_name.
         "functions": {"def", "defp"},
         "classes": {"defmodule"},
         "imports": {"call"},
@@ -529,6 +535,53 @@ def _elixir_module_name(node) -> Optional[str]:
     return None
 
 
+def _elixir_call_target_text(node) -> Optional[str]:
+    """Return an Elixir `call` node's target identifier text (e.g. "def",
+    "defmodule", "foo"), or None if the target isn't a plain identifier
+    (e.g. a dotted call like IO.puts)."""
+    target = node.child_by_field_name("target")
+    if target is not None and target.type == "identifier":
+        return target.text.decode("utf-8")
+    return None
+
+
+def _elixir_defmodule_name(node) -> Optional[str]:
+    """Return the dotted module name from a `defmodule` call node's
+    `arguments` (the `alias` node's text, e.g. "Foo.Bar")."""
+    arguments = next((c for c in node.children if c.type == "arguments"), None)
+    if arguments is None:
+        return None
+    alias_node = next((c for c in arguments.children if c.type == "alias"), None)
+    return alias_node.text.decode("utf-8") if alias_node is not None else None
+
+
+def _elixir_def_function_name(node) -> Optional[str]:
+    """Return the function name from a `def`/`defp` call node's `arguments`.
+
+    `def bar do` -> arguments' sole named child is a bare `identifier` (no
+    parens, zero-arg). `def bar(x, y) do` -> arguments' sole named child is a
+    `call` node (the parenthesized parameter list itself parses as a nested
+    call expression) whose own target identifier is the function name. A
+    guard clause (`def bar(x) when x > 0 do`) wraps that call one level
+    deeper in a `binary_operator` chain (`field:operator` text "when") --
+    descend its `field:left` to reach the same call node.
+    """
+    arguments = next((c for c in node.children if c.type == "arguments"), None)
+    if arguments is None:
+        return None
+    target = next(iter(arguments.named_children), None)
+    while target is not None:
+        if target.type == "identifier":
+            return target.text.decode("utf-8")
+        if target.type == "call":
+            return _elixir_call_target_text(target)
+        if target.type == "binary_operator":
+            target = target.child_by_field_name("left")
+            continue
+        return None
+    return None
+
+
 def _extract_import_name(node, lang_name: str) -> List[str]:
     """Extract top-level module names from an import node (may return multiple)."""
     names: List[str] = []
@@ -721,7 +774,33 @@ def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
     rather than duplicating every _LANG_NODE_TYPES entry — the TSX grammar is
     a strict superset of TypeScript's node types for the constructs this
     module cares about (functions, classes, imports, calls).
+
+    Elixir bypasses the generic node_types-driven dispatch below entirely:
+    `defmodule`/`def`/`defp`/`alias`/`import`/`use`/`require` (and every
+    ordinary function call) all parse as the *same* generic `call` node type
+    in the real tree-sitter-elixir grammar — there is no dedicated
+    `defmodule`/`def`/`defp` node type to match against, the way
+    `_LANG_NODE_TYPES["elixir"]` used to assume (#170). Disambiguation
+    requires inspecting the call's target identifier text instead.
     """
+    if lang_name == "elixir":
+        if node.type == "call":
+            target_text = _elixir_call_target_text(node)
+            if target_text == "defmodule":
+                name = _elixir_defmodule_name(node)
+                if name:
+                    results["classes"].append(name)
+            elif target_text in ("def", "defp"):
+                name = _elixir_def_function_name(node)
+                if name:
+                    results["functions"].append(name)
+            else:
+                names = _extract_import_name(node, lang_name)
+                results["imports"].extend(names)
+        for child in node.children:
+            _walk_ast(child, results, lang_name)
+        return
+
     node_types = _LANG_NODE_TYPES.get("typescript" if lang_name == "tsx" else lang_name)
     if node_types is None:
         return
@@ -2366,14 +2445,8 @@ def _extract_elixir_globals_and_fields(root_node: Any) -> Dict[str, Any]:
 
     def walk(node: Any) -> None:
         if node.type == "call":
-            target = node.child_by_field_name("target")
-            if target is not None and target.type == "identifier" and target.text == b"defmodule":
-                arguments = next((c for c in node.children if c.type == "arguments"), None)
-                module_name = ""
-                if arguments is not None:
-                    alias_node = next((c for c in arguments.children if c.type == "alias"), None)
-                    if alias_node is not None:
-                        module_name = alias_node.text.decode("utf-8")
+            if _elixir_call_target_text(node) == "defmodule":
+                module_name = _elixir_defmodule_name(node) or ""
                 do_block = next((c for c in node.children if c.type == "do_block"), None)
                 if do_block is not None:
                     for member in do_block.children:
@@ -2731,8 +2804,27 @@ def _collect_entity_nodes(root_node: Any, lang_name: str) -> Dict[str, Dict[str,
     are collected here; Task 26 extends this for globals/fields once those
     categories exist.
     """
-    node_types = _LANG_NODE_TYPES.get("typescript" if lang_name == "tsx" else lang_name)
     result: Dict[str, Dict[str, Any]] = {"function": {}, "class": {}}
+
+    if lang_name == "elixir":
+        def walk_elixir(node: Any) -> None:
+            if node.type == "call":
+                target_text = _elixir_call_target_text(node)
+                if target_text == "defmodule":
+                    name = _elixir_defmodule_name(node)
+                    if name:
+                        result["class"][name] = node
+                elif target_text in ("def", "defp"):
+                    name = _elixir_def_function_name(node)
+                    if name:
+                        result["function"][name] = node
+            for child in node.children:
+                walk_elixir(child)
+
+        walk_elixir(root_node)
+        return result
+
+    node_types = _LANG_NODE_TYPES.get("typescript" if lang_name == "tsx" else lang_name)
     if node_types is None:
         return result
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4353,6 +4353,93 @@ class TestElixirGlobalsAndFields:
         assert result["fields"] == []
 
 
+class TestElixirFunctionsAndClasses:
+    """Regression tests for #170: defmodule/def/defp all parse as generic
+    `call` nodes in the real tree-sitter-elixir grammar, not as dedicated
+    `defmodule`/`def`/`defp` node types the way `_LANG_NODE_TYPES["elixir"]`
+    assumed -- so no Elixir function or module was ever extracted via the
+    generic _walk_ast/_collect_entity_nodes dispatch."""
+
+    def _parser(self):
+        import tree_sitter_elixir
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_elixir.language()))
+
+    def test_walk_ast_extracts_module_and_functions(self):
+        import mcp_server
+        source = (
+            b"defmodule Foo.Bar do\n"
+            b"  def pub_fn(x) do\n"
+            b"    x\n"
+            b"  end\n\n"
+            b"  defp priv_fn do\n"
+            b"    :ok\n"
+            b"  end\n"
+            b"end\n"
+        )
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "elixir")
+        assert results["classes"] == ["Foo.Bar"]
+        assert sorted(results["functions"]) == ["priv_fn", "pub_fn"]
+
+    def test_walk_ast_def_with_guard_clause(self):
+        # `def bar(x) when x > 0 do` wraps the parenthesized call in a
+        # binary_operator ("when") chain -- the name is nested one level
+        # deeper than a plain `def bar(x) do`.
+        import mcp_server
+        source = b"defmodule Foo do\n  def bar(x) when x > 0 do\n    x\n  end\nend\n"
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "elixir")
+        assert results["functions"] == ["bar"]
+
+    def test_walk_ast_zero_arg_def_without_parens(self):
+        import mcp_server
+        source = b"defmodule Foo do\n  def bar do\n    :ok\n  end\nend\n"
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "elixir")
+        assert results["functions"] == ["bar"]
+
+    def test_walk_ast_imports_still_extracted_alongside_functions(self):
+        # alias/import/use/require must keep working now that functions and
+        # classes are pulled out of the generic call-node dispatch.
+        import mcp_server
+        source = b"defmodule Foo do\n  alias MyApp.Router\n\n  def bar do\n    :ok\n  end\nend\n"
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "elixir")
+        assert results["imports"] == ["MyApp.Router"]
+        assert results["functions"] == ["bar"]
+        assert results["classes"] == ["Foo"]
+
+    def test_collect_entity_nodes_extracts_module_and_functions(self):
+        import mcp_server
+        source = b"defmodule Foo do\n  def bar do\n    :ok\n  end\nend\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._collect_entity_nodes(tree.root_node, "elixir")
+        assert "bar" in result["function"]
+        assert "Foo" in result["class"]
+
+    def test_extract_from_source_end_to_end(self):
+        pytest.importorskip("tree_sitter_elixir")
+        import mcp_server
+        source = (
+            b"defmodule Foo.Bar do\n"
+            b"  alias MyApp.Router\n\n"
+            b"  def bar do\n"
+            b"    :ok\n"
+            b"  end\n"
+            b"end\n"
+        )
+        parser = mcp_server._get_parser("mymod.ex")
+        result = mcp_server._extract_from_source(source, parser, "mymod.ex")
+        assert result["classes"] == ["Foo.Bar"]
+        assert result["functions"] == ["bar"]
+        assert result["imports"] == ["MyApp.Router"]
+
+
 class TestMatchCandidatePair:
     def _parse(self, source: str):
         import mcp_server
@@ -7004,15 +7091,21 @@ class TestFieldClassContainment:
         assert f"[{class_ident} :contains {field_ident}]" not in triples
         assert result["field_class_map"] == {}
 
-    def test_elixir_module_attribute_falls_back_to_module_only(self):
+    def test_elixir_module_attribute_gets_both_contains_and_class_edge(self):
+        # Before #170, defmodule was never extracted as a class (its "call"
+        # node type was mismatched against a bogus "defmodule" node-type
+        # entry in _LANG_NODE_TYPES), so this same repro fell back to
+        # module-only containment. Now that #170 fixes _extract_from_source
+        # to actually extract "Foo" as a class, this is just the ordinary
+        # real-class-field case, matching
+        # test_real_class_field_gets_both_contains_and_class_edge above.
         import mcp_server
         parser = self._parser("tree_sitter_elixir", "elixir")
         extracted = mcp_server._extract_from_source(
             b"defmodule Foo do\n  @attr 1\nend\n", parser, "foo.ex",
         )
-        # Confirm the reproduction from issues.md: field extracted, no class.
         assert extracted["fields"] == [("attr", "Foo", True)]
-        assert extracted["classes"] == []
+        assert extracted["classes"] == ["Foo"]
         result = mcp_server._precompute_file_triples(
             "foo.ex", extracted, ":commit/c1", {}, segment_index=None,
         )
@@ -7021,9 +7114,9 @@ class TestFieldClassContainment:
         class_ident = mcp_server._code_ident("class", "foo.ex", "Foo")
         _, _, triples = result["field_entries"][0]
         assert f"[{module_ident} :contains {field_ident}]" in triples
-        assert all(":class " not in t for t in triples)
-        assert f"[{class_ident} :contains {field_ident}]" not in triples
-        assert result["field_class_map"] == {}
+        assert f"[{class_ident} :contains {field_ident}]" in triples
+        assert f"[{field_ident} :class {class_ident}]" in triples
+        assert result["field_class_map"] == {field_ident: class_ident}
 
     def test_haskell_newtype_field_falls_back_to_module_only(self):
         import mcp_server


### PR DESCRIPTION
## Summary
- `defmodule`/`def`/`defp` all parse as generic `call` nodes in the real tree-sitter-elixir grammar, not their own dedicated node types the way `_LANG_NODE_TYPES["elixir"]` assumed — so `_walk_ast`'s generic dispatch never matched any real node, and every Elixir file ingested produced zero functions and zero classes.
- Adds `_elixir_call_target_text`/`_elixir_defmodule_name`/`_elixir_def_function_name` helpers and special-cases `lang_name == "elixir"` in `_walk_ast`/`_collect_entity_nodes`, disambiguating by the call's target identifier text — mirroring the existing C/C++ declarator-chain special case.
- Refactors `_extract_elixir_globals_and_fields`'s pre-existing inline `defmodule`-detection to reuse the new helpers instead of a third duplicate implementation.

Fixes #170.

## Review
Independent code-review subagent verdict: **Ready to merge: Yes**, no Critical/Important findings. Empirically verified `_elixir_def_function_name` against the real grammar across guard clauses, pattern-matched args, default args, one-liner `do:` syntax, and multi-clause functions — no false positives or silent drops found within #170's scope. One Minor finding (`defmacro`/`defmacrop`/`defguard`/`defdelegate` are a separate, out-of-scope instance of the same bug class) filed as follow-up #205.

## Test plan
- [x] New `TestElixirFunctionsAndClasses` class (6 tests) watched RED against pre-fix code, GREEN after — covers `_walk_ast`, `_collect_entity_nodes`, and end-to-end `_extract_from_source`, including guard clauses and imports-still-work-alongside-functions.
- [x] Updated `TestFieldClassContainment::test_elixir_module_attribute_gets_both_contains_and_class_edge` (previously `..._falls_back_to_module_only`) to reflect the fixed behavior — `defmodule` is now correctly extracted as a class.
- [x] Full suite: 658 passed, no regressions.
- [x] `ruff`/`black`: identical pre-existing findings before/after (confirmed via `git stash`), nothing new introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL