### PR TITLE
Add provisional/authoritative lineage fact model (#222 phase 2a)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-lineage-provisional-fact-model.md
+++ b/docs/superpowers/plans/2026-07-24-lineage-provisional-fact-model.md
@@ -1,0 +1,719 @@
+# Provisional/Authoritative Lineage Fact Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build sub-phase 2a of #222's phase 2: the provisional/authoritative lineage fact model and candidate-diff persistence primitives. No caller yet — 2b (Stream 2's walk) writes with these, 2c (Stream 1's correction sweep) reads/clears with them, 2d wires concurrency.
+
+**Architecture:** All new persistence functions live in `mcp_server.py`, following the exact query-before-write idempotent pattern `_watermark_update`/`_frontier_persist_claim` already established. Two new entity types (`:type/lineage-marker`, `:type/candidate-diff`) are deliberately unregistered in `MINIGRAF_SCHEMA` — safe from `minigraf_audit`'s sweep since it only iterates known types — but every write MUST go through the internal `_transact`/`_retract` helpers directly, never the public `handle_minigraf_transact`/`handle_minigraf_retract` MCP handlers, whose own write-time validation gate would reject an unregistered type outright. One new watermark entity (`:ingestion/lineage-confirmed-through`) deliberately *is* registered (`:type/ingestion`, same as `:ingestion/watermark`) and must carry the same required `:description` constant.
+
+**Tech Stack:** Python 3, minigraf Datalog (via existing `_db_execute`/`_transact`/`_retract`/`_edn_escape` helpers), pytest.
+
+## Global Constraints
+
+- Design spec: `docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md` (revised 4 times after review — every fix in it is binding, not just the final prose). In particular:
+  - `:type/lineage-marker` and `:type/candidate-diff` are **not** added to `MINIGRAF_SCHEMA` — do not add them there.
+  - Every new persistence function must call internal `_transact`/`_retract` directly — never `handle_minigraf_transact`/`handle_minigraf_retract`.
+  - Every new write is idempotent via query-before-write (read current state, no-op if unchanged, retract-then-reassert only if it genuinely differs) — never a blind unconditional transact.
+  - `:ingestion/lineage-confirmed-through` uses entity-type `:type/ingestion` (registered, audited) and must carry the same `:entity-type`/`:ident`/`:description` constants pattern `_watermark_update` uses.
+- Follow `docs/testing-conventions.md`: every test uses a real `MiniGrafDb` (`real_db` fixture), never mocked.
+- Phase 2a only. Do not wire any of these functions into `_run_ingestion`'s actual commit loop or into `_frontier_seed_from_watermark`'s existing migration branch — the one exception is a single new call added to `_frontier_load` (Task 3), which is this sub-phase's only change to existing code.
+
+---
+
+### Task 1: Provisional lineage marker (`_lineage_mark_provisional` / `_lineage_confirm` / `_lineage_is_provisional`)
+
+**Files:**
+- Modify: `mcp_server.py` — insert after `_frontier_persist_claim` (currently ends at line 5017, immediately before `_LAST_RUN_KEYWORD_ATTRS` at line 5020).
+- Test: `tests/test_mcp_server.py` — new `TestLineageProvisionalMarker` class.
+
+**Interfaces:**
+- Consumes: `_db_execute(db, datalog) -> str`, `_transact(db, datalog_facts, valid_from, index_con=None) -> str`, `_retract(db, datalog_facts, index_con=None) -> str` (all pre-existing).
+- Produces:
+  - `_LINEAGE_MARKER_ENTITY_TYPE: str = ":type/lineage-marker"`
+  - `_lineage_marker_ident(entity_ident: str) -> str`
+  - `_lineage_mark_provisional(db, entity_ident: str, commit_ts_iso: str, index_con=None) -> None`
+  - `_lineage_confirm(db, entity_ident: str, index_con=None) -> None`
+  - `_lineage_is_provisional(db, entity_ident: str) -> bool`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add near the top of `tests/test_mcp_server.py`, alongside other module-level imports if not already present (check first — `import frontier_registry` was added in phase 1's Task 3):
+
+```python
+import frontier_registry
+```
+
+Add this test class (e.g. right after the existing `TestFrontierPersistClaim` class, currently ending around line 6086, before `TestGitCommitsTopoOrder`):
+
+```python
+class TestLineageProvisionalMarker:
+    def test_unmarked_entity_reads_as_authoritative(self, real_db):
+        import mcp_server
+        db = real_db
+        assert mcp_server._lineage_is_provisional(db, ":function/src-auth-py-login") is False
+
+    def test_mark_then_confirm_round_trip(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._lineage_mark_provisional(db, entity_ident, "2026-01-01T00:00:00Z")
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is True
+
+        mcp_server._lineage_confirm(db, entity_ident)
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is False
+
+    def test_confirm_already_authoritative_entity_is_a_noop(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        # Never marked -- confirming must not raise or create anything.
+        mcp_server._lineage_confirm(db, entity_ident)
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is False
+
+    def test_mark_provisional_is_idempotent(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._lineage_mark_provisional(db, entity_ident, "2026-01-01T00:00:00Z")
+        mcp_server._lineage_mark_provisional(db, entity_ident, "2026-01-01T00:00:01Z")
+
+        ident = mcp_server._lineage_marker_ident(entity_ident)
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?e) :where [{ident} :entity ?e]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_provisional_marker_survives_audit(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            db,
+            f'[[{entity_ident} :entity-type :type/function] '
+            f'[{entity_ident} :description "login"] '
+            f'[{entity_ident} :file "src/auth.py"]]',
+            "2026-01-01T00:00:00Z",
+        )
+
+        mcp_server._lineage_mark_provisional(db, entity_ident, "2026-01-01T00:00:00Z")
+        result = mcp_server.handle_minigraf_audit()
+
+        assert result["retracted"] == 0
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is True
+        raw = mcp_server._db_execute(
+            db, f'(query [:find (count ?d) :where [{entity_ident} :description ?d]])'
+        )
+        assert json.loads(raw)["results"] == [[1]]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestLineageProvisionalMarker -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_lineage_is_provisional'` (or similar for the other new functions).
+
+- [ ] **Step 3: Add the functions to `mcp_server.py`**
+
+Insert immediately after `_frontier_persist_claim` (line 5017), before `_LAST_RUN_KEYWORD_ATTRS` (line 5020):
+
+```python
+_LINEAGE_MARKER_ENTITY_TYPE = ":type/lineage-marker"
+
+
+def _lineage_marker_ident(entity_ident: str) -> str:
+    """Deterministic companion-entity ident for entity_ident's provisional
+    marker. Not a public schema type -- see the #222 phase 2a design spec's
+    "Schema/audit status of new entity types" section.
+    """
+    return f":lineage/{entity_ident.lstrip(':').replace('/', '-')}"
+
+
+def _lineage_mark_provisional(
+    db: Any, entity_ident: str, commit_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Create the :type/lineage-marker companion entity for entity_ident, if
+    one doesn't already exist. Query-before-write (mirrors _watermark_update)
+    -- a marker already present is a no-op, never a duplicate write. Uses
+    internal _transact directly, never handle_minigraf_transact: :type/
+    lineage-marker is deliberately unregistered in MINIGRAF_SCHEMA, and the
+    public handler's schema gate would reject it outright.
+    """
+    if _lineage_is_provisional(db, entity_ident):
+        return
+    ident = _lineage_marker_ident(entity_ident)
+    facts = [
+        f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
+        f"[{ident} :entity {entity_ident}]",
+        f"[{ident} :status :provisional]",
+    ]
+    _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
+
+
+def _lineage_confirm(db: Any, entity_ident: str, index_con: Optional[Any] = None) -> None:
+    """Retract the :type/lineage-marker companion entity's facts for
+    entity_ident if present; no-op if absent, so callers (2c) can call this
+    unconditionally without checking first.
+    """
+    if not _lineage_is_provisional(db, entity_ident):
+        return
+    ident = _lineage_marker_ident(entity_ident)
+    facts = [
+        f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
+        f"[{ident} :entity {entity_ident}]",
+        f"[{ident} :status :provisional]",
+    ]
+    _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+
+
+def _lineage_is_provisional(db: Any, entity_ident: str) -> bool:
+    """True iff a :type/lineage-marker companion entity currently exists for
+    entity_ident."""
+    ident = _lineage_marker_ident(entity_ident)
+    raw = _db_execute(db, f"(query [:find ?e :where [{ident} :entity ?e]])")
+    return bool(json.loads(raw).get("results", []))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestLineageProvisionalMarker -v`
+Expected: PASS (all 5 tests).
+
+Also run the full existing suite to confirm no regression:
+
+Run: `python -m pytest tests/test_mcp_server.py -x -q`
+Expected: PASS (no new failures beyond the pre-existing, unrelated ones — see phase 1's plan notes on the ~120 missing-grammar-package failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add provisional lineage marker: _lineage_mark_provisional/_confirm/_is_provisional
+
+Companion-entity marker (:type/lineage-marker, deliberately unregistered
+in MINIGRAF_SCHEMA) for #222 phase 2a -- not an attribute on the tracked
+code entity itself, since module/function/class/variable/field are
+schema-audited and :lineage-status would be silently retracted by a
+routine minigraf_audit run. Idempotent by query-before-write, writes via
+internal _transact/_retract only. No caller yet (2c wires this in)."
+```
+
+---
+
+### Task 2: `lineage-confirmed-through` watermark
+
+**Files:**
+- Modify: `mcp_server.py` — insert immediately after Task 1's functions.
+- Test: `tests/test_mcp_server.py` — new `TestLineageConfirmedThroughWatermark` class.
+
+**Interfaces:**
+- Consumes: `_db_execute`, `_transact`, `_retract`, `_edn_escape` (all pre-existing).
+- Produces:
+  - `_LINEAGE_CONFIRMED_THROUGH_IDENT: str = ":ingestion/lineage-confirmed-through"`
+  - `_lineage_confirmed_through_query(db) -> Optional[str]`
+  - `_lineage_confirmed_through_update(db, commit_hash: str, commit_ts_iso: str, index_con=None) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this test class to `tests/test_mcp_server.py`:
+
+```python
+class TestLineageConfirmedThroughWatermark:
+    def test_unset_reads_as_none(self, real_db):
+        import mcp_server
+        assert mcp_server._lineage_confirmed_through_query(real_db) is None
+
+    def test_update_then_query_round_trip(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._lineage_confirmed_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+
+        mcp_server._lineage_confirmed_through_update(db, "h2", "2026-01-02T00:00:00Z")
+        assert mcp_server._lineage_confirmed_through_query(db) == "h2"
+
+    def test_update_does_not_duplicate_hash_fact(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._lineage_confirmed_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_confirmed_through_update(db, "h2", "2026-01-02T00:00:00Z")
+
+        ident = mcp_server._LINEAGE_CONFIRMED_THROUGH_IDENT
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_entity_carries_expected_constants_and_survives_audit(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._lineage_confirmed_through_update(db, "h1", "2026-01-01T00:00:00Z")
+
+        ident = mcp_server._LINEAGE_CONFIRMED_THROUGH_IDENT
+        raw = mcp_server._db_execute(
+            db, f"(query [:find ?a ?v :where [{ident} ?a ?v]])"
+        )
+        attrs = dict(json.loads(raw)["results"])
+        assert attrs[":entity-type"] == ":type/ingestion"
+        assert attrs[":ident"] == ident
+        assert isinstance(attrs[":description"], str) and attrs[":description"]
+
+        result = mcp_server.handle_minigraf_audit()
+        assert result["retracted"] == 0
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestLineageConfirmedThroughWatermark -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_lineage_confirmed_through_query'`.
+
+- [ ] **Step 3: Add the functions to `mcp_server.py`**
+
+Insert immediately after Task 1's `_lineage_is_provisional`:
+
+```python
+_LINEAGE_CONFIRMED_THROUGH_IDENT = ":ingestion/lineage-confirmed-through"
+
+
+def _lineage_confirmed_through_query(db: Any) -> Optional[str]:
+    """Return the hash of the last commit through which lineage is fully
+    confirmed, or None if nothing has been confirmed yet."""
+    raw = _db_execute(
+        db, f"(query [:find ?h :where [{_LINEAGE_CONFIRMED_THROUGH_IDENT} :hash ?h]])"
+    )
+    results = json.loads(raw).get("results", [])
+    return results[0][0] if results else None
+
+
+def _lineage_confirmed_through_update(
+    db: Any, commit_hash: str, commit_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Record the last lineage-confirmed commit hash, mirroring
+    _watermark_update's retract-only-if-changed pattern. Uses :type/
+    ingestion -- the SAME registered/audited entity type :ingestion/
+    watermark already uses -- so this entity carries the same required
+    :description constant _watermark_update's own entity does.
+    """
+    current_raw = _db_execute(
+        db, f"(query [:find ?a ?v :where [{_LINEAGE_CONFIRMED_THROUGH_IDENT} ?a ?v]])"
+    )
+    current: Dict[str, str] = dict(json.loads(current_raw).get("results", []))
+
+    def _edn(attr: str, value: str) -> str:
+        return value if attr == ":entity-type" else f'"{_edn_escape(value)}"'
+
+    constants = {
+        ":entity-type": ":type/ingestion",
+        ":ident": _LINEAGE_CONFIRMED_THROUGH_IDENT,
+        ":description": "lineage confirmed-through watermark",
+    }
+
+    to_retract: List[str] = []
+    to_transact: List[str] = []
+    for attr, value in constants.items():
+        if current.get(attr) == value:
+            continue
+        if attr in current:
+            to_retract.append(f"[{_LINEAGE_CONFIRMED_THROUGH_IDENT} {attr} {_edn(attr, current[attr])}]")
+        to_transact.append(f"[{_LINEAGE_CONFIRMED_THROUGH_IDENT} {attr} {_edn(attr, value)}]")
+
+    if ":hash" in current:
+        to_retract.append(f"[{_LINEAGE_CONFIRMED_THROUGH_IDENT} :hash {_edn(':hash', current[':hash'])}]")
+    to_transact.append(f"[{_LINEAGE_CONFIRMED_THROUGH_IDENT} :hash {_edn(':hash', commit_hash)}]")
+
+    if to_retract:
+        _retract(db, "[" + " ".join(to_retract) + "]", index_con=index_con)
+    _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestLineageConfirmedThroughWatermark -v`
+Expected: PASS (all 4 tests).
+
+Also run the full existing suite: `python -m pytest tests/test_mcp_server.py -x -q` — expect no new failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add lineage-confirmed-through watermark (:ingestion/lineage-confirmed-through)
+
+Mirrors _watermark_update's exact retract-only-if-changed pattern.
+Unlike :type/lineage-marker/:type/candidate-diff, this entity uses the
+registered/audited :type/ingestion type (same as :ingestion/watermark),
+so it carries the same :entity-type/:ident/:description constants and
+must survive minigraf_audit by genuinely conforming, not by being
+invisible to it. No caller yet."
+```
+
+---
+
+### Task 3: Migration catch-up (`_lineage_confirmed_through_migrate`)
+
+**Files:**
+- Modify: `mcp_server.py` — add the new function immediately after Task 2's functions; add one call inside the existing `_frontier_load` (currently lines 4950-4978).
+- Test: `tests/test_mcp_server.py` — new `TestLineageConfirmedThroughMigration` class.
+
+**Interfaces:**
+- Consumes: `_lineage_confirmed_through_query`, `_lineage_confirmed_through_update` (Task 2); `_frontier_read_bounds`, `_FRONTIER_LOW_IDENT` (phase 1, already merged).
+- Produces: `_lineage_confirmed_through_migrate(db, run_ts_iso: str, index_con=None) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this test class to `tests/test_mcp_server.py`:
+
+```python
+class TestLineageConfirmedThroughMigration:
+    def test_fresh_migration_seeds_from_watermark(self, real_db):
+        import mcp_server
+        db = real_db
+        linearization = ["h0", "h1", "h2"]
+        mcp_server._watermark_update(db, "h1", "2026-01-01T00:00:00Z", "seed watermark")
+
+        mcp_server._frontier_load(db, linearization, "2026-01-02T00:00:00Z")
+
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+
+    def test_already_migrated_graph_still_gets_watermark_seeded(self, real_db):
+        import mcp_server
+        db = real_db
+        linearization = ["h0", "h1", "h2"]
+        mcp_server._watermark_update(db, "h1", "2026-01-01T00:00:00Z", "seed watermark")
+
+        # Simulate an earlier Phase-1-only run: frontier-low gets created,
+        # but lineage-confirmed-through (new in Phase 2a) doesn't exist yet.
+        mcp_server._frontier_seed_from_watermark(db, linearization, "2026-01-01T00:00:01Z")
+        assert mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_LOW_IDENT) is not None
+        assert mcp_server._lineage_confirmed_through_query(db) is None
+
+        mcp_server._frontier_load(db, linearization, "2026-01-02T00:00:00Z")
+
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+
+    def test_repeated_load_does_not_duplicate_same_value(self, real_db):
+        import mcp_server
+        db = real_db
+        linearization = ["h0", "h1", "h2"]
+        mcp_server._watermark_update(db, "h1", "2026-01-01T00:00:00Z", "seed watermark")
+
+        mcp_server._frontier_load(db, linearization, "2026-01-02T00:00:00Z")
+        mcp_server._frontier_load(db, linearization, "2026-01-03T00:00:00Z")
+
+        ident = mcp_server._LINEAGE_CONFIRMED_THROUGH_IDENT
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_does_not_clobber_a_value_advanced_past_migration_boundary(self, real_db):
+        import mcp_server
+        db = real_db
+        linearization = ["h0", "h1", "h2"]
+        mcp_server._watermark_update(db, "h1", "2026-01-01T00:00:00Z", "seed watermark")
+        mcp_server._frontier_load(db, linearization, "2026-01-02T00:00:00Z")
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+
+        # Simulate phase 2c's real sweep having advanced past the original
+        # migration boundary.
+        mcp_server._lineage_confirmed_through_update(db, "h2", "2026-01-03T00:00:00Z")
+
+        mcp_server._frontier_load(db, linearization, "2026-01-04T00:00:00Z")
+
+        assert mcp_server._lineage_confirmed_through_query(db) == "h2"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestLineageConfirmedThroughMigration -v`
+Expected: FAIL — `test_fresh_migration_seeds_from_watermark` and the others fail with `assert None == "h1"` (or similar), since `_frontier_load` doesn't call any lineage-confirmed-through seeding yet.
+
+- [ ] **Step 3: Add `_lineage_confirmed_through_migrate` and wire it into `_frontier_load`**
+
+Insert immediately after Task 2's `_lineage_confirmed_through_update`:
+
+```python
+def _lineage_confirmed_through_migrate(
+    db: Any, run_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """One-time catch-up: if :ingestion/frontier-low exists (this graph has
+    an authoritative region, whether freshly migrated by
+    _frontier_seed_from_watermark just now or already established by an
+    earlier Phase-1-only run) but :ingestion/lineage-confirmed-through is
+    unset, seed the watermark from frontier-low's *current* :hi-hash --
+    that whole region was ingested by the original single-stream
+    forward-only authoritative walk, so it is already fully
+    lineage-confirmed. No-op if frontier-low doesn't exist yet, or
+    lineage-confirmed-through is already set (so later phases' own sweep
+    updates are never clobbered back to a stale value).
+    """
+    if _lineage_confirmed_through_query(db) is not None:
+        return
+    low_bounds = _frontier_read_bounds(db, _FRONTIER_LOW_IDENT)
+    if low_bounds is None:
+        return
+    _, hi_hash = low_bounds
+    _lineage_confirmed_through_update(db, hi_hash, run_ts_iso, index_con=index_con)
+```
+
+Modify the existing `_frontier_load` (currently lines 4950-4978) — change:
+
+```python
+    if (
+        _frontier_read_bounds(db, _FRONTIER_LOW_IDENT) is None
+        and _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT) is None
+    ):
+        _frontier_seed_from_watermark(db, linearization, run_ts_iso, index_con=index_con)
+
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+```
+
+to:
+
+```python
+    if (
+        _frontier_read_bounds(db, _FRONTIER_LOW_IDENT) is None
+        and _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT) is None
+    ):
+        _frontier_seed_from_watermark(db, linearization, run_ts_iso, index_con=index_con)
+    _lineage_confirmed_through_migrate(db, run_ts_iso, index_con=index_con)
+
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+```
+
+(This is the only edit to code merged in phase 1 that this whole sub-phase makes — everything else is new functions.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestLineageConfirmedThroughMigration -v`
+Expected: PASS (all 4 tests).
+
+Also run the full existing suite, and specifically phase 1's own `TestFrontierLoad` class (since `_frontier_load` was modified) to confirm no regression:
+
+Run: `python -m pytest tests/test_mcp_server.py::TestFrontierLoad tests/test_mcp_server.py -x -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add _lineage_confirmed_through_migrate, wire into _frontier_load
+
+Seeds the new lineage-confirmed-through watermark from frontier-low's
+current :hi-hash whenever it's unset -- covers both a fresh migration
+and a graph that already ran Phase 1 standalone before Phase 2a landed
+(this project's own actual situation), since the catch-up isn't tied to
+_frontier_seed_from_watermark's narrower neither-interval-exists guard.
+Guarded so it never clobbers a value phase 2c's real sweep has since
+advanced past the migration boundary."
+```
+
+---
+
+### Task 4: Candidate-diff persistence (`_candidate_diff_persist` / `_candidate_diff_read` / `_candidate_diff_clear`)
+
+**Files:**
+- Modify: `mcp_server.py` — insert immediately after Task 3's `_lineage_confirmed_through_migrate`.
+- Test: `tests/test_mcp_server.py` — new `TestCandidateDiff` class.
+
+**Interfaces:**
+- Consumes: `_db_execute`, `_transact`, `_retract`, `_edn_escape` (all pre-existing).
+- Produces:
+  - `_candidate_diff_ident(commit_hash: str, entity_ident: str) -> str`
+  - `_candidate_diff_persist(db, commit_hash: str, entity_ident: str, body_hash: str, commit_ts_iso: str, index_con=None) -> None`
+  - `_candidate_diff_read(db, commit_hash: str, entity_ident: str) -> Optional[str]`
+  - `_candidate_diff_clear(db, commit_hash: str, entity_ident: str, index_con=None) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this test class to `tests/test_mcp_server.py`:
+
+```python
+class TestCandidateDiff:
+    def test_read_absent_record_returns_none(self, real_db):
+        import mcp_server
+        assert mcp_server._candidate_diff_read(real_db, "a" * 40, ":function/foo") is None
+
+    def test_persist_then_read_round_trip(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+
+        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash1"
+        # A different (commit, entity) pair must not resolve to this record.
+        assert mcp_server._candidate_diff_read(db, "b" * 40, entity_ident) is None
+        assert mcp_server._candidate_diff_read(db, commit_hash, ":function/other") is None
+
+    def test_persist_same_hash_twice_does_not_duplicate(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:01Z")
+
+        ident = mcp_server._candidate_diff_ident(commit_hash, entity_ident)
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :body-hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_persist_different_hash_updates_without_duplicating(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash2", "2026-01-01T00:00:01Z")
+
+        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash2"
+        ident = mcp_server._candidate_diff_ident(commit_hash, entity_ident)
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :body-hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_clear_removes_the_record(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+        mcp_server._candidate_diff_clear(db, commit_hash, entity_ident)
+
+        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) is None
+        ident = mcp_server._candidate_diff_ident(commit_hash, entity_ident)
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?e) :where [{ident} :entity ?e]])")
+        assert json.loads(raw)["results"] == [[0]]
+
+    def test_clear_absent_record_is_a_noop(self, real_db):
+        import mcp_server
+        db = real_db
+        # Must not raise.
+        mcp_server._candidate_diff_clear(db, "a" * 40, ":function/never-persisted")
+
+    def test_candidate_diff_survives_audit(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+        result = mcp_server.handle_minigraf_audit()
+
+        assert result["retracted"] == 0
+        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash1"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCandidateDiff -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_candidate_diff_read'`.
+
+- [ ] **Step 3: Add the functions to `mcp_server.py`**
+
+Insert immediately after Task 3's `_lineage_confirmed_through_migrate`:
+
+```python
+def _candidate_diff_ident(commit_hash: str, entity_ident: str) -> str:
+    """Deterministic ident for a candidate-diff record. Not a public schema
+    type -- see the #222 phase 2a design spec's "Schema/audit status of new
+    entity types" section.
+    """
+    return f":candidate/{commit_hash[:12]}-{entity_ident.lstrip(':').replace('/', '-')}"
+
+
+def _candidate_diff_persist(
+    db: Any,
+    commit_hash: str,
+    entity_ident: str,
+    body_hash: str,
+    commit_ts_iso: str,
+    index_con: Optional[Any] = None,
+) -> None:
+    """Mint/update one candidate-diff record for (commit_hash, entity_ident).
+    Query-before-write -- no-ops if the persisted body_hash already
+    matches, retracts+reasserts only the :body-hash if it genuinely
+    changed (the other attributes are all derived from commit_hash/
+    entity_ident, which never change for a given record's ident). Uses
+    internal _transact/_retract directly, never handle_minigraf_transact:
+    :type/candidate-diff is deliberately unregistered in MINIGRAF_SCHEMA.
+    """
+    ident = _candidate_diff_ident(commit_hash, entity_ident)
+    existing = _candidate_diff_read(db, commit_hash, entity_ident)
+    if existing == body_hash:
+        return
+    if existing is None:
+        commit_ident = f":commit/{commit_hash[:12]}"
+        facts = [
+            f"[{ident} :entity-type :type/candidate-diff]",
+            f"[{ident} :commit {commit_ident}]",
+            f"[{ident} :entity {entity_ident}]",
+            f'[{ident} :body-hash "{_edn_escape(body_hash)}"]',
+        ]
+        _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
+    else:
+        _retract(db, f'[[{ident} :body-hash "{_edn_escape(existing)}"]]', index_con=index_con)
+        _transact(
+            db, f'[[{ident} :body-hash "{_edn_escape(body_hash)}"]]', commit_ts_iso, index_con=index_con
+        )
+
+
+def _candidate_diff_read(db: Any, commit_hash: str, entity_ident: str) -> Optional[str]:
+    """Return the persisted body_hash for (commit_hash, entity_ident), or
+    None if no candidate record exists for that pair."""
+    ident = _candidate_diff_ident(commit_hash, entity_ident)
+    raw = _db_execute(db, f"(query [:find ?h :where [{ident} :body-hash ?h]])")
+    results = json.loads(raw).get("results", [])
+    return results[0][0] if results else None
+
+
+def _candidate_diff_clear(
+    db: Any, commit_hash: str, entity_ident: str, index_con: Optional[Any] = None
+) -> None:
+    """Retract the candidate record once consumed (2c calls this after
+    confirming/rejecting), so these scratch facts don't accumulate
+    unbounded across a full ingest. No-op if no record exists.
+    """
+    existing = _candidate_diff_read(db, commit_hash, entity_ident)
+    if existing is None:
+        return
+    ident = _candidate_diff_ident(commit_hash, entity_ident)
+    commit_ident = f":commit/{commit_hash[:12]}"
+    facts = [
+        f"[{ident} :entity-type :type/candidate-diff]",
+        f"[{ident} :commit {commit_ident}]",
+        f"[{ident} :entity {entity_ident}]",
+        f'[{ident} :body-hash "{_edn_escape(existing)}"]',
+    ]
+    _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCandidateDiff -v`
+Expected: PASS (all 7 tests).
+
+Also run the full existing suite to confirm no regression:
+
+Run: `python -m pytest tests/test_mcp_server.py -x -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add candidate-diff persistence: _candidate_diff_persist/_read/_clear
+
+One :type/candidate-diff entity per (commit, entity) pair (deliberately
+unregistered in MINIGRAF_SCHEMA, same status as :type/lineage-marker),
+holding the entity's #221 normalized-body-hash -- lets Stream 1's future
+correction sweep (2c) confirm/reject a candidate via hash comparison
+without re-invoking git-show + tree-sitter. Idempotent by
+query-before-write, writes via internal _transact/_retract only. No
+caller yet (2b writes, 2c reads/clears)."
+```
+
+## Self-Review Notes
+
+- **Spec coverage:** Provisional marker (Task 1) — covered, including audit safety. `lineage-confirmed-through` watermark (Task 2) — covered, including the registered-type constants/audit test the final review round asked for. Migration catch-up covering both fresh and already-migrated graphs, plus non-clobbering of an advanced value (Task 3) — covered, directly testing the exact scenarios Revision notes #3/#5/#8 called out. Candidate-diff persistence with idempotency and audit safety (Task 4) — covered. The internal-`_transact`-only constraint (Revision note #7) is stated in every new function's docstring and Global Constraints, and no task routes through `handle_minigraf_transact`/`handle_minigraf_retract`.
+- **Type consistency:** `entity_ident`/`commit_hash`/`commit_ts_iso`/`index_con` parameter names and types are used identically across all 4 tasks. `_lineage_marker_ident`/`_candidate_diff_ident` naming and signature style match `_frontier_read_bounds`'s existing `Optional[Tuple[str, str]]`-returning-helper pattern from phase 1.
+- **No placeholders:** every step has complete, runnable code — no TBD/TODO markers, no "similar to Task N" shorthand.

--- a/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
+++ b/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
@@ -1,0 +1,184 @@
+# Provisional/Authoritative Lineage Fact Model + Candidate-Diff Persistence — Design Spec
+
+**Issue:** #222 (Phase 2, sub-phase 2a of 4)
+**Date:** 2026-07-24
+
+## Background
+
+#222's overall design is a converging multi-stream ingestion: a forward-truth
+stream (the existing engine) running concurrently with a reverse-bulk-fill
+stream that provisionally back-fills recent history from `HEAD` downward, so
+recent history is visible almost immediately while the forward stream still
+owns lineage correctness. Phase 1 (merged, PR #226) built the foundational
+piece both streams need to claim work from — a frontier/interval registry
+and shared-gap allocator (`frontier_registry.py` + `mcp_server.py`'s
+`_frontier_load`/`_frontier_persist_claim`) — but nothing from phase 1 is
+wired into the actual ingestion walk yet.
+
+Phase 2 ("Streams 1+2 converging") is itself too large for one cycle and
+splits into four sub-phases:
+
+- **2a (this spec)** — the provisional/authoritative fact model and
+  candidate-diff persistence primitives. Foundational: 2b/2c/2d all depend
+  on this existing first.
+- **2b** — Stream 2's actual reverse-bulk-fill walk, using 2a's primitives
+  to write provisional lineage.
+- **2c** — Stream 1's correction sweep, continuing past the point where
+  Stream 2 already covered ground, converting provisional facts to
+  authoritative using 2a's persisted candidate diffs (cheap replay, no
+  re-parse).
+- **2d** — the actual concurrency wiring inside `_run_ingestion`: two
+  asyncio tasks sharing the frontier allocator and the existing single
+  write_executor, with fairness so neither starves.
+
+Like phase 1, 2a builds only the data-model plumbing — no caller yet. 2b
+writes with it, 2c reads/clears with it, 2d ties everything together into
+the actual commit loop.
+
+## Scope (2a only)
+
+In scope:
+
+- A per-entity provisional marker for lineage (`:introduced-by`), following
+  phase 1's migration precedent: absent = authoritative, so every entity
+  ingested by today's existing forward-only walk (which never writes this
+  marker) reads as authoritative with zero migration required.
+- A `lineage-confirmed-through` watermark entity, structurally identical to
+  `:ingestion/watermark`, giving a cheap single-query "is region X's lineage
+  fully confirmed" answer without scanning individual entity markers — the
+  same mechanism phase 4's status reporting (and a future
+  `memory_prepare_turn` trustworthiness check) will read.
+- A persisted candidate-diff record schema: one entity per (commit,
+  candidate entity) pair, holding the entity's #221 normalized-body-hash —
+  enough for Stream 1's later correction sweep (2c) to confirm or reject a
+  candidate via hash comparison, without re-invoking git-show + tree-sitter
+  parsing.
+
+Explicitly deferred: the actual reverse-walk diffing logic that decides
+what counts as a "candidate" (2b), the rename-spanning-the-gap resolution
+and confirm/reject replay logic (2c), and the concurrency wiring (2d). 2a
+provides only the read/write primitives those will call.
+
+## Design
+
+### Provisional marker
+
+A companion fact per entity, written only by Stream 2 (2b) alongside its
+`:introduced-by`:
+
+```
+[<entity-ident> :lineage-status :provisional]
+```
+
+Absence of this fact means authoritative — matching phase 1's "unflagged =
+authoritative" migration default exactly. When Stream 1's correction sweep
+(2c) later confirms an entity's `:introduced-by` is correct as-is, it
+retracts `:lineage-status :provisional` (no re-assertion — absence is the
+authoritative state). When the sweep finds the provisional guess was
+*wrong* (e.g. a rename-spanning-the-gap case, resolved in 2c), it retracts
+both `:lineage-status :provisional` and the incorrect `:introduced-by`,
+then asserts the correct `:introduced-by` — still no new marker, since the
+entity is now authoritative.
+
+2a's primitives (no caller yet):
+
+```python
+def _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=None) -> None:
+    """Assert [entity_ident :lineage-status :provisional]."""
+
+def _lineage_confirm(db, entity_ident, index_con=None) -> None:
+    """Retract :lineage-status :provisional if present; no-op if absent,
+    so callers (2c) can call this unconditionally without checking first --
+    same idempotent-by-design style as _frontier_seed_from_watermark's guard."""
+
+def _lineage_is_provisional(db, entity_ident) -> bool:
+    """Plain existence query for the marker."""
+```
+
+### `lineage-confirmed-through` watermark
+
+A new entity `:ingestion/lineage-confirmed-through` with a `:hash`
+attribute, structurally identical to `:ingestion/watermark` — same
+retract-then-reassert-only-if-changed pattern as `_watermark_update`, just
+a different ident:
+
+```python
+def _lineage_confirmed_through_query(db) -> Optional[str]:
+    """Return the hash of the last commit through which lineage is fully
+    confirmed, or None if nothing has been confirmed yet."""
+
+def _lineage_confirmed_through_update(db, commit_hash, commit_ts_iso, index_con=None) -> None:
+    """Record the last lineage-confirmed commit hash, mirroring
+    _watermark_update's retract-only-if-changed pattern."""
+```
+
+Absent means "nothing confirmed past `C0` by this watermark" — correct
+both for pre-phase-2 graphs and, notably, for the region phase 1's
+migration already seeded as `[C0, W]` authoritative: that region was never
+provisional in the first place (no `:lineage-status` facts were ever
+written for it), so it needs no confirmation sweep, and this watermark
+starting unset for it does not imply that region is untrustworthy — it
+implies "the confirmation *sweep* hasn't started," which is a distinct
+question from "is this region's lineage authoritative," already answered by
+the per-entity marker's absence. Sub-phase 2a's own tests must cover this
+distinction explicitly (see Testing).
+
+### Candidate-diff persistence schema
+
+One small entity per (commit, candidate entity) pair — mirroring the
+codebase's existing style of minting entities with clean single-valued
+attributes (e.g. `:type/commit` entities) rather than packing multiple
+values into one delimited string:
+
+```
+[:candidate/<commit-hash[:12]>-<entity-ident-slug> :entity-type :type/candidate-diff]
+[:candidate/<commit-hash[:12]>-<entity-ident-slug> :commit :commit/<commit-hash[:12]>]
+[:candidate/<commit-hash[:12]>-<entity-ident-slug> :entity <entity-ident>]
+[:candidate/<commit-hash[:12]>-<entity-ident-slug> :body-hash "<normalized-body-hash>"]
+```
+
+The ident is deterministic: `f":candidate/{commit_hash[:12]}-{entity_ident.lstrip(':').replace('/', '-')}"` — strip the entity ident's leading `:` and replace its `/` with `-`, then prefix with the commit hash's existing 12-char short form (matching `commit_ident = f":commit/{commit_hash[:12]}"`'s existing truncation elsewhere in `_run_ingestion`). No separate ID-generation scheme needed, and naturally idempotent if a caller ever revisits the same (commit, entity) pair.
+
+2a's primitives (2b writes, 2c reads/clears — no caller in this sub-phase):
+
+```python
+def _candidate_diff_persist(db, commit_hash, entity_ident, body_hash, commit_ts_iso, index_con=None) -> None:
+    """Mint/write one candidate-diff record for (commit_hash, entity_ident)."""
+
+def _candidate_diff_read(db, commit_hash, entity_ident) -> Optional[str]:
+    """Return the persisted body_hash for (commit_hash, entity_ident), or
+    None if no candidate record exists for that pair."""
+
+def _candidate_diff_clear(db, commit_hash, entity_ident, index_con=None) -> None:
+    """Retract the candidate record once consumed (2c calls this after
+    confirming/rejecting), so these scratch facts don't accumulate
+    unbounded across a full ingest."""
+```
+
+## Testing
+
+Following `docs/testing-conventions.md` (real backend, no mocked
+`MiniGrafDb`):
+
+- **Provisional marker round-trip**: an entity with no marker reads as
+  authoritative (`_lineage_is_provisional` returns `False`); mark it
+  provisional, assert `True`; confirm it, assert `False` again; confirm an
+  already-authoritative entity a second time (never marked, or already
+  confirmed) and assert it's a genuine no-op — verified via a raw
+  fact-count query on `:lineage-status`, not just the derived boolean, per
+  the row-collapsing lesson from phase 1's Tasks 3/4.
+- **Watermark round-trip**: mirrors phase 1's `_watermark_update`/
+  `_watermark_query` tests — persist, re-query, update again, confirm only
+  one live `:hash` fact exists via a `(count ...)` query.
+- **Candidate-diff round-trip**: persist a candidate record, read it back,
+  confirm the correct `(commit, entity)` pair resolves to the correct hash
+  and a *different* `(commit, entity)` pair returns `None`; clear it;
+  confirm a cleared record reads back as `None`, verified via both the
+  accessor and a raw fact-count check that the underlying
+  `:type/candidate-diff` entity's facts are actually gone.
+- **Migration interaction test**: after phase 1's
+  `_frontier_seed_from_watermark` migration seeds `[C0, W]` as authoritative
+  with zero provisional facts, confirm `_lineage_confirmed_through_query`
+  still correctly reads as unset (`None`) for that region, and that this is
+  understood as "sweep hasn't run," not "region untrustworthy" (already
+  answered by the per-entity marker's absence, not this watermark).

--- a/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
+++ b/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
@@ -1,7 +1,7 @@
 # Provisional/Authoritative Lineage Fact Model + Candidate-Diff Persistence — Design Spec
 
 **Issue:** #222 (Phase 2, sub-phase 2a of 4)
-**Date:** 2026-07-24 (revised same day after spec review — see "Revision" note)
+**Date:** 2026-07-24 (revised twice same day after spec review — see "Revision" note)
 
 ## Background
 
@@ -68,6 +68,29 @@ real against the code before this revision:
    bookkeeping — the same status phase 1's own `:type/ingest-interval`
    already has.
 
+A second review pass on that revision found one more High and one more
+Medium issue, both confirmed real and fixed in this version:
+
+5. **High** — the point-3 fix only fired *inside*
+   `_frontier_seed_from_watermark`, which `_frontier_load` only calls when
+   *both* frontier intervals are absent. A graph that already ran Phase 1
+   standalone before Phase 2a lands (exactly this project's own situation —
+   Phase 1 is merged and Phase 2a is not) already has
+   `:ingestion/frontier-low`, so that migration branch never runs for it and
+   `lineage-confirmed-through` stays unset forever, breaking the "complete
+   standalone predicate" property for precisely the graphs most likely to
+   need it. **Fixed** by decoupling the seeding from
+   `_frontier_seed_from_watermark` entirely: a new, self-contained
+   `_lineage_confirmed_through_migrate` catches up from
+   `:ingestion/frontier-low`'s *current* `:hi-hash` whenever
+   `lineage-confirmed-through` is unset — regardless of whether
+   `frontier-low` was just created this call or already existed from an
+   earlier run — called unconditionally from `_frontier_load` (see below).
+6. **Medium** — the audit-safety test only covered `:type/lineage-marker`,
+   not `:type/candidate-diff`, even though the schema/audit argument applies
+   to both equally. **Fixed** by adding a symmetric candidate-diff audit
+   test (see Testing).
+
 ## Scope (2a only)
 
 In scope:
@@ -88,9 +111,11 @@ In scope:
   enough for Stream 1's later correction sweep (2c) to confirm or reject a
   candidate via hash comparison, without re-invoking git-show + tree-sitter
   parsing.
-- A small addition to phase 1's already-merged `_frontier_seed_from_watermark`
-  to also seed the new lineage-confirmed-through watermark (see Revision
-  note #3) — the only change to existing code in this sub-phase.
+- A small addition to phase 1's already-merged `_frontier_load` to
+  unconditionally call a new self-contained catch-up function seeding
+  `lineage-confirmed-through` from `:ingestion/frontier-low`'s current
+  `:hi-hash` whenever the watermark is unset (see Revision notes #3 and
+  #5) — the only change to existing code in this sub-phase.
 
 Explicitly deferred: the actual reverse-walk diffing logic that decides
 what counts as a "candidate" (2b), the rename-spanning-the-gap resolution
@@ -185,15 +210,45 @@ def _lineage_confirmed_through_update(db, commit_hash, commit_ts_iso, index_con=
     _watermark_update's retract-only-if-changed pattern."""
 ```
 
-**Migration seeding (fixes Revision note #3):** phase 1's already-merged
-`_frontier_seed_from_watermark` (mcp_server.py) gains one addition: after
-seeding the `[C0, W]` frontier interval as authoritative, it also calls
-`_lineage_confirmed_through_update(db, watermark_hash, run_ts_iso,
-index_con=index_con)`. That region's lineage genuinely *is* fully
-confirmed — it was ingested by the original single-stream forward-only
-authoritative walk, so it needs no separate confirmation sweep. With this
-seeding, the watermark becomes a complete, standalone trust predicate with
-no special-casing: an entity's lineage is trustworthy exactly when
+**Migration seeding (fixes Revision notes #3 and #5):** rather than hooking
+into `_frontier_seed_from_watermark` (which only runs when *neither*
+frontier interval exists yet — missing the case where `:ingestion/
+frontier-low` already exists from an earlier Phase-1-only run, exactly this
+project's own current situation), 2a adds a wholly new, self-contained
+catch-up function:
+
+```python
+def _lineage_confirmed_through_migrate(db, run_ts_iso, index_con=None) -> None:
+    """One-time catch-up: if :ingestion/frontier-low exists (this graph has
+    an authoritative region, whether freshly migrated by
+    _frontier_seed_from_watermark just now or already established by an
+    earlier Phase-1-only run) but :ingestion/lineage-confirmed-through is
+    unset, seed the watermark from frontier-low's *current* :hi-hash --
+    that whole region was ingested by the original single-stream
+    forward-only authoritative walk, so it is already fully
+    lineage-confirmed. No-op if frontier-low doesn't exist yet, or
+    lineage-confirmed-through is already set (so later phases' own sweep
+    updates are never clobbered back to a stale value)."""
+    if _lineage_confirmed_through_query(db) is not None:
+        return
+    low_bounds = _frontier_read_bounds(db, _FRONTIER_LOW_IDENT)
+    if low_bounds is None:
+        return
+    _, hi_hash = low_bounds
+    _lineage_confirmed_through_update(db, hi_hash, run_ts_iso, index_con=index_con)
+```
+
+`_frontier_load` (phase 1, already merged) gains one addition: after its
+existing migration block runs (whether or not it actually did anything —
+the new function's own guards make it safe to call unconditionally), it
+calls `_lineage_confirmed_through_migrate(db, run_ts_iso, index_con=index_con)`.
+This covers both cases uniformly: a graph migrating for the first time
+*and* a graph that already migrated under Phase-1-only code before Phase 2a
+existed — in both, `frontier-low` already has *some* `:hi-hash` by the time
+this call happens, and that is always the correct trust boundary to seed
+from, regardless of how `frontier-low` got there. Once seeded, this
+watermark becomes a complete, standalone trust predicate with no
+special-casing: an entity's lineage is trustworthy exactly when
 `_lineage_is_provisional(entity)` is `False` **and** its `:introduced-by`
 commit's position is `<=` the position of `_lineage_confirmed_through_query`'s
 hash in the current linearization. (2a does not implement this composed
@@ -267,12 +322,18 @@ Following `docs/testing-conventions.md` (real backend, no mocked
   `_lineage_is_provisional`'s boolean) — this is the test that would have
   caught Revision note #2 if it had been run against the first draft's
   (incorrect) unconditional-transact implementation.
-- **Audit safety test**: mark an entity provisional, run
+- **Audit safety test (lineage marker)**: mark an entity provisional, run
   `handle_minigraf_audit()`, and assert the `:type/lineage-marker` entity
   (and, separately, a real `:type/function`/`:type/module` entity carrying
   ordinary schema-valid attributes alongside it) both survive unretracted —
   this directly verifies Revision note #1's fix, not just that the schema
   doesn't reject the write at transact time.
+- **Audit safety test (candidate-diff)**: persist a candidate-diff record,
+  run `handle_minigraf_audit()`, and assert the `:type/candidate-diff`
+  entity's facts survive unretracted — the schema/audit argument in this
+  spec applies equally to both new entity types (Revision note #6), and
+  this test is what proves it for the one that had no coverage in the
+  prior revision.
 - **Watermark round-trip**: mirrors phase 1's `_watermark_update`/
   `_watermark_query` tests — persist, re-query, update again, confirm only
   one live `:hash` fact exists via a `(count ...)` query.
@@ -285,7 +346,21 @@ Following `docs/testing-conventions.md` (real backend, no mocked
   only one live record; clear it; confirm a cleared record reads back as
   `None`, verified via both the accessor and a raw fact-count check that the
   underlying `:type/candidate-diff` entity's facts are actually gone.
-- **Migration seeding test**: run phase 1's migration path (`_frontier_load`
-  against a graph with only the old `:ingestion/watermark`) and assert
-  `_lineage_confirmed_through_query` now returns `W` (the watermark hash),
-  not `None` — this directly verifies Revision note #3's fix.
+- **Migration seeding test, fresh migration**: run phase 1's migration path
+  (`_frontier_load` against a graph with only the old `:ingestion/
+  watermark`) and assert `_lineage_confirmed_through_query` now returns `W`
+  (the watermark hash), not `None`.
+- **Migration seeding test, already-migrated graph**: seed a graph with
+  `:ingestion/frontier-low` already present (e.g. by calling `_frontier_load`
+  once already, simulating an earlier Phase-1-only run) and no
+  `lineage-confirmed-through` fact, then call `_frontier_load` again and
+  assert `_lineage_confirmed_through_query` now returns frontier-low's
+  `:hi-hash` — this is the test that would have caught Revision note #5:
+  it fails against the prior revision's `_frontier_seed_from_watermark`-only
+  fix, since that branch never runs when `frontier-low` already exists.
+- **Migration seeding idempotency**: call `_frontier_load` a third time
+  after the watermark is already seeded and assert (via raw count) it's
+  still exactly one live `:hash` fact, unchanged — confirms
+  `_lineage_confirmed_through_migrate`'s own guard prevents it from ever
+  clobbering a value phase 2c's real sweep has since advanced past the
+  original migration seed.

--- a/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
+++ b/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
@@ -1,7 +1,7 @@
 # Provisional/Authoritative Lineage Fact Model + Candidate-Diff Persistence — Design Spec
 
 **Issue:** #222 (Phase 2, sub-phase 2a of 4)
-**Date:** 2026-07-24 (revised twice same day after spec review — see "Revision" note)
+**Date:** 2026-07-24 (revised three times same day after spec review — see "Revision" note)
 
 ## Background
 
@@ -91,6 +91,38 @@ Medium issue, both confirmed real and fixed in this version:
    to both equally. **Fixed** by adding a symmetric candidate-diff audit
    test (see Testing).
 
+A third review pass found two more Medium issues, both confirmed real and
+fixed in this version:
+
+7. **Medium** — the spec established that unregistered scratch types are
+   safe from `minigraf_audit` (point 4/#4 above), but didn't say anything
+   about `handle_minigraf_transact` — a *different* code path with its own,
+   narrower validation gate. Verified: `handle_minigraf_transact`
+   (mcp_server.py:3623) calls `_validate_facts` on every string-valued
+   triple (mcp_server.py:3638-3642), which *would* reject
+   `[:candidate/... :body-hash "..."]` outright ("unknown entity type
+   candidate") since `candidate-diff` isn't in `MINIGRAF_SCHEMA` — unlike
+   `minigraf_audit`, this gate runs at write time, not just on a later
+   sweep. The internal `_transact` helper (mcp_server.py:3532) has no such
+   check. **Fixed** by stating explicitly (see below) that every function
+   this spec defines must call the internal `_transact`/`_retract` helpers
+   directly, the same way `_watermark_update`/`_frontier_persist_claim`
+   already do — never the public `handle_minigraf_transact`/
+   `handle_minigraf_retract` MCP tool handlers.
+8. **Medium** — the migration idempotency test only proved "doesn't
+   duplicate the initial seeded value," not the spec's actual claim
+   ("later phases' own sweep updates are never clobbered back to a stale
+   value"). A test that re-seeds the *same* value twice cannot distinguish
+   a correct implementation from a buggy one that ignores its own guard and
+   unconditionally re-derives from `frontier-low`'s `:hi-hash` every call —
+   both would show "still one value, unchanged," since re-deriving the same
+   stale boundary twice looks identical to leaving an already-correct value
+   alone. **Fixed** by adding a test that first advances
+   `lineage-confirmed-through` *past* `frontier-low`'s current `:hi-hash`
+   (simulating phase 2c's real sweep), then calls `_frontier_load` again
+   and asserts the *advanced* value survives, not a clobber back to
+   `frontier-low`'s boundary.
+
 ## Scope (2a only)
 
 In scope:
@@ -138,6 +170,21 @@ scratch/tracking entities safe from ever being silently swept by a routine
 audit run. Neither type needs `:description`/`:ident` or any other
 schema-required attribute for the same reason — they are outside the
 closed-world surface `MINIGRAF_SCHEMA` governs entirely.
+
+**Implementation constraint (fixes Revision note #7): internal `_transact`/
+`_retract` only, never the public handlers.** Being unregistered protects
+these entity types from `minigraf_audit`'s later sweep, but *not* from
+`handle_minigraf_transact`'s (mcp_server.py:3623) write-time validation gate
+— that handler calls `_validate_facts` on every string-valued triple
+(mcp_server.py:3638-3642) and would reject `[:candidate/... :body-hash
+"..."]` outright as an unknown entity type, since `candidate-diff` isn't in
+`MINIGRAF_SCHEMA` either. The internal `_transact`/`_retract` helpers
+(mcp_server.py:3532/3567) have no such check. Every function this spec
+defines — `_lineage_mark_provisional`, `_lineage_confirm`,
+`_candidate_diff_persist`, `_candidate_diff_clear`, and the watermark
+functions below — **must** call `_transact`/`_retract` directly, the same
+way `_watermark_update`/`_frontier_persist_claim` already do, never route
+through `handle_minigraf_transact`/`handle_minigraf_retract`.
 
 ### Provisional marker
 
@@ -358,9 +405,18 @@ Following `docs/testing-conventions.md` (real backend, no mocked
   `:hi-hash` — this is the test that would have caught Revision note #5:
   it fails against the prior revision's `_frontier_seed_from_watermark`-only
   fix, since that branch never runs when `frontier-low` already exists.
-- **Migration seeding idempotency**: call `_frontier_load` a third time
-  after the watermark is already seeded and assert (via raw count) it's
-  still exactly one live `:hash` fact, unchanged — confirms
-  `_lineage_confirmed_through_migrate`'s own guard prevents it from ever
-  clobbering a value phase 2c's real sweep has since advanced past the
-  original migration seed.
+- **Migration seeding idempotency (same value)**: call `_frontier_load` a
+  third time after the watermark is already seeded and assert (via raw
+  count) it's still exactly one live `:hash` fact, unchanged.
+- **Migration seeding does not clobber an advanced value**: after the
+  watermark is seeded once, directly advance
+  `lineage-confirmed-through` to a hash *past* `frontier-low`'s current
+  `:hi-hash` (simulating phase 2c's real sweep having progressed further
+  than the original migration boundary), then call `_frontier_load` again
+  and assert `_lineage_confirmed_through_query` still returns the
+  *advanced* hash, not a clobber back to `frontier-low`'s boundary — the
+  "same value" idempotency test above cannot distinguish a correct
+  implementation from one that ignores its own guard and unconditionally
+  re-derives from `frontier-low` every call, since re-deriving an unchanged
+  value looks identical to leaving it alone; only advancing past it first
+  exposes the difference.

--- a/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
+++ b/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
@@ -1,7 +1,7 @@
 # Provisional/Authoritative Lineage Fact Model + Candidate-Diff Persistence — Design Spec
 
 **Issue:** #222 (Phase 2, sub-phase 2a of 4)
-**Date:** 2026-07-24
+**Date:** 2026-07-24 (revised same day after spec review — see "Revision" note)
 
 ## Background
 
@@ -35,14 +35,49 @@ Like phase 1, 2a builds only the data-model plumbing — no caller yet. 2b
 writes with it, 2c reads/clears with it, 2d ties everything together into
 the actual commit loop.
 
+## Revision note
+
+A review of the first draft of this spec (grounded in the actual repo code
+and `MINIGRAF_SCHEMA`) found two High and two Medium issues, all confirmed
+real against the code before this revision:
+
+1. **High** — writing `:lineage-status` directly onto tracked code entities
+   (`module`/`function`/`class`/`variable`/`field`) is unsafe: those types
+   are registered in `MINIGRAF_SCHEMA` (mcp_server.py:5083) and audited by
+   `minigraf_audit` (mcp_server.py:3711), which retracts any attribute not
+   in a type's allowed set — `:lineage-status` isn't one, so a routine
+   audit run would silently destroy the provisional marker. **Fixed** by
+   moving the marker to its own unregistered companion entity (see below).
+2. **High** — "the deterministic ident is naturally idempotent" was false:
+   re-transacting the same (entity, attribute, value) at a new valid_from
+   creates a *duplicate live datom* under minigraf's actual write semantics
+   (documented at `_checkpoint_after_write`, mcp_server.py:3295, issue
+   #156), independent of whether the ident itself is deterministic. **Fixed**
+   by giving every new write function the same query-before-write guard
+   `_watermark_update` already established (mcp_server.py:4867-4909).
+3. **Medium** — `lineage-confirmed-through` was underspecified as a trust
+   predicate: it stays unset for the region phase 1's migration already
+   seeded `[C0, W]` authoritative, so a consumer checking only the
+   watermark would wrongly treat that region as unconfirmed. **Fixed** by
+   seeding the watermark to `W` at the same moment migration seeds the
+   `[C0, W]` frontier interval, making "position ≤ lineage-confirmed-through"
+   a complete standalone predicate with no special-casing.
+4. **Medium** — candidate-diff records' schema/audit status was implicit.
+   **Fixed** by stating explicitly (see below) that both new entity types
+   this spec introduces are deliberately unregistered, internal/scratch
+   bookkeeping — the same status phase 1's own `:type/ingest-interval`
+   already has.
+
 ## Scope (2a only)
 
 In scope:
 
-- A per-entity provisional marker for lineage (`:introduced-by`), following
-  phase 1's migration precedent: absent = authoritative, so every entity
-  ingested by today's existing forward-only walk (which never writes this
-  marker) reads as authoritative with zero migration required.
+- A per-entity provisional marker for lineage (`:introduced-by`), stored on
+  its own companion entity (not on the tracked code entity itself — see
+  Revision note #1), following phase 1's migration precedent: absent =
+  authoritative, so every entity ingested by today's existing forward-only
+  walk (which never creates this companion entity) reads as authoritative
+  with zero migration required.
 - A `lineage-confirmed-through` watermark entity, structurally identical to
   `:ingestion/watermark`, giving a cheap single-query "is region X's lineage
   fully confirmed" answer without scanning individual entity markers — the
@@ -53,6 +88,9 @@ In scope:
   enough for Stream 1's later correction sweep (2c) to confirm or reject a
   candidate via hash comparison, without re-invoking git-show + tree-sitter
   parsing.
+- A small addition to phase 1's already-merged `_frontier_seed_from_watermark`
+  to also seed the new lineage-confirmed-through watermark (see Revision
+  note #3) — the only change to existing code in this sub-phase.
 
 Explicitly deferred: the actual reverse-walk diffing logic that decides
 what counts as a "candidate" (2b), the rename-spanning-the-gap resolution
@@ -61,38 +99,73 @@ provides only the read/write primitives those will call.
 
 ## Design
 
+### Schema/audit status of new entity types (applies to both sections below)
+
+`:type/lineage-marker` and `:type/candidate-diff` (defined below) are
+**deliberately not added to `MINIGRAF_SCHEMA`** — internal bookkeeping,
+same status as phase 1's own `:type/ingest-interval`. `minigraf_audit`
+(mcp_server.py:3711) only iterates `MINIGRAF_SCHEMA`'s known entity types
+when looking for violations to retract (`for entity_type in
+MINIGRAF_SCHEMA`, mcp_server.py:3728) — it never scans for or touches
+entities of a type it doesn't know about. This is a load-bearing property
+this design relies on, not an incidental detail: it is what keeps these
+scratch/tracking entities safe from ever being silently swept by a routine
+audit run. Neither type needs `:description`/`:ident` or any other
+schema-required attribute for the same reason — they are outside the
+closed-world surface `MINIGRAF_SCHEMA` governs entirely.
+
 ### Provisional marker
 
-A companion fact per entity, written only by Stream 2 (2b) alongside its
-`:introduced-by`:
+A separate companion entity per tracked entity — **not** an attribute on
+the tracked entity itself (see Revision note #1: `module`/`function`/
+`class`/`variable`/`field` are schema-validated/audited types, and
+`:lineage-status` is not an allowed attribute for any of them):
 
 ```
-[<entity-ident> :lineage-status :provisional]
+[:lineage/<entity-ident-slug> :entity-type :type/lineage-marker]
+[:lineage/<entity-ident-slug> :entity <entity-ident>]
+[:lineage/<entity-ident-slug> :status :provisional]
 ```
 
-Absence of this fact means authoritative — matching phase 1's "unflagged =
-authoritative" migration default exactly. When Stream 1's correction sweep
-(2c) later confirms an entity's `:introduced-by` is correct as-is, it
-retracts `:lineage-status :provisional` (no re-assertion — absence is the
-authoritative state). When the sweep finds the provisional guess was
-*wrong* (e.g. a rename-spanning-the-gap case, resolved in 2c), it retracts
-both `:lineage-status :provisional` and the incorrect `:introduced-by`,
-then asserts the correct `:introduced-by` — still no new marker, since the
-entity is now authoritative.
+The ident is deterministic from the tracked entity's own ident:
+`f":lineage/{entity_ident.lstrip(':').replace('/', '-')}"`.
 
-2a's primitives (no caller yet):
+Presence of this companion entity means the tracked entity's
+`:introduced-by` is not yet confirmed; absence means authoritative —
+matching phase 1's "unflagged = authoritative" migration default exactly,
+since today's existing forward-only walk never creates a
+`:type/lineage-marker` entity at all.
+
+When Stream 1's correction sweep (2c) later confirms an entity's
+`:introduced-by` is correct as-is, it retracts the companion entity's facts
+entirely (no re-assertion — absence is the authoritative state). When the
+sweep finds the provisional guess was *wrong* (e.g. a rename-spanning-the-gap
+case, resolved in 2c), it retracts the companion entity's facts *and* the
+tracked entity's incorrect `:introduced-by`, then asserts the tracked
+entity's correct `:introduced-by` — still no new companion entity, since
+the tracked entity is now authoritative.
+
+2a's primitives (no caller yet). Each write is idempotent via the same
+query-before-write guard `_watermark_update` established (mcp_server.py:
+4867-4909) — never a blind unconditional transact, since re-transacting an
+identical (entity, attribute, value) at a new valid_from creates a
+duplicate live datom (see Revision note #2):
 
 ```python
 def _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=None) -> None:
-    """Assert [entity_ident :lineage-status :provisional]."""
+    """Create the :type/lineage-marker companion entity for entity_ident,
+    if one doesn't already exist. Queries for an existing marker first
+    (mirrors _watermark_update) -- a marker already present is a no-op,
+    never a duplicate write."""
 
 def _lineage_confirm(db, entity_ident, index_con=None) -> None:
-    """Retract :lineage-status :provisional if present; no-op if absent,
-    so callers (2c) can call this unconditionally without checking first --
-    same idempotent-by-design style as _frontier_seed_from_watermark's guard."""
+    """Retract the :type/lineage-marker companion entity's facts for
+    entity_ident if present; no-op if absent, so callers (2c) can call
+    this unconditionally without checking first."""
 
 def _lineage_is_provisional(db, entity_ident) -> bool:
-    """Plain existence query for the marker."""
+    """True iff a :type/lineage-marker companion entity currently exists
+    for entity_ident."""
 ```
 
 ### `lineage-confirmed-through` watermark
@@ -112,16 +185,21 @@ def _lineage_confirmed_through_update(db, commit_hash, commit_ts_iso, index_con=
     _watermark_update's retract-only-if-changed pattern."""
 ```
 
-Absent means "nothing confirmed past `C0` by this watermark" — correct
-both for pre-phase-2 graphs and, notably, for the region phase 1's
-migration already seeded as `[C0, W]` authoritative: that region was never
-provisional in the first place (no `:lineage-status` facts were ever
-written for it), so it needs no confirmation sweep, and this watermark
-starting unset for it does not imply that region is untrustworthy — it
-implies "the confirmation *sweep* hasn't started," which is a distinct
-question from "is this region's lineage authoritative," already answered by
-the per-entity marker's absence. Sub-phase 2a's own tests must cover this
-distinction explicitly (see Testing).
+**Migration seeding (fixes Revision note #3):** phase 1's already-merged
+`_frontier_seed_from_watermark` (mcp_server.py) gains one addition: after
+seeding the `[C0, W]` frontier interval as authoritative, it also calls
+`_lineage_confirmed_through_update(db, watermark_hash, run_ts_iso,
+index_con=index_con)`. That region's lineage genuinely *is* fully
+confirmed — it was ingested by the original single-stream forward-only
+authoritative walk, so it needs no separate confirmation sweep. With this
+seeding, the watermark becomes a complete, standalone trust predicate with
+no special-casing: an entity's lineage is trustworthy exactly when
+`_lineage_is_provisional(entity)` is `False` **and** its `:introduced-by`
+commit's position is `<=` the position of `_lineage_confirmed_through_query`'s
+hash in the current linearization. (2a does not implement this composed
+query itself — that's a consumer concern for phase 4's status reporting —
+but 2a's migration seeding is what makes the predicate well-defined instead
+of needing a special case for migrated graphs.)
 
 ### Candidate-diff persistence schema
 
@@ -137,13 +215,28 @@ values into one delimited string:
 [:candidate/<commit-hash[:12]>-<entity-ident-slug> :body-hash "<normalized-body-hash>"]
 ```
 
-The ident is deterministic: `f":candidate/{commit_hash[:12]}-{entity_ident.lstrip(':').replace('/', '-')}"` — strip the entity ident's leading `:` and replace its `/` with `-`, then prefix with the commit hash's existing 12-char short form (matching `commit_ident = f":commit/{commit_hash[:12]}"`'s existing truncation elsewhere in `_run_ingestion`). No separate ID-generation scheme needed, and naturally idempotent if a caller ever revisits the same (commit, entity) pair.
+The ident is deterministic:
+`f":candidate/{commit_hash[:12]}-{entity_ident.lstrip(':').replace('/', '-')}"`
+— strip the entity ident's leading `:` and replace its `/` with `-`, then
+prefix with the commit hash's existing 12-char short form (matching
+`commit_ident = f":commit/{commit_hash[:12]}"`'s existing truncation
+elsewhere in `_run_ingestion`).
+
+A deterministic ident makes repeated writes target the *same* entity, but
+(per Revision note #2) does **not** by itself make the write idempotent —
+`_candidate_diff_persist` must query for an existing record at that ident
+first, no-op if the persisted hash already matches, and retract-and-reassert
+only if it's genuinely different (same guard as the provisional marker
+above).
 
 2a's primitives (2b writes, 2c reads/clears — no caller in this sub-phase):
 
 ```python
 def _candidate_diff_persist(db, commit_hash, entity_ident, body_hash, commit_ts_iso, index_con=None) -> None:
-    """Mint/write one candidate-diff record for (commit_hash, entity_ident)."""
+    """Mint/update one candidate-diff record for (commit_hash, entity_ident).
+    Queries for an existing record first (mirrors _watermark_update) --
+    no-ops if the persisted body_hash already matches, retracts+reasserts
+    only if it genuinely changed."""
 
 def _candidate_diff_read(db, commit_hash, entity_ident) -> Optional[str]:
     """Return the persisted body_hash for (commit_hash, entity_ident), or
@@ -160,25 +253,39 @@ def _candidate_diff_clear(db, commit_hash, entity_ident, index_con=None) -> None
 Following `docs/testing-conventions.md` (real backend, no mocked
 `MiniGrafDb`):
 
-- **Provisional marker round-trip**: an entity with no marker reads as
-  authoritative (`_lineage_is_provisional` returns `False`); mark it
-  provisional, assert `True`; confirm it, assert `False` again; confirm an
-  already-authoritative entity a second time (never marked, or already
-  confirmed) and assert it's a genuine no-op — verified via a raw
-  fact-count query on `:lineage-status`, not just the derived boolean, per
-  the row-collapsing lesson from phase 1's Tasks 3/4.
+- **Provisional marker round-trip**: an entity with no companion marker
+  entity reads as authoritative (`_lineage_is_provisional` returns
+  `False`); mark it provisional, assert `True`; confirm it, assert `False`
+  again; confirm an already-authoritative entity a second time (never
+  marked, or already confirmed) and assert it's a genuine no-op — verified
+  via a raw fact-count query on the `:type/lineage-marker` entity's facts,
+  not just the derived boolean, per the row-collapsing lesson from phase
+  1's Tasks 3/4.
+- **Provisional marker idempotency**: call `_lineage_mark_provisional`
+  twice for the same entity and assert exactly one live `:type/
+  lineage-marker` entity/fact set exists afterward (raw count, not
+  `_lineage_is_provisional`'s boolean) — this is the test that would have
+  caught Revision note #2 if it had been run against the first draft's
+  (incorrect) unconditional-transact implementation.
+- **Audit safety test**: mark an entity provisional, run
+  `handle_minigraf_audit()`, and assert the `:type/lineage-marker` entity
+  (and, separately, a real `:type/function`/`:type/module` entity carrying
+  ordinary schema-valid attributes alongside it) both survive unretracted —
+  this directly verifies Revision note #1's fix, not just that the schema
+  doesn't reject the write at transact time.
 - **Watermark round-trip**: mirrors phase 1's `_watermark_update`/
   `_watermark_query` tests — persist, re-query, update again, confirm only
   one live `:hash` fact exists via a `(count ...)` query.
-- **Candidate-diff round-trip**: persist a candidate record, read it back,
-  confirm the correct `(commit, entity)` pair resolves to the correct hash
-  and a *different* `(commit, entity)` pair returns `None`; clear it;
-  confirm a cleared record reads back as `None`, verified via both the
-  accessor and a raw fact-count check that the underlying
-  `:type/candidate-diff` entity's facts are actually gone.
-- **Migration interaction test**: after phase 1's
-  `_frontier_seed_from_watermark` migration seeds `[C0, W]` as authoritative
-  with zero provisional facts, confirm `_lineage_confirmed_through_query`
-  still correctly reads as unset (`None`) for that region, and that this is
-  understood as "sweep hasn't run," not "region untrustworthy" (already
-  answered by the per-entity marker's absence, not this watermark).
+- **Candidate-diff round-trip + idempotency**: persist a candidate record,
+  read it back, confirm the correct `(commit, entity)` pair resolves to the
+  correct hash and a *different* `(commit, entity)` pair returns `None`;
+  persist the same `(commit, entity)` pair again with the same hash and
+  assert via raw count that no duplicate was created; persist again with a
+  *different* hash and assert the read now returns the new hash with still
+  only one live record; clear it; confirm a cleared record reads back as
+  `None`, verified via both the accessor and a raw fact-count check that the
+  underlying `:type/candidate-diff` entity's facts are actually gone.
+- **Migration seeding test**: run phase 1's migration path (`_frontier_load`
+  against a graph with only the old `:ingestion/watermark`) and assert
+  `_lineage_confirmed_through_query` now returns `W` (the watermark hash),
+  not `None` — this directly verifies Revision note #3's fix.

--- a/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
+++ b/docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md
@@ -383,7 +383,17 @@ Following `docs/testing-conventions.md` (real backend, no mocked
   prior revision.
 - **Watermark round-trip**: mirrors phase 1's `_watermark_update`/
   `_watermark_query` tests — persist, re-query, update again, confirm only
-  one live `:hash` fact exists via a `(count ...)` query.
+  one live `:hash` fact exists via a `(count ...)` query. Unlike the
+  lineage-marker/candidate-diff entities, `:ingestion/lineage-confirmed-through`
+  uses entity-type `:type/ingestion` — the *same registered, audited* type
+  `:ingestion/watermark` already uses (`ingestion` is in `MINIGRAF_SCHEMA`,
+  requiring `:description` and allowing `:hash` among its optional attrs).
+  This test must additionally assert the entity has the expected constant
+  attrs (`:entity-type`, `:ident`, `:description`) — matching
+  `_watermark_update`'s own constants block exactly — and/or survives a
+  `handle_minigraf_audit()` run unretracted, since (unlike the deliberately
+  unregistered types above) this one *is* subject to schema validation and
+  must genuinely conform, not merely avoid audit by being invisible to it.
 - **Candidate-diff round-trip + idempotency**: persist a candidate record,
   read it back, confirm the correct `(commit, entity)` pair resolves to the
   correct hash and a *different* `(commit, entity)` pair returns `None`;

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5073,6 +5073,60 @@ def _lineage_is_provisional(db: Any, entity_ident: str) -> bool:
     return bool(json.loads(raw).get("results", []))
 
 
+_LINEAGE_CONFIRMED_THROUGH_IDENT = ":ingestion/lineage-confirmed-through"
+
+
+def _lineage_confirmed_through_query(db: Any) -> Optional[str]:
+    """Return the hash of the last commit through which lineage is fully
+    confirmed, or None if nothing has been confirmed yet."""
+    raw = _db_execute(
+        db, f"(query [:find ?h :where [{_LINEAGE_CONFIRMED_THROUGH_IDENT} :hash ?h]])"
+    )
+    results = json.loads(raw).get("results", [])
+    return results[0][0] if results else None
+
+
+def _lineage_confirmed_through_update(
+    db: Any, commit_hash: str, commit_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Record the last lineage-confirmed commit hash, mirroring
+    _watermark_update's retract-only-if-changed pattern. Uses :type/
+    ingestion -- the SAME registered/audited entity type :ingestion/
+    watermark already uses -- so this entity carries the same required
+    :description constant _watermark_update's own entity does.
+    """
+    current_raw = _db_execute(
+        db, f"(query [:find ?a ?v :where [{_LINEAGE_CONFIRMED_THROUGH_IDENT} ?a ?v]])"
+    )
+    current: Dict[str, str] = dict(json.loads(current_raw).get("results", []))
+
+    def _edn(attr: str, value: str) -> str:
+        return value if attr == ":entity-type" else f'"{_edn_escape(value)}"'
+
+    constants = {
+        ":entity-type": ":type/ingestion",
+        ":ident": _LINEAGE_CONFIRMED_THROUGH_IDENT,
+        ":description": "lineage confirmed-through watermark",
+    }
+
+    to_retract: List[str] = []
+    to_transact: List[str] = []
+    for attr, value in constants.items():
+        if current.get(attr) == value:
+            continue
+        if attr in current:
+            to_retract.append(f"[{_LINEAGE_CONFIRMED_THROUGH_IDENT} {attr} {_edn(attr, current[attr])}]")
+        to_transact.append(f"[{_LINEAGE_CONFIRMED_THROUGH_IDENT} {attr} {_edn(attr, value)}]")
+
+    if ":hash" in current:
+        to_retract.append(f"[{_LINEAGE_CONFIRMED_THROUGH_IDENT} :hash {_edn(':hash', current[':hash'])}]")
+    to_transact.append(f"[{_LINEAGE_CONFIRMED_THROUGH_IDENT} :hash {_edn(':hash', commit_hash)}]")
+
+    if to_retract:
+        _retract(db, "[" + " ".join(to_retract) + "]", index_con=index_con)
+    _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
+
+
 _LAST_RUN_KEYWORD_ATTRS = frozenset({":entity-type"})
 _LAST_RUN_NUMERIC_ATTRS = frozenset({":total-ingested"})
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5151,6 +5151,80 @@ def _lineage_confirmed_through_migrate(
     _lineage_confirmed_through_update(db, hi_hash, run_ts_iso, index_con=index_con)
 
 
+def _candidate_diff_ident(commit_hash: str, entity_ident: str) -> str:
+    """Deterministic ident for a candidate-diff record. Not a public schema
+    type -- see the #222 phase 2a design spec's "Schema/audit status of new
+    entity types" section.
+    """
+    return f":candidate/{commit_hash[:12]}-{entity_ident.lstrip(':').replace('/', '-')}"
+
+
+def _candidate_diff_persist(
+    db: Any,
+    commit_hash: str,
+    entity_ident: str,
+    body_hash: str,
+    commit_ts_iso: str,
+    index_con: Optional[Any] = None,
+) -> None:
+    """Mint/update one candidate-diff record for (commit_hash, entity_ident).
+    Query-before-write -- no-ops if the persisted body_hash already
+    matches, retracts+reasserts only the :body-hash if it genuinely
+    changed (the other attributes are all derived from commit_hash/
+    entity_ident, which never change for a given record's ident). Uses
+    internal _transact/_retract directly, never handle_minigraf_transact:
+    :type/candidate-diff is deliberately unregistered in MINIGRAF_SCHEMA.
+    """
+    ident = _candidate_diff_ident(commit_hash, entity_ident)
+    existing = _candidate_diff_read(db, commit_hash, entity_ident)
+    if existing == body_hash:
+        return
+    if existing is None:
+        commit_ident = f":commit/{commit_hash[:12]}"
+        facts = [
+            f"[{ident} :entity-type :type/candidate-diff]",
+            f"[{ident} :commit {commit_ident}]",
+            f"[{ident} :entity {entity_ident}]",
+            f'[{ident} :body-hash "{_edn_escape(body_hash)}"]',
+        ]
+        _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
+    else:
+        _retract(db, f'[[{ident} :body-hash "{_edn_escape(existing)}"]]', index_con=index_con)
+        _transact(
+            db, f'[[{ident} :body-hash "{_edn_escape(body_hash)}"]]', commit_ts_iso, index_con=index_con
+        )
+
+
+def _candidate_diff_read(db: Any, commit_hash: str, entity_ident: str) -> Optional[str]:
+    """Return the persisted body_hash for (commit_hash, entity_ident), or
+    None if no candidate record exists for that pair."""
+    ident = _candidate_diff_ident(commit_hash, entity_ident)
+    raw = _db_execute(db, f"(query [:find ?h :where [{ident} :body-hash ?h]])")
+    results = json.loads(raw).get("results", [])
+    return results[0][0] if results else None
+
+
+def _candidate_diff_clear(
+    db: Any, commit_hash: str, entity_ident: str, index_con: Optional[Any] = None
+) -> None:
+    """Retract the candidate record once consumed (2c calls this after
+    confirming/rejecting), so these scratch facts don't accumulate
+    unbounded across a full ingest. No-op if no record exists.
+    """
+    existing = _candidate_diff_read(db, commit_hash, entity_ident)
+    if existing is None:
+        return
+    ident = _candidate_diff_ident(commit_hash, entity_ident)
+    commit_ident = f":commit/{commit_hash[:12]}"
+    facts = [
+        f"[{ident} :entity-type :type/candidate-diff]",
+        f"[{ident} :commit {commit_ident}]",
+        f"[{ident} :entity {entity_ident}]",
+        f'[{ident} :body-hash "{_edn_escape(existing)}"]',
+    ]
+    _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+
+
 _LAST_RUN_KEYWORD_ATTRS = frozenset({":entity-type"})
 _LAST_RUN_NUMERIC_ATTRS = frozenset({":total-ingested"})
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4962,6 +4962,7 @@ def _frontier_load(
         and _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT) is None
     ):
         _frontier_seed_from_watermark(db, linearization, run_ts_iso, index_con=index_con)
+    _lineage_confirmed_through_migrate(db, run_ts_iso, index_con=index_con)
 
     hash_to_pos = {h: i for i, h in enumerate(linearization)}
     intervals: List[frontier_registry.Interval] = []
@@ -5125,6 +5126,29 @@ def _lineage_confirmed_through_update(
     if to_retract:
         _retract(db, "[" + " ".join(to_retract) + "]", index_con=index_con)
     _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
+
+
+def _lineage_confirmed_through_migrate(
+    db: Any, run_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """One-time catch-up: if :ingestion/frontier-low exists (this graph has
+    an authoritative region, whether freshly migrated by
+    _frontier_seed_from_watermark just now or already established by an
+    earlier Phase-1-only run) but :ingestion/lineage-confirmed-through is
+    unset, seed the watermark from frontier-low's *current* :hi-hash --
+    that whole region was ingested by the original single-stream
+    forward-only authoritative walk, so it is already fully
+    lineage-confirmed. No-op if frontier-low doesn't exist yet, or
+    lineage-confirmed-through is already set (so later phases' own sweep
+    updates are never clobbered back to a stale value).
+    """
+    if _lineage_confirmed_through_query(db) is not None:
+        return
+    low_bounds = _frontier_read_bounds(db, _FRONTIER_LOW_IDENT)
+    if low_bounds is None:
+        return
+    _, hi_hash = low_bounds
+    _lineage_confirmed_through_update(db, hi_hash, run_ts_iso, index_con=index_con)
 
 
 _LAST_RUN_KEYWORD_ATTRS = frozenset({":entity-type"})

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5017,6 +5017,62 @@ def _frontier_persist_claim(
     _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
 
 
+_LINEAGE_MARKER_ENTITY_TYPE = ":type/lineage-marker"
+
+
+def _lineage_marker_ident(entity_ident: str) -> str:
+    """Deterministic companion-entity ident for entity_ident's provisional
+    marker. Not a public schema type -- see the #222 phase 2a design spec's
+    "Schema/audit status of new entity types" section.
+    """
+    return f":lineage/{entity_ident.lstrip(':').replace('/', '-')}"
+
+
+def _lineage_mark_provisional(
+    db: Any, entity_ident: str, commit_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Create the :type/lineage-marker companion entity for entity_ident, if
+    one doesn't already exist. Query-before-write (mirrors _watermark_update)
+    -- a marker already present is a no-op, never a duplicate write. Uses
+    internal _transact directly, never handle_minigraf_transact: :type/
+    lineage-marker is deliberately unregistered in MINIGRAF_SCHEMA, and the
+    public handler's schema gate would reject it outright.
+    """
+    if _lineage_is_provisional(db, entity_ident):
+        return
+    ident = _lineage_marker_ident(entity_ident)
+    facts = [
+        f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
+        f"[{ident} :entity {entity_ident}]",
+        f"[{ident} :status :provisional]",
+    ]
+    _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
+
+
+def _lineage_confirm(db: Any, entity_ident: str, index_con: Optional[Any] = None) -> None:
+    """Retract the :type/lineage-marker companion entity's facts for
+    entity_ident if present; no-op if absent, so callers (2c) can call this
+    unconditionally without checking first.
+    """
+    if not _lineage_is_provisional(db, entity_ident):
+        return
+    ident = _lineage_marker_ident(entity_ident)
+    facts = [
+        f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
+        f"[{ident} :entity {entity_ident}]",
+        f"[{ident} :status :provisional]",
+    ]
+    _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+
+
+def _lineage_is_provisional(db: Any, entity_ident: str) -> bool:
+    """True iff a :type/lineage-marker companion entity currently exists for
+    entity_ident."""
+    ident = _lineage_marker_ident(entity_ident)
+    raw = _db_execute(db, f"(query [:find ?e :where [{ident} :entity ?e]])")
+    return bool(json.loads(raw).get("results", []))
+
+
 _LAST_RUN_KEYWORD_ATTRS = frozenset({":entity-type"})
 _LAST_RUN_NUMERIC_ATTRS = frozenset({":total-ingested"})
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6084,6 +6084,67 @@ class TestFrontierPersistClaim:
         ]
 
 
+class TestLineageProvisionalMarker:
+    def test_unmarked_entity_reads_as_authoritative(self, real_db):
+        import mcp_server
+        db = real_db
+        assert mcp_server._lineage_is_provisional(db, ":function/src-auth-py-login") is False
+
+    def test_mark_then_confirm_round_trip(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._lineage_mark_provisional(db, entity_ident, "2026-01-01T00:00:00Z")
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is True
+
+        mcp_server._lineage_confirm(db, entity_ident)
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is False
+
+    def test_confirm_already_authoritative_entity_is_a_noop(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        # Never marked -- confirming must not raise or create anything.
+        mcp_server._lineage_confirm(db, entity_ident)
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is False
+
+    def test_mark_provisional_is_idempotent(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._lineage_mark_provisional(db, entity_ident, "2026-01-01T00:00:00Z")
+        mcp_server._lineage_mark_provisional(db, entity_ident, "2026-01-01T00:00:01Z")
+
+        ident = mcp_server._lineage_marker_ident(entity_ident)
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?e) :where [{ident} :entity ?e]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_provisional_marker_survives_audit(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            db,
+            f'[[{entity_ident} :entity-type :type/function] '
+            f'[{entity_ident} :description "login"] '
+            f'[{entity_ident} :file "src/auth.py"]]',
+            "2026-01-01T00:00:00Z",
+        )
+
+        mcp_server._lineage_mark_provisional(db, entity_ident, "2026-01-01T00:00:00Z")
+        result = mcp_server.handle_minigraf_audit()
+
+        assert result["retracted"] == 0
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is True
+        raw = mcp_server._db_execute(
+            db, f'(query [:find (count ?d) :where [{entity_ident} :description ?d]])'
+        )
+        assert json.loads(raw)["results"] == [[1]]
+
+
 class TestGitCommitsTopoOrder:
     def test_orders_by_topology_not_committer_date(self, git_repo_diamond_clock_skewed):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6188,6 +6188,63 @@ class TestLineageConfirmedThroughWatermark:
         assert mcp_server._lineage_confirmed_through_query(db) == "h1"
 
 
+class TestLineageConfirmedThroughMigration:
+    def test_fresh_migration_seeds_from_watermark(self, real_db):
+        import mcp_server
+        db = real_db
+        linearization = ["h0", "h1", "h2"]
+        mcp_server._watermark_update(db, "h1", "2026-01-01T00:00:00Z", "seed watermark")
+
+        mcp_server._frontier_load(db, linearization, "2026-01-02T00:00:00Z")
+
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+
+    def test_already_migrated_graph_still_gets_watermark_seeded(self, real_db):
+        import mcp_server
+        db = real_db
+        linearization = ["h0", "h1", "h2"]
+        mcp_server._watermark_update(db, "h1", "2026-01-01T00:00:00Z", "seed watermark")
+
+        # Simulate an earlier Phase-1-only run: frontier-low gets created,
+        # but lineage-confirmed-through (new in Phase 2a) doesn't exist yet.
+        mcp_server._frontier_seed_from_watermark(db, linearization, "2026-01-01T00:00:01Z")
+        assert mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_LOW_IDENT) is not None
+        assert mcp_server._lineage_confirmed_through_query(db) is None
+
+        mcp_server._frontier_load(db, linearization, "2026-01-02T00:00:00Z")
+
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+
+    def test_repeated_load_does_not_duplicate_same_value(self, real_db):
+        import mcp_server
+        db = real_db
+        linearization = ["h0", "h1", "h2"]
+        mcp_server._watermark_update(db, "h1", "2026-01-01T00:00:00Z", "seed watermark")
+
+        mcp_server._frontier_load(db, linearization, "2026-01-02T00:00:00Z")
+        mcp_server._frontier_load(db, linearization, "2026-01-03T00:00:00Z")
+
+        ident = mcp_server._LINEAGE_CONFIRMED_THROUGH_IDENT
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_does_not_clobber_a_value_advanced_past_migration_boundary(self, real_db):
+        import mcp_server
+        db = real_db
+        linearization = ["h0", "h1", "h2"]
+        mcp_server._watermark_update(db, "h1", "2026-01-01T00:00:00Z", "seed watermark")
+        mcp_server._frontier_load(db, linearization, "2026-01-02T00:00:00Z")
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+
+        # Simulate phase 2c's real sweep having advanced past the original
+        # migration boundary.
+        mcp_server._lineage_confirmed_through_update(db, "h2", "2026-01-03T00:00:00Z")
+
+        mcp_server._frontier_load(db, linearization, "2026-01-04T00:00:00Z")
+
+        assert mcp_server._lineage_confirmed_through_query(db) == "h2"
+
+
 class TestGitCommitsTopoOrder:
     def test_orders_by_topology_not_committer_date(self, git_repo_diamond_clock_skewed):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6145,6 +6145,49 @@ class TestLineageProvisionalMarker:
         assert json.loads(raw)["results"] == [[1]]
 
 
+class TestLineageConfirmedThroughWatermark:
+    def test_unset_reads_as_none(self, real_db):
+        import mcp_server
+        assert mcp_server._lineage_confirmed_through_query(real_db) is None
+
+    def test_update_then_query_round_trip(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._lineage_confirmed_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+
+        mcp_server._lineage_confirmed_through_update(db, "h2", "2026-01-02T00:00:00Z")
+        assert mcp_server._lineage_confirmed_through_query(db) == "h2"
+
+    def test_update_does_not_duplicate_hash_fact(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._lineage_confirmed_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_confirmed_through_update(db, "h2", "2026-01-02T00:00:00Z")
+
+        ident = mcp_server._LINEAGE_CONFIRMED_THROUGH_IDENT
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_entity_carries_expected_constants_and_survives_audit(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._lineage_confirmed_through_update(db, "h1", "2026-01-01T00:00:00Z")
+
+        ident = mcp_server._LINEAGE_CONFIRMED_THROUGH_IDENT
+        raw = mcp_server._db_execute(
+            db, f"(query [:find ?a ?v :where [{ident} ?a ?v]])"
+        )
+        attrs = dict(json.loads(raw)["results"])
+        assert attrs[":entity-type"] == ":type/ingestion"
+        assert attrs[":ident"] == ident
+        assert isinstance(attrs[":description"], str) and attrs[":description"]
+
+        result = mcp_server.handle_minigraf_audit()
+        assert result["retracted"] == 0
+        assert mcp_server._lineage_confirmed_through_query(db) == "h1"
+
+
 class TestGitCommitsTopoOrder:
     def test_orders_by_topology_not_committer_date(self, git_repo_diamond_clock_skewed):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6245,6 +6245,84 @@ class TestLineageConfirmedThroughMigration:
         assert mcp_server._lineage_confirmed_through_query(db) == "h2"
 
 
+class TestCandidateDiff:
+    def test_read_absent_record_returns_none(self, real_db):
+        import mcp_server
+        assert mcp_server._candidate_diff_read(real_db, "a" * 40, ":function/foo") is None
+
+    def test_persist_then_read_round_trip(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+
+        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash1"
+        # A different (commit, entity) pair must not resolve to this record.
+        assert mcp_server._candidate_diff_read(db, "b" * 40, entity_ident) is None
+        assert mcp_server._candidate_diff_read(db, commit_hash, ":function/other") is None
+
+    def test_persist_same_hash_twice_does_not_duplicate(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:01Z")
+
+        ident = mcp_server._candidate_diff_ident(commit_hash, entity_ident)
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :body-hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_persist_different_hash_updates_without_duplicating(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash2", "2026-01-01T00:00:01Z")
+
+        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash2"
+        ident = mcp_server._candidate_diff_ident(commit_hash, entity_ident)
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :body-hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_clear_removes_the_record(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+        mcp_server._candidate_diff_clear(db, commit_hash, entity_ident)
+
+        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) is None
+        ident = mcp_server._candidate_diff_ident(commit_hash, entity_ident)
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?e) :where [{ident} :entity ?e]])")
+        assert json.loads(raw)["results"] == [[0]]
+
+    def test_clear_absent_record_is_a_noop(self, real_db):
+        import mcp_server
+        db = real_db
+        # Must not raise.
+        mcp_server._candidate_diff_clear(db, "a" * 40, ":function/never-persisted")
+
+    def test_candidate_diff_survives_audit(self, real_db):
+        import mcp_server
+        db = real_db
+        commit_hash = "a" * 40
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
+        result = mcp_server.handle_minigraf_audit()
+
+        assert result["retracted"] == 0
+        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash1"
+
+
 class TestGitCommitsTopoOrder:
     def test_orders_by_topology_not_committer_date(self, git_repo_diamond_clock_skewed):
         import mcp_server


### PR DESCRIPTION
## Summary
- Sub-phase 2a of 4 within #222's phase 2 ("Streams 1+2 converging"): builds the provisional/authoritative lineage fact model and candidate-diff persistence primitives — pure data-model plumbing, no caller yet.
- Provisional lineage marker: a companion entity (`:type/lineage-marker`, deliberately unregistered in `MINIGRAF_SCHEMA`) tagging an entity's `:introduced-by` as unconfirmed. Not an attribute on the tracked code entity itself, since `module`/`function`/`class`/`variable`/`field` are schema-registered/audited and an unknown attribute would be silently retracted by `minigraf_audit`.
- `lineage-confirmed-through` watermark: `:ingestion/lineage-confirmed-through`, mirroring `:ingestion/watermark`'s exact pattern — unlike the marker above, this uses a registered/audited type and genuinely conforms to schema.
- Migration catch-up wired into phase 1's existing `_frontier_load`: seeds the new watermark from `frontier-low`'s current `:hi-hash`, covering both a fresh migration and a graph that already ran phase 1 standalone before this sub-phase landed (this project's own actual situation).
- Candidate-diff persistence: one entity per (commit, entity) pair holding a normalized-body-hash, for a future correction sweep to confirm/reject a candidate lineage guess without re-parsing source.
- The underlying design spec went through 4 review rounds catching real bugs (schema/audit safety, false idempotency claims, a migration-coverage gap for already-migrated graphs, internal-vs-public transact path) — all fixes verified intact by the final whole-branch review.

Design spec: `docs/superpowers/specs/2026-07-24-lineage-provisional-fact-model-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-24-lineage-provisional-fact-model.md`

## Test plan
- [x] All 4 tasks individually implemented via TDD, each passed task-level review with no fix rounds needed
- [x] Final whole-branch review: ready to merge, no Critical/Important findings
- [x] 20 new tests across `TestLineageProvisionalMarker`/`TestLineageConfirmedThroughWatermark`/`TestLineageConfirmedThroughMigration`/`TestCandidateDiff`, real backend throughout (no mocked DB)
- [x] Confirmed the 120 pre-existing test failures (missing tree-sitter grammar packages) are unchanged — not a regression
- [x] Confirmed both new unregistered entity types survive a real `handle_minigraf_audit()` run
- [x] Confirmed the migration catch-up correctly handles both a fresh migration and an already-migrated (phase-1-only) graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYoDWi6xS1Rh5N84KERmLL