### PR TITLE
Fix #205: extract defmacro/defguard/defdelegate in Elixir AST

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -344,7 +344,7 @@ _LANG_NODE_TYPES: Dict[str, Dict[str, set]] = {
         # lang_name == "elixir" entirely and never consult these two sets
         # (see #170). "imports" is still consulted only indirectly, via the
         # same elixir-specific branch's fallback to _extract_import_name.
-        "functions": {"def", "defp"},
+        "functions": {"def", "defp", "defmacro", "defmacrop", "defguard", "defguardp", "defdelegate"},
         "classes": {"defmodule"},
         "imports": {"call"},
         "calls": set(),
@@ -562,15 +562,20 @@ def _elixir_defmodule_name(node) -> Optional[str]:
 
 
 def _elixir_def_function_name(node) -> Optional[str]:
-    """Return the function name from a `def`/`defp` call node's `arguments`.
+    """Return the function name from a def/defmacro/defguard/defdelegate-family
+    call node's `arguments` (`def`, `defp`, `defmacro`, `defmacrop`, `defguard`,
+    `defguardp`, `defdelegate` -- all parse to this identical `call` shape, #205).
 
-    `def bar do` -> arguments' sole named child is a bare `identifier` (no
-    parens, zero-arg). `def bar(x, y) do` -> arguments' sole named child is a
+    `def bar do` -> arguments' first named child is a bare `identifier` (no
+    parens, zero-arg). `def bar(x, y) do` -> arguments' first named child is a
     `call` node (the parenthesized parameter list itself parses as a nested
     call expression) whose own target identifier is the function name. A
-    guard clause (`def bar(x) when x > 0 do`) wraps that call one level
-    deeper in a `binary_operator` chain (`field:operator` text "when") --
-    descend its `field:left` to reach the same call node.
+    guard clause (`def bar(x) when x > 0 do`, or any `defguard`/`defguardp`,
+    which always carries one) wraps that call one level deeper in a
+    `binary_operator` chain (`field:operator` text "when") -- descend its
+    `field:left` to reach the same call node. `defdelegate qux(x), to: Other`
+    has a second named child (the `to:` keyword pair) that's ignored since
+    only the first named child is inspected.
     """
     arguments = next((c for c in node.children if c.type == "arguments"), None)
     if arguments is None:
@@ -809,12 +814,14 @@ def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
     module cares about (functions, classes, imports, calls).
 
     Elixir bypasses the generic node_types-driven dispatch below entirely:
-    `defmodule`/`def`/`defp`/`alias`/`import`/`use`/`require` (and every
-    ordinary function call) all parse as the *same* generic `call` node type
-    in the real tree-sitter-elixir grammar — there is no dedicated
-    `defmodule`/`def`/`defp` node type to match against, the way
-    `_LANG_NODE_TYPES["elixir"]` used to assume (#170). Disambiguation
-    requires inspecting the call's target identifier text instead.
+    `defmodule`/`def`/`defp`/`defmacro`/`defmacrop`/`defguard`/`defguardp`/
+    `defdelegate`/`alias`/`import`/`use`/`require` (and every ordinary
+    function call) all parse as the *same* generic `call` node type in the
+    real tree-sitter-elixir grammar — there is no dedicated `defmodule`/`def`/
+    `defp` node type to match against, the way `_LANG_NODE_TYPES["elixir"]`
+    used to assume (#170, extended to the macro/guard/delegate forms in #205).
+    Disambiguation requires inspecting the call's target identifier text
+    instead.
     """
     if lang_name == "elixir":
         if node.type == "call":
@@ -823,7 +830,10 @@ def _walk_ast(node, results: Dict[str, List[str]], lang_name: str) -> None:
                 name = _elixir_defmodule_name(node)
                 if name:
                     results["classes"].append(name)
-            elif target_text in ("def", "defp"):
+            elif target_text in (
+                "def", "defp", "defmacro", "defmacrop",
+                "defguard", "defguardp", "defdelegate",
+            ):
                 name = _elixir_def_function_name(node)
                 if name:
                     results["functions"].append(name)
@@ -2891,7 +2901,10 @@ def _collect_entity_nodes(root_node: Any, lang_name: str) -> Dict[str, Dict[str,
                     name = _elixir_defmodule_name(node)
                     if name:
                         result["class"][name] = node
-                elif target_text in ("def", "defp"):
+                elif target_text in (
+                    "def", "defp", "defmacro", "defmacrop",
+                    "defguard", "defguardp", "defdelegate",
+                ):
                     name = _elixir_def_function_name(node)
                     if name:
                         result["function"][name] = node

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4769,6 +4769,69 @@ class TestElixirFunctionsAndClasses:
         assert result["functions"] == ["bar"]
         assert result["imports"] == ["MyApp.Router"]
 
+    def test_walk_ast_extracts_defmacro_and_defmacrop(self):
+        # Regression test for #205: defmacro/defmacrop parse as the same
+        # generic `call` node as def/defp (same bug class as #170) and were
+        # silently dropped because the elixir dispatch only matched
+        # ("def", "defp").
+        import mcp_server
+        source = (
+            b"defmodule Foo do\n"
+            b"  defmacro pub_macro(x) do\n"
+            b"    x\n"
+            b"  end\n\n"
+            b"  defmacrop priv_macro do\n"
+            b"    :ok\n"
+            b"  end\n"
+            b"end\n"
+        )
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "elixir")
+        assert sorted(results["functions"]) == ["priv_macro", "pub_macro"]
+
+    def test_walk_ast_extracts_defguard_and_defguardp(self):
+        # defguard/defguardp always carry a `when` guard clause, so the name
+        # is nested inside a binary_operator -- same shape _elixir_def_function_name
+        # already unwraps for `def bar(x) when x > 0 do`.
+        import mcp_server
+        source = (
+            b"defmodule Foo do\n"
+            b"  defguard is_pos(x) when x > 0\n\n"
+            b"  defguardp is_priv(x) when x > 0\n"
+            b"end\n"
+        )
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "elixir")
+        assert sorted(results["functions"]) == ["is_pos", "is_priv"]
+
+    def test_walk_ast_extracts_defdelegate(self):
+        # `defdelegate qux(x), to: Other` -- the arguments field's first
+        # named child is the `call` node for `qux(x)`; the trailing `to:`
+        # keyword pair is a second named child that must be ignored.
+        import mcp_server
+        source = b"defmodule Foo do\n  defdelegate qux(x), to: Other\nend\n"
+        tree = self._parser().parse(source)
+        results = {"functions": [], "classes": [], "imports": [], "calls": []}
+        mcp_server._walk_ast(tree.root_node, results, "elixir")
+        assert results["functions"] == ["qux"]
+
+    def test_collect_entity_nodes_extracts_defmacro_and_defguard(self):
+        import mcp_server
+        source = (
+            b"defmodule Foo do\n"
+            b"  defmacro bar(x) do\n"
+            b"    x\n"
+            b"  end\n\n"
+            b"  defguard is_pos(x) when x > 0\n"
+            b"end\n"
+        )
+        tree = self._parser().parse(source)
+        result = mcp_server._collect_entity_nodes(tree.root_node, "elixir")
+        assert "bar" in result["function"]
+        assert "is_pos" in result["function"]
+
 
 class TestMatchCandidatePair:
     def _parse(self, source: str):


### PR DESCRIPTION
## Summary
- `defmodule`/`def`/`defp`/`defmacro`/`defmacrop`/`defguard`/`defguardp`/`defdelegate` all parse as the same generic `call` node in the real tree-sitter-elixir grammar. #170 fixed dispatch for `def`/`defp` but left the macro/guard/delegate forms unmatched, so they silently fell through and were dropped from structural extraction (e.g. `defmacro bar do ... end` produced `functions: []`).
- Verified empirically against `tree_sitter_elixir` that all five additional forms share `def`/`defp`'s exact `arguments` shape (bare identifier / nested `call` / `when`-guard `binary_operator`), so `_elixir_def_function_name` is reused unchanged.
- Extended the two elixir-specific dispatch sites (`_walk_ast`, `_collect_entity_nodes` in `mcp_server.py`) to also match the new keywords, tagged as `:function` entities — matching the issue's stated simplest option (macro/guard/delegate distinct entity types left out of scope).

## Test plan
- [x] Added failing tests first (RED) for `defmacro`/`defmacrop`, `defguard`/`defguardp`, and `defdelegate` (including its trailing `to:` keyword argument) across both `_walk_ast` and `_collect_entity_nodes`
- [x] Confirmed tests fail for the right reason (feature missing) before the fix
- [x] Implemented minimal fix, tests now pass (GREEN)
- [x] Full suite: `pytest tests/test_mcp_server.py -q` → 692 passed

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL