### PR TITLE
Fix #198: _unwrap_facts_block_token doesn't unescape captured string values

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3316,11 +3316,11 @@ _TAGGED_LITERAL_PATTERN = re.compile(r'#(?:uuid|inst)\s+"([^"\\]*)"')
 
 def _unwrap_facts_block_token(raw: str) -> str:
     """Strip quoting/tagging from a captured entity or value token: a quoted
-    string loses its quotes, a #uuid/#inst "..." literal loses the tag and
-    keeps the raw UUID/timestamp text, anything else (keyword, number) is
-    kept as-is."""
+    string loses its quotes and has its EDN escaping reversed (\\" -> ",
+    \\\\ -> \\), a #uuid/#inst "..." literal loses the tag and keeps the raw
+    UUID/timestamp text, anything else (keyword, number) is kept as-is."""
     if raw.startswith('"'):
-        return raw[1:-1]
+        return _edn_unescape(raw[1:-1])
     m = _TAGGED_LITERAL_PATTERN.match(raw)
     if m:
         return m.group(1)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1105,6 +1105,24 @@ class TestParseFactsBlock:
             ),
         ]
 
+    def test_string_value_with_embedded_escaped_quote_is_unescaped(self):
+        import mcp_server
+        result = mcp_server._parse_facts_block(
+            r'[:decision/x :description "he said \"hello\" to me"]'
+        )
+        assert result == [
+            (":decision/x", ":description", 'he said "hello" to me'),
+        ]
+
+    def test_string_value_with_escaped_backslash_is_unescaped(self):
+        import mcp_server
+        result = mcp_server._parse_facts_block(
+            r'[:decision/x :path "C:\\Users\\x"]'
+        )
+        assert result == [
+            (":decision/x", ":path", r"C:\Users\x"),
+        ]
+
 
 class TestTransactRetractChokePoint:
     def test_transact_writes_to_index(self, real_db, tmp_path):


### PR DESCRIPTION
## Summary
- `_parse_facts_block` (populates the FTS fact index) unquoted captured string values but never reversed EDN escaping, so a fact value containing an embedded quote or backslash was indexed with literal `\"`/`\\` still in it — polluting retrieval-index text (not a graph-level bug).
- Fixed by routing the quoted-string branch of `_unwrap_facts_block_token` through the existing `_edn_unescape` helper (added for #181, used identically by `_parse_transact_facts`).
- No change needed for the `#uuid`/`#inst`-tagged branch — its capturing regex structurally disallows escapable content.

Fixes #198

## Test plan
- [x] 2 new tests in `TestParseFactsBlock` (embedded escaped quote, escaped backslash), watched RED against pre-fix code
- [x] Full suite: 817 passed, no regressions
- [x] `ruff`/`black`: identical pre-existing findings, nothing new (confirmed via throwaway worktree diff)
- [x] Independent code-review subagent dispatched: zero Critical/Important/Minor findings, "Ready to merge: yes" — verified RED→GREEN manually, checked no other callers depend on old unescaped behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL