### PR TITLE
Fix #175: _parse_tx_result reads the wrong JSON key

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3286,7 +3286,8 @@ def _parse_tx_result(raw_json: str) -> Dict[str, Any]:
     """Parse JSON returned by MiniGrafDb.execute() for a transact/retract command."""
     try:
         data = json.loads(raw_json)
-        return {"ok": True, "tx": str(data.get("tx", "unknown"))}
+        tx = data.get("transacted", data.get("retracted", data.get("tx", "unknown")))
+        return {"ok": True, "tx": str(tx)}
     except json.JSONDecodeError as e:
         return {"ok": False, "error": f"Unexpected result format: {e} — raw: {raw_json[:200]}"}
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -829,6 +829,17 @@ class TestMinigrafTransact:
         results = fact_index.query_facts(index_path, "reviewed", top_n=10, boost=2.0, historical_discount=1.0)
         assert any(r[1] == ":status" and r[2] == "reviewed" for r in results)
 
+    def test_reports_real_tx_id_not_unknown(self, real_db):
+        """#175: the real minigraf library returns a "transacted" key, never
+        "tx" -- a successful transact must report that real id, not the
+        literal string "unknown"."""
+        import mcp_server
+        result = mcp_server.handle_minigraf_transact(
+            '[[:decision/cache :description "use Redis"]]', reason="test"
+        )
+        assert result["ok"] is True
+        assert result["tx"] != "unknown"
+
     def test_checkpoint_failure_after_successful_write_still_reports_ok(self, tmp_path, monkeypatch):
         """#176: the graph write (and fact-index write) already happened by
         the time _db_checkpoint runs -- a checkpoint-only failure must not be
@@ -933,6 +944,18 @@ class TestMinigrafRetract:
         results = fact_index.query_facts(index_path, "reviewed", top_n=10, boost=2.0, historical_discount=1.0)
         assert results == []
 
+    def test_reports_real_tx_id_not_unknown(self, real_db):
+        """#175 retract-side mirror: the real minigraf library returns a
+        "retracted" key, never "tx"."""
+        import mcp_server
+        real_db.execute('(transact {} [[:decision/old :description "deprecated"]])')
+
+        result = mcp_server.handle_minigraf_retract(
+            '[[:decision/old :description "deprecated"]]', reason="gone"
+        )
+        assert result["ok"] is True
+        assert result["tx"] != "unknown"
+
     def test_checkpoint_failure_after_successful_write_still_reports_ok(self, tmp_path, monkeypatch):
         """#176 retract-side mirror: the retract itself already happened by
         the time _db_checkpoint runs, so a checkpoint-only failure must not
@@ -969,6 +992,28 @@ class TestMinigrafRetract:
             '[:find ?d :where [:decision/old :description ?d]]'
         )
         assert queried["results"] == []
+
+
+class TestParseTxResult:
+    """#175: minigraf's real execute() output uses "transacted"/"retracted"
+    keys, never "tx" -- _parse_tx_result must read the key that's actually
+    there instead of always falling back to the literal string "unknown"."""
+
+    def test_reads_transacted_key(self):
+        import mcp_server
+        result = mcp_server._parse_tx_result('{"transacted":1784641334419}')
+        assert result == {"ok": True, "tx": "1784641334419"}
+
+    def test_reads_retracted_key(self):
+        import mcp_server
+        result = mcp_server._parse_tx_result('{"retracted":1784641334420}')
+        assert result == {"ok": True, "tx": "1784641334420"}
+
+    def test_invalid_json_still_reports_error(self):
+        import mcp_server
+        result = mcp_server._parse_tx_result("not json")
+        assert result["ok"] is False
+        assert "error" in result
 
 
 class TestParseFactsBlock:


### PR DESCRIPTION
## Summary
- `_parse_tx_result` looked for a `"tx"` key in minigraf's transact/retract JSON output, but the real library returns `"transacted"` or `"retracted"` — so every successful `minigraf_transact`/`minigraf_retract` call reported `tx: "unknown"` regardless of the actual transaction id.
- Fixed by checking `transacted` → `retracted` → `tx` (kept as a backward-compat fallback) in that order.

## Test plan
- [x] New unit tests (`TestParseTxResult`) assert `_parse_tx_result` reads `"transacted"`/`"retracted"` correctly, watched RED before the fix
- [x] New real-backend regression tests in `TestMinigrafTransact`/`TestMinigrafRetract` assert `result["tx"] != "unknown"` after a successful write, watched RED before the fix
- [x] Full suite: 809 passed, no regressions
- [x] `ruff`/`black`: identical pre-existing findings (confirmed via `git stash`), nothing new
- [x] Independent code-review subagent dispatched — verified live in an isolated worktree (including a falsy `0`-tx-id edge case) — verdict "Ready to merge: Yes," zero findings

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL