### PR TITLE
Fix #174: rename matcher can confirm a false rename between unrelated entities in different files

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2640,6 +2640,16 @@ def _match_candidate_pair(
 
 _MAX_MATCH_ROUNDS = 10
 _MIN_MATCH_BODY_LEN = 20  # normalized chars; avoids matching trivial boilerplate stubs
+# A pair straddling two files with no established relationship (i.e. not the
+# same path, and not linked by a git-detected "R" rename — see file_groups in
+# _match_renamed_entities) is confirmed on structural equality alone, with no
+# corroborating evidence a real rename/move happened. That's a much weaker
+# signal than a same-file or git-confirmed-rename match, so it needs a much
+# larger body before two entities are unlikely to collide by coincidence
+# (#174 — a same-shaped one-line boilerplate stub/getter/repr in two unrelated
+# classes/files cleared the old single 20-char floor easily and was
+# confirmed as a false "rename").
+_MIN_CROSS_FILE_MATCH_BODY_LEN = 80
 # Above this total pool size (removed + added entries across all categories)
 # the matcher skips a commit entirely, mirroring git's own `-M` rename-limit
 # degradation: a missed rename is the accepted fallback, never an unbounded
@@ -2683,10 +2693,31 @@ def _match_renamed_entities(
     removed: Dict[str, List[Tuple[str, Any]]],
     added: Dict[str, List[Tuple[str, Any]]],
     unchanged_names: Optional[Set[str]] = None,
+    file_groups: Optional[Dict[int, str]] = None,
 ) -> List[Tuple[str, str, Any, str, Any]]:
     """Round-based rename matching across entity categories, scoped to a
     single commit's touched files (callers build removed/added from just
     that commit — see _extract_commit's use in Task 9).
+
+    file_groups (#174) is an optional {id(node): group_key} map used to tell
+    a genuinely file-related candidate pair from a purely coincidental
+    cross-file one. Two nodes share a group when they come from the same
+    path (an in-file "M" edit) or from the two sides of one git-detected "R"
+    rename (including a combined rename+move) — real, evidence-backed
+    relationships. Nodes from an unrelated "D" (whole file deleted) and "A"
+    (whole file added, different path) pair get distinct, never-equal group
+    keys, since git itself draws no connection between them. When a
+    candidate pair's groups differ, matching still proceeds but must clear
+    the higher _MIN_CROSS_FILE_MATCH_BODY_LEN bar rather than
+    _MIN_MATCH_BODY_LEN — cross-file matches remain possible (a function
+    really can move from one file to a wholly unrelated new one, since
+    that's simply invisible to git's own diff), just at a much narrower,
+    less coincidence-prone confidence threshold than same-file/git-rename
+    matches. file_groups is None for every standalone/test caller below
+    (no file information exists at that level) — the original single
+    _MIN_MATCH_BODY_LEN floor applies unchanged in that case, preserving
+    this function's pre-#174 behavior for callers that never had file
+    context to begin with.
 
     A rename confirmed in one category (e.g. a function) becomes available
     as a "tracked, confirmed-renamed" name for other not-yet-matched pairs
@@ -2778,6 +2809,15 @@ def _match_renamed_entities(
                 r_reserved_token = confirmed.get(r_match_name, r_match_name)
                 candidates = []
                 for a_name, a_node in a_list:
+                    if file_groups is not None:
+                        # #174: a pair with no established file relationship
+                        # (different group keys — see file_groups' docstring)
+                        # needs a much larger body before structural equality
+                        # alone is trusted as rename evidence.
+                        same_file_group = file_groups.get(id(r_node)) == file_groups.get(id(a_node))
+                        min_len = _MIN_MATCH_BODY_LEN if same_file_group else _MIN_CROSS_FILE_MATCH_BODY_LEN
+                        if len(r_text) < min_len:
+                            continue
                     a_match_name = _match_body_name(category, a_name)
                     a_reserved_token = confirmed.get(a_match_name, a_match_name)
                     # Exclude this specific pair's own old/new names from the
@@ -6263,6 +6303,18 @@ def _extract_commit(
     # two different removed entities in two different deleted files could
     # coincidentally share a name.
     node_origin: Dict[int, str] = {}  # id(node) -> file_path
+    # id(node) -> file-relationship group key, fed to _match_renamed_entities'
+    # file_groups param (#174). A "D" or plain "A" node's own path is unique
+    # to it (no other node shares that exact string), so it can never
+    # coincidentally group with an unrelated file's nodes; an "M" node's old
+    # and new sides share the same literal path already; an "R" pair's old
+    # and new sides get one synthetic shared key (their paths genuinely
+    # differ) so a git-confirmed rename/move still matches at the lower,
+    # same-file confidence bar. Distinct from node_origin (which always
+    # records the real path, for renamed_pairs' output) since D/A's own path
+    # must stay a valid, reportable file_path while still acting as a
+    # never-shared group key here.
+    node_group: Dict[int, str] = {}
     # Bare body-text names (see _match_body_name) present, with the SAME name,
     # on BOTH the old and new side of some touched file this commit — tracked
     # entities that survived unrenamed. Passed to _match_renamed_entities so a
@@ -6355,6 +6407,7 @@ def _extract_commit(
                 for name, node in old_entity_nodes[category].items():
                     removed_pool[category].append((name, node))
                     node_origin[id(node)] = old_lang_path
+                    node_group[id(node)] = old_lang_path
             results.append((status, file_path, None, None, ""))
             continue
 
@@ -6413,17 +6466,26 @@ def _extract_commit(
                 for name, node in new_entity_nodes[category].items():
                     added_pool[category].append((name, node))
                     node_origin[id(node)] = file_path
+                    node_group[id(node)] = file_path
         elif status == "R":
             # Ident changes for every entity in a renamed file, even ones
             # whose text is byte-identical — pool everything on both sides,
-            # not just the local diff (unlike "M" below).
+            # not just the local diff (unlike "M" below). Both sides share
+            # ONE synthetic group key (#174) — old_lang_path != file_path
+            # here, but git already confirmed this specific pair as a real
+            # rename/move, so they're linked at the lower, same-file
+            # confidence bar rather than treated as unrelated cross-file
+            # candidates.
+            rename_group = f"rename:{old_lang_path}->{file_path}"
             for category in ("function", "class", "variable", "field"):
                 for name, node in old_entity_nodes[category].items():
                     removed_pool[category].append((name, node))
                     node_origin[id(node)] = old_lang_path
+                    node_group[id(node)] = rename_group
                 for name, node in new_entity_nodes[category].items():
                     added_pool[category].append((name, node))
                     node_origin[id(node)] = file_path
+                    node_group[id(node)] = rename_group
         else:  # "M" — same path, only the local diff needs matching
             for category in ("function", "class", "variable", "field"):
                 old_names = set(old_entity_nodes[category].keys())
@@ -6432,12 +6494,14 @@ def _extract_commit(
                     node = old_entity_nodes[category][name]
                     removed_pool[category].append((name, node))
                     node_origin[id(node)] = old_lang_path
+                    node_group[id(node)] = old_lang_path
                 for name in new_names - old_names:
                     node = new_entity_nodes[category][name]
                     added_pool[category].append((name, node))
                     node_origin[id(node)] = file_path
+                    node_group[id(node)] = file_path
 
-    raw_matches = _match_renamed_entities(removed_pool, added_pool, unchanged_names)
+    raw_matches = _match_renamed_entities(removed_pool, added_pool, unchanged_names, file_groups=node_group)
     # raw_matches carries the matched node objects themselves (see Task 8's
     # _match_renamed_entities retrofit), so file paths can be recovered
     # directly via node_origin — no second pass or pre-mutation snapshot

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6287,6 +6287,35 @@ class TestExtractCommitRename:
         assert old_path == "old_name.py"
         assert "login" in extracted["functions"]
 
+    def test_rename_status_short_body_still_matched_at_low_floor(self, tmp_path):
+        """#174: a git-confirmed "R" rename must keep matching a renamed
+        function at the ORIGINAL, lower _MIN_MATCH_BODY_LEN floor, not the
+        higher _MIN_CROSS_FILE_MATCH_BODY_LEN bar reserved for genuinely
+        unrelated cross-file pairs — old_name.py/new_name.py share a real,
+        git-detected relationship here, unlike the unrelated-files case
+        above. `new_fn`'s body is deliberately short (well under the
+        cross-file floor) to prove the low floor, not the high one, is what
+        applies."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "old_name.py").write_text("def old_fn(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "mv", "old_name.py", "new_name.py"], cwd=repo, check=True, capture_output=True)
+        (repo / "new_name.py").write_text("def new_fn(x):\n    return x + 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "rename file and function"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        results, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        status = results[0][0]
+        assert status == "R"  # sanity: git itself must have detected this as a rename
+        assert ("function", "old_name.py", "old_fn", "new_name.py", "new_fn") in renamed_pairs
+
     def test_non_rename_status_has_empty_old_path(self, git_repo):
         import mcp_server
         commits = mcp_server._git_commits(str(git_repo), watermark_hash=None)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4903,6 +4903,77 @@ class TestMatchRenamedEntities:
         assert len(matches) == n
         assert elapsed < 12.0, f"600x600 matcher took {elapsed:.2f}s (expected ~5s; cubic regression?)"
 
+    def test_cross_file_short_body_not_matched_without_relationship(self):
+        """#174: two unrelated entities (different file_groups keys) with a
+        short, plausible-boilerplate identical body must NOT be confirmed as
+        a rename just because nothing else distinguishes them — this is the
+        issue's own repro (a trivial one-line getter-shaped body, 57
+        normalized chars, comfortably clears the old single 20-char floor but
+        must not clear the higher cross-file bar)."""
+        import mcp_server
+        old = self._parse_fn("def compute_alpha(self):\n    return self.identifier_value + 1\n")
+        new = self._parse_fn("def compute_beta(self):\n    return self.identifier_value + 1\n")
+        removed = {"function": [("compute_alpha", old)]}
+        added = {"function": [("compute_beta", new)]}
+        matches = mcp_server._match_renamed_entities(
+            removed, added, file_groups={id(old): "fileA.py", id(new): "fileB.py"}
+        )
+        assert matches == []
+
+    def test_same_file_group_short_body_still_matched(self):
+        """The exact same short body/pair as above, but sharing ONE file
+        group (e.g. a same-path "M" edit or a git-confirmed "R" rename) —
+        the lower, pre-#174 floor still applies since there's real evidence
+        of a file-level relationship."""
+        import mcp_server
+        old = self._parse_fn("def compute_alpha(self):\n    return self.identifier_value + 1\n")
+        new = self._parse_fn("def compute_beta(self):\n    return self.identifier_value + 1\n")
+        removed = {"function": [("compute_alpha", old)]}
+        added = {"function": [("compute_beta", new)]}
+        matches = mcp_server._match_renamed_entities(
+            removed, added, file_groups={id(old): "fileA.py", id(new): "fileA.py"}
+        )
+        projected = [(c, o, n) for c, o, _, n, _ in matches]
+        assert projected == [("function", "compute_alpha", "compute_beta")]
+
+    def test_cross_file_long_body_still_matched(self):
+        """A genuinely moved function between two unrelated files is still
+        detected when its body clears the higher cross-file bar — the
+        legitimate case #174's fix must not regress."""
+        import mcp_server
+        old = self._parse_fn(
+            "def moveMe(x, y, z):\n"
+            "    total = x * 2 + y * 3 + z * 5\n"
+            "    adjusted = total + 7\n"
+            "    return adjusted\n"
+        )
+        new = self._parse_fn(
+            "def movedNow(x, y, z):\n"
+            "    total = x * 2 + y * 3 + z * 5\n"
+            "    adjusted = total + 7\n"
+            "    return adjusted\n"
+        )
+        removed = {"function": [("moveMe", old)]}
+        added = {"function": [("movedNow", new)]}
+        matches = mcp_server._match_renamed_entities(
+            removed, added, file_groups={id(old): "fileA.py", id(new): "fileB.py"}
+        )
+        projected = [(c, o, n) for c, o, _, n, _ in matches]
+        assert projected == [("function", "moveMe", "movedNow")]
+
+    def test_file_groups_none_preserves_pre_174_behavior(self):
+        """Callers with no file information at all (file_groups=None, the
+        default — every other test in this class) are unaffected by #174:
+        the single, lower _MIN_MATCH_BODY_LEN floor still applies."""
+        import mcp_server
+        old = self._parse_fn("def compute_alpha(self):\n    return self.identifier_value + 1\n")
+        new = self._parse_fn("def compute_beta(self):\n    return self.identifier_value + 1\n")
+        removed = {"function": [("compute_alpha", old)]}
+        added = {"function": [("compute_beta", new)]}
+        matches = mcp_server._match_renamed_entities(removed, added)
+        projected = [(c, o, n) for c, o, _, n, _ in matches]
+        assert projected == [("function", "compute_alpha", "compute_beta")]
+
 
 class TestCollectEntityNodes:
     def test_collects_function_and_class_nodes_by_name(self):
@@ -6225,6 +6296,43 @@ class TestExtractCommitRename:
         assert old_path == ""
 
     def test_cross_file_move_produces_renamed_pair(self, tmp_path):
+        """`moveMe`'s body is deliberately longer than a trivial one-liner
+        (#174 raised the cross-file confidence bar to _MIN_CROSS_FILE_MATCH_BODY_LEN
+        precisely because a short body provides no real signal that fileA.py
+        and fileB.py are actually related — see
+        test_unrelated_same_shaped_entities_across_files_not_matched below for
+        the case this bar is meant to reject) — a real cross-file move with a
+        sufficiently distinctive body must still be detected."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        move_me_body = (
+            "def moveMe(x, y, z):\n"
+            "    total = x * 2 + y * 3 + z * 5\n"
+            "    adjusted = total + 7\n"
+            "    return adjusted\n"
+        )
+        (repo / "fileA.py").write_text("def stayHere(x):\n    return x + 1\n\n" + move_me_body)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+        (repo / "fileA.py").write_text("def stayHere(x):\n    return x + 1\n")
+        (repo / "fileB.py").write_text(move_me_body)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "move function"], cwd=repo, check=True, capture_output=True)
+
+        commits = mcp_server._git_commits(str(repo), watermark_hash=None)
+        _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
+        assert ("function", "fileA.py", "moveMe", "fileB.py", "moveMe") in renamed_pairs
+
+    def test_unrelated_same_shaped_entities_across_files_not_matched(self, tmp_path):
+        """#174's own repro, reproduced end-to-end through _extract_commit:
+        two unrelated classes in two unrelated files, each with a trivial,
+        identically-shaped one-line method — nothing here indicates fileA.py
+        and fileB.py are actually related, so the matcher must not confirm a
+        false rename between compute_alpha and compute_beta."""
         import mcp_server
         repo = tmp_path / "repo"
         repo.mkdir()
@@ -6232,18 +6340,29 @@ class TestExtractCommitRename:
         _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
         _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
         (repo / "fileA.py").write_text(
-            "def stayHere(x):\n    return x + 1\n\ndef moveMe(x):\n    return x * 2 + 7\n"
+            "class Widget:\n"
+            "    def compute_alpha(self):\n"
+            "        return self.identifier_value + 1\n"
         )
+        (repo / "fileB.py").write_text("class Placeholder:\n    pass\n")
         _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
         _subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
-        (repo / "fileA.py").write_text("def stayHere(x):\n    return x + 1\n")
-        (repo / "fileB.py").write_text("def moveMe(x):\n    return x * 2 + 7\n")
+        # fileA.py loses compute_alpha (an "M" edit, file still exists);
+        # fileB.py independently gains an unrelated compute_beta with the
+        # exact same trivial body (also an "M" edit) — git draws no
+        # connection between these two files at all.
+        (repo / "fileA.py").write_text("class Widget:\n    pass\n")
+        (repo / "fileB.py").write_text(
+            "class Placeholder:\n"
+            "    def compute_beta(self):\n"
+            "        return self.identifier_value + 1\n"
+        )
         _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
-        _subprocess.run(["git", "commit", "-m", "move function"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "unrelated edits"], cwd=repo, check=True, capture_output=True)
 
         commits = mcp_server._git_commits(str(repo), watermark_hash=None)
         _, _, _, renamed_pairs = mcp_server._extract_commit(str(repo), commits[1][0])
-        assert ("function", "fileA.py", "moveMe", "fileB.py", "moveMe") in renamed_pairs
+        assert renamed_pairs == []
 
     def test_cross_extension_rename_parses_old_blob_with_old_grammar(self, tmp_path, monkeypatch):
         """Reviewer finding 2 on Task 9 (47b962e): for status "R", `parser =


### PR DESCRIPTION
## Summary
- `_match_renamed_entities` confirmed a candidate pair as a rename purely on structural body equality, with no check that the two files involved have any real relationship — a trivial, identically-shaped one-line body (getter, `__repr__`, boilerplate stub) in two unrelated classes/files cleared the old single 20-char floor easily and got silently merged into one entity's history.
- Threads a file-relationship group key from `_extract_commit` into `_match_renamed_entities`: same-path ("M") and git-confirmed-rename ("R", including combined rename+move) pairs share a group and keep the existing low `_MIN_MATCH_BODY_LEN` (20 chars) floor; genuinely unrelated cross-file pairs get distinct groups and must clear a new, much higher `_MIN_CROSS_FILE_MATCH_BODY_LEN` (80 chars) floor instead.
- Preserves the legitimate, pre-existing "function moved to a brand-new, git-unrelated file" detection capability (`test_cross_file_move_produces_renamed_pair`) — cross-file matching is still possible, just requires a sufficiently distinctive body rather than any coincidental match. `file_groups` defaults to `None`, preserving exact prior behavior for every standalone/test caller with no file context.

## Test plan
- [x] New unit tests in `TestMatchRenamedEntities` covering: cross-file short body not matched, same-group short body still matched, cross-file long body still matched, `file_groups=None` preserves old behavior.
- [x] New end-to-end test in `TestExtractCommitRename` reproducing the issue's own Widget/Gadget repro through real git commits — asserts no false `renamed_pairs` entry.
- [x] New end-to-end test confirming a git-detected "R" rename with a short body still matches at the low floor (independent-review follow-up).
- [x] Existing `test_cross_file_move_produces_renamed_pair` fixture lengthened (verified via real tree-sitter parsing, not hand-counted chars) to keep validating genuine cross-file moves above the new floor.
- [x] Full suite: 635 passed, 116 pre-existing failures (missing tree-sitter grammars in this sandbox), identical baseline confirmed via `git stash` before/after.
- [x] `ruff`/`black`: identical pre-existing findings before/after, nothing new introduced.
- [x] Independent code-review subagent dispatched before push — verdict "Ready to merge: Yes", no Critical/Important findings; the one substantive Minor (missing R-path low-floor regression test) addressed in a follow-up commit.

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL