### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "temporal-reasoning",
       "description": "Temporal Reasoning gives AI coding agents bi-temporal graph memory: query any past state, traverse live dependency graphs, and correlate architectural decisions with structural change — all with deterministic Datalog, no fuzzy retrieval.",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "temporal-reasoning",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Temporal Reasoning gives AI coding agents bi-temporal graph memory: query any past state, traverse live dependency graphs, and correlate architectural decisions with structural change — all with deterministic Datalog, no fuzzy retrieval.",
   "author": {
     "name": "Minigraf"


### PR DESCRIPTION
## Summary
- Bumps `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` version to 0.6.0, in sync
- This release batches 20+ bug fixes since v0.5.4 (181 commits): AST extraction fixes for Elixir, Lua, Go, Java, Kotlin, Swift, PHP, Haskell; ingestion fixes (gitlink ignore patterns, merge content loss); MCP server fixes (tx result parsing, audit exception swallowing, LLM extraction blocking the event loop); lock file safety; and more

## Test plan
- [ ] CI green
- [ ] After merge: `git tag v0.6.0 && git push origin v0.6.0` to trigger the PyPI release workflow

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL