### PR TITLE
Fix #180: MINIGRAF_EXTRACTION_STRATEGY=llm blocks the entire MCP event loop

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -176,7 +176,9 @@ When the MCP server is configured and hooks are enabled, memory is managed autom
 
 Extraction strategy is controlled by `MINIGRAF_EXTRACTION_STRATEGY` (env var):
 - `heuristic` (default) — regex signal detection, zero API calls
-- `llm` — Claude Haiku extracts facts; falls back to agent on API failure
+- `llm` — Claude Haiku extracts facts; falls back to heuristic on API failure. Runs on a worker
+  thread so a slow/hung provider doesn't stall other concurrent tool calls; the underlying
+  client's request timeout defaults to 30s, override via `MINIGRAF_LLM_TIMEOUT_SECONDS`.
 - `agent` — MCP sampling asks the connected agent to identify facts
 
 **Without hooks** (OpenCode, OpenClaw, or unconfigured): call the tools explicitly at the start and end of each turn.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5343,6 +5343,9 @@ Conversation:
 {conversation}"""
 
 
+_LLM_CLIENT_TIMEOUT_SECONDS = float(os.environ.get("MINIGRAF_LLM_TIMEOUT_SECONDS", "30"))
+
+
 def _get_anthropic_client():
     """Return an Anthropic client. Raises if anthropic package or API key is missing."""
     try:
@@ -5352,7 +5355,7 @@ def _get_anthropic_client():
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         raise RuntimeError("ANTHROPIC_API_KEY not set")
-    return anthropic.Anthropic(api_key=api_key)
+    return anthropic.Anthropic(api_key=api_key, timeout=_LLM_CLIENT_TIMEOUT_SECONDS)
 
 
 _OPENAI_MODEL_PREFIXES = ("gpt-", "o1", "o3", "o4")
@@ -5371,7 +5374,7 @@ def _get_openai_client():
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
-    return openai.OpenAI(api_key=api_key)
+    return openai.OpenAI(api_key=api_key, timeout=_LLM_CLIENT_TIMEOUT_SECONDS)
 
 
 def _strip_code_fences(text: str) -> str:
@@ -5609,7 +5612,15 @@ async def handle_memory_finalize_turn(conversation_delta: str) -> Dict[str, Any]
         return {"ok": True, "stored_count": stored, "strategy": "heuristic"}
 
     if strategy == "llm":
-        result = _llm_extract_and_transact(conversation_delta)
+        # _llm_extract_and_transact makes a blocking network call (_call_llm);
+        # run it in a worker thread so it can't freeze the shared event loop
+        # for other concurrent tool calls (#180), mirroring the executor
+        # pattern already used for fact-index rebuild and git ingestion.
+        loop = asyncio.get_running_loop()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as llm_executor:
+            result = await loop.run_in_executor(
+                llm_executor, _llm_extract_and_transact, conversation_delta
+            )
         if result["ok"]:
             return result
         # LLM failed — fall back to heuristic and surface a warning so the user

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1622,6 +1622,93 @@ class TestLlmStrategy:
         assert queried["results"] == [["Kafka"]]
 
 
+class TestLlmStrategyEventLoopNonBlocking:
+    def test_slow_call_llm_does_not_block_concurrent_coroutine(self, real_db, monkeypatch):
+        """#180: a slow/hanging LLM provider call must not freeze the whole
+        asyncio event loop -- other coroutines (heartbeats, other tool calls)
+        need to keep making progress while _call_llm is in flight. Uses
+        absolute wall-clock enter/exit timestamps from the blocking call
+        itself (not a per-task relative clock, which can't distinguish "ticked
+        before the block started" from "ticked during it")."""
+        monkeypatch.setenv("MINIGRAF_EXTRACTION_STRATEGY", "llm")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        import mcp_server
+
+        call_times = {}
+
+        def slow_call_llm(model, prompt):
+            call_times["enter"] = time.monotonic()
+            time.sleep(0.3)
+            call_times["exit"] = time.monotonic()
+            return "[]"
+
+        monkeypatch.setattr(mcp_server, "_call_llm", slow_call_llm)
+
+        heartbeat_ticks = []
+
+        async def heartbeat():
+            for _ in range(20):
+                heartbeat_ticks.append(time.monotonic())
+                await asyncio.sleep(0.03)
+
+        async def run_both():
+            await asyncio.gather(
+                mcp_server.handle_memory_finalize_turn("User: test\nAgent: ok"),
+                heartbeat(),
+            )
+
+        asyncio.run(run_both())
+
+        assert "enter" in call_times and "exit" in call_times
+        overlapping = [
+            t for t in heartbeat_ticks if call_times["enter"] < t < call_times["exit"]
+        ]
+        assert overlapping, (
+            "no heartbeat ticks landed between the LLM call's enter/exit -- "
+            "the event loop was blocked for the full duration of the call "
+            "instead of yielding to other coroutines"
+        )
+
+    def test_call_llm_client_construction_sets_timeout(self, monkeypatch):
+        """A hung provider must not block indefinitely even inside the
+        executor thread -- both clients must be built with an explicit
+        timeout."""
+        import mcp_server
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        captured = {}
+
+        class FakeAnthropic:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        fake_anthropic_module = MagicMock()
+        fake_anthropic_module.Anthropic = FakeAnthropic
+        with patch.dict(sys.modules, {"anthropic": fake_anthropic_module}):
+            mcp_server._get_anthropic_client()
+
+        assert "timeout" in captured
+        assert captured["timeout"] is not None
+
+    def test_call_llm_openai_client_construction_sets_timeout(self, monkeypatch):
+        import mcp_server
+
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        captured = {}
+
+        class FakeOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        fake_openai_module = MagicMock()
+        fake_openai_module.OpenAI = FakeOpenAI
+        with patch.dict(sys.modules, {"openai": fake_openai_module}):
+            mcp_server._get_openai_client()
+
+        assert "timeout" in captured
+        assert captured["timeout"] is not None
+
+
 class TestAgentStrategy:
     def test_returns_ok_result(self, real_db, monkeypatch):
         import asyncio


### PR DESCRIPTION
## Summary
- `_llm_extract_and_transact` (blocking Anthropic/OpenAI SDK calls via `_call_llm`) was called directly from `async def handle_memory_finalize_turn` with no `await`/executor — unlike every other blocking path in this file. A slow/hanging LLM provider froze the whole MCP server for the duration of the call.
- Routes the `llm` strategy branch through `loop.run_in_executor` on a dedicated `ThreadPoolExecutor`, mirroring the existing `backfill_executor`/`write_executor` pattern.
- Adds an explicit client-construction timeout (`MINIGRAF_LLM_TIMEOUT_SECONDS`, default 30s) to both the Anthropic and OpenAI clients so a stalled provider can't block the worker thread indefinitely either.
- SKILL.md: documents the new env var, and corrects a pre-existing inaccuracy in the same line (llm strategy falls back to `heuristic` on API failure, not `agent`).

Fixes #180.

## Test plan
- [x] New `TestLlmStrategyEventLoopNonBlocking` class (3 tests): event-loop-not-blocked test (watched RED against pre-fix code via an independent review agent, GREEN after), both client-timeout tests (RED before fix, GREEN after)
- [x] Full suite: 804 passed, no regressions
- [x] `ruff`/`black`: identical pre-existing findings, nothing new
- [x] Independent code-review subagent dispatched before push — verdict "Ready to merge: yes", zero blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL