### PR TITLE
Fix #184: install.py ignores update_skill()'s failure

### DIFF
--- a/install.py
+++ b/install.py
@@ -796,7 +796,7 @@ def register_plugin_with_claude() -> bool:
     return True
 
 
-def main(target_dir: str = "", harness: str = "claude-code") -> None:
+def main(target_dir: str = "", harness: str = "claude-code", update_ok: bool = True) -> None:
     print("=" * 50)
     print("Temporal Reasoning Skill Setup")
     print("=" * 50)
@@ -830,7 +830,7 @@ def main(target_dir: str = "", harness: str = "claude-code") -> None:
         print()
 
     if harness != "claude-code":
-        ok = all(results)
+        ok = all(results) and update_ok
         print("=" * 50)
         print("✓ Setup complete!" if ok else "✗ Setup incomplete — fix errors above")
         print("=" * 50)
@@ -857,7 +857,7 @@ def main(target_dir: str = "", harness: str = "claude-code") -> None:
     plugin_ok = register_plugin_with_claude()
     print()
 
-    if all(results) and mcp_ok and settings_json_ok and settings_ok and plugin_ok:
+    if all(results) and mcp_ok and settings_json_ok and settings_ok and plugin_ok and update_ok:
         print("=" * 50)
         print("✓ Setup complete!")
         print("=" * 50)
@@ -886,8 +886,9 @@ if __name__ == "__main__":
         print(f"Installing into: {target_dir}")
 
     if force or should_update():
-        update_skill(target_dir, harness)
+        update_ok = update_skill(target_dir, harness)
     else:
         _sync_files(target_dir, harness)
+        update_ok = True
 
-    main(target_dir, harness)
+    main(target_dir, harness, update_ok=update_ok)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -265,3 +265,41 @@ class TestMainHarnessGating:
         settings_json.assert_called_once_with(str(tmp_path))
         settings_local.assert_called_once_with(str(tmp_path))
         register.assert_called_once()
+
+    def test_update_failure_marks_setup_incomplete_for_claude_code(self, monkeypatch, tmp_path, capsys):
+        self._patch_common(monkeypatch)
+        monkeypatch.setattr(install, "setup_mcp_json", lambda *_: True)
+        monkeypatch.setattr(install, "setup_claude_settings_json", lambda *_: True)
+        monkeypatch.setattr(install, "setup_claude_settings", lambda *_: True)
+        monkeypatch.setattr(install, "register_plugin_with_claude", lambda: True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            install.main(str(tmp_path), "claude-code", update_ok=False)
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "Setup incomplete" in out
+        assert "Setup complete!" not in out
+
+    def test_update_failure_marks_setup_incomplete_for_non_claude_harness(self, monkeypatch, tmp_path, capsys):
+        self._patch_common(monkeypatch)
+
+        with pytest.raises(SystemExit) as exc_info:
+            install.main(str(tmp_path), "opencode", update_ok=False)
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "Setup incomplete" in out
+        assert "Setup complete!" not in out
+
+    def test_update_ok_true_still_completes_normally(self, monkeypatch, tmp_path, capsys):
+        self._patch_common(monkeypatch)
+        monkeypatch.setattr(install, "setup_mcp_json", lambda *_: True)
+        monkeypatch.setattr(install, "setup_claude_settings_json", lambda *_: True)
+        monkeypatch.setattr(install, "setup_claude_settings", lambda *_: True)
+        monkeypatch.setattr(install, "register_plugin_with_claude", lambda: True)
+
+        install.main(str(tmp_path), "claude-code", update_ok=True)
+
+        out = capsys.readouterr().out
+        assert "Setup complete!" in out


### PR DESCRIPTION
## Summary
- `install.py`'s `__main__` block discarded `update_skill()`'s boolean return value, so a failed `git pull` (which already prints a distinct `ERROR: ...` line) was still followed by a misleading "✓ Setup complete!"
- `main()` now accepts an `update_ok: bool = True` parameter, folded into the existing success predicate alongside `checks`/`mcp_ok`/`settings_ok`/`plugin_ok` on both the claude-code and non-claude-code branches
- `__main__` captures `update_skill()`'s return value and threads it through; the `_sync_files`-only path (no update attempted) passes `update_ok=True` since nothing was attempted that could fail

Implements option (a) from the issue's own suggested fix (reflect the failure in final status). Option (b) (fall back to `_sync_files()` on a failed pull) was deliberately not implemented — that's an honest failure report instead of a silent stale-sync, and can be a follow-up if wanted.

## Test plan
- [x] 3 new tests in `TestMainHarnessGating` (`test_update_failure_marks_setup_incomplete_for_claude_code`, `..._for_non_claude_harness`, `test_update_ok_true_still_completes_normally`), all watched RED before the fix
- [x] Full suite: 812 passed (identical 116-failure pre-existing baseline before this change, confirmed via `git stash`/diff comparison — unrelated missing tree-sitter grammar packages)
- [x] `ruff`/`black`: identical pre-existing findings, nothing new
- [x] Independent code-review subagent dispatched — zero Critical/Important findings, "Ready to merge: Yes"

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL