### PR TITLE
Fix #172: Go struct/type declarations never extracted as classes

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -773,6 +773,33 @@ def _c_family_function_name(node) -> Optional[str]:
     return None
 
 
+def _go_struct_type_specs(node) -> List[Tuple[str, Any]]:
+    """Resolve (name, type_spec) pairs for struct types from a Go
+    `type_declaration` node.
+
+    Unlike most tree-sitter grammars, `type_declaration` has no `name` field
+    of its own -- it belongs to the nested `type_spec` child(ren), one level
+    down (#172). A grouped `type (\n A struct{...}\n B struct{...}\n)` block
+    keeps its `type_spec` children direct (no `type_spec_list` wrapper,
+    unlike grouped `var (...)`) -- verified empirically -- so a single
+    `type_declaration` node can carry more than one struct. Scoped to struct
+    types only, matching `_extract_go_globals_and_fields`'s existing scope
+    (a plain alias like `type MyInt int` has no fields to attribute, so it's
+    not treated as a class-equivalent entity here).
+    """
+    results: List[Tuple[str, Any]] = []
+    for type_spec in node.children:
+        if type_spec.type != "type_spec":
+            continue
+        struct_type = type_spec.child_by_field_name("type")
+        if struct_type is None or struct_type.type != "struct_type":
+            continue
+        name_node = type_spec.child_by_field_name("name")
+        if name_node:
+            results.append((name_node.text.decode("utf-8"), type_spec))
+    return results
+
+
 def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
     """Recursively extract code entities from a tree-sitter AST node.
 
@@ -823,10 +850,14 @@ def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
                 results["functions"].append(name)
 
     elif node.type in node_types.get("classes", set()):
-        name_node = node.child_by_field_name("name")
-        if name_node:
-            name = name_node.text.decode("utf-8")
-            results["classes"].append(name)
+        if lang_name == "go":
+            for name, _type_spec in _go_struct_type_specs(node):
+                results["classes"].append(name)
+        else:
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                name = name_node.text.decode("utf-8")
+                results["classes"].append(name)
 
     elif node.type in node_types.get("imports", set()):
         names = _extract_import_name(node, lang_name)
@@ -2845,9 +2876,13 @@ def _collect_entity_nodes(root_node: Any, lang_name: str) -> Dict[str, Dict[str,
                 if name_node:
                     result["function"][name_node.text.decode("utf-8")] = node
         elif node.type in node_types.get("classes", set()):
-            name_node = node.child_by_field_name("name")
-            if name_node:
-                result["class"][name_node.text.decode("utf-8")] = node
+            if lang_name == "go":
+                for name, type_spec in _go_struct_type_specs(node):
+                    result["class"][name] = type_spec
+            else:
+                name_node = node.child_by_field_name("name")
+                if name_node:
+                    result["class"][name_node.text.decode("utf-8")] = node
         for child in node.children:
             walk(child)
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3265,6 +3265,77 @@ class TestRustGoCGlobalsAndFields:
         assert info["b"] == ("Foo", False)
 
 
+class TestGoStructClasses:
+    """Regression tests for #172: `type_declaration` has no `name` field of
+    its own in the real tree-sitter-go grammar -- it belongs to the nested
+    `type_spec` child, one level down. `_walk_ast`/`_collect_entity_nodes`'s
+    generic `node.child_by_field_name("name")` lookup on `type_declaration`
+    itself always returned None, so no Go struct/type was ever extracted as
+    a class via the generic dispatch (same failure mode as #170/#171)."""
+
+    def _parser(self):
+        import tree_sitter_go
+        from tree_sitter import Language, Parser
+        return Parser(Language(tree_sitter_go.language()))
+
+    def test_walk_ast_extracts_struct_type(self):
+        import mcp_server
+        source = b"package main\n\ntype Foo struct {\n\tField1 int\n}\n"
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "go")
+        assert results["classes"] == ["Foo"]
+
+    def test_walk_ast_extracts_all_specs_in_grouped_type_block(self):
+        # A grouped `type (...)` block keeps its type_spec children direct
+        # (no type_spec_list wrapper, unlike grouped var blocks) -- verified
+        # empirically -- so a single type_declaration node can carry more
+        # than one struct.
+        import mcp_server
+        source = (
+            b"package main\n\ntype (\n\tBar struct {\n\t\tX int\n\t}\n"
+            b"\tBaz struct {\n\t\tY int\n\t}\n)\n"
+        )
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "go")
+        assert results["classes"] == ["Bar", "Baz"]
+
+    def test_walk_ast_non_struct_type_alias_not_captured(self):
+        # `type MyInt int` has no fields to attribute, so it's not treated
+        # as a class-equivalent entity, matching
+        # _extract_go_globals_and_fields's existing struct-only scope.
+        import mcp_server
+        source = b"package main\n\ntype MyInt int\n"
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "go")
+        assert results["classes"] == []
+
+    def test_collect_entity_nodes_extracts_struct_type(self):
+        import mcp_server
+        source = b"package main\n\ntype Foo struct {\n\tField1 int\n}\n"
+        tree = self._parser().parse(source)
+        result = mcp_server._collect_entity_nodes(tree.root_node, "go")
+        assert "Foo" in result["class"]
+
+    def test_collect_entity_nodes_grouped_specs_have_distinct_bodies(self):
+        # Each name in a grouped type block must map to its OWN type_spec
+        # node, not the shared parent type_declaration -- otherwise two
+        # different structs in the same group would compare as having
+        # identical body text to the rename matcher.
+        import mcp_server
+        source = (
+            b"package main\n\ntype (\n\tBar struct {\n\t\tX int\n\t}\n"
+            b"\tBaz struct {\n\t\tY int\n\t}\n)\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._collect_entity_nodes(tree.root_node, "go")
+        assert result["class"]["Bar"].text != result["class"]["Baz"].text
+        assert b"Bar" in result["class"]["Bar"].text
+        assert b"Baz" in result["class"]["Baz"].text
+
+
 class TestJavaCSharpGlobalsAndFields:
     def _java_parser(self):
         import tree_sitter_java


### PR DESCRIPTION
## Summary
- `type_declaration` has no `name` field of its own in the real tree-sitter-go grammar — it belongs to the nested `type_spec` child, one level down. The generic `_walk_ast`/`_collect_entity_nodes` dispatch called `child_by_field_name("name")` directly on `type_declaration`, which always returned `None`, so no Go struct was ever extracted as a `:class` entity via the generic path — same failure mode as #170/#171/#173.
- Adds `_go_struct_type_specs`, mirroring the existing C/C++ declarator-chain special case, to resolve `(name, type_spec)` pairs scoped to struct types only, matching `_extract_go_globals_and_fields`'s existing scope.
- Handles grouped `type (...)` blocks, which keep multiple `type_spec` children direct on one `type_declaration` node (verified empirically against the real installed grammar) — each struct in the group now gets its own name and its own body-text node (not the shared parent), so the rename matcher doesn't compare two different structs as identical.

## Test plan
- [x] Added `TestGoStructClasses` (5 tests) covering: single struct, grouped `type (...)` block with multiple structs, non-struct alias (`type MyInt int`) correctly excluded, `_collect_entity_nodes` extraction, and distinct per-struct body text in grouped blocks
- [x] Confirmed all 4 relevant new tests fail against pre-fix code (reproducing #172), pass after the fix
- [x] Full suite: `667 passed`

Claude-Session: https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL