### PR TITLE
Fix #220: prepare_turn nudge toward code-graph navigation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -192,6 +192,12 @@ memory_prepare_turn(user_message="what database did we decide on?")
 # → "Relevant memory context:\n  :name | PostgreSQL 15\n  :role | primary database"
 ```
 
+On build/fix/navigate-shaped messages (verbs like add/implement/build/fix/debug/refactor,
+or phrasings like "where is"/"how does", combined with a code-ish noun), and only once the
+repo has an ingested code graph, the block also gets a one-line nudge toward
+`minigraf_query`-based navigation — see "[Using ingested code structure to scope a
+change](#using-ingested-code-structure-to-scope-a-change)" below.
+
 ### memory_finalize_turn
 
 Call at the **end** of each turn. Extracts durable facts from the completed exchange and stores them.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5361,7 +5361,9 @@ async def _run_startup_backfill() -> None:
 
 
 _NAV_TASK_VERBS = re.compile(
-    r"\b(?:add|implement|build|fix|debug|refactor)\b", re.IGNORECASE
+    r"\b(?:add(?:ing|ed|s)?|implement(?:ing|ed|s)?|build(?:ing|s)?|built|"
+    r"fix(?:ing|ed|es)?|debug(?:ging|ged|s)?|refactor(?:ing|ed|s)?)\b",
+    re.IGNORECASE,
 )
 _NAV_TASK_PHRASES = re.compile(
     r"\b(?:where\s+is|where's|how\s+does|how\s+do)\b", re.IGNORECASE
@@ -5383,7 +5385,8 @@ _NAV_NUDGE = (
 
 def _looks_like_navigation_task(user_message: str) -> bool:
     """Heuristic match for a build/fix/navigate task shape (#220): a task
-    verb (add/implement/build/fix/debug/refactor) or a navigation phrase
+    verb (add/implement/build/fix/debug/refactor, including common
+    inflections like "fixing"/"fixed"/"debugged") or a navigation phrase
     (where is/how does) combined with a code-ish noun -- the noun
     requirement keeps everyday phrasing that happens to share a verb (e.g.
     "fix dinner") from triggering the nudge.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5360,10 +5360,45 @@ async def _run_startup_backfill() -> None:
         _db = None
 
 
+_NAV_TASK_VERBS = re.compile(
+    r"\b(?:add|implement|build|fix|debug|refactor)\b", re.IGNORECASE
+)
+_NAV_TASK_PHRASES = re.compile(
+    r"\b(?:where\s+is|where's|how\s+does|how\s+do)\b", re.IGNORECASE
+)
+_NAV_TASK_NOUNS = re.compile(
+    r"\b(?:code|function|method|class|module|file|bug|feature|endpoint|api|"
+    r"service|component|test|logic|handler|query|database|schema|route|"
+    r"script|implementation)\b",
+    re.IGNORECASE,
+)
+
+_NAV_NUDGE = (
+    'This repo has an ingested code graph. Consider minigraf_query for impact '
+    '(reverse :depends-on plus the reachable rule) and co-change precedent '
+    '(shared :introduced-by/:modified-in commits) before diving in -- see '
+    'SKILL.md\'s "Using ingested code structure to scope a change" section.'
+)
+
+
+def _looks_like_navigation_task(user_message: str) -> bool:
+    """Heuristic match for a build/fix/navigate task shape (#220): a task
+    verb (add/implement/build/fix/debug/refactor) or a navigation phrase
+    (where is/how does) combined with a code-ish noun -- the noun
+    requirement keeps everyday phrasing that happens to share a verb (e.g.
+    "fix dinner") from triggering the nudge.
+    """
+    if not (_NAV_TASK_VERBS.search(user_message) or _NAV_TASK_PHRASES.search(user_message)):
+        return False
+    return bool(_NAV_TASK_NOUNS.search(user_message))
+
+
 def handle_memory_prepare_turn(user_message: str) -> str:
     """Query the persisted fact index for facts relevant to the user message,
     including labeled historical (retracted/superseded) facts -- the index
     is the entry point into history, the bi-temporal graph is the archive.
+    Also appends a lightweight code-graph navigation nudge (#220) on
+    build/fix/navigate-shaped messages, gated on ingestion being present.
 
     Returns a formatted context block string for injection as
     additionalContext, or an empty string if no relevant facts are found.
@@ -5377,6 +5412,7 @@ def handle_memory_prepare_turn(user_message: str) -> str:
     boost = float(os.environ.get("MINIGRAF_MEMORY_BOOST", "2.0"))
     historical_discount = float(os.environ.get("MINIGRAF_HISTORICAL_DISCOUNT", "0.5"))
     path = fact_index.index_path_for(_graph_path or _get_graph_path())
+    memory_block = ""
     try:
         if fact_index.needs_backfill(path):
             _rebuild_index_from_graph()
@@ -5384,12 +5420,20 @@ def handle_memory_prepare_turn(user_message: str) -> str:
             path, user_message, top_n=scan_limit, boost=boost,
             historical_discount=historical_discount,
         )
+        if results:
+            memory_block = f"Relevant memory context:\n{_format_facts(results)}"
     except Exception as e:
         print(f"[fact_index] prepare_turn failed: {e}", file=sys.stderr)
-        return ""
-    if not results:
-        return ""
-    return f"Relevant memory context:\n{_format_facts(results)}"
+
+    nav_nudge = ""
+    if _looks_like_navigation_task(user_message):
+        try:
+            if _count_commit_entities(get_db()) > 0:
+                nav_nudge = _NAV_NUDGE
+        except Exception as e:
+            print(f"[prepare_turn] navigation nudge check failed: {e}", file=sys.stderr)
+
+    return "\n\n".join(part for part in (memory_block, nav_nudge) if part)
 
 
 # ---------------------------------------------------------------------------
@@ -7699,7 +7743,10 @@ _TOOLS: List[Tool] = [
         description=(
             "Retrieve relevant memory context for the current user message. "
             "Call this at the START of every turn, before reading the user's message. "
-            "Returns a context block string to prepend to your working context."
+            "Returns a context block string to prepend to your working context. "
+            "On build/fix/navigate-shaped messages, also appends a one-line nudge "
+            "toward minigraf_query-based code-graph navigation when the repo has "
+            "an ingested graph."
         ),
         inputSchema={
             "type": "object",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10478,6 +10478,16 @@ class TestLooksLikeNavigationTask:
         assert mcp_server._looks_like_navigation_task("where is the caching logic?")
         assert mcp_server._looks_like_navigation_task("how does the query handler work")
 
+    def test_inflected_task_verb_with_code_noun_matches(self):
+        import mcp_server
+        assert mcp_server._looks_like_navigation_task("I've been fixing the login bug")
+        assert mcp_server._looks_like_navigation_task("just fixed the query handler")
+        assert mcp_server._looks_like_navigation_task("debugging the auth module now")
+        assert mcp_server._looks_like_navigation_task("we refactored the test file")
+        assert mcp_server._looks_like_navigation_task("added a new API endpoint")
+        assert mcp_server._looks_like_navigation_task("implementing the schema module")
+        assert mcp_server._looks_like_navigation_task("built a caching component")
+
     def test_task_verb_without_code_noun_does_not_match(self):
         import mcp_server
         assert not mcp_server._looks_like_navigation_task("let's fix dinner tonight")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10464,6 +10464,83 @@ class TestHandleMemoryPrepareTurnFts5:
         assert ":module/old-cache" in result
 
 
+class TestLooksLikeNavigationTask:
+    """Heuristic verb/phrase + code-noun match for #220's lightweight nudge."""
+
+    def test_task_verb_with_code_noun_matches(self):
+        import mcp_server
+        assert mcp_server._looks_like_navigation_task("fix the login bug")
+        assert mcp_server._looks_like_navigation_task("please implement a new auth module")
+        assert mcp_server._looks_like_navigation_task("let's refactor this function")
+
+    def test_navigation_phrase_with_code_noun_matches(self):
+        import mcp_server
+        assert mcp_server._looks_like_navigation_task("where is the caching logic?")
+        assert mcp_server._looks_like_navigation_task("how does the query handler work")
+
+    def test_task_verb_without_code_noun_does_not_match(self):
+        import mcp_server
+        assert not mcp_server._looks_like_navigation_task("let's fix dinner tonight")
+        assert not mcp_server._looks_like_navigation_task("we should build a sandcastle")
+
+    def test_code_noun_without_task_verb_does_not_match(self):
+        import mcp_server
+        assert not mcp_server._looks_like_navigation_task("the module looks fine to me")
+
+    def test_unrelated_message_does_not_match(self):
+        import mcp_server
+        assert not mcp_server._looks_like_navigation_task("what's the weather like today?")
+
+
+class TestHandleMemoryPrepareTurnNavigationNudge:
+    """#220: memory_prepare_turn appends a one-line code-graph navigation nudge
+    on build/fix/navigate-shaped messages, gated on ingestion being present."""
+
+    def test_nudge_appended_when_task_shaped_and_ingestion_present(self, real_db, monkeypatch):
+        import mcp_server
+        monkeypatch.setattr(mcp_server, "_count_commit_entities", lambda db: 5)
+        result = mcp_server.handle_memory_prepare_turn("fix the login bug")
+        assert "minigraf_query" in result
+        assert "Using ingested code structure to scope a change" in result
+
+    def test_no_nudge_when_task_shaped_but_no_ingestion(self, real_db, monkeypatch):
+        import mcp_server
+        monkeypatch.setattr(mcp_server, "_count_commit_entities", lambda db: 0)
+        result = mcp_server.handle_memory_prepare_turn("fix the login bug")
+        assert result == ""
+
+    def test_no_nudge_when_ingestion_present_but_not_task_shaped(self, real_db, monkeypatch):
+        import mcp_server
+        monkeypatch.setattr(mcp_server, "_count_commit_entities", lambda db: 5)
+        result = mcp_server.handle_memory_prepare_turn("what's the weather like today?")
+        assert result == ""
+
+    def test_nudge_combined_with_memory_context(self, real_db, monkeypatch):
+        import mcp_server
+        monkeypatch.setattr(mcp_server, "_count_commit_entities", lambda db: 5)
+        mcp_server.handle_minigraf_transact(
+            '[[:decision/use-redis :description "use redis for caching"]]', reason="test"
+        )
+        result = mcp_server.handle_memory_prepare_turn("fix the redis caching bug")
+        assert "Relevant memory context:" in result
+        assert "use redis for caching" in result
+        assert "minigraf_query" in result
+
+    def test_nudge_check_failure_does_not_break_memory_context(self, real_db, monkeypatch):
+        import mcp_server
+
+        def _boom(db):
+            raise RuntimeError("simulated ingestion-check failure")
+
+        monkeypatch.setattr(mcp_server, "_count_commit_entities", _boom)
+        mcp_server.handle_minigraf_transact(
+            '[[:decision/use-redis :description "use redis for caching"]]', reason="test"
+        )
+        result = mcp_server.handle_memory_prepare_turn("fix the redis caching bug")
+        assert "use redis for caching" in result
+        assert "minigraf_query" not in result
+
+
 class TestIndexCacheInvalidation:
     def test_successful_transact_triggers_invalidation(self, real_db):
         import mcp_server


### PR DESCRIPTION
## Summary
- `memory_prepare_turn` now appends a one-line nudge toward `minigraf_query`-based navigation (blast-radius via reverse `:depends-on` + the `reachable` rule, co-change precedent via shared `:introduced-by`/`:modified-in` commits) on build/fix/navigate-shaped user messages
- Gated on the graph actually having ingested commits (`_count_commit_entities > 0`), so it's silent on a fresh/ungrafted repo
- Heuristic requires a task verb/phrase (add/implement/build/fix/debug/refactor, "where is"/"how does") **plus** a code-ish noun, to avoid false positives on unrelated phrasing that happens to share a verb (e.g. "fix dinner")
- Points at the SKILL.md section #219 added ("Using ingested code structure to scope a change")
- Ships the lightweight tier only, per the issue's own "ship the nudge first" scope note — no structural query execution, no ranked-result injection

Closes #220

## Test plan
- [x] New `TestLooksLikeNavigationTask` unit tests for the heuristic (verb+noun, phrase+noun, verb-without-noun, noun-without-verb, unrelated)
- [x] New `TestHandleMemoryPrepareTurnNavigationNudge` integration tests against `real_db` (nudge fires when task-shaped + ingestion present; suppressed when either condition is missing; combines correctly with existing memory-context block; nudge-check failure doesn't break memory-context retrieval)
- [x] Full existing `TestHandleMemoryPrepareTurnFts5` + `TestMcpToolWiring` suites pass unchanged (one pre-existing unrelated failure, `test_call_tool_memory_finalize_turn`, reproduces identically on master)
- [x] Full suite: 690 passed (680 baseline + 10 new), 120 pre-existing failures (missing tree-sitter grammars, unchanged), 48 skipped
- [x] `ruff`/`black`: identical pre-existing findings before/after, nothing new
- [x] Independent code-review subagent (opus): Ready to merge — zero Critical/Important findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL