### PR TITLE
Fix #191: content discarded entirely at a merge is silently lost

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4045,6 +4045,12 @@ def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
     is exactly the signal ("root or single-parent commit truly touched
     nothing" vs. "this is a merge commit, plain diff-tree always returns
     nothing regardless of content") this needs to distinguish.
+
+    On that merge path, _git_diff_tree_merge_missed_removals additionally
+    supplements --cc's own output with content genuinely discarded at the
+    merge (#191) -- present on exactly one parent's side and dropped
+    entirely during conflict resolution, which --cc's combined-diff
+    semantics can never surface (see that function's docstring).
     """
     result = _subprocess.run(
         ["git", "diff-tree", "--no-commit-id", "-r", "-M", "--raw", "--root", commit_hash],
@@ -4068,8 +4074,15 @@ def _git_diff_tree_raw(repo_path: str, commit_hash: str) -> List[tuple]:
         else:
             old_path, path = "", rest
         entries.append((status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity))
-    if not entries and len(_git_parent_hashes(repo_path, commit_hash)) > 1:
-        return _git_diff_tree_combined_raw(repo_path, commit_hash)
+    if not entries:
+        parent_hashes = _git_parent_hashes(repo_path, commit_hash)
+        if len(parent_hashes) > 1:
+            cc_entries = _git_diff_tree_combined_raw(repo_path, commit_hash)
+            cc_paths = {e[5] for e in cc_entries}
+            missed_removals = _git_diff_tree_merge_missed_removals(
+                repo_path, commit_hash, parent_hashes, cc_paths
+            )
+            return cc_entries + missed_removals
     return entries
 
 
@@ -4104,16 +4117,13 @@ def _git_diff_tree_combined_raw(repo_path: str, commit_hash: str) -> List[tuple]
     best-effort rename-matching heuristic (_extract_commit's
     old_entity_nodes), not the fact-extraction this issue is about.
 
-    Known residual gap (verified, not yet fixed -- see #185's follow-up):
-    --cc only reports a path when it differs from EVERY parent, so content
-    that exists on exactly one parent's side and is discarded entirely at
-    the merge (final tree matches the OTHER parent, which never had it)
-    never appears here either -- e.g. a submodule added on a feature branch
-    but dropped while resolving the merge leaves its `:pinned-commit` fact
-    open forever, since neither plain diff-tree nor --cc ever reports the
-    removal. Distinct root cause from the content-authored-at-merge case
-    this function fixes (that content is genuinely new; this content is
-    genuinely gone), so deliberately out of scope here.
+    Residual gap (--cc only reports a path when it differs from EVERY
+    parent, so content that exists on exactly one parent's side and is
+    discarded entirely at the merge -- final tree matches the OTHER parent,
+    which never had it -- never appears here) is covered by a separate
+    supplement, `_git_diff_tree_merge_missed_removals`, called from
+    `_git_diff_tree_raw` right after this function for every merge commit.
+    See #191 and that function's docstring.
     """
     result = _subprocess.run(
         ["git", "diff-tree", "--cc", "--no-commit-id", "-r", "--raw", "--root", commit_hash],
@@ -4142,6 +4152,92 @@ def _git_diff_tree_combined_raw(repo_path: str, commit_hash: str) -> List[tuple]
         else:
             status = "M"
         entries.append((status, old_modes[0], new_mode, old_shas[0], new_sha, path, "", None))
+    return entries
+
+
+def _git_diff_tree_merge_missed_removals(
+    repo_path: str, commit_hash: str, parent_hashes: List[str], already_reported_paths: Set[str],
+) -> List[tuple]:
+    """Recover paths whose content was discarded entirely while resolving a
+    merge (#191) -- present on exactly one parent's side, absent from the
+    merge's own final tree, and therefore invisible to both the plain
+    diff-tree call (always empty for any merge commit) and `--cc`'s combined
+    diff (which only reports a path when it differs from EVERY parent -- a
+    path absent from the final tree AND absent from some other parent
+    matches that other parent trivially, so --cc excludes it too; see
+    _git_diff_tree_combined_raw's docstring).
+
+    Only ever called as a supplement to _git_diff_tree_combined_raw's output
+    for a merge commit, with that output's paths passed in as
+    already_reported_paths so a path --cc already reported (e.g. a genuine
+    full removal, differing from every parent) is never double-counted.
+
+    For each parent Pi, diffing the merge commit directly against Pi's own
+    tree (mirroring what `-m` reports for that parent) surfaces every path
+    Pi had that the merge's final tree lacks, as an ordinary "D" row. Most of
+    these are NOT this issue's bug: the overwhelmingly common case is a path
+    that already existed back at the merge-base too, and was deleted by an
+    ordinary single-parent commit on some OTHER parent's own lineage --
+    `_git_commits`' plain walk already visited that commit directly and
+    reported the same "D" there, so re-reporting it here would double-close
+    an already-closed fact. The distinguishing test: was this path already
+    absent at the merge-base between Pi and every other parent? If so, the
+    removal is old news, already handled by that ordinary commit -- skip it.
+    Only a path that did NOT exist at any other-parent merge-base (i.e. it
+    was born strictly after the branches diverged, entirely on Pi's side,
+    and the merge simply never incorporated it) is the
+    never-recorded-elsewhere case #191 is about.
+
+    An octopus merge (>2 parents) is handled the same way, checking each
+    candidate path's history against every OTHER parent individually -- a
+    path only counts as genuinely new if it's absent at the merge-base with
+    ALL of them, not just one.
+    """
+    entries: List[tuple] = []
+    seen = set(already_reported_paths)
+    for i, parent in enumerate(parent_hashes):
+        other_parents = [p for j, p in enumerate(parent_hashes) if j != i]
+        if not other_parents:
+            continue
+        result = _subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "-r", "-M", "--raw", parent, commit_hash],
+            cwd=repo_path, capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            continue
+        for line in result.stdout.strip().splitlines():
+            if not line.startswith(":"):
+                continue
+            meta, sep, path = line.partition("\t")
+            if not sep:
+                continue
+            fields = meta[1:].split(" ")
+            if len(fields) < 5:
+                continue
+            old_mode, new_mode, old_sha, new_sha, status_field = fields[0], fields[1], fields[2], fields[3], fields[4]
+            if status_field[0] != "D" or path in seen:
+                continue
+            existed_elsewhere_at_divergence = False
+            for other in other_parents:
+                mb = _subprocess.run(
+                    ["git", "merge-base", parent, other],
+                    cwd=repo_path, capture_output=True, text=True,
+                )
+                base = mb.stdout.strip() if mb.returncode == 0 else ""
+                if not base:
+                    existed_elsewhere_at_divergence = True  # no common ancestor -- be conservative
+                    break
+                check = _subprocess.run(
+                    ["git", "cat-file", "-e", f"{base}:{path}"],
+                    cwd=repo_path, capture_output=True,
+                )
+                if check.returncode == 0:
+                    existed_elsewhere_at_divergence = True
+                    break
+            if existed_elsewhere_at_divergence:
+                continue
+            seen.add(path)
+            entries.append(("D", old_mode, new_mode, old_sha, new_sha, path, "", None))
     return entries
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5850,6 +5850,82 @@ class TestGitDiffTreeRawMergeCommits:
 
         assert call_count["n"] == 0, "expected zero _git_parent_hashes calls for an ordinary non-empty commit"
 
+    def test_content_discarded_entirely_at_merge_is_recovered(self, tmp_path):
+        """See #191: a file added on ONE branch only, never touched on the
+        other, whose content is deliberately dropped while resolving the
+        merge -- the final tree matches the branch that never had the file
+        at all. Neither plain diff-tree nor --cc report anything for this
+        commit (both documented as the residual gap in #185's fix), so
+        without the new supplement this file's facts would never close."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        self._init_repo(repo)
+
+        (repo / "base.py").write_text("x = 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "-b", "side"], cwd=repo, check=True, capture_output=True)
+        (repo / "dropped.py").write_text("y = 2\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add dropped.py"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+        # main never touches dropped.py -- clean merge, then hand-remove the
+        # file before completing the merge commit.
+        _subprocess.run(["git", "merge", "side", "--no-ff", "--no-commit"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "rm", "-f", "dropped.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "merge side, drop dropped.py"], cwd=repo, check=True, capture_output=True)
+
+        merge_hash = _subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert len(mcp_server._git_parent_hashes(str(repo), merge_hash)) == 2
+
+        entries = mcp_server._git_diff_tree_raw(str(repo), merge_hash)
+        assert len(entries) == 1
+        status, old_mode, new_mode, old_sha, new_sha, path, old_path, similarity = entries[0]
+        assert path == "dropped.py"
+        assert status == "D"
+
+    def test_deletion_already_handled_by_ordinary_commit_is_not_double_reported(self, tmp_path):
+        """Regression guard: a file that existed before the branches diverged,
+        deleted by an ORDINARY single-parent commit on one lineage and left
+        untouched on the other, is a plain clean merge -- `_git_commits`'
+        walk already visited the deleting commit directly and reported its
+        "D" there. The new per-parent supplement must recognize the path was
+        already absent at the merge-base and NOT report it a second time."""
+        import mcp_server
+        repo = tmp_path / "repo"
+        self._init_repo(repo)
+
+        (repo / "shared.py").write_text("x = 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "-b", "side"], cwd=repo, check=True, capture_output=True)
+        (repo / "side_only.py").write_text("y = 2\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "add side_only.py"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "rm", "-f", "shared.py"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "remove shared.py"], cwd=repo, check=True, capture_output=True)
+
+        merge_result = _subprocess.run(
+            ["git", "merge", "side", "--no-ff", "-m", "merge side"],
+            cwd=repo, capture_output=True, text=True,
+        )
+        assert merge_result.returncode == 0, "expected a clean, non-conflicting merge"
+
+        merge_hash = _subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        assert len(mcp_server._git_parent_hashes(str(repo), merge_hash)) == 2
+
+        entries = mcp_server._git_diff_tree_raw(str(repo), merge_hash)
+        assert entries == [], "shared.py's removal was already reported by the ordinary deleting commit"
+
 
 class TestIsIgnoredPath:
     def test_directory_pattern_matches_nested_path(self):
@@ -11895,6 +11971,60 @@ class TestRunIngestionGitlinks:
             "removed submodule's :path must be closed (issue #137)"
 
         mcp_server._db = None  # release the real file lock for subsequent tests
+
+    @pytest.mark.asyncio
+    async def test_submodule_discarded_entirely_at_merge_closes_pinned_commit(self, tmp_path):
+        """Issue #191's exact repro: a submodule added on `side` (never touched
+        by `main`), then removed entirely while resolving the merge -- the
+        final tree matches `main`, which never had the submodule at all.
+        Pre-fix, neither plain diff-tree nor --cc ever report this removal,
+        so the :pinned-commit fact opened by the add commit stayed open
+        forever even though the submodule doesn't exist in the repo from the
+        merge commit onward. Verified against the REAL minigraf backend.
+        """
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "base.py").write_text("x = 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True, capture_output=True)
+
+        _subprocess.run(["git", "checkout", "-b", "side"], cwd=repo, check=True, capture_output=True)
+        sub_hash = self._add_submodule_commit(repo, path="modules/lib", name="lib")
+
+        _subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+        # main never touches modules/lib -- clean merge, then hand-remove the
+        # submodule (and .gitmodules) before completing the merge commit.
+        _subprocess.run(["git", "merge", "side", "--no-ff", "--no-commit"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "rm", "-f", "modules/lib", ".gitmodules"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(
+            ["git", "commit", "-m", "merge side, drop submodule during resolution"],
+            cwd=repo, check=True, capture_output=True,
+        )
+
+        mcp_server._db = None
+        mcp_server._graph_path = None
+        mcp_server.open_db(str(repo / "memory.graph"))
+        mcp_server._ingest_progress = self._make_progress()
+        try:
+            await mcp_server._run_ingestion(str(repo), "HEAD")
+
+            db = mcp_server.get_db()
+            real_execute = mcp_server._db_execute
+
+            def count(attr, value):
+                raw = real_execute(db, f"(query [:find ?e :where [?e {attr} {value}]])")
+                return len(json.loads(raw).get("results", []))
+
+            assert count(":pinned-commit", f'"{sub_hash}"') == 0, \
+                "pinned-commit must be closed once the submodule is discarded at the merge (#191)"
+            assert count(":entity-type", ":type/external-dependency") == 0, \
+                "the submodule's external-dependency entity must be closed too"
+        finally:
+            mcp_server._db = None
 
 
 class TestSubmoduleDependencyLinking:


### PR DESCRIPTION
## Summary
- `--cc` only reports a path when it differs from EVERY parent, so a file added on one branch and discarded entirely while resolving a merge (final tree matches the other parent, which never had it) was invisible to both plain `diff-tree` and `--cc` — e.g. a removed submodule's `:pinned-commit` fact stayed open forever, and non-gitlink module/function/class facts never closed either.
- Adds `_git_diff_tree_merge_missed_removals`, a supplement run after `--cc` for every merge commit: it diffs the merge directly against each parent (mirroring `-m`'s per-parent output), and for each "D" row not already reported by `--cc`, checks whether the path existed at the merge-base between that parent and every other parent. If it did, the removal is old news already handled by an ordinary single-parent commit `_git_commits`' own walk visited directly — skip it (avoids double-closing an already-closed fact). Only a path that was born strictly after the branches diverged, and never made it into the final tree, is reported.

## Test plan
- [x] New unit tests in `TestGitDiffTreeRawMergeCommits`: the issue's repro (content discarded at merge is now recovered as `D`) and a regression guard (an ordinary already-handled clean-merge deletion is not double-reported).
- [x] New end-to-end test in `TestRunIngestionGitlinks` reproducing the issue's exact submodule scenario via `_run_ingestion`, verified against the real minigraf backend that `:pinned-commit` and `:entity-type` actually close.
- [x] Full suite: `pytest tests/test_mcp_server.py` — 686 passed.
- [x] `ruff check mcp_server.py` clean.

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL