### PR TITLE
Fix #171: Lua functions never extracted — wrong grammar node type

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -326,7 +326,13 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         "calls": {"apply"},
     },
     "lua": {
-        "functions": {"function_definition"},
+        # Named function statements (`function foo() end`, `local function
+        # bar() end`, `function t.baz() end`, `function t:qux() end`) parse
+        # as "function_declaration" in the real tree-sitter-lua grammar, with
+        # a "name" field -- verified empirically (#171). "function_definition"
+        # is the anonymous `function() end` expression form and never carries
+        # a "name" field, so it can never surface a function name here.
+        "functions": {"function_declaration"},
         "classes": set(),
         "imports": {"function_call"},
         "calls": set(),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4236,6 +4236,50 @@ class TestLuaGlobalsAndFields:
         assert result["fields"] == []
 
 
+class TestLuaFunctions:
+    """Regression tests for #171: named Lua function statements parse as
+    `function_declaration` in the real tree-sitter-lua grammar, not the
+    `function_definition` type `_LANG_NODE_TYPES["lua"]["functions"]` used
+    to assume -- so no Lua function was ever extracted via the generic
+    _walk_ast/_collect_entity_nodes dispatch."""
+
+    def _parser(self):
+        import tree_sitter_lua
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_lua.language()))
+
+    def test_walk_ast_extracts_top_level_function(self):
+        import mcp_server
+        tree = self._parser().parse(b"function foo()\n  return 1\nend\n")
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "lua")
+        assert results["functions"] == ["foo"]
+
+    def test_walk_ast_extracts_local_function(self):
+        import mcp_server
+        tree = self._parser().parse(b"local function bar()\n  return 2\nend\n")
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "lua")
+        assert results["functions"] == ["bar"]
+
+    def test_collect_entity_nodes_extracts_function(self):
+        import mcp_server
+        tree = self._parser().parse(b"function foo()\n  return 1\nend\n")
+        result = mcp_server._collect_entity_nodes(tree.root_node, "lua")
+        assert "foo" in result["function"]
+
+    def test_anonymous_function_expression_not_captured(self):
+        # `t.qux = function() end` parses its RHS as a `function_definition`
+        # node, which never carries a "name" field -- verified empirically --
+        # so it correctly surfaces no function name, same as an anonymous
+        # function expression in any other language.
+        import mcp_server
+        tree = self._parser().parse(b"t.qux = function()\n  return 4\nend\n")
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "lua")
+        assert results["functions"] == []
+
+
 class TestElixirGlobalsAndFields:
     def _parser(self):
         import tree_sitter_elixir


### PR DESCRIPTION
## Summary
- `_LANG_NODE_TYPES["lua"]["functions"]` used `"function_definition"`, but named Lua function statements (`function foo() end`, `local function bar() end`, `function t.baz() end`, `function t:qux() end`) parse as `function_declaration` in the real tree-sitter-lua grammar — `function_definition` is only the anonymous `function() end` expression form, which never carries a `"name"` field.
- Result: every Lua file ingested produced zero `:function` entities via `_walk_ast`/`_collect_entity_nodes`, regardless of how many functions it defined. Same failure class as #170 (Elixir) and #92 (C/C++).
- Fix: switch the entry to `{"function_declaration"}`. Verified against the real `tree_sitter_lua` grammar (dumped the parse tree for top-level/local/dotted/method-style function statements) before making the change.

## Test plan
- [x] Added `TestLuaFunctions` covering: top-level function, `local function`, `_collect_entity_nodes`, and confirming anonymous `function() end` expressions still correctly yield no name.
- [x] `pytest tests/test_mcp_server.py -k Lua` — 14 passed
- [x] Full suite: `pytest tests/` — 788 passed

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL