### PR TITLE
Fix #179: handle_minigraf_audit silently swallows per-entity exceptions

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3593,6 +3593,7 @@ def handle_minigraf_audit(as_of: Optional[int] = None) -> Dict[str, Any]:
     audited = 0
     retracted = 0
     all_violations: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, Any]] = []
 
     as_of_clause = f":as-of {as_of} " if as_of is not None else ""
 
@@ -3605,7 +3606,12 @@ def handle_minigraf_audit(as_of: Optional[int] = None) -> Dict[str, Any]:
         try:
             type_result = handle_minigraf_query(type_query)
             type_rows = type_result.get("results", [])
-        except Exception:
+        except Exception as e:
+            print(
+                f"[minigraf_audit] type query failed for {entity_type}: {e}",
+                file=sys.stderr,
+            )
+            skipped.append({"entity_type": entity_type, "stage": "type_query", "error": str(e)})
             continue
 
         for row in type_rows:
@@ -3625,7 +3631,18 @@ def handle_minigraf_audit(as_of: Optional[int] = None) -> Dict[str, Any]:
             try:
                 attr_result = handle_minigraf_query(attr_query)
                 attr_rows = attr_result.get("results", [])
-            except Exception:
+            except Exception as e:
+                print(
+                    f"[minigraf_audit] attr query failed for {entity_uuid} "
+                    f"({entity_type}): {e}",
+                    file=sys.stderr,
+                )
+                skipped.append({
+                    "entity": entity_uuid,
+                    "entity_type": entity_type,
+                    "stage": "attr_query",
+                    "error": str(e),
+                })
                 continue
 
             # Extract keyword ident from the stored :ident datom for reporting.
@@ -3699,6 +3716,7 @@ def handle_minigraf_audit(as_of: Optional[int] = None) -> Dict[str, Any]:
         "audited": audited,
         "retracted": retracted,
         "violations": all_violations,
+        "skipped": skipped,
     }
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2651,6 +2651,71 @@ class TestMinigrafAudit:
         )
         assert queried["results"] == []
 
+    def test_type_query_failure_is_logged_and_reported_as_skipped(self, real_db, capsys):
+        """#179: a real failure fetching an entity-type's UUIDs must not look
+        like a clean, empty audit -- it must be logged to stderr and surfaced
+        in the returned "skipped" list so a caller can tell the difference."""
+        import mcp_server
+        real_query = mcp_server.handle_minigraf_query
+        calls = {"n": 0}
+
+        def flaky_query(datalog):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("simulated real backend failure on type fetch")
+            return real_query(datalog)
+
+        mcp_server.handle_minigraf_query = flaky_query
+        try:
+            result = mcp_server.handle_minigraf_audit()
+        finally:
+            mcp_server.handle_minigraf_query = real_query
+
+        assert result["ok"] is True
+        assert result["audited"] == 0
+        assert len(result["skipped"]) == 1
+        assert result["skipped"][0]["stage"] == "type_query"
+        assert result["skipped"][0]["entity_type"] == "decision"
+        err = capsys.readouterr().err
+        assert "[minigraf_audit] type query failed for decision" in err
+
+    def test_attr_query_failure_is_logged_and_reported_as_skipped(self, real_db, capsys):
+        """#179: a real failure fetching one entity's attributes must not
+        silently exclude that entity from the audit forever -- it must be
+        logged and surfaced in "skipped", and must not abort auditing the
+        rest of the entities."""
+        import mcp_server
+        mcp_server.handle_minigraf_transact(
+            '[[:decision/redis :entity-type :type/decision] '
+            '[:decision/redis :ident ":decision/redis"] '
+            '[:decision/redis :description "use Redis"]]',
+            reason="setup",
+        )
+
+        real_query = mcp_server.handle_minigraf_query
+        calls = {"n": 0}
+
+        def flaky_query(datalog):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("simulated real backend failure on attr fetch")
+            return real_query(datalog)
+
+        mcp_server.handle_minigraf_query = flaky_query
+        try:
+            result = mcp_server.handle_minigraf_audit()
+        finally:
+            mcp_server.handle_minigraf_query = real_query
+
+        assert result["ok"] is True
+        assert result["audited"] == 1
+        assert result["retracted"] == 0
+        assert len(result["skipped"]) == 1
+        assert result["skipped"][0]["stage"] == "attr_query"
+        assert result["skipped"][0]["entity_type"] == "decision"
+        err = capsys.readouterr().err
+        assert "[minigraf_audit] attr query failed for" in err
+
 
 class TestPhase5Schema:
     def test_module_entity_passes_validation(self):


### PR DESCRIPTION
## Summary
- `handle_minigraf_audit`'s type-query and attr-query exception handlers caught real backend failures with a bare `continue` and zero logging — a genuinely erroring entity was silently excluded from every audit run forever, with the tool reporting a clean `{"ok": True, ...}` result.
- Both handlers now log to stderr (matching this file's existing `_index_write`/checkpoint convention), and the returned dict gains a `"skipped"` list (entity/entity_type/stage/error) so callers can distinguish "nothing to audit" from "some entities errored and were skipped" without needing to watch logs.
- The third handler in this function (the post-retract checkpoint) was already fixed under #176 and needed no change.

## Test plan
- [x] `pytest tests/test_mcp_server.py -k TestMinigrafAudit -v` — 10/10 pass, including two new tests reproducing the issue's exact repro (flaky `handle_minigraf_query` injected via monkeypatch, no DB mocking) for both the type-query and attr-query failure paths, asserting stderr output and the new `skipped` field.
- [x] Full `tests/test_mcp_server.py` run — only pre-existing failures from optional tree-sitter grammar packages not installed in this environment (Lua/Elixir/Haskell/Swift/Scala/etc.), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL