### PR TITLE
Add #222 phase 2b: reverse-bulk-fill walk (Stream 2)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-reverse-bulk-fill-walk.md
+++ b/docs/superpowers/plans/2026-07-24-reverse-bulk-fill-walk.md
@@ -433,7 +433,7 @@ class TestReverseFillClaimAndProcess:
             )
 
         fn_ident = mcp_server._code_ident("function", "auth.py", "login")
-        oldest_hash = linearization[0]  # h0
+        oldest_hash, mid_hash, newest_hash = linearization[0], linearization[1], linearization[2]
         assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{oldest_hash[:12]}"
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
         raw = mcp_server._db_execute(
@@ -441,6 +441,48 @@ class TestReverseFillClaimAndProcess:
         )
         assert json.loads(raw)["results"] == [[1]]
         assert mcp_server._candidate_diff_read(real_db, oldest_hash, fn_ident) is not None
+
+        # The converged :modified-in set must match what forward walk would
+        # have produced: every later touch except the true introduction
+        # commit itself (h0 gets none -- see the design spec's corrected
+        # "Per-commit algorithm" section and the final whole-branch
+        # review's Critical finding #1 that this test was added to catch).
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :modified-in ?c]])"
+        )
+        modified_in_commits = {row[0] for row in json.loads(raw)["results"]}
+        assert modified_in_commits == {f":commit/{mid_hash[:12]}", f":commit/{newest_hash[:12]}"}
+
+    def test_two_entities_in_one_commit_get_different_classifications(self, real_db, tmp_path):
+        """A single claimed commit can simultaneously introduce a brand-new
+        entity and add a real touch to an already-authoritative one --
+        the two must not cross-contaminate each other's handling."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        extra_ident = mcp_server._code_ident("function", "auth.py", "extra")
+        # Simulate Stream 1 having already confirmed extra() authoritatively,
+        # before Stream 2 ever runs -- extra() first appears at h1, and this
+        # commit (h2, claimed first) also touches it (its body is identical
+        # at h1/h2, but it still shares the file with a genuinely new touch).
+        mcp_server._transact(
+            real_db, f"[[{extra_ident} :introduced-by :commit/preexisting]]", "2025-01-01T00:00:00Z",
+        )
+
+        claimed_hash = mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        commit_ident = f":commit/{claimed_hash[:12]}"
+
+        more_ident = mcp_server._code_ident("function", "auth.py", "more")
+        # more() is genuinely new at h2 -- first sighting, provisional.
+        assert mcp_server._entity_introduced_by_query(real_db, more_ident) == commit_ident
+        assert mcp_server._lineage_is_provisional(real_db, more_ident) is True
+
+        # extra() stays authoritative and untouched on :introduced-by.
+        assert mcp_server._entity_introduced_by_query(real_db, extra_ident) == ":commit/preexisting"
+        assert mcp_server._lineage_is_provisional(real_db, extra_ident) is False
 
     def test_already_authoritative_entity_only_gets_modified_in(self, real_db, tmp_path):
         import mcp_server
@@ -508,17 +550,41 @@ def _reverse_fill_claim_and_process(
     files are skipped entirely (deletions and renames are out of scope for
     this sub-phase -- see the design spec).
 
-    Reuses _extract_commit/_build_code_triples unchanged: entity discovery
-    is direction-agnostic. The only new mechanism is substituting a DB
-    query (_entity_introduced_by_query) for forward walk's in-memory
-    entity_valid_from dict, since reverse walk has no accumulated-forward
-    state -- built fresh, per file, from currently-persisted graph state.
+    Reuses _extract_commit/_build_code_triples unchanged for entity
+    discovery/parsing (direction-agnostic). BOTH :introduced-by and
+    :modified-in are filtered out of _build_code_triples's own output and
+    written by this function instead -- _build_code_triples's gate for
+    both attributes is entity_valid_from membership, which for forward
+    walk coincides with "is this the introduction commit" but for reverse
+    walk does not: the first commit reverse walk sees an entity at is the
+    newest touch (not the introduction), and the commit where reverse walk
+    finally stops finding an even-earlier occurrence (the true
+    introduction) is by then already "known" from later, already-visited
+    commits. Reusing _build_code_triples's :modified-in emission verbatim
+    would misclassify both ends. See the design spec's "Per-commit
+    algorithm" section (revised after the final whole-branch review found
+    this defect) for the full derivation.
 
-    _build_code_triples's own candidate :introduced-by triples are filtered
-    out of what gets transacted here -- _entity_introduced_by_set_provisional
-    is the sole writer of :introduced-by in this walk, so a newly
-    discovered entity and one whose guess is being moved earlier go
-    through exactly the same code path.
+    :introduced-by: a newly-discovered entity's guess is asserted via
+    _entity_introduced_by_set_provisional and gets no :modified-in yet
+    (mirrors forward walk never emitting :modified-in at an entity's own
+    introduction commit). When an already-provisional entity is found at
+    an even earlier commit, its guess moves to this commit (also getting
+    no :modified-in yet) and the PREVIOUSLY-guessed commit -- now
+    confirmed to be a genuine modification, not the introduction --
+    retroactively receives a :modified-in fact using its OWN commit
+    timestamp (looked up from commit_metadata), not this commit's.
+    Already-authoritative entities are never touched, but a genuine later
+    touch always gets :modified-in (unless #221's unchanged-body check
+    says the body is provably unchanged this commit).
+
+    Known, documented limitation: the retroactive :modified-in for a
+    superseded commit does not re-check #221's unchanged-body narrowing
+    against THAT commit's own diff (only this call's diff has that data) --
+    it is asserted unconditionally. This can rarely over-assert an edge
+    forward walk would have suppressed; it can never produce a missing or
+    misattributed edge. See the design spec for why this is an accepted
+    simplification for this sub-phase.
 
     Returns the claimed commit's hash, or None if the gap was already
     empty (allocator.claim_high() returned None) -- caller's signal to
@@ -548,8 +614,10 @@ def _reverse_fill_claim_and_process(
         f'[{commit_ident} :date "{commit_ts_iso}"]',
     ]
     new_candidates: List[str] = []
-    provisional_moves: List[str] = []
+    provisional_moves: List[Tuple[str, str]] = []  # (ident, superseded_commit_ident)
+    already_authoritative_touched: List[str] = []
     body_hash_by_ident: Dict[str, str] = {}
+    unchanged_by_ident: Dict[str, bool] = {}
 
     for status, file_path, extracted, precomputed, _old_path in file_results:
         if status not in ("A", "M"):
@@ -572,22 +640,56 @@ def _reverse_fill_claim_and_process(
             file_path, extracted, commit_ts_iso, known_before, {}, {}, commit_ident,
             precomputed, {}, {},
         )
-        all_triples.extend(t for t in triples if ":introduced-by" not in t)
+        # This walk owns the write timing of BOTH attributes itself now --
+        # filter both out of _build_code_triples's forward-biased gating.
+        all_triples.extend(
+            t for t in triples if ":introduced-by" not in t and ":modified-in" not in t
+        )
+
+        unchanged_idents = precomputed.get("unchanged_idents", set())
+        for ident in candidate_idents:
+            unchanged_by_ident[ident] = ident in unchanged_idents
 
         new_candidates.extend(set(known_before.keys()) - known_before_snapshot)
         for ident in set(candidate_idents) & known_before_snapshot:
             if _lineage_is_provisional(db, ident):
-                provisional_moves.append(ident)
+                superseded_ident = _entity_introduced_by_query(db, ident)
+                provisional_moves.append((ident, superseded_ident))
+            else:
+                already_authoritative_touched.append(ident)
 
         body_hash_by_ident.update(precomputed.get("body_hashes", {}))
 
     _transact(db, "[" + " ".join(all_triples) + "]", commit_ts_iso, index_con=index_con)
 
-    for ident in new_candidates + provisional_moves:
+    authoritative_modified_triples = [
+        f"[{ident} :modified-in {commit_ident}]"
+        for ident in already_authoritative_touched
+        if not unchanged_by_ident.get(ident, False)
+    ]
+    if authoritative_modified_triples:
+        _transact(
+            db, "[" + " ".join(authoritative_modified_triples) + "]", commit_ts_iso, index_con=index_con,
+        )
+
+    for ident in new_candidates:
         _entity_introduced_by_set_provisional(db, ident, commit_ident, commit_ts_iso, index_con=index_con)
         if ident in body_hash_by_ident:
             _candidate_diff_persist(
                 db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
+            )
+
+    ts_by_commit_ident = {f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata}
+    for ident, superseded_ident in provisional_moves:
+        _entity_introduced_by_set_provisional(db, ident, commit_ident, commit_ts_iso, index_con=index_con)
+        if ident in body_hash_by_ident:
+            _candidate_diff_persist(
+                db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
+            )
+        if superseded_ident is not None and superseded_ident != commit_ident:
+            superseded_ts = ts_by_commit_ident.get(superseded_ident, commit_ts_iso)
+            _transact(
+                db, f"[[{ident} :modified-in {superseded_ident}]]", superseded_ts, index_con=index_con,
             )
 
     _frontier_persist_claim(db, linearization, pos, from_low=False, commit_ts_iso=commit_ts_iso, index_con=index_con)
@@ -598,7 +700,7 @@ def _reverse_fill_claim_and_process(
 - [ ] **Step 4: Run tests to verify they pass**
 
 Run: `python -m pytest tests/test_mcp_server.py::TestReverseFillClaimAndProcess -v`
-Expected: PASS (all 5 tests).
+Expected: PASS (all 6 tests).
 
 Also run the full existing suite:
 

--- a/docs/superpowers/plans/2026-07-24-reverse-bulk-fill-walk.md
+++ b/docs/superpowers/plans/2026-07-24-reverse-bulk-fill-walk.md
@@ -1,0 +1,759 @@
+# Reverse-Bulk-Fill Walk (Stream 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build sub-phase 2b of #222's phase 2: Stream 2's actual reverse-bulk-fill walk, which claims commits from the frontier gap's high end and writes structural facts, `:modified-in` edges, and provisional `:introduced-by` lineage using phase 2a's primitives. No caller wired into `_run_ingestion` yet — 2d wires the real concurrency.
+
+**Architecture:** Reuses `_extract_commit` (already a pure, direction-agnostic per-commit diff/parse) and `_build_code_triples` (already gates "write structural facts once" purely by dict membership) unchanged. The only new mechanism is a DB-query-based substitute for forward walk's in-memory `entity_valid_from` accumulation, since reverse walk has no accumulated-forward state to consult — "is this entity already known" becomes "does it already have an `:introduced-by` fact", and 2a's `_lineage_is_provisional` distinguishes a confirmed fact from a movable guess.
+
+**Tech Stack:** Python 3, minigraf Datalog (via existing `_db_execute`/`_transact`/`_retract`/`_edn_escape`/`_db_checkpoint` helpers), `frontier_registry.FrontierAllocator` (phase 1), 2a's lineage/candidate-diff primitives, pytest, real git repos under `tmp_path`.
+
+## Global Constraints
+
+- Design spec: `docs/superpowers/specs/2026-07-24-reverse-bulk-fill-walk-design.md` — every fix and decision in it is binding. In particular:
+  - Out of scope for this sub-phase: `:depends-on` edges, renames (`:renamed-from`/`:renamed-to`), and deletion/close handling in the reverse direction. Skip `"D"` and `"R"` status files entirely in the new walk.
+  - `:introduced-by` is written via ONE code path only in the new reverse-walk functions: `_entity_introduced_by_set_provisional` (Task 1). `_build_code_triples`'s own candidate `:introduced-by` triples must be filtered out of whatever gets transacted by the reverse walk, so there is never a second writer for the same attribute.
+  - Every new write in Tasks 1/3/4 uses the internal `_transact`/`_retract` helpers directly, never `handle_minigraf_transact`/`handle_minigraf_retract` (`:introduced-by`/`:modified-in` are already-registered attributes on registered types, so this constraint is about matching existing internal-engine style, not schema/audit safety — see the design spec's "Schema/audit safety" section).
+  - Each claimed commit's full write (structural facts, lineage moves, candidate-diff persists, frontier claim) is followed by exactly one `_db_checkpoint(db)` call, mirroring `_run_ingestion`'s own one-checkpoint-per-commit cadence (see the design spec's "Resume-safety / atomicity boundary" section).
+- Follow `docs/testing-conventions.md`: every test uses a real `MiniGrafDb` (`real_db` fixture) and, where a git repo is needed, a real repo under `tmp_path` — never mocked.
+- No caller wired into `_run_ingestion`. Nothing outside the new functions themselves changes existing behavior.
+
+---
+
+### Task 1: `_entity_introduced_by_query` / `_entity_introduced_by_set_provisional`
+
+**Files:**
+- Modify: `mcp_server.py` — insert immediately after `_candidate_diff_clear` (currently ends at line 5225), before `_LAST_RUN_KEYWORD_ATTRS` (currently line 5228).
+- Test: `tests/test_mcp_server.py` — new `TestEntityIntroducedBySetProvisional` class.
+
+**Interfaces:**
+- Consumes: `_db_execute(db, datalog) -> str`, `_transact(db, datalog_facts, valid_from, index_con=None) -> str`, `_retract(db, datalog_facts, index_con=None) -> str`, `_lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=None) -> None`, `_lineage_is_provisional(db, entity_ident) -> bool` (all pre-existing, phase 2a).
+- Produces:
+  - `_entity_introduced_by_query(db, entity_ident: str) -> Optional[str]`
+  - `_entity_introduced_by_set_provisional(db, entity_ident: str, commit_ident: str, commit_ts_iso: str, index_con=None) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this test class to `tests/test_mcp_server.py` (near the existing `TestLineageProvisionalMarker`/`TestCandidateDiff` classes):
+
+```python
+class TestEntityIntroducedBySetProvisional:
+    def test_query_absent_returns_none(self, real_db):
+        import mcp_server
+        assert mcp_server._entity_introduced_by_query(real_db, ":function/src-auth-py-login") is None
+
+    def test_first_assert_is_provisional(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h2", "2026-01-03T00:00:00Z")
+
+        assert mcp_server._entity_introduced_by_query(db, entity_ident) == ":commit/h2"
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is True
+
+    def test_moving_provisional_value_retracts_old_and_asserts_new(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h2", "2026-01-03T00:00:00Z")
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h0", "2026-01-01T00:00:00Z")
+
+        assert mcp_server._entity_introduced_by_query(db, entity_ident) == ":commit/h0"
+        raw = mcp_server._db_execute(
+            db, f"(query [:find (count ?c) :where [{entity_ident} :introduced-by ?c]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_same_value_twice_is_idempotent(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h1", "2026-01-02T00:00:00Z")
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h1", "2026-01-02T00:00:01Z")
+
+        raw = mcp_server._db_execute(
+            db, f"(query [:find (count ?c) :where [{entity_ident} :introduced-by ?c]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_never_clobbers_an_authoritative_fact(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        # Simulate forward walk (Stream 1) having already confirmed this
+        # entity authoritatively -- a plain _transact, no lineage marker.
+        mcp_server._transact(
+            db, f"[[{entity_ident} :introduced-by :commit/original]]", "2026-01-01T00:00:00Z",
+        )
+
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h5", "2026-01-05T00:00:00Z")
+
+        assert mcp_server._entity_introduced_by_query(db, entity_ident) == ":commit/original"
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestEntityIntroducedBySetProvisional -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_entity_introduced_by_query'`.
+
+- [ ] **Step 3: Add the functions to `mcp_server.py`**
+
+Insert immediately after `_candidate_diff_clear` (before `_LAST_RUN_KEYWORD_ATTRS`):
+
+```python
+def _entity_introduced_by_query(db: Any, entity_ident: str) -> Optional[str]:
+    """Return entity_ident's current :introduced-by value (a commit ident
+    string), or None if it has none yet."""
+    raw = _db_execute(db, f"(query [:find ?c :where [{entity_ident} :introduced-by ?c]])")
+    results = json.loads(raw).get("results", [])
+    return results[0][0] if results else None
+
+
+def _entity_introduced_by_set_provisional(
+    db: Any,
+    entity_ident: str,
+    commit_ident: str,
+    commit_ts_iso: str,
+    index_con: Optional[Any] = None,
+) -> None:
+    """Assert or move entity_ident's PROVISIONAL :introduced-by to
+    commit_ident. Never touches an entity whose :introduced-by is already
+    authoritative (a fact exists and _lineage_is_provisional is False) --
+    reverse walk (#222 phase 2b) must never clobber a fact Stream 1 has
+    already confirmed. Idempotent: no-ops the fact write (but still ensures
+    the marker is present) if the current value already equals
+    commit_ident. Query-before-write, retract-then-reassert only if the
+    value genuinely changed -- mirrors _watermark_update's pattern, since
+    re-transacting the same (entity, attribute, value) at a new valid_from
+    creates a duplicate live datom under minigraf's write semantics.
+    """
+    current = _entity_introduced_by_query(db, entity_ident)
+    if current is not None and not _lineage_is_provisional(db, entity_ident):
+        return  # authoritative -- never touch
+    if current == commit_ident:
+        _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
+        return
+    if current is not None:
+        _retract(db, f"[[{entity_ident} :introduced-by {current}]]", index_con=index_con)
+    _transact(db, f"[[{entity_ident} :introduced-by {commit_ident}]]", commit_ts_iso, index_con=index_con)
+    _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestEntityIntroducedBySetProvisional -v`
+Expected: PASS (all 5 tests).
+
+Also run the full existing suite to confirm no regression:
+
+Run: `python -m pytest tests/test_mcp_server.py -x -q`
+Expected: PASS (no new failures beyond pre-existing, unrelated ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add _entity_introduced_by_query/_set_provisional for #222 phase 2b
+
+Query-before-write helper pair for reading/moving an entity's
+:introduced-by fact while it's still provisional. Never touches an
+already-authoritative fact (Stream 1's confirmed lineage is untouchable).
+Idempotent by query-before-write, writes via internal _transact/_retract
+only. No caller yet -- Task 3 wires this into the reverse walk."
+```
+
+---
+
+### Task 2: `_precompute_file_triples` exposes per-entity body hashes
+
+**Files:**
+- Modify: `mcp_server.py` — `_precompute_file_triples` (currently starts at line 6235, return statement at lines 6385-6396).
+- Test: `tests/test_mcp_server.py` — new tests added to the existing `TestPrecomputeFileTriplesBodyDiff` class (currently starts at line 8426).
+
+**Interfaces:**
+- Consumes: `_normalized_body_hash(node) -> str` (pre-existing, #221), `new_entity_nodes` (an existing parameter of `_precompute_file_triples`, already populated by `_extract_commit` for every `"A"`/`"M"`/`"R"` file — see the design spec's "Why `_extract_commit` needs no changes" section).
+- Produces: a new `"body_hashes": Dict[str, str]` key in `_precompute_file_triples`'s returned dict, mapping each function/class/variable/field ident present in `new_entity_nodes` to its `_normalized_body_hash`. (Module idents are deliberately excluded — there is no tree-sitter node to hash for a whole file; the design spec's candidate-diff persistence is function/class/variable/field-only, matching #221's own `unchanged_idents` category scope.)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests to the existing `TestPrecomputeFileTriplesBodyDiff` class in `tests/test_mcp_server.py` (it already has a `_python_parser`/`_all_nodes` helper pair — reuse them, don't redefine):
+
+```python
+    def test_body_hashes_populated_for_every_new_side_function(self):
+        import mcp_server
+        parser = self._python_parser()
+        new_nodes = self._all_nodes(parser, b"def login(user):\n    return user.ok\n")
+        extracted = {"functions": ["login"], "classes": [], "imports": []}
+        result = mcp_server._precompute_file_triples(
+            "auth.py", extracted, ":commit/c1", {}, new_entity_nodes=new_nodes,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        assert result["body_hashes"][fn_ident] == mcp_server._normalized_body_hash(new_nodes["function"]["login"])
+
+    def test_body_hashes_match_across_textually_identical_bodies(self):
+        import mcp_server
+        parser = self._python_parser()
+        nodes_a = self._all_nodes(parser, b"def login(user):\n    return user.ok\n")
+        nodes_b = self._all_nodes(parser, b"def login(user):\n\n    return   user.ok\n")
+        extracted = {"functions": ["login"], "classes": [], "imports": []}
+        result_a = mcp_server._precompute_file_triples(
+            "auth.py", extracted, ":commit/c1", {}, new_entity_nodes=nodes_a,
+        )
+        result_b = mcp_server._precompute_file_triples(
+            "auth.py", extracted, ":commit/c2", {}, new_entity_nodes=nodes_b,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        assert result_a["body_hashes"][fn_ident] == result_b["body_hashes"][fn_ident]
+
+    def test_body_hashes_absent_without_new_entity_nodes(self):
+        import mcp_server
+        extracted = {"functions": ["login"], "classes": [], "imports": []}
+        result = mcp_server._precompute_file_triples("auth.py", extracted, ":commit/c1", {})
+        assert result["body_hashes"] == {}
+
+    def test_module_ident_never_appears_in_body_hashes(self):
+        import mcp_server
+        parser = self._python_parser()
+        new_nodes = self._all_nodes(parser, b"def login(user):\n    return user.ok\n")
+        extracted = {"functions": ["login"], "classes": [], "imports": []}
+        result = mcp_server._precompute_file_triples(
+            "auth.py", extracted, ":commit/c1", {}, new_entity_nodes=new_nodes,
+        )
+        module_ident = mcp_server._code_ident("module", "auth.py")
+        assert module_ident not in result["body_hashes"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestPrecomputeFileTriplesBodyDiff -v`
+Expected: FAIL with `KeyError: 'body_hashes'`.
+
+- [ ] **Step 3: Add `body_hashes` computation to `_precompute_file_triples`**
+
+Modify the existing block immediately before the function's `return` statement (currently lines 6372-6396) — change:
+
+```python
+    unchanged_idents: Set[str] = set()
+    try:
+        old_nodes = old_entity_nodes or {}
+        new_nodes = new_entity_nodes or {}
+        for category in ("function", "class", "variable", "field"):
+            old_cat = old_nodes.get(category, {})
+            new_cat = new_nodes.get(category, {})
+            for name in old_cat.keys() & new_cat.keys():
+                if _normalized_body_hash(old_cat[name]) == _normalized_body_hash(new_cat[name]):
+                    unchanged_idents.add(_code_ident(category, file_path, name))
+    except Exception:
+        unchanged_idents = set()
+
+    return {
+        "module_ident": module_ident,
+        "module_candidate_triples": module_candidate_triples,
+        "function_entries": function_entries,
+        "class_entries": class_entries,
+        "global_entries": global_entries,
+        "field_entries": field_entries,
+        "field_class_map": field_class_map,
+        "field_static_map": field_static_map,
+        "resolved_imports": resolved_imports,
+        "unchanged_idents": unchanged_idents,
+    }
+```
+
+to:
+
+```python
+    unchanged_idents: Set[str] = set()
+    try:
+        old_nodes = old_entity_nodes or {}
+        new_nodes = new_entity_nodes or {}
+        for category in ("function", "class", "variable", "field"):
+            old_cat = old_nodes.get(category, {})
+            new_cat = new_nodes.get(category, {})
+            for name in old_cat.keys() & new_cat.keys():
+                if _normalized_body_hash(old_cat[name]) == _normalized_body_hash(new_cat[name]):
+                    unchanged_idents.add(_code_ident(category, file_path, name))
+    except Exception:
+        unchanged_idents = set()
+
+    # #222 phase 2b: per-entity body hash for every entity present on the
+    # NEW side, keyed the same way unchanged_idents is above -- lets the
+    # reverse-bulk-fill walk persist a candidate-diff record (body hash)
+    # for an entity without needing the raw tree-sitter node itself.
+    # Module-level entries are deliberately excluded: there is no
+    # tree-sitter node to hash for a whole file, and candidate-diff
+    # persistence is function/class/variable/field-only (matching
+    # unchanged_idents' own category scope).
+    body_hashes: Dict[str, str] = {}
+    try:
+        new_nodes_for_hash = new_entity_nodes or {}
+        for category in ("function", "class", "variable", "field"):
+            for name, node in new_nodes_for_hash.get(category, {}).items():
+                body_hashes[_code_ident(category, file_path, name)] = _normalized_body_hash(node)
+    except Exception:
+        body_hashes = {}
+
+    return {
+        "module_ident": module_ident,
+        "module_candidate_triples": module_candidate_triples,
+        "function_entries": function_entries,
+        "class_entries": class_entries,
+        "global_entries": global_entries,
+        "field_entries": field_entries,
+        "field_class_map": field_class_map,
+        "field_static_map": field_static_map,
+        "resolved_imports": resolved_imports,
+        "unchanged_idents": unchanged_idents,
+        "body_hashes": body_hashes,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestPrecomputeFileTriplesBodyDiff -v`
+Expected: PASS (all tests in the class, including the 4 new ones).
+
+Also run the full existing suite, and specifically every existing caller of `_precompute_file_triples`/`_build_code_triples`/`_extract_commit` (a new dict key is additive and must not break any existing consumer that doesn't know about it):
+
+Run: `python -m pytest tests/test_mcp_server.py -x -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add per-entity body_hashes to _precompute_file_triples for #222 phase 2b
+
+Additive dict key, computed from new_entity_nodes (already parsed for
+every A/M/R file, no new plumbing) the same way #221's unchanged_idents
+already is. Lets the reverse-bulk-fill walk (Task 3) persist a
+candidate-diff body hash without needing the raw tree-sitter node.
+Module idents excluded -- no node to hash for a whole file."
+```
+
+---
+
+### Task 3: `_reverse_fill_claim_and_process`
+
+**Files:**
+- Modify: `mcp_server.py` — insert immediately after `_extract_commit` (currently ends at line 7192), before `_run_ingestion` (currently line 7195).
+- Test: `tests/test_mcp_server.py` — new `TestReverseFillClaimAndProcess` class.
+
+**Interfaces:**
+- Consumes: `_extract_commit(repo_path, commit_hash, ignore_patterns) -> tuple` (pre-existing), `_build_code_triples(...)` (pre-existing), `_entity_introduced_by_query`/`_entity_introduced_by_set_provisional` (Task 1), `_lineage_is_provisional`/`_candidate_diff_persist` (phase 2a), `_frontier_persist_claim` (phase 1), `_db_checkpoint(db)` (pre-existing), `frontier_registry.FrontierAllocator.claim_high() -> Optional[int]` (phase 1).
+- Produces: `_reverse_fill_claim_and_process(db, repo_path: str, linearization: List[str], commit_metadata: List[Tuple[str, str, str, str]], allocator: "frontier_registry.FrontierAllocator", ignore_patterns: Sequence[str] = (), index_con=None) -> Optional[str]`
+
+`commit_metadata` is `linearization`-position-indexed, same shape `_git_commits` already returns: `(hash, ts_iso, author, subject)` per position. Tests build it with `_git_commits(str(repo), watermark_hash=None)` against the same repo `linearization` came from — both use `git log --topo-order --reverse`, so the two lists share the same order/indices.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add near the top of `tests/test_mcp_server.py` if not already present: `import frontier_registry` (already added in phase 1's Task 3 — check first, don't duplicate the import).
+
+Add this test class:
+
+```python
+class TestReverseFillClaimAndProcess:
+    def _repo_with_evolving_function(self, tmp_path):
+        """Three commits, each genuinely changing auth.py's login() body (not
+        just whitespace -- #221's unchanged-body detection would otherwise
+        suppress :modified-in and complicate the assertions below), plus an
+        unrelated function added at h1/h2 so the file is in each commit's
+        diff for a real reason."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text("def login():\n    return 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text("def login():\n    return 2\n\ndef extra():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h1"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text(
+            "def login():\n    return 3\n\ndef extra():\n    pass\n\ndef more():\n    pass\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h2"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _allocator_and_metadata(self, repo, real_db):
+        import mcp_server
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        return linearization, commit_metadata, allocator
+
+    def test_gap_empty_returns_none_and_writes_nothing(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+        # Drain the gap entirely first (forward-claim everything low).
+        while allocator.claim_low() is not None:
+            pass
+
+        result = mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert result is None
+
+    def test_single_claim_writes_structure_and_provisional_introduced_by(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        claimed_hash = mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert claimed_hash == linearization[-1]  # newest commit (h2) claimed first
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        commit_ident = f":commit/{claimed_hash[:12]}"
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == commit_ident
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        assert mcp_server._candidate_diff_read(real_db, claimed_hash, fn_ident) is not None
+
+    def test_walking_backward_moves_introduced_by_to_the_oldest_commit(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        for _ in range(3):
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        oldest_hash = linearization[0]  # h0
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{oldest_hash[:12]}"
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find (count ?c) :where [{fn_ident} :introduced-by ?c]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+        assert mcp_server._candidate_diff_read(real_db, oldest_hash, fn_ident) is not None
+
+    def test_already_authoritative_entity_only_gets_modified_in(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        # Simulate Stream 1 having already confirmed login() authoritatively
+        # at the oldest commit, before Stream 2 ever runs.
+        mcp_server._transact(
+            real_db, f"[[{fn_ident} :introduced-by :commit/preexisting]]", "2025-01-01T00:00:00Z",
+        )
+
+        claimed_hash = mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        commit_ident = f":commit/{claimed_hash[:12]}"
+
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == ":commit/preexisting"
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find (count ?c) :where [{fn_ident} :modified-in {commit_ident}]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_frontier_high_interval_advances_by_one(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert bounds is not None
+        _lo_hash, hi_hash = bounds
+        assert hi_hash == linearization[-1]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestReverseFillClaimAndProcess -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_reverse_fill_claim_and_process'`.
+
+- [ ] **Step 3: Add `_reverse_fill_claim_and_process` to `mcp_server.py`**
+
+Insert immediately after `_extract_commit` (before `_run_ingestion`):
+
+```python
+def _reverse_fill_claim_and_process(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    allocator: "frontier_registry.FrontierAllocator",
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> Optional[str]:
+    """#222 phase 2b: claim exactly one position from the gap's high end
+    (allocator.claim_high()) and process that one commit -- structural
+    facts, :modified-in edges, provisional :introduced-by, and candidate-diff
+    records for every entity the commit's "A"/"M" files touch. "D"/"R"
+    files are skipped entirely (deletions and renames are out of scope for
+    this sub-phase -- see the design spec).
+
+    Reuses _extract_commit/_build_code_triples unchanged: entity discovery
+    is direction-agnostic. The only new mechanism is substituting a DB
+    query (_entity_introduced_by_query) for forward walk's in-memory
+    entity_valid_from dict, since reverse walk has no accumulated-forward
+    state -- built fresh, per file, from currently-persisted graph state.
+
+    _build_code_triples's own candidate :introduced-by triples are filtered
+    out of what gets transacted here -- _entity_introduced_by_set_provisional
+    is the sole writer of :introduced-by in this walk, so a newly
+    discovered entity and one whose guess is being moved earlier go
+    through exactly the same code path.
+
+    Returns the claimed commit's hash, or None if the gap was already
+    empty (allocator.claim_high() returned None) -- caller's signal to
+    stop. Writes for one commit are followed by exactly one
+    _db_checkpoint(db) call, after _frontier_persist_claim records the
+    claim -- mirrors _run_ingestion's one-checkpoint-per-commit cadence
+    (see the design spec's "Resume-safety / atomicity boundary" section).
+    """
+    pos = allocator.claim_high()
+    if pos is None:
+        return None
+
+    commit_hash, commit_ts_iso, author, subject = commit_metadata[pos]
+    commit_ident = f":commit/{commit_hash[:12]}"
+
+    file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
+        repo_path, commit_hash, ignore_patterns
+    )
+
+    all_triples: List[str] = [
+        f"[{commit_ident} :entity-type :type/commit]",
+        f'[{commit_ident} :ident "{commit_ident}"]',
+        f'[{commit_ident} :description "{_edn_escape(subject[:120])}"]',
+        f'[{commit_ident} :hash "{commit_hash}"]',
+        f'[{commit_ident} :author "{_edn_escape(author)}"]',
+        f'[{commit_ident} :subject "{_edn_escape(subject[:200])}"]',
+        f'[{commit_ident} :date "{commit_ts_iso}"]',
+    ]
+    new_candidates: List[str] = []
+    provisional_moves: List[str] = []
+    body_hash_by_ident: Dict[str, str] = {}
+
+    for status, file_path, extracted, precomputed, _old_path in file_results:
+        if status not in ("A", "M"):
+            continue  # "D"/"R" deferred -- see design spec scope
+
+        candidate_idents = (
+            [precomputed["module_ident"]]
+            + [ident for ident, _name, _t in precomputed["function_entries"]]
+            + [ident for ident, _name, _t in precomputed["class_entries"]]
+            + [ident for ident, _name, _t in precomputed["global_entries"]]
+            + [ident for ident, _name, _t in precomputed["field_entries"]]
+        )
+        known_before: Dict[str, str] = {
+            ident: "known" for ident in candidate_idents
+            if _entity_introduced_by_query(db, ident) is not None
+        }
+        known_before_snapshot = set(known_before.keys())
+
+        triples = _build_code_triples(
+            file_path, extracted, commit_ts_iso, known_before, {}, {}, commit_ident,
+            precomputed, {}, {},
+        )
+        all_triples.extend(t for t in triples if ":introduced-by" not in t)
+
+        new_candidates.extend(set(known_before.keys()) - known_before_snapshot)
+        for ident in set(candidate_idents) & known_before_snapshot:
+            if _lineage_is_provisional(db, ident):
+                provisional_moves.append(ident)
+
+        body_hash_by_ident.update(precomputed.get("body_hashes", {}))
+
+    _transact(db, "[" + " ".join(all_triples) + "]", commit_ts_iso, index_con=index_con)
+
+    for ident in new_candidates + provisional_moves:
+        _entity_introduced_by_set_provisional(db, ident, commit_ident, commit_ts_iso, index_con=index_con)
+        if ident in body_hash_by_ident:
+            _candidate_diff_persist(
+                db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
+            )
+
+    _frontier_persist_claim(db, linearization, pos, from_low=False, commit_ts_iso=commit_ts_iso, index_con=index_con)
+    _db_checkpoint(db)
+    return commit_hash
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestReverseFillClaimAndProcess -v`
+Expected: PASS (all 5 tests).
+
+Also run the full existing suite:
+
+Run: `python -m pytest tests/test_mcp_server.py -x -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add _reverse_fill_claim_and_process for #222 phase 2b
+
+Stream 2's per-commit reverse-fill step: claims one position from the
+frontier gap's high end and writes structure + :modified-in + provisional
+:introduced-by, reusing _extract_commit/_build_code_triples unchanged.
+_entity_introduced_by_set_provisional (Task 1) is the sole writer of
+:introduced-by in this walk -- _build_code_triples's own candidate
+triples for that attribute are filtered out before transacting. D/R
+files and dependency edges are out of scope (see design spec). No caller
+yet -- Task 4 adds the driving loop."
+```
+
+---
+
+### Task 4: `_reverse_bulk_fill_walk`
+
+**Files:**
+- Modify: `mcp_server.py` — insert immediately after `_reverse_fill_claim_and_process`.
+- Test: `tests/test_mcp_server.py` — new `TestReverseBulkFillWalk` class.
+
+**Interfaces:**
+- Consumes: `_reverse_fill_claim_and_process` (Task 3).
+- Produces: `_reverse_bulk_fill_walk(db, repo_path: str, linearization: List[str], commit_metadata: List[Tuple[str, str, str, str]], allocator: "frontier_registry.FrontierAllocator", ignore_patterns: Sequence[str] = (), index_con=None) -> int`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this test class to `tests/test_mcp_server.py`:
+
+```python
+class TestReverseBulkFillWalk:
+    def test_walks_until_gap_closes_and_returns_count(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "a.py").write_text("def a(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+        (repo / "b.py").write_text("def b(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h1"], cwd=repo, check=True, capture_output=True)
+        (repo / "c.py").write_text("def c(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h2"], cwd=repo, check=True, capture_output=True)
+
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        count = mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        assert count == 3
+        assert allocator.is_gap_empty() is True
+        fn_ident_a = mcp_server._code_ident("function", "a.py", "a")
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident_a) == f":commit/{linearization[0][:12]}"
+
+    def test_gap_already_empty_returns_zero(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "a.py").write_text("def a(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-02T00:00:00Z")
+        while allocator.claim_low() is not None:
+            pass  # drain the gap forward first
+
+        count = mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert count == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestReverseBulkFillWalk -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_reverse_bulk_fill_walk'`.
+
+- [ ] **Step 3: Add `_reverse_bulk_fill_walk` to `mcp_server.py`**
+
+Insert immediately after `_reverse_fill_claim_and_process`:
+
+```python
+def _reverse_bulk_fill_walk(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    allocator: "frontier_registry.FrontierAllocator",
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> int:
+    """#222 phase 2b: repeatedly call _reverse_fill_claim_and_process until
+    the gap closes. Returns the count of commits processed. No caller in
+    this sub-phase -- 2d wires this into the real concurrent ingestion
+    loop alongside the forward stream.
+    """
+    count = 0
+    while True:
+        result = _reverse_fill_claim_and_process(
+            db, repo_path, linearization, commit_metadata, allocator,
+            ignore_patterns=ignore_patterns, index_con=index_con,
+        )
+        if result is None:
+            break
+        count += 1
+    return count
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestReverseBulkFillWalk -v`
+Expected: PASS (both tests).
+
+Also run the full existing suite one final time:
+
+Run: `python -m pytest tests/test_mcp_server.py -x -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add _reverse_bulk_fill_walk driving loop for #222 phase 2b
+
+Thin loop over _reverse_fill_claim_and_process until the frontier gap
+closes. Completes phase 2b: Stream 2's reverse-bulk-fill walk exists as
+a standalone, independently-testable unit. No caller wired into
+_run_ingestion -- 2d wires the real concurrency."
+```
+
+## Self-Review Notes
+
+- **Spec coverage:** Schema/audit safety (no new attributes, matched against `MINIGRAF_SCHEMA`) — not a task, since it required no code change, just verification (done during design). Resume-safety/atomicity boundary — covered by Task 3's single `_db_checkpoint` call placed after all writes including the frontier claim. The `_entity_introduced_by_set_provisional` sole-writer requirement — covered by Task 3's explicit `:introduced-by` filter on `_build_code_triples`'s output. The core algorithm (structural gate, first-sighting vs. move-earlier vs. authoritative-untouched) — covered by Task 3 and directly tested by `TestReverseFillClaimAndProcess`'s four scenario tests. The driving loop — Task 4. Explicitly deferred scope (deps/renames/deletions) — enforced by Task 3's `if status not in ("A", "M"): continue` guard.
+- **Type consistency:** `entity_ident`/`commit_ident`/`commit_ts_iso`/`index_con` naming matches phase 1/2a's existing convention throughout. `commit_metadata`'s shape (`List[Tuple[str, str, str, str]]`, position-indexed to `linearization`) is used identically in Tasks 3 and 4 and in their tests, built via `_git_commits(repo_path, watermark_hash=None)` in every test — confirmed both `build_linearization` and `_git_commits` use `git log --topo-order --reverse`, so their orderings/indices align.
+- **No placeholders:** every step has complete, runnable code — no TBD/TODO markers, no "similar to Task N" shorthand. Test repo fixtures are written out in full in each task that needs one (not shared via a new pytest fixture, since each task's repo shape differs slightly and the design favors explicit, readable test setup over cross-task fixture coupling).

--- a/docs/superpowers/plans/2026-07-24-reverse-bulk-fill-walk.md
+++ b/docs/superpowers/plans/2026-07-24-reverse-bulk-fill-walk.md
@@ -462,9 +462,9 @@ class TestReverseFillClaimAndProcess:
         assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == ":commit/preexisting"
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
         raw = mcp_server._db_execute(
-            real_db, f"(query [:find (count ?c) :where [{fn_ident} :modified-in {commit_ident}]])"
+            real_db, f"(query [:find ?c :where [{fn_ident} :modified-in ?c]])"
         )
-        assert json.loads(raw)["results"] == [[1]]
+        assert [commit_ident] in json.loads(raw)["results"]
 
     def test_frontier_high_interval_advances_by_one(self, real_db, tmp_path):
         import mcp_server

--- a/docs/superpowers/specs/2026-07-24-reverse-bulk-fill-walk-design.md
+++ b/docs/superpowers/specs/2026-07-24-reverse-bulk-fill-walk-design.md
@@ -1,0 +1,270 @@
+# Reverse-Bulk-Fill Walk (Stream 2) — Design Spec
+
+**Issue:** #222 (Phase 2, sub-phase 2b of 4)
+**Date:** 2026-07-24
+
+## Background
+
+#222's overall design is a converging multi-stream ingestion: a forward-truth
+stream (the existing `_run_ingestion` engine) running concurrently with a
+reverse-bulk-fill stream that provisionally back-fills recent history from
+`HEAD` downward, so recent history is visible almost immediately while the
+forward stream still owns lineage correctness.
+
+- **Phase 1** (merged, PR #226) built `frontier_registry.py`
+  (`Interval`/`FrontierAllocator`/`build_linearization`) plus
+  `mcp_server.py`'s `_frontier_load`/`_frontier_persist_claim`/
+  `_frontier_read_bounds` — the shared-gap allocator both streams claim work
+  from. Nothing calls `FrontierAllocator.claim_low`/`claim_high` yet.
+- **Phase 2a** (merged, PR #227) built the provisional/authoritative fact
+  model primitives with no caller: `_lineage_mark_provisional`/
+  `_lineage_confirm`/`_lineage_is_provisional` (a companion
+  `:type/lineage-marker` entity per tracked entity, since `:lineage-status`
+  can't live directly on schema-audited code entities — see that spec's
+  Revision note #1), `_lineage_confirmed_through_query`/`_update`/`_migrate`
+  (a watermark for "is region X's lineage fully confirmed"), and
+  `_candidate_diff_persist`/`_read`/`_clear` (per-`(commit, entity)`
+  body-hash records so Stream 1 can later confirm/reject a candidate by hash
+  comparison instead of re-parsing).
+- **2b (this spec)** — Stream 2's actual reverse-bulk-fill walk, using 2a's
+  primitives to write provisional lineage. No caller wired into
+  `_run_ingestion` yet — that's 2d.
+- **2c** — Stream 1's correction sweep, converting provisional facts to
+  authoritative using 2a's persisted candidate diffs.
+- **2d** — the actual concurrency wiring inside `_run_ingestion`.
+
+## Scope (2b only)
+
+In scope:
+
+- A per-commit reverse-fill step function that claims one position from the
+  gap (`FrontierAllocator.claim_high()`) and, for every entity touched by
+  that commit's diff, writes structural facts + a `:modified-in` edge
+  (always authoritative — order-independent per the issue's own design
+  principle) + a provisional `:introduced-by` (using 2a's primitives).
+- A thin driving loop that repeats the above until the gap closes and
+  persists each claim via `_frontier_persist_claim`.
+- Two small new helpers this sub-phase needs and 2a didn't provide:
+  `_entity_introduced_by_query` (read the current `:introduced-by` value, if
+  any) and `_entity_introduced_by_set_provisional` (idempotent
+  retract-then-reassert, gated so it never clobbers an already-authoritative
+  fact).
+
+Explicitly deferred (matches the issue's own phase breakdown and this
+sub-phase's tighter cut):
+
+- `:depends-on` edges, renames (`:renamed-from`/`:renamed-to`), and
+  deletion/close handling in the reverse direction. Forward walk's existing
+  logic for these is intentionally not mirrored here.
+- The "entity born, removed, and reborn entirely within the open gap" edge
+  case from the issue — since 2b never closes a lifecycle segment, this
+  case is 2c's reconciliation problem, not 2b's.
+- Reconciling a *stale* candidate-diff record left behind when reverse walk
+  moves a candidate's `:introduced-by` earlier (see below) — 2c's job.
+- Wiring into `_run_ingestion` / real concurrency (2d).
+
+## Design
+
+### Schema/audit safety
+
+Unlike 2a's `:type/lineage-marker`/`:type/candidate-diff` (deliberately
+unregistered, internal bookkeeping), `:introduced-by` and `:modified-in`
+are **already** registered optional attributes on every entity type this
+sub-phase touches — `module`, `function`, `class`, `variable`, `field` all
+list both in `MINIGRAF_SCHEMA`'s `"optional"` set (mcp_server.py:5307-5352).
+Forward walk already writes both today. 2b introduces no new schema
+surface and no new audit risk: `handle_minigraf_audit` already treats these
+facts as valid for these types, provisional or not — provisionality is
+carried entirely by the separate `:type/lineage-marker` companion entity
+2a built, never by the shape of the `:introduced-by` fact itself.
+
+### Resume-safety / atomicity boundary
+
+`_run_ingestion` checkpoints once per source-commit — an entire commit's
+`add_triples`/`close_items` batch is one `_transact` + one fsync'd
+checkpoint, never split across two checkpoints (see its `write_executor`
+docstring comments on "committed once per source-commit"). A crash
+mid-commit therefore leaves that commit's writes entirely uncommitted, and
+`_git_commits(repo_path, watermark, branch)` re-derives the resume point
+from the DB's actual persisted state, not an in-memory cursor — so a
+reprocessed commit never sees its own partial writes still present.
+
+2b's `_reverse_fill_claim_and_process` must follow the same discipline: one
+claimed commit's structural facts, `:modified-in` edges,
+`:introduced-by` write, and candidate-diff persist all happen within that
+call's own atomic write boundary, with `_frontier_persist_claim` recording
+the claim as part of the same unit of work. A crash before that boundary
+completes means the position was never actually claimed (from the
+allocator's persisted perspective — see phase 1's `_frontier_persist_claim`
+design), so re-invoking `_reverse_fill_claim_and_process` against the same
+still-unclaimed position on resume is safe: it either finds nothing was
+written yet (clean retry) or, at worst, hits `_entity_introduced_by_set_provisional`'s
+own idempotency guard for any entity whose facts *did* land before the
+crash (same value → no-op).
+
+### Why `_extract_commit` needs no changes
+
+`_extract_commit` (mcp_server.py:6888) is already a pure, stateless function
+of one commit: it diffs that commit against its own parent(s) via
+`git diff-tree`, independent of any accumulated walk state, and (for
+`M`/`D`/`R` files) already fetches and parses the parent's blob content
+(`old_sha` → `_git_blob_content` → `old_parser.parse`) to support rename
+detection and #221's unchanged-body detection. It is safe to call from a
+reverse walk exactly as forward walk calls it today — no walk-direction
+dependency exists in this function.
+
+What genuinely differs between forward and reverse is the **bookkeeping
+layer**: forward walk's `_build_code_triples` (mcp_server.py:6399) decides
+"is this the first time I've ever seen this ident" purely from its own
+in-memory `entity_valid_from` dict, accumulated oldest→newest. Reverse walk
+has no equivalent accumulated-forward state (it's walking backward through
+territory forward hasn't reached), so it substitutes a **DB query** for the
+same question — resume-safe, since the gap allocator is itself resumed from
+persisted state, not memory (Phase 1's own design principle).
+
+### New helpers
+
+```python
+def _entity_introduced_by_query(db: Any, entity_ident: str) -> Optional[str]:
+    """Return entity_ident's current :introduced-by value (a commit ident
+    string), or None if it has none yet."""
+    raw = _db_execute(db, f"(query [:find ?c :where [{entity_ident} :introduced-by ?c]])")
+    results = json.loads(raw).get("results", [])
+    return results[0][0] if results else None
+
+
+def _entity_introduced_by_set_provisional(
+    db: Any,
+    entity_ident: str,
+    commit_ident: str,
+    commit_ts_iso: str,
+    index_con: Optional[Any] = None,
+) -> None:
+    """Assert or move entity_ident's PROVISIONAL :introduced-by to
+    commit_ident. Never touches an entity whose :introduced-by is already
+    authoritative (i.e. a fact exists and _lineage_is_provisional is False)
+    -- reverse walk must never clobber a fact Stream 1 has already
+    confirmed. Idempotent: no-ops (but still ensures the marker is present)
+    if the current value already equals commit_ident. Always ensures
+    _lineage_mark_provisional is called when a provisional value is
+    asserted or moved -- that call is itself idempotent, so calling it
+    unconditionally on the write path is safe.
+    """
+    current = _entity_introduced_by_query(db, entity_ident)
+    if current is not None and not _lineage_is_provisional(db, entity_ident):
+        return  # authoritative -- never touch
+    if current == commit_ident:
+        _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
+        return
+    if current is not None:
+        _retract(db, f"[[{entity_ident} :introduced-by {current}]]", index_con=index_con)
+    _transact(db, f"[[{entity_ident} :introduced-by {commit_ident}]]", commit_ts_iso, index_con=index_con)
+    _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
+```
+
+### Per-commit algorithm
+
+For a claimed commit `C` (positions processed strictly newest→oldest via
+repeated `claim_high()` calls), for every entity touched by `C`'s diff
+(reusing the same per-file A/M walk `_build_code_triples` already performs
+— entity discovery/parsing is unchanged, only the bookkeeping gate differs):
+
+1. **Structural facts**: gate on `_entity_introduced_by_query(db,
+   entity_ident) is None` — if the entity has no `:introduced-by` fact yet
+   from *either* stream, write its structural facts (`:entity-type`,
+   `:description`, `:file`/`:path`, `:contains`, matching forward's
+   candidate-triple shape) as well as its first provisional
+   `:introduced-by` (step 2 below). If the entity already has a fact (from
+   either stream), only a `:modified-in` edge is added — never
+   re-asserted structural attributes, matching forward's existing
+   "written once" invariant (mcp_server.py:6414).
+2. **`:introduced-by`**:
+   - **No fact yet** → `_entity_introduced_by_set_provisional(db,
+     entity_ident, commit_ident, commit_ts_iso)`, then
+     `_candidate_diff_persist(db, commit_hash, entity_ident,
+     _normalized_body_hash(node), commit_ts_iso)`.
+   - **Fact exists and is provisional** → reverse walk has now reached an
+     *earlier* commit where the same entity is still present, meaning its
+     previous guess was too late. Call
+     `_entity_introduced_by_set_provisional` again with `C`'s
+     `commit_ident` (moves it earlier) and persist a fresh candidate-diff
+     record for `(C, entity_ident)`. The now-stale candidate-diff record at
+     the previously-guessed commit is intentionally left in place — 2c
+     decides how to reconcile a superseded candidate when it reaches that
+     commit chronologically.
+   - **Fact exists and is authoritative** → do nothing to `:introduced-by`;
+     only the `:modified-in` edge from step 1 applies.
+3. **`:modified-in`**: always asserted for every entity touched by `C`,
+   regardless of which branch above fired — this edge is order-independent
+   and always authoritative per the issue's own design principle, so it
+   never goes through the provisional marker.
+
+### Driving functions
+
+```python
+def _reverse_fill_claim_and_process(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    allocator: "frontier_registry.FrontierAllocator",
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> Optional[str]:
+    """Claim exactly one position from the gap's high end and process that
+    one commit per the algorithm above. Returns the claimed commit's hash,
+    or None if the gap was already empty (allocator.claim_high() returned
+    None) -- caller's signal to stop."""
+
+
+def _reverse_bulk_fill_walk(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    allocator: "frontier_registry.FrontierAllocator",
+    run_ts_iso: str,
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> int:
+    """Repeatedly call _reverse_fill_claim_and_process, persisting each
+    claim via _frontier_persist_claim, until the gap closes. Returns the
+    count of commits processed. No caller in this sub-phase -- 2d wires
+    this into the real concurrent ingestion loop."""
+```
+
+Both functions live in `mcp_server.py`, immediately after phase 2a's
+existing functions. Neither is called by `_run_ingestion` in this
+sub-phase.
+
+## Testing
+
+Following `docs/testing-conventions.md` (real `MiniGrafDb`, no mocks), using
+the same `tmp_path / "repo"` real-git-repo fixture pattern already used
+throughout `tests/test_mcp_server.py`'s existing ingestion tests:
+
+- **Single-commit claim**: a two-commit repo; claim once; assert the
+  correct (newest) commit was claimed, structural facts + provisional
+  `:introduced-by` + `:modified-in` were written, and the entity reads as
+  provisional via `_lineage_is_provisional`.
+- **Multi-commit walk moves the candidate earlier**: a function present
+  across three commits `h0 < h1 < h2` (all touching the file); walk from
+  `h2` down through `h0`; assert `:introduced-by` ends up pointing at `h0`
+  (not `h2` or `h1`), only one live `:introduced-by` fact exists (raw count,
+  not just the accessor — matching the phase 1/2a lesson on row-collapsing
+  checks), and a candidate-diff record exists for `h0` (the final,
+  correct guess).
+- **Already-authoritative entity is left alone**: pre-seed an entity with a
+  non-provisional `:introduced-by` (simulating Stream 1 having already
+  confirmed it); run the reverse walk over a commit that touches it; assert
+  `:introduced-by` is unchanged and no `:type/lineage-marker` companion
+  entity was created, but a `:modified-in` edge was still added.
+  `_entity_introduced_by_set_provisional` must be directly tested for this
+  no-op-on-authoritative guard, not only indirectly through the walk.
+- **Gap-empty no-op**: an allocator whose gap is already empty; assert
+  `_reverse_fill_claim_and_process` returns `None` and writes nothing.
+- **`_frontier_persist_claim` integration**: after `_reverse_bulk_fill_walk`
+  processes N commits, assert the persisted frontier-high interval reflects
+  N claimed positions (mirrors phase 1's own `TestFrontierPersistClaim`
+  assertions).
+- **Idempotency of `_entity_introduced_by_set_provisional`**: calling it
+  twice with the same `commit_ident` results in exactly one live
+  `:introduced-by` fact (raw count check).

--- a/docs/superpowers/specs/2026-07-24-reverse-bulk-fill-walk-design.md
+++ b/docs/superpowers/specs/2026-07-24-reverse-bulk-fill-walk-design.md
@@ -59,9 +59,35 @@ sub-phase's tighter cut):
 - The "entity born, removed, and reborn entirely within the open gap" edge
   case from the issue — since 2b never closes a lifecycle segment, this
   case is 2c's reconciliation problem, not 2b's.
-- Reconciling a *stale* candidate-diff record left behind when reverse walk
-  moves a candidate's `:introduced-by` earlier (see below) — 2c's job.
+- ~~Reconciling a *stale* candidate-diff record left behind when reverse walk
+  moves a candidate's `:introduced-by` earlier (see below) — 2c's job.~~
+  **Revised in 2b1:** this walk now clears the superseded record at move
+  time, where `superseded_ident` is already in hand. Deferring it made the
+  records accumulate as O(entity touches) rather than O(entities), which is
+  what `_candidate_diff_clear`'s own docstring says must not happen. 2c's
+  opportunistic cleanup remains, for records orphaned by earlier runs.
 - Wiring into `_run_ingestion` / real concurrency (2d).
+
+Not deferred, and previously missing from both lists (added in 2b1):
+
+- `:parent` edges. Forward walk writes them and the bootstrap `ancestor`
+  rule is defined purely over `:parent`, so omitting them silently made
+  `ancestor` return nothing across the whole reverse-filled region. This
+  walk now emits them via `_git_parent_hashes`. Because the walk reaches a
+  commit's parents *after* the commit itself, the edge briefly points at an
+  entity that does not exist yet and materialises when the walk descends to
+  it (or when the forward stream covers it, for parents below
+  frontier-high's floor) — temporarily dangling and convergent, the same
+  shape as the lineage facts around it, so `ancestor` returns partial
+  results until the region is complete.
+- Valid-time parity for structural facts. They were written once, at the
+  timestamp of the commit where the walk first *sighted* the entity, and
+  never re-dated as the guess moved earlier — leaving a window where
+  `:introduced-by` is live for an entity with no `:entity-type`, name or
+  file, so `:as-of` the introduction answers "did not exist" while
+  `:introduced-by` names that very commit. 2b1 re-dates them on each move.
+  The cost is write amplification: an entity touched N times in the claimed
+  range pays N retract+re-assert cycles instead of one.
 
 ## Design
 
@@ -255,11 +281,18 @@ repeated `claim_high()` calls), for every entity touched by `C`'s diff
 
 ### Driving functions
 
+These signatures are what actually shipped. An earlier draft of this
+section omitted `commit_metadata` entirely and gave `_reverse_bulk_fill_walk`
+a `run_ts_iso` it never had — corrected in 2b1, along with the contract note
+below, since a spec that misdescribes the parameter carrying the
+misalignment hazard is worse than one that omits it.
+
 ```python
 def _reverse_fill_claim_and_process(
     db: Any,
     repo_path: str,
     linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
     allocator: "frontier_registry.FrontierAllocator",
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
@@ -274,16 +307,40 @@ def _reverse_bulk_fill_walk(
     db: Any,
     repo_path: str,
     linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
     allocator: "frontier_registry.FrontierAllocator",
-    run_ts_iso: str,
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
 ) -> int:
     """Repeatedly call _reverse_fill_claim_and_process, persisting each
-    claim via _frontier_persist_claim, until the gap closes. Returns the
-    count of commits processed. No caller in this sub-phase -- 2d wires
-    this into the real concurrent ingestion loop."""
+    claim via _frontier_persist_claim, until the gap closes or a claim
+    fails to move strictly downward. Returns the count of commits
+    processed. No caller in this sub-phase -- 2d wires this into the real
+    concurrent ingestion loop."""
 ```
+
+**`commit_metadata`'s contract.** It must be full-history and positionally
+aligned with `linearization` — i.e. `_git_commits(repo, watermark_hash=None)`,
+which shares `git log --topo-order --reverse` with `build_linearization`.
+Both functions index it positionally (`commit_metadata[pos]`) while
+`_frontier_persist_claim` persists `linearization[pos]`, so a misaligned list
+attributes entities to one commit and persists another: silent, systematic
+misattribution. `_run_ingestion` builds a *watermark-relative* list for its
+own use, which is exactly the wrong thing to pass, so 2d must build the
+full-history list separately. Both length and the per-position hash are
+checked on entry and raise `ValueError` — this walk is handed a position by
+an allocator that has already claimed it, so unlike 2c's mirror-image guard
+(which selects its own position and returns `None`) it cannot decline.
+
+**Repeated-`(entity, attribute)` facts cannot share a transact.** Minigraf's
+EAVT pending index omits value bytes from the key, so several facts sharing
+`(entity, attribute, valid_from)` in one `transact` collapse to the last.
+`:contains` (a module or class with N children) and `:parent` (a merge
+commit's two parents) therefore get one transact each, exactly as forward
+walk does; retraction has the same constraint, which the structural
+re-dating below observes. Facts differing in *entity* do not collide, so the
+per-entity `:modified-in` batch is safe. Getting this wrong is silent: the
+graph simply ends up with one edge where it should have N.
 
 Both functions live in `mcp_server.py`, immediately after phase 2a's
 existing functions. Neither is called by `_run_ingestion` in this

--- a/docs/superpowers/specs/2026-07-24-reverse-bulk-fill-walk-design.md
+++ b/docs/superpowers/specs/2026-07-24-reverse-bulk-fill-walk-design.md
@@ -173,31 +173,85 @@ repeated `claim_high()` calls), for every entity touched by `C`'s diff
    entity_ident) is None` — if the entity has no `:introduced-by` fact yet
    from *either* stream, write its structural facts (`:entity-type`,
    `:description`, `:file`/`:path`, `:contains`, matching forward's
-   candidate-triple shape) as well as its first provisional
-   `:introduced-by` (step 2 below). If the entity already has a fact (from
-   either stream), only a `:modified-in` edge is added — never
-   re-asserted structural attributes, matching forward's existing
-   "written once" invariant (mcp_server.py:6414).
+   candidate-triple shape). If the entity already has a fact (from either
+   stream), no structural attributes are re-asserted — matching forward's
+   existing "written once" invariant (mcp_server.py:6414).
+
+   **Correction (this section was revised after the final whole-branch
+   review of the implementation found step 3 below, as originally
+   written, was internally inconsistent with reusing `_build_code_triples`
+   unchanged — see that review's Critical finding #1 / Spec Issue #7):**
+   `_build_code_triples`'s own `:modified-in` emission is gated by the
+   *same* `entity_valid_from`-membership check as its structural-attribute
+   gate (mcp_server.py: `is_new_module`/`fn_ident not in entity_valid_from`
+   branches) — for forward walk this is correct, because "not yet known"
+   and "this is the introduction commit" are the same event when walking
+   oldest→newest. Reversed, they are *not* the same event: the first
+   commit reverse walk sees an entity at is the *newest* touch, not the
+   introduction, and the commit where reverse walk finally stops finding
+   an even-earlier occurrence (i.e. the true introduction) is by then
+   already "known" to reverse walk from later, already-visited commits.
+   Reusing `_build_code_triples`'s `:modified-in` emission verbatim
+   therefore produces the wrong edge set (misses a real `:modified-in` at
+   the newest touch, adds a spurious one at the true introduction commit).
+   The reverse walk must filter `:modified-in` out of
+   `_build_code_triples`'s output exactly as it already filters
+   `:introduced-by`, and emit `:modified-in` itself per steps 2-3 below.
+
 2. **`:introduced-by`**:
    - **No fact yet** → `_entity_introduced_by_set_provisional(db,
      entity_ident, commit_ident, commit_ts_iso)`, then
      `_candidate_diff_persist(db, commit_hash, entity_ident,
-     _normalized_body_hash(node), commit_ts_iso)`.
+     _normalized_body_hash(node), commit_ts_iso)`. This commit is the
+     current best-guess introduction — no `:modified-in` is emitted for it
+     yet (mirrors forward walk never emitting `:modified-in` at an
+     entity's own introduction commit; see step 3).
    - **Fact exists and is provisional** → reverse walk has now reached an
      *earlier* commit where the same entity is still present, meaning its
-     previous guess was too late. Call
-     `_entity_introduced_by_set_provisional` again with `C`'s
-     `commit_ident` (moves it earlier) and persist a fresh candidate-diff
-     record for `(C, entity_ident)`. The now-stale candidate-diff record at
-     the previously-guessed commit is intentionally left in place — 2c
-     decides how to reconcile a superseded candidate when it reaches that
-     commit chronologically.
+     previous guess was too late. Before moving it, read the
+     currently-guessed commit ident via `_entity_introduced_by_query` (call
+     it `superseded_ident`). Call `_entity_introduced_by_set_provisional`
+     with `C`'s `commit_ident` (moves the guess to `C`) and persist a fresh
+     candidate-diff record for `(C, entity_ident)`. The now-stale
+     candidate-diff record at `superseded_ident` is intentionally left in
+     place — 2c decides how to reconcile a superseded candidate when it
+     reaches that commit chronologically. `C` itself gets no `:modified-in`
+     yet (it is now the tentative introduction); `superseded_ident` is
+     handled by step 3.
    - **Fact exists and is authoritative** → do nothing to `:introduced-by`;
-     only the `:modified-in` edge from step 1 applies.
-3. **`:modified-in`**: always asserted for every entity touched by `C`,
-   regardless of which branch above fired — this edge is order-independent
-   and always authoritative per the issue's own design principle, so it
-   never goes through the provisional marker.
+     the touch still gets a `:modified-in` per step 3.
+3. **`:modified-in`** — converges to exactly the same edge set forward
+   walk would have produced, via two cases:
+   - **Already-authoritative entity touched again**: assert
+     `[entity_ident :modified-in commit_ident]` with `commit_ts_iso` as
+     `valid_from` (this commit's own timestamp) — a genuine later
+     modification of an entity Stream 1 already introduced elsewhere.
+   - **A provisional guess just got superseded** (the second bullet of
+     step 2): assert `[entity_ident :modified-in superseded_ident]` using
+     `superseded_ident`'s *own* commit timestamp as `valid_from` — looked
+     up from `commit_metadata` — not `C`'s timestamp, since the fact
+     "`superseded_ident` modified this entity" became true on
+     `superseded_ident`'s own date, not on `C`'s (`C` is chronologically
+     *earlier* than `superseded_ident`, since reverse walk discovers
+     `superseded_ident`'s falseness-as-introduction only after walking
+     backward past it). A commit newly discovered this call (first
+     sighting) or one that is *never* later superseded gets no
+     `:modified-in` of its own, by construction — matching forward walk's
+     own omission of `:modified-in` at an entity's true introduction
+     commit exactly, once the walk (or a later phase) reaches that
+     entity's true origin.
+
+   **Known, documented limitation**: the retroactive `:modified-in` for a
+   superseded commit does not re-check #221's unchanged-body narrowing
+   against *that* commit's own diff (the current call only has unchanged-
+   body data for `C`'s diff, not `superseded_ident`'s) — it is asserted
+   unconditionally. This can rarely over-assert a `:modified-in` edge
+   forward walk would have suppressed as a no-op touch; it can never
+   produce a *missing* or *misattributed* edge. Revisit if a later phase
+   needs exact parity here — 2c already has each commit's persisted
+   candidate-diff body hash available to correct this precisely during its
+   own sweep, matching the "provisional now, cheap replay correction
+   later" philosophy this design already relies on elsewhere.
 
 ### Driving functions
 

--- a/docs/superpowers/specs/2026-07-25-reverse-fill-corrections-design.md
+++ b/docs/superpowers/specs/2026-07-25-reverse-fill-corrections-design.md
@@ -1,0 +1,449 @@
+# Reverse-Bulk-Fill Corrections (2b1) — Design Spec
+
+**Issue:** #222 (Phase 2, corrective sub-phase 2b1)
+**Date:** 2026-07-25
+**Branches from:** `design-222-phase2b-reverse-bulk-fill-walk` (`55dd993`, PR #228)
+**Merge order:** #228 → **2b1** → 2c
+
+## Background
+
+Sub-phase 2b (PR #228, open) built Stream 2's reverse-bulk-fill walk. A
+spec-plus-implementation review
+(`docs/superpowers/specs/2026-07-24-reverse-bulk-fill-walk-review.md`, every
+finding reproduced against a real `MiniGrafDb` and a real git repo) found three
+High and four lower-severity defects in it, plus two phase-1 defects that 2b is
+the first caller to exercise. 2b's code is already committed, so none of those
+are changes to PR #228 — they are this sub-phase.
+
+2b1 branches from 2b's tip rather than amending PR #228, so #228 keeps its
+review history. This is safe because **2b has no caller wired into
+`_run_ingestion`** — 2d does that — so merging #228 with these defects present
+changes no production behavior. 2c stacks on 2b separately and is being
+implemented concurrently; 2b1 touches only functions 2c does not add, so the two
+branches conflict only incidentally (both edit `mcp_server.py`, in different
+regions).
+
+## Scope
+
+**Group 1 — phase-1 root cause.** The frontier/allocator defects behind 2b's
+infinite loop. Not 2b's bugs, but untestable without a caller that grows a
+linearization, which is exactly 2b's walk — so they land here, as the first
+commits, reviewable as their own half of the PR.
+
+**Group 2 — 2b's own defects.** The seven findings in bucket (a) of the review,
+plus one additional write path the review missed (see "Monotonicity" below).
+
+**Group 3 — tests.** The review's twelve test gaps, anchored on four
+high-value ones.
+
+Explicitly deferred:
+
+- **The interval lifecycle on incremental re-ingest** — what *should* happen
+  when new commits land above a previously-filled region. See "Why re-ingest is
+  made safe, not efficient" below. Assigned to 2d.
+- **Duplicate `:introduced-by` from an uncoordinated forward walk** (review
+  bucket (c)) — 2b has no caller and cannot prevent it; 2d's to fix. 2b1 adds a
+  one-line note to 2b's spec so 2d inherits the constraint.
+- 2b's own original deferrals — `:depends-on`, deletions, renames — unchanged.
+
+## Design
+
+### Group 1: phase-1 root cause
+
+#### 1.1 `_extend` must pick the interval adjacent in the direction of growth
+
+`FrontierAllocator._extend` looks up `_interval_covering(neighbor_pos)`, and
+`_interval_covering` returns the **first match in insertion order**
+(`frontier_registry.py:71-75`). With two provisional intervals in play, it can
+merge into the wrong one and make no progress at all. From the review's
+allocator-only repro (3 positions claimed in run 1, 2 commits added, high
+interval reloaded as `[1, 2]` against a 5-position linearization):
+
+```
+claim 0: pos=4 gap_hi=3 intervals=[Interval(1,2,'provisional'), Interval(4,4,'provisional')]
+claim 1: pos=3 gap_hi=2 intervals=[Interval(1,2,...), Interval(3,4,...)]
+claim 2: pos=2 gap_hi=1 intervals=[Interval(1,2,...), Interval(2,4,...)]
+claim 3: pos=1 gap_hi=1 intervals=[Interval(1,2,...), Interval(2,4,...)]
+claim 4: pos=1 ...   (unchanged forever)
+sequence: [4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+```
+
+`_extend(1, ...)` finds `Interval(1,2)` via `_interval_covering(2)` and rewrites
+it to `Interval(1,2)` — a no-op — pinning `gap_hi` at 1 so `is_gap_empty()` is
+never true.
+
+Fix: `_extend` selects the interval that is adjacent *in the direction of
+growth* (for `from_low=False`, the one whose `lo_pos == pos + 1`; for
+`from_low=True`, the one whose `hi_pos == pos - 1`), rather than any interval
+covering the neighbour position. Where no such interval exists, append a new
+one, as today. This makes `_extend` monotone by construction: every call either
+extends an interval by exactly one position or creates a one-position interval,
+and `gap_lo`/`gap_hi` therefore strictly converge.
+
+#### 1.2 `_frontier_load` normalises an unrepresentable persisted interval
+
+`_frontier_persist_claim` writes only the moved bound — `:lo-hash` for
+`from_low=False` (`mcp_server.py:5007-5014`) — so `:hi-hash` is written once, at
+interval creation, and never again. On a grown linearization the first
+`claim_high()` of the new run returns the new last position and persists it as
+`:lo-hash`, leaving the pair **inverted**:
+
+```
+after claiming pos 4: persisted frontier-high = ('pos4', 'pos2')
+after claiming pos 3: persisted frontier-high = ('pos3', 'pos2')
+```
+
+`_frontier_load` will rebuild `Interval(lo_pos=4, hi_pos=2)` from that, which
+`_interval_covering` can never match, so the whole high region reads as
+unclaimed after a crash there.
+
+Fix, in `_frontier_load`, applied to the high interval before it is
+reconstructed:
+
+1. If `lo_pos > hi_pos` (inverted), **discard** the interval.
+2. If `hi_hash` is not the linearization's last position (the grown case),
+   **discard** the interval.
+
+Both cases mean "the persisted pair cannot faithfully describe this run's
+claimed region", and dropping it yields one contiguous gap again —
+`[frontier-low.hi + 1, N-1]` — which is the only shape the rest of phase 1 and
+both streams are written against.
+
+Discarding is sound rather than merely convenient because **re-processing an
+already-processed position is idempotent**: the review verified this on a real
+repo (`:introduced-by` and the `:modified-in` set byte-identical before and
+after a replay, live count unchanged), and the mechanism is that a replayed
+provisional move sees `superseded_ident == commit_ident` and skips the
+retroactive edge. The graph converges to the same state; only work is wasted.
+
+**Discarding must also retract the persisted facts, and persistence must mirror
+the allocator.** Dropping the interval only from the in-memory allocator is not
+enough — and getting this wrong re-creates the very state being fixed. If
+`_frontier_load` discards `('pos4', 'pos2')` but leaves it in the graph, the
+next `_frontier_persist_claim(from_low=False)` call sees `existing is not None`
+and rewrites only `:lo-hash` again, reproducing an inverted pair on the first
+claim of the new run. Two changes, together:
+
+1. When `_frontier_load` discards an unrepresentable interval, it retracts that
+   interval's persisted facts, so the graph and the allocator agree on "this
+   side holds nothing".
+2. `_frontier_persist_claim` writes the bounds of **the allocator's interval
+   containing `pos`**, rather than inferring which single bound moved from the
+   persisted pair. The caller already holds the allocator, so it passes the
+   interval (or its `lo_pos`/`hi_pos`) in. This removes the whole class of
+   drift between what the allocator believes and what is persisted, of which the
+   never-moving `:hi-hash` is one instance: a freshly created one-position
+   interval persists as `(pos, pos)`, and each subsequent claim persists the
+   interval as it actually stands.
+
+Consequence for 2c, which reads frontier-high's persisted bounds directly rather
+than through the allocator: after a discard it sees no high interval at all
+(`_frontier_read_bounds` returns `None`) instead of an inverted pair. Its
+position-selection guard already returns `None` for both
+(`2026-07-25-stream1-correction-sweep-design.md`, "Position tracker"), so the
+sweep no-ops safely either way — but "absent" is the honest state, and it is the
+one 2c's `low_bounds is None or high_bounds is None` branch was written for.
+
+#### Why re-ingest is made safe, not efficient
+
+Discarding means an incremental re-ingest re-walks the entire previously-filled
+region — the opposite of what Stream 2 exists for. That is a deliberate,
+bounded choice, and the reason is a representation limit this sub-phase should
+not unilaterally change:
+
+The persisted schema holds **one `lo`/`hi` pair per side**
+(`mcp_server.py:4917-4925`). After growth the real state is three spans — the
+authoritative low region, the already-filled high region, and the newly-arrived
+commits above it — with the unclaimed gap now sitting **above** the high
+interval rather than between the two. One pair per side cannot express that.
+
+The correct resolution is that a fully-confirmed high region should be folded
+into the authoritative low region on load, so the new commits form the new gap
+with no re-walking at all. That requires knowing whether 2c's sweep has
+confirmed the region — i.e. reading `:ingestion/correction-sweep-through`, a
+watermark that does not exist yet (2c is being implemented concurrently) — and
+it is a run-lifecycle decision spanning all three streams. It is therefore 2d's,
+and this spec states it as an explicit open item rather than guessing. What 2b1
+guarantees is that until 2d gets there, a re-ingest is **correct and
+terminating**, just slower than it should be.
+
+#### 1.3 Progress guard in `_reverse_bulk_fill_walk`
+
+`while True: ... if result is None: break` (`mcp_server.py:7428-7437`) assumes
+`claim_high()` either makes progress or returns `None`. With 1.1 and 1.2 fixed
+that assumption holds, but the loop is unbounded by construction and drives an
+`_extract_commit` (git subprocess plus tree-sitter parse), a DB write batch and
+a `_db_checkpoint` fsync per iteration — an unbounded fsync loop inside what 2d
+intends to run as a background task. The walk therefore tracks the last claimed
+position and breaks, logging to stderr, if `claim_high()` does not return a
+strictly smaller position. The guard stays even though the allocator is fixed:
+it converts any future allocator regression from a hang into a loud stop.
+
+### Group 2: 2b's own defects
+
+#### 2.1 Split `:contains` out of the batched transact
+
+`_reverse_fill_claim_and_process` writes every structural triple for a commit in
+one call (`mcp_server.py:7377`). Minigraf's EAVT pending index omits value bytes
+from the key, so facts sharing `(entity, attribute, valid_from)` in one
+`transact` collapse to the last. Re-verified during this design:
+
+```
+batched  -> {"results":[[":function/c"]]}                      # 3 in, 1 survives
+split    -> {"results":[[":function/x"],[":function/y"],[":function/z"]]}
+distinctE-> 2 results                                          # different E: no collision
+```
+
+The third line matters for scoping the fix: only facts sharing the *same
+entity* collide, so within `all_triples` the only affected attribute is
+`:contains` (module→N children, class→N fields). The batched
+`[ident :modified-in commit_ident]` writes are for distinct entities and are
+safe as they are.
+
+Fix: build `:contains` triples into a separate list and `_transact` each
+individually, exactly as `_run_ingestion` does (`mcp_server.py:7957-7970`, which
+carries a comment explaining the same constraint). The same rule applies to any
+future repeated-`(E, A)` attribute, and to the `:parent` edges added in 2.6.
+
+The consequence of not fixing this is permanent: no phase rewrites `:contains`,
+and 2c's sweep touches only `:introduced-by`/`:modified-in`/lineage markers. The
+review measured five of six module-containment edges and one of two
+class-containment edges lost on a single ordinary file.
+
+#### 2.2 Monotonicity: one invariant, three write paths
+
+The invariant: **no entity may carry a `:modified-in` at a position earlier than
+or equal to its `:introduced-by`'s position.** Forward walk cannot produce such
+a fact (`_build_code_triples` emits `:modified-in` only on its already-known
+branch, `mcp_server.py:6511-6521`); 2b produces both variants today, and nothing
+in the graph, the audit, or the test suite detects it.
+
+**Positions, not timestamps.** The comparison must use topological positions.
+Committer dates are not monotonic in topological order — which is why
+`build_linearization` uses `--topo-order` in the first place
+(`frontier_registry.py:28-32`) — and this repository's own history contains a
+real inversion (`df6b8be`, ~6 days earlier than its topological predecessor).
+Comparing `:date` values would silently mis-order those commits.
+
+`_entity_introduced_by_set_provisional` therefore takes two new parameters,
+`pos: Optional[int]` and `pos_by_commit_ident: Optional[Dict[str, int]]`, and
+refuses any move whose `pos` is not strictly less than the current guess's
+position. The guard lives in the helper rather than the caller because the
+helper's docstring already claims the contract ("reverse walk has now reached an
+*earlier* commit", `mcp_server.py:5243-5252`) while nothing enforced it — which
+is how the defect arose. Both parameters default to `None`, in which case the
+guard is skipped and behavior is exactly as today, so 2a's existing callers and
+tests are unaffected; 2b passes them always.
+
+`_reverse_fill_claim_and_process` builds `pos_by_commit_ident` alongside the
+`ts_by_commit_ident` map it already builds (`mcp_server.py:7396`), and applies
+the invariant at all three write paths:
+
+1. **The provisional move** — delegated to the helper's new guard. A rejected
+   move leaves the guess where it is; the walk logs and continues.
+2. **The retroactive `:modified-in`** — currently written unconditionally on
+   every move (`mcp_server.py:7397-7407`). Skipped unless `superseded_ident` is
+   strictly later than `commit_ident`.
+3. **`already_authoritative_touched`** (`mcp_server.py:7379-7387`) — **not in
+   the review's list**, and the remaining path that can violate the invariant: an
+   entity whose `:introduced-by` is authoritative at some commit can still be
+   handed a `:modified-in` at an earlier claimed commit, with no check at all.
+   Gated on the same comparison. This is also the symptom half of the
+   2c-interleaving scenario (`2026-07-25-stream1-correction-sweep-review.md`,
+   round 4), so the two reviews' findings converge here.
+
+Note what path 3 does **not** fix: 2b must never clobber an authoritative
+`:introduced-by` (`mcp_server.py:5254-5256`, "never clobber a fact Stream 1 has
+already confirmed"), so when this case fires, the entity's *introduction* is
+still wrong — only the contradictory edge is suppressed. Preventing the wrong
+lineage is 2c's gap-closed precondition, which stays load-bearing. The two fixes
+are complementary, not alternatives.
+
+#### 2.3 Clear the superseded candidate-diff record at move time
+
+2b persists a candidate-diff record for every `(claimed commit, entity)` pair,
+on both the first-sighting path and every provisional move
+(`mcp_server.py:7391-7394`, `7399-7402`). Only the final, lowest one is a
+correct guess. Measured: one function touched in each of 8 commits leaves 8
+records for a single live `:introduced-by`. `_candidate_diff_clear`'s own
+docstring states these must not "accumulate unbounded across a full ingest"
+(`mcp_server.py:5210-5213`).
+
+Fix: call `_candidate_diff_clear(db, superseded_hash, ident)` in the
+`provisional_moves` loop, where `superseded_ident` is already in hand.
+`superseded_hash` comes from stripping the `":commit/"` prefix (8 characters —
+`_candidate_diff_ident` keys on `commit_hash[:12]`, which is exactly what the
+ident was minted from). Storage then tracks O(live guesses), not O(entity
+touches).
+
+This does not remove 2c's opportunistic cleanup, which still covers records
+orphaned by earlier runs.
+
+#### 2.4 Re-date structural facts on each provisional move
+
+2b writes an entity's `:entity-type`/`:ident`/`:description`/`:file`/`:path`
+once, at the timestamp of the commit where the walk first *sighted* it
+(`mcp_server.py:7353-7361`), and never re-dates them as the guess moves earlier.
+The result is a valid-time window where lineage is live for an entity with no
+type, name, or file:
+
+```
+REVERSE  valid-at 2026-01-15: [[':introduced-by', ':commit/cc340bfa5ae3']]
+FORWARD  valid-at 2026-01-15: [':description','login'] [':entity-type',':type/function']
+                              [':file','auth.py'] [':ident',...] [':introduced-by',...]
+```
+
+Current-time queries agree between the streams; only valid-time queries differ —
+but `:valid-at`/`:as-of` history is the product's advertised feature, and every
+such query joins `:entity-type`, so "which functions existed in January" returns
+nothing across the whole reverse-filled region while "when was `login`
+introduced" answers January.
+
+Fix: in the `provisional_moves` loop, retract the entity's live structural
+triples and re-assert them at the new (earlier) `commit_ts_iso`. The candidate
+triples are already in `precomputed`, and `_retract` targets live rows
+regardless of their original `valid_from`, so this is mechanical. Three
+constraints:
+
+- `:introduced-by` is excluded from the re-dated set — it is owned by
+  `_entity_introduced_by_set_provisional`, which already retracts and re-asserts
+  it at the right timestamp.
+- The re-asserted set includes `:contains` edges, so it goes through 2.1's
+  one-transact-per-edge path, not the batch.
+- Cost is write amplification: an entity touched N times in the claimed range
+  pays N retract+assert cycles of ~5 facts instead of one. Accepted in exchange
+  for exact forward/reverse `:valid-at` parity, which 3.2 asserts directly.
+
+#### 2.5 `commit_metadata`: state the contract, assert it, fix the spec
+
+The shipped signatures take a 4th positional `commit_metadata` that 2b's own
+design spec's "Driving functions" section does not contain at all, and
+`_reverse_bulk_fill_walk` has no `run_ts_iso` despite the spec declaring one
+(design:258-286 vs `mcp_server.py:7251-7259`, `7414-7422`).
+
+The code indexes the parameter positionally against `linearization`
+(`commit_metadata[pos]`, `mcp_server.py:7314`) while persisting
+`linearization[pos]` (`:7409`). `build_linearization` and
+`_git_commits(repo, watermark_hash=None)` are aligned, which is what every 2b
+test supplies — but `_run_ingestion` builds a **watermark-relative** list
+(`mcp_server.py:7486`, `4116`). Handed that on a resumed ingest, 2b either
+raises `IndexError` or silently attributes entities to the wrong commit while
+persisting the right one.
+
+Fix: state the contract in the docstring and the 2b spec (full-history,
+positionally aligned with `linearization`, i.e.
+`_git_commits(repo, watermark_hash=None)`); assert
+`len(commit_metadata) == len(linearization)` at entry to both functions, raising
+a named error rather than mis-attributing; and correct the spec's stale
+signatures. 2c's spec already documents the mirror-image contract with a
+`return None` guard — the wording should match, with the difference in
+failure mode (2b raises, since it is given a position by an allocator that has
+already claimed it; 2c returns `None`, since it selects its own position and can
+decline) stated in both.
+
+#### 2.6 Emit `:parent`
+
+Forward walk writes `[commit :parent parent_commit]` per commit, one transact
+each (`mcp_server.py:7982-7999`, split for the same EAVT reason as `:contains`,
+since a merge commit has two parents). 2b writes the other seven commit facts —
+verified byte-identical to forward's — but no `:parent`, and the bootstrap
+`ancestor` rule is defined purely over `:parent` (`mcp_server.py:46-49`), so
+`ancestor` queries return nothing across the reverse-filled region. The gap is
+not in 2b's deferred list either.
+
+Fix: emit them, reusing the existing `_git_parent_hashes(repo_path,
+commit_hash)` helper, one `_transact` per parent.
+
+Reverse-walk-specific note to state in the docstring: the walk reaches a
+commit's parents *later* than the commit itself, so a `:parent` edge points at a
+commit entity that does not exist yet and materialises when the walk descends to
+it (or when the forward stream covers it, for parents below frontier-high's
+floor). The edge is temporarily dangling and converges — the same shape as the
+lineage facts around it — and `ancestor` returns partial results until the
+region is complete.
+
+#### 2.7 Retroactive-`:modified-in`: correct the ownership note, stop back-dating
+
+Two small things in the same paragraph (`mcp_server.py:7295-7301`,
+design:244-254).
+
+**Ownership.** 2b's docstring says 2c will correct the un-narrowed retroactive
+edge using persisted candidate-diff hashes. The review recorded this as
+ownerless because 2c's spec had dropped the case. That is now out of date: 2c's
+case-3 reconcile retracts the over-asserted edge when its own `unchanged_idents`
+disagrees (`2026-07-25-stream1-correction-sweep-design.md`, "Per-commit
+algorithm"). So the limitation **is** owned by 2c — the docstring needs
+rewording, not reassignment: 2c corrects the fact after the fact, rather than
+2b preventing the write. 2b cannot self-narrow here, because narrowing needs the
+superseded commit's own diff, which 2b does not have while processing a
+different commit.
+
+**Back-dating.** `superseded_ts = ts_by_commit_ident.get(superseded_ident,
+commit_ts_iso)` (`mcp_server.py:7404`) falls back to the *current* commit's
+timestamp when the superseded ident is absent from `commit_metadata` — earlier
+than the modification it describes, i.e. a fact asserted valid before it was
+true, silently. Fix: skip the edge and log to stderr instead of back-dating. With
+2.5's alignment assertion this should be unreachable; it is a fail-safe, and a
+silent wrong answer is the worst available behavior for one.
+
+### Group 3: tests
+
+Following `docs/testing-conventions.md` (real `MiniGrafDb`, no mocks), and the
+existing real-git-repo fixture pattern. The review lists twelve gaps; these four
+carry the most weight, and the rest follow mechanically.
+
+1. **`:contains` completeness, forward vs reverse.** Ingest one multi-entity
+   file (a class with 2 fields plus 3 functions) through
+   `_reverse_bulk_fill_walk` and through `_run_ingestion`, and assert the
+   `:contains` *sets* are equal for both the module and the class. Fails today
+   with 1 edge against 6. This is the single highest-value test in the
+   sub-phase.
+2. **Valid-time parity, forward vs reverse.** Same repo through both streams;
+   for every commit date in the range, assert the `:valid-at` fact set for a
+   tracked entity is identical. Fails today at every date before the entity's
+   first sighting. Pins 2.4.
+3. **A genuine resume.** Every existing 2b test builds its allocator from a
+   graph with no persisted frontier
+   (`tests/test_mcp_server.py:13927`, `14082`, `14107`). Add: run a walk, add
+   commits, rebuild the linearization, run again — asserting the second walk
+   terminates, the persisted interval is never inverted, and no entity ends up
+   with a `:modified-in` earlier than its `:introduced-by`. This one test covers
+   the hang, the inverted interval, and the guess-moving-later corruption
+   together.
+4. **The cross-cutting invariant.** A helper asserting no entity carries a
+   `:modified-in` at a position `<=` its `:introduced-by`'s, called at the end of
+   every walk-level test. Cheap, and it would have caught 2.2 on its own.
+
+Also, per the review: fix
+`test_frontier_high_interval_advances_by_one`
+(`tests/test_mcp_server.py:14045-14058`), which asserts only `hi_hash` — the one
+bound `_frontier_persist_claim` never moves for `from_low=False` — and never
+claims twice despite its name, so it would pass if the claim were never
+persisted at all; and give
+`test_walks_until_gap_closes_and_returns_count` (`:14062-14091`) a file touched
+by more than one commit, so the provisional-move path it is meant to exercise
+actually runs. Add coverage for the `"D"`/`"R"` skip, the structural
+written-once invariant, the retroactive edge's `valid_from`, the unchanged-body
+suppression path, the candidate-diff record count after a multi-commit walk, and
+the `commit_metadata` misalignment assertion.
+
+## Schema/audit safety
+
+No new entity types or attributes. `:parent` is already registered optional on
+`:type/commit` (`mcp_server.py:5399`). `:contains`, `:entity-type`, `:ident`,
+`:description`, `:file`, `:path`, `:introduced-by` and `:modified-in` are
+unchanged in both shape and registration; 2b1 changes only *when* and *in how
+many transacts* they are written. The structural re-dating in 2.4 retracts and
+re-asserts existing facts through the same `_transact`/`_retract` choke points
+that already maintain the persisted fact index, so index consistency is
+preserved by construction — every call threads `index_con`.
+
+## Verified during design
+
+- **EAVT collapse and its scope** — repro above; only same-entity facts collide,
+  so `:contains` (and `:parent` on merge commits) is the whole exposure.
+- **Committer dates are not topologically monotonic** — one real inversion in
+  this repository's own 548-commit history, which is what forces position-based
+  comparison in 2.2.
+- **Baseline before any change** — full suite green in the 2b1 worktree: 915
+  passed.

--- a/frontier_registry.py
+++ b/frontier_registry.py
@@ -88,14 +88,59 @@ class FrontierAllocator:
         self._extend(pos, tag=TAG_PROVISIONAL, from_low=False)
         return pos
 
-    def _extend(self, pos: int, tag: str, from_low: bool) -> None:
-        neighbor_pos = pos - 1 if from_low else pos + 1
-        existing = self._interval_covering(neighbor_pos)
-        if existing is not None and existing.tag == tag:
-            idx = self._intervals.index(existing)
-            if from_low:
-                self._intervals[idx] = Interval(existing.lo_pos, pos, tag)
+    def _adjacent_interval(self, pos: int, tag: str, from_low: bool) -> Optional[Interval]:
+        """The same-tag interval this claim should grow: the one whose edge
+        touches pos from the direction of growth.
+
+        Deliberately NOT "the first interval covering the neighbour
+        position" (#222 phase 2b1). Those differ once a side holds two
+        intervals, which happens whenever a run reloads a persisted high
+        interval that no longer reaches the last position -- new commits
+        landed on HEAD since. There, claim_high() opens a second provisional
+        interval near the top while the reloaded one sits lower, and picking
+        the first *covering* interval can select the lower one and rewrite it
+        to itself: gap_hi never moves, claim_high() returns the same position
+        forever, and _reverse_bulk_fill_walk spins on it, re-parsing and
+        re-fsyncing every iteration.
+        """
+        for iv in self._intervals:
+            if iv.tag != tag:
+                continue
+            touches = (iv.hi_pos == pos - 1) if from_low else (iv.lo_pos == pos + 1)
+            if touches:
+                return iv
+        return None
+
+    def _coalesce(self, tag: str) -> None:
+        """Merge same-tag intervals that overlap or touch, keeping intervals
+        disjoint and sorted.
+
+        Growing toward a stale interval eventually makes the two meet; left
+        overlapping, _interval_covering's first-match lookup becomes
+        order-dependent and gap_lo/gap_hi stop describing a coherent gap.
+        Only same-tag intervals merge -- the authoritative/provisional
+        boundary is the lineage frontier later phases read, and must survive
+        the two sides becoming adjacent.
+        """
+        same = sorted((iv for iv in self._intervals if iv.tag == tag), key=lambda iv: iv.lo_pos)
+        merged: List[Interval] = []
+        for iv in same:
+            if merged and iv.lo_pos <= merged[-1].hi_pos + 1:
+                prev = merged[-1]
+                merged[-1] = Interval(prev.lo_pos, max(prev.hi_pos, iv.hi_pos), tag)
             else:
-                self._intervals[idx] = Interval(pos, existing.hi_pos, tag)
+                merged.append(iv)
+        others = [iv for iv in self._intervals if iv.tag != tag]
+        self._intervals = sorted(others + merged, key=lambda iv: iv.lo_pos)
+
+    def _extend(self, pos: int, tag: str, from_low: bool) -> None:
+        target = self._adjacent_interval(pos, tag, from_low)
+        if target is not None:
+            idx = next(i for i, iv in enumerate(self._intervals) if iv is target)
+            if from_low:
+                self._intervals[idx] = Interval(target.lo_pos, pos, tag)
+            else:
+                self._intervals[idx] = Interval(pos, target.hi_pos, tag)
         else:
             self._intervals.append(Interval(pos, pos, tag))
+        self._coalesce(tag)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5282,6 +5282,8 @@ def _entity_introduced_by_set_provisional(
     commit_ident: str,
     commit_ts_iso: str,
     index_con: Optional[Any] = None,
+    pos: Optional[int] = None,
+    pos_by_commit_ident: Optional[Dict[str, int]] = None,
 ) -> None:
     """Assert or move entity_ident's PROVISIONAL :introduced-by to
     commit_ident. Never touches an entity whose :introduced-by is already
@@ -5293,6 +5295,23 @@ def _entity_introduced_by_set_provisional(
     value genuinely changed -- mirrors _watermark_update's pattern, since
     re-transacting the same (entity, attribute, value) at a new valid_from
     creates a duplicate live datom under minigraf's write semantics.
+
+    Monotonicity (#222 phase 2b1): when pos and pos_by_commit_ident are
+    supplied, a move is REFUSED unless commit_ident is strictly earlier than
+    the current guess. This docstring always claimed the contract ("reverse
+    walk has now reached an earlier commit") but nothing enforced it, so a
+    re-claim of a higher position -- routine on a resumed run -- dragged the
+    guess forward while the caller's retroactive :modified-in landed at the
+    older, lower commit, producing an entity modified before it was
+    introduced. Forward walk cannot produce that shape, nothing in the graph
+    or the audit detects it, and it persists.
+
+    Positions, never timestamps: committer dates are not monotonic in
+    topological order (clock skew, rebases), which is why
+    build_linearization uses --topo-order at all, so comparing :date values
+    would silently mis-order commits. Both parameters default to None, in
+    which case the guard is skipped and behaviour is exactly as before --
+    2a's existing callers are unaffected; 2b passes them always.
     """
     current = _entity_introduced_by_query(db, entity_ident)
     if current is not None and not _lineage_is_provisional(db, entity_ident):
@@ -5300,6 +5319,16 @@ def _entity_introduced_by_set_provisional(
     if current == commit_ident:
         _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
         return
+    if current is not None and pos is not None and pos_by_commit_ident is not None:
+        current_pos = pos_by_commit_ident.get(current)
+        if current_pos is not None and pos >= current_pos:
+            print(
+                f"[_entity_introduced_by_set_provisional] refusing to move "
+                f"{entity_ident}'s guess from {current} (position {current_pos}) "
+                f"to {commit_ident} (position {pos}): a guess may only move earlier",
+                file=sys.stderr,
+            )
+            return
     if current is not None:
         _retract(db, f"[[{entity_ident} :introduced-by {current}]]", index_con=index_con)
     _transact(db, f"[[{entity_ident} :introduced-by {commit_ident}]]", commit_ts_iso, index_con=index_con)
@@ -7370,9 +7399,11 @@ def _reverse_fill_claim_and_process(
         f'[{commit_ident} :subject "{_edn_escape(subject[:200])}"]',
         f'[{commit_ident} :date "{commit_ts_iso}"]',
     ]
+    pos_by_commit_ident = {f":commit/{h[:12]}": i for i, (h, _t, _a, _s) in enumerate(commit_metadata)}
+    ts_by_commit_ident = {f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata}
     new_candidates: List[str] = []
     provisional_moves: List[Tuple[str, str]] = []  # (ident, superseded_commit_ident)
-    already_authoritative_touched: List[str] = []
+    already_authoritative_touched: List[Tuple[str, Optional[str]]] = []
     body_hash_by_ident: Dict[str, str] = {}
     unchanged_by_ident: Dict[str, bool] = {}
 
@@ -7413,38 +7444,93 @@ def _reverse_fill_claim_and_process(
                 superseded_ident = _entity_introduced_by_query(db, ident)
                 provisional_moves.append((ident, superseded_ident))
             else:
-                already_authoritative_touched.append(ident)
+                already_authoritative_touched.append(
+                    (ident, _entity_introduced_by_query(db, ident))
+                )
 
         body_hash_by_ident.update(precomputed.get("body_hashes", {}))
 
-    _transact(db, "[" + " ".join(all_triples) + "]", commit_ts_iso, index_con=index_con)
+    # Split :contains out before batching (#222 phase 2b1). Minigraf's EAVT
+    # pending index lacks value bytes in the key, so batching multiple
+    # [module :contains fn] facts in ONE transact silently keeps only the
+    # last -- five of six containment edges on an ordinary multi-entity file.
+    # Forward walk splits them for exactly this reason (see _run_ingestion's
+    # own one-transact-per-edge loop and _ingest_close's docstring). Only
+    # :contains repeats (entity, attribute) within this batch: the
+    # :modified-in triples below are one per DISTINCT entity, and facts
+    # differing in entity do not collide.
+    contains_triples = [t for t in all_triples if ":contains" in t]
+    other_triples = [t for t in all_triples if ":contains" not in t]
+    _transact(db, "[" + " ".join(other_triples) + "]", commit_ts_iso, index_con=index_con)
+    for contains_triple in contains_triples:
+        _transact(db, "[" + contains_triple + "]", commit_ts_iso, index_con=index_con)
 
-    authoritative_modified_triples = [
-        f"[{ident} :modified-in {commit_ident}]"
-        for ident in already_authoritative_touched
-        if not unchanged_by_ident.get(ident, False)
-    ]
+    # Third of the three write paths the monotonicity invariant covers
+    # (#222 phase 2b1), and the one the 2b review did not list: an entity
+    # whose :introduced-by is already authoritative could still be handed a
+    # :modified-in at an EARLIER claimed commit, with no check at all. That
+    # is also the symptom half of the 2c interleaving (a sweep confirms an
+    # entity, then this walk descends past it). Suppressing the edge does
+    # not fix that entity's lineage -- reverse walk must never clobber an
+    # authoritative :introduced-by -- so 2c's gap-closed precondition stays
+    # load-bearing; this only stops the contradictory fact being written.
+    authoritative_modified_triples = []
+    for ident, intro_ident in already_authoritative_touched:
+        if unchanged_by_ident.get(ident, False):
+            continue
+        intro_pos = pos_by_commit_ident.get(intro_ident) if intro_ident is not None else None
+        if intro_pos is not None and pos <= intro_pos:
+            print(
+                f"[_reverse_fill_claim_and_process] skipping :modified-in for {ident} at "
+                f"position {pos}: not later than its introduction {intro_ident} "
+                f"(position {intro_pos})",
+                file=sys.stderr,
+            )
+            continue
+        authoritative_modified_triples.append(f"[{ident} :modified-in {commit_ident}]")
     if authoritative_modified_triples:
         _transact(
             db, "[" + " ".join(authoritative_modified_triples) + "]", commit_ts_iso, index_con=index_con,
         )
 
     for ident in new_candidates:
-        _entity_introduced_by_set_provisional(db, ident, commit_ident, commit_ts_iso, index_con=index_con)
+        _entity_introduced_by_set_provisional(
+            db, ident, commit_ident, commit_ts_iso, index_con=index_con,
+            pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+        )
         if ident in body_hash_by_ident:
             _candidate_diff_persist(
                 db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
             )
 
-    ts_by_commit_ident = {f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata}
     for ident, superseded_ident in provisional_moves:
-        _entity_introduced_by_set_provisional(db, ident, commit_ident, commit_ts_iso, index_con=index_con)
+        _entity_introduced_by_set_provisional(
+            db, ident, commit_ident, commit_ts_iso, index_con=index_con,
+            pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+        )
         if ident in body_hash_by_ident:
             _candidate_diff_persist(
                 db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
             )
         if superseded_ident is not None and superseded_ident != commit_ident:
-            superseded_ts = ts_by_commit_ident.get(superseded_ident, commit_ts_iso)
+            superseded_pos = pos_by_commit_ident.get(superseded_ident)
+            if superseded_pos is not None and superseded_pos <= pos:
+                # The move was refused (or would be): the "superseded" guess
+                # is not actually later than this commit, so asserting it as
+                # a modification would claim the entity changed at or before
+                # its own introduction.
+                continue
+            superseded_ts = ts_by_commit_ident.get(superseded_ident)
+            if superseded_ts is None:
+                # Falling back to THIS commit's timestamp back-dates the edge
+                # to before the modification it describes -- a fact asserted
+                # valid before it was true. Skip and say so instead.
+                print(
+                    f"[_reverse_fill_claim_and_process] skipping retroactive :modified-in "
+                    f"for {ident} at {superseded_ident}: no timestamp in commit_metadata",
+                    file=sys.stderr,
+                )
+                continue
             _transact(
                 db, f"[[{ident} :modified-in {superseded_ident}]]", superseded_ts, index_con=index_con,
             )

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7364,13 +7364,22 @@ def _reverse_fill_claim_and_process(
     touch always gets :modified-in (unless #221's unchanged-body check
     says the body is provably unchanged this commit).
 
-    Known, documented limitation: the retroactive :modified-in for a
-    superseded commit does not re-check #221's unchanged-body narrowing
-    against THAT commit's own diff (only this call's diff has that data) --
-    it is asserted unconditionally. This can rarely over-assert an edge
-    forward walk would have suppressed; it can never produce a missing or
-    misattributed edge. See the design spec for why this is an accepted
-    simplification for this sub-phase.
+    Known, documented limitation, and who fixes it: the retroactive
+    :modified-in for a superseded commit does not re-check #221's
+    unchanged-body narrowing against THAT commit's own diff, because only
+    this call's diff carries that data -- so it is asserted whenever the
+    superseded commit is genuinely later (see the monotonicity guard
+    above). This can over-assert an edge forward walk would have
+    suppressed; it can never produce a missing or misattributed one.
+
+    2c's correction sweep corrects it, in the ordinary already-authoritative
+    branch of _correction_sweep_apply: walking forward with its own parse in
+    hand, it retracts a :modified-in whose entity reads as unchanged at that
+    commit. Note the shape of the fix -- 2c repairs the fact after the fact
+    rather than this walk preventing the write, which is why this stays a
+    documented limitation here rather than a bug. Phrased carefully because
+    an intermediate draft of 2c's spec dropped the case entirely, leaving it
+    briefly owned by nobody (see the 2b review).
 
     Returns the claimed commit's hash, or None if the gap was already
     empty (allocator.claim_high() returned None) -- caller's signal to
@@ -7379,11 +7388,33 @@ def _reverse_fill_claim_and_process(
     claim -- mirrors _run_ingestion's one-checkpoint-per-commit cadence
     (see the design spec's "Resume-safety / atomicity boundary" section).
     """
+    # commit_metadata is indexed POSITIONALLY against linearization below,
+    # while _frontier_persist_claim persists linearization[pos] -- so a
+    # misaligned list makes this walk attribute entities to one commit and
+    # persist another: silent, systematic misattribution. _run_ingestion
+    # builds a watermark-relative list for its own use
+    # (_git_commits(repo, watermark, branch)), which is exactly the wrong
+    # thing to hand this function. Checked before claim_high() so a bad call
+    # does not consume a position. This raises rather than returning None
+    # (2c's mirror-image guard returns None) because 2c selects its own
+    # position and can decline, whereas this walk has been handed one.
+    if len(commit_metadata) != len(linearization):
+        raise ValueError(
+            "commit_metadata must be full-history and positionally aligned with "
+            f"linearization (got {len(commit_metadata)} entries vs {len(linearization)}); "
+            "pass _git_commits(repo, watermark_hash=None)"
+        )
+
     pos = allocator.claim_high()
     if pos is None:
         return None
 
     commit_hash, commit_ts_iso, author, subject = commit_metadata[pos]
+    if commit_hash != linearization[pos]:
+        raise ValueError(
+            f"commit_metadata[{pos}] is {commit_hash}, but linearization[{pos}] is "
+            f"{linearization[pos]}: the two must be positionally aligned"
+        )
     commit_ident = f":commit/{commit_hash[:12]}"
 
     file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
@@ -7399,6 +7430,7 @@ def _reverse_fill_claim_and_process(
         f'[{commit_ident} :subject "{_edn_escape(subject[:200])}"]',
         f'[{commit_ident} :date "{commit_ts_iso}"]',
     ]
+    candidate_triples_by_ident: Dict[str, List[str]] = {}
     pos_by_commit_ident = {f":commit/{h[:12]}": i for i, (h, _t, _a, _s) in enumerate(commit_metadata)}
     ts_by_commit_ident = {f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata}
     new_candidates: List[str] = []
@@ -7438,6 +7470,17 @@ def _reverse_fill_claim_and_process(
         for ident in candidate_idents:
             unchanged_by_ident[ident] = ident in unchanged_idents
 
+        # Keep each entity's candidate triples so a provisional move can
+        # re-date them (#222 phase 2b1). A child's own list carries its
+        # [parent :contains child] edge, so re-dating a child re-dates its
+        # containment edge with it.
+        candidate_triples_by_ident[precomputed["module_ident"]] = list(
+            precomputed["module_candidate_triples"]
+        )
+        for entries_key in ("function_entries", "class_entries", "global_entries", "field_entries"):
+            for entry_ident, _entry_name, entry_triples in precomputed[entries_key]:
+                candidate_triples_by_ident[entry_ident] = list(entry_triples)
+
         new_candidates.extend(set(known_before.keys()) - known_before_snapshot)
         for ident in set(candidate_idents) & known_before_snapshot:
             if _lineage_is_provisional(db, ident):
@@ -7464,6 +7507,22 @@ def _reverse_fill_claim_and_process(
     _transact(db, "[" + " ".join(other_triples) + "]", commit_ts_iso, index_con=index_con)
     for contains_triple in contains_triples:
         _transact(db, "[" + contains_triple + "]", commit_ts_iso, index_con=index_con)
+
+    # :parent edges (#222 phase 2b1), one transact per parent -- a merge
+    # commit has two, and they share (entity, attribute, valid_from), the
+    # same EAVT collision :contains has. The bootstrap `ancestor` rule is
+    # defined purely over :parent, so without these it returns nothing
+    # across the whole reverse-filled region. Reverse walk reaches a
+    # commit's parents LATER than the commit itself, so the edge points at
+    # an entity that does not exist yet and materialises when the walk
+    # descends to it (or when the forward stream covers it, for parents
+    # below frontier-high's floor): temporarily dangling, and convergent --
+    # the same shape as the lineage facts around it.
+    for parent_hash in _git_parent_hashes(repo_path, commit_hash):
+        _transact(
+            db, f"[[{commit_ident} :parent :commit/{parent_hash[:12]}]]",
+            commit_ts_iso, index_con=index_con,
+        )
 
     # Third of the three write paths the monotonicity invariant covers
     # (#222 phase 2b1), and the one the 2b review did not list: an entity
@@ -7514,6 +7573,44 @@ def _reverse_fill_claim_and_process(
             )
         if superseded_ident is not None and superseded_ident != commit_ident:
             superseded_pos = pos_by_commit_ident.get(superseded_ident)
+            if superseded_pos is None or superseded_pos > pos:
+                # The move happened: this commit is genuinely earlier.
+                #
+                # Re-date the entity's structural facts to match (#222 phase
+                # 2b1). They were written at the timestamp of the commit
+                # where the walk first SIGHTED the entity, which is later
+                # than the guess now is -- leaving a valid-time window where
+                # :introduced-by is live for an entity with no type, name or
+                # file, so ":as-of the introduction" says it did not exist.
+                # _retract targets live rows regardless of their original
+                # valid_from, so this is a straight re-assert at the earlier
+                # timestamp. :contains goes one per call for the same EAVT
+                # reason as above, on the retract side too (see
+                # _ingest_close's docstring).
+                structural = [
+                    t for t in candidate_triples_by_ident.get(ident, [])
+                    if ":introduced-by" not in t
+                ]
+                structural_contains = [t for t in structural if ":contains" in t]
+                structural_other = [t for t in structural if ":contains" not in t]
+                if structural_other:
+                    _retract(db, "[" + " ".join(structural_other) + "]", index_con=index_con)
+                    _transact(
+                        db, "[" + " ".join(structural_other) + "]", commit_ts_iso, index_con=index_con,
+                    )
+                for structural_triple in structural_contains:
+                    _retract(db, "[" + structural_triple + "]", index_con=index_con)
+                    _transact(db, "[" + structural_triple + "]", commit_ts_iso, index_con=index_con)
+
+                # The superseded candidate-diff record is stale the moment
+                # the guess moves off it, and this is the cheapest place to
+                # drop it -- superseded_ident is right here. Without it these
+                # scratch facts accumulate as O(entity touches) rather than
+                # O(entities), which is exactly what _candidate_diff_clear's
+                # own docstring says must not happen.
+                _candidate_diff_clear(
+                    db, superseded_ident[len(":commit/"):], ident, index_con=index_con,
+                )
             if superseded_pos is not None and superseded_pos <= pos:
                 # The move was refused (or would be): the "superseded" guess
                 # is not actually later than this commit, so asserting it as

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4973,10 +4973,53 @@ def _frontier_load(
         ))
     high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
     if high_bounds is not None and high_bounds[0] in hash_to_pos and high_bounds[1] in hash_to_pos:
-        intervals.append(frontier_registry.Interval(
-            hash_to_pos[high_bounds[0]], hash_to_pos[high_bounds[1]], frontier_registry.TAG_PROVISIONAL
-        ))
+        hi_lo_pos, hi_hi_pos = hash_to_pos[high_bounds[0]], hash_to_pos[high_bounds[1]]
+        if hi_lo_pos <= hi_hi_pos and hi_hi_pos == len(linearization) - 1:
+            intervals.append(frontier_registry.Interval(
+                hi_lo_pos, hi_hi_pos, frontier_registry.TAG_PROVISIONAL
+            ))
+        else:
+            # Unrepresentable (#222 phase 2b1). Either the pair is inverted
+            # (what the pre-2b1 persist path produced once the linearization
+            # grew), or it no longer reaches the last position -- meaning new
+            # commits have landed above it, so the real state is three spans
+            # (authoritative low, filled high, new unclaimed above) and the
+            # gap now sits ABOVE this interval. One lo/hi pair per side
+            # cannot express that, so drop it and let the region be
+            # re-walked: re-processing an already-processed position is
+            # idempotent, so the graph converges and only work is wasted.
+            #
+            # Retract the facts too, not just the in-memory interval. Leaving
+            # them behind means the next _frontier_persist_claim sees a
+            # non-None `existing` and extends a pair the allocator no longer
+            # believes in, re-creating the inverted state on the first claim
+            # of the new run.
+            #
+            # Folding a 2c-confirmed high region into frontier-low instead
+            # (no re-walk at all) needs :ingestion/correction-sweep-through
+            # and spans all three streams -- that is 2d's, see the 2b1 design
+            # spec's "Why re-ingest is made safe, not efficient".
+            _frontier_discard_interval(
+                db, _FRONTIER_HIGH_IDENT, high_bounds, index_con=index_con
+            )
     return frontier_registry.FrontierAllocator(len(linearization), intervals)
+
+
+def _frontier_discard_interval(
+    db: Any, ident: str, bounds: Tuple[str, str], index_con: Optional[Any] = None
+) -> None:
+    """Retract an interval's four persisted facts, mirroring the set
+    _frontier_persist_claim creates. Used by _frontier_load when a persisted
+    pair cannot faithfully describe the claimed region (see its call site).
+    """
+    tag = ":authoritative" if ident == _FRONTIER_LOW_IDENT else ":provisional"
+    facts = [
+        f"[{ident} :entity-type :type/ingest-interval]",
+        f"[{ident} :tag {tag}]",
+        f'[{ident} :lo-hash "{_edn_escape(bounds[0])}"]',
+        f'[{ident} :hi-hash "{_edn_escape(bounds[1])}"]',
+    ]
+    _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
 
 
 def _frontier_persist_claim(
@@ -7424,8 +7467,20 @@ def _reverse_bulk_fill_walk(
     the gap closes. Returns the count of commits processed. No caller in
     this sub-phase -- 2d wires this into the real concurrent ingestion
     loop alongside the forward stream.
+
+    Stops loudly if a claim ever fails to move strictly downward (#222
+    phase 2b1). This loop is unbounded by construction and drives a git
+    subprocess, a tree-sitter parse, a DB write batch and a _db_checkpoint
+    fsync on every iteration, so an allocator that stops making progress
+    turns it into an unbounded fsync loop inside what 2d intends to run as a
+    background task -- which is exactly what happened before 2b1 fixed
+    FrontierAllocator._extend. The guard stays even though that root cause
+    is fixed: it converts any future allocator regression from a hang into a
+    stop plus a stderr line.
     """
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
     count = 0
+    last_pos: Optional[int] = None
     while True:
         result = _reverse_fill_claim_and_process(
             db, repo_path, linearization, commit_metadata, allocator,
@@ -7434,6 +7489,15 @@ def _reverse_bulk_fill_walk(
         if result is None:
             break
         count += 1
+        pos = hash_to_pos.get(result)
+        if pos is not None and last_pos is not None and pos >= last_pos:
+            print(
+                f"[_reverse_bulk_fill_walk] no progress: claim returned position {pos} "
+                f"after {last_pos}; stopping after {count} commits to avoid spinning",
+                file=sys.stderr,
+            )
+            break
+        last_pos = pos
     return count
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7248,6 +7248,109 @@ def _extract_commit(
     return results, gitlink_changes, gitmodules_map, renamed_pairs
 
 
+def _reverse_fill_claim_and_process(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    allocator: "frontier_registry.FrontierAllocator",
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> Optional[str]:
+    """#222 phase 2b: claim exactly one position from the gap's high end
+    (allocator.claim_high()) and process that one commit -- structural
+    facts, :modified-in edges, provisional :introduced-by, and candidate-diff
+    records for every entity the commit's "A"/"M" files touch. "D"/"R"
+    files are skipped entirely (deletions and renames are out of scope for
+    this sub-phase -- see the design spec).
+
+    Reuses _extract_commit/_build_code_triples unchanged: entity discovery
+    is direction-agnostic. The only new mechanism is substituting a DB
+    query (_entity_introduced_by_query) for forward walk's in-memory
+    entity_valid_from dict, since reverse walk has no accumulated-forward
+    state -- built fresh, per file, from currently-persisted graph state.
+
+    _build_code_triples's own candidate :introduced-by triples are filtered
+    out of what gets transacted here -- _entity_introduced_by_set_provisional
+    is the sole writer of :introduced-by in this walk, so a newly
+    discovered entity and one whose guess is being moved earlier go
+    through exactly the same code path.
+
+    Returns the claimed commit's hash, or None if the gap was already
+    empty (allocator.claim_high() returned None) -- caller's signal to
+    stop. Writes for one commit are followed by exactly one
+    _db_checkpoint(db) call, after _frontier_persist_claim records the
+    claim -- mirrors _run_ingestion's one-checkpoint-per-commit cadence
+    (see the design spec's "Resume-safety / atomicity boundary" section).
+    """
+    pos = allocator.claim_high()
+    if pos is None:
+        return None
+
+    commit_hash, commit_ts_iso, author, subject = commit_metadata[pos]
+    commit_ident = f":commit/{commit_hash[:12]}"
+
+    file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
+        repo_path, commit_hash, ignore_patterns
+    )
+
+    all_triples: List[str] = [
+        f"[{commit_ident} :entity-type :type/commit]",
+        f'[{commit_ident} :ident "{commit_ident}"]',
+        f'[{commit_ident} :description "{_edn_escape(subject[:120])}"]',
+        f'[{commit_ident} :hash "{commit_hash}"]',
+        f'[{commit_ident} :author "{_edn_escape(author)}"]',
+        f'[{commit_ident} :subject "{_edn_escape(subject[:200])}"]',
+        f'[{commit_ident} :date "{commit_ts_iso}"]',
+    ]
+    new_candidates: List[str] = []
+    provisional_moves: List[str] = []
+    body_hash_by_ident: Dict[str, str] = {}
+
+    for status, file_path, extracted, precomputed, _old_path in file_results:
+        if status not in ("A", "M"):
+            continue  # "D"/"R" deferred -- see design spec scope
+
+        candidate_idents = (
+            [precomputed["module_ident"]]
+            + [ident for ident, _name, _t in precomputed["function_entries"]]
+            + [ident for ident, _name, _t in precomputed["class_entries"]]
+            + [ident for ident, _name, _t in precomputed["global_entries"]]
+            + [ident for ident, _name, _t in precomputed["field_entries"]]
+        )
+        known_before: Dict[str, str] = {
+            ident: "known" for ident in candidate_idents
+            if _entity_introduced_by_query(db, ident) is not None
+        }
+        known_before_snapshot = set(known_before.keys())
+
+        triples = _build_code_triples(
+            file_path, extracted, commit_ts_iso, known_before, {}, {}, commit_ident,
+            precomputed, {}, {},
+        )
+        all_triples.extend(t for t in triples if ":introduced-by" not in t)
+
+        new_candidates.extend(set(known_before.keys()) - known_before_snapshot)
+        for ident in set(candidate_idents) & known_before_snapshot:
+            if _lineage_is_provisional(db, ident):
+                provisional_moves.append(ident)
+
+        body_hash_by_ident.update(precomputed.get("body_hashes", {}))
+
+    _transact(db, "[" + " ".join(all_triples) + "]", commit_ts_iso, index_con=index_con)
+
+    for ident in new_candidates + provisional_moves:
+        _entity_introduced_by_set_provisional(db, ident, commit_ident, commit_ts_iso, index_con=index_con)
+        if ident in body_hash_by_ident:
+            _candidate_diff_persist(
+                db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
+            )
+
+    _frontier_persist_claim(db, linearization, pos, from_low=False, commit_ts_iso=commit_ts_iso, index_con=index_con)
+    _db_checkpoint(db)
+    return commit_hash
+
+
 async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7351,6 +7351,32 @@ def _reverse_fill_claim_and_process(
     return commit_hash
 
 
+def _reverse_bulk_fill_walk(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    allocator: "frontier_registry.FrontierAllocator",
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> int:
+    """#222 phase 2b: repeatedly call _reverse_fill_claim_and_process until
+    the gap closes. Returns the count of commits processed. No caller in
+    this sub-phase -- 2d wires this into the real concurrent ingestion
+    loop alongside the forward stream.
+    """
+    count = 0
+    while True:
+        result = _reverse_fill_claim_and_process(
+            db, repo_path, linearization, commit_metadata, allocator,
+            ignore_patterns=ignore_patterns, index_con=index_con,
+        )
+        if result is None:
+            break
+        count += 1
+    return count
+
+
 async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7264,17 +7264,41 @@ def _reverse_fill_claim_and_process(
     files are skipped entirely (deletions and renames are out of scope for
     this sub-phase -- see the design spec).
 
-    Reuses _extract_commit/_build_code_triples unchanged: entity discovery
-    is direction-agnostic. The only new mechanism is substituting a DB
-    query (_entity_introduced_by_query) for forward walk's in-memory
-    entity_valid_from dict, since reverse walk has no accumulated-forward
-    state -- built fresh, per file, from currently-persisted graph state.
+    Reuses _extract_commit/_build_code_triples unchanged for entity
+    discovery/parsing (direction-agnostic). BOTH :introduced-by and
+    :modified-in are filtered out of _build_code_triples's own output and
+    written by this function instead -- _build_code_triples's gate for
+    both attributes is entity_valid_from membership, which for forward
+    walk coincides with "is this the introduction commit" but for reverse
+    walk does not: the first commit reverse walk sees an entity at is the
+    newest touch (not the introduction), and the commit where reverse walk
+    finally stops finding an even-earlier occurrence (the true
+    introduction) is by then already "known" from later, already-visited
+    commits. Reusing _build_code_triples's :modified-in emission verbatim
+    would misclassify both ends. See the design spec's "Per-commit
+    algorithm" section (revised after the final whole-branch review found
+    this defect) for the full derivation.
 
-    _build_code_triples's own candidate :introduced-by triples are filtered
-    out of what gets transacted here -- _entity_introduced_by_set_provisional
-    is the sole writer of :introduced-by in this walk, so a newly
-    discovered entity and one whose guess is being moved earlier go
-    through exactly the same code path.
+    :introduced-by: a newly-discovered entity's guess is asserted via
+    _entity_introduced_by_set_provisional and gets no :modified-in yet
+    (mirrors forward walk never emitting :modified-in at an entity's own
+    introduction commit). When an already-provisional entity is found at
+    an even earlier commit, its guess moves to this commit (also getting
+    no :modified-in yet) and the PREVIOUSLY-guessed commit -- now
+    confirmed to be a genuine modification, not the introduction --
+    retroactively receives a :modified-in fact using its OWN commit
+    timestamp (looked up from commit_metadata), not this commit's.
+    Already-authoritative entities are never touched, but a genuine later
+    touch always gets :modified-in (unless #221's unchanged-body check
+    says the body is provably unchanged this commit).
+
+    Known, documented limitation: the retroactive :modified-in for a
+    superseded commit does not re-check #221's unchanged-body narrowing
+    against THAT commit's own diff (only this call's diff has that data) --
+    it is asserted unconditionally. This can rarely over-assert an edge
+    forward walk would have suppressed; it can never produce a missing or
+    misattributed edge. See the design spec for why this is an accepted
+    simplification for this sub-phase.
 
     Returns the claimed commit's hash, or None if the gap was already
     empty (allocator.claim_high() returned None) -- caller's signal to
@@ -7304,8 +7328,10 @@ def _reverse_fill_claim_and_process(
         f'[{commit_ident} :date "{commit_ts_iso}"]',
     ]
     new_candidates: List[str] = []
-    provisional_moves: List[str] = []
+    provisional_moves: List[Tuple[str, str]] = []  # (ident, superseded_commit_ident)
+    already_authoritative_touched: List[str] = []
     body_hash_by_ident: Dict[str, str] = {}
+    unchanged_by_ident: Dict[str, bool] = {}
 
     for status, file_path, extracted, precomputed, _old_path in file_results:
         if status not in ("A", "M"):
@@ -7328,22 +7354,56 @@ def _reverse_fill_claim_and_process(
             file_path, extracted, commit_ts_iso, known_before, {}, {}, commit_ident,
             precomputed, {}, {},
         )
-        all_triples.extend(t for t in triples if ":introduced-by" not in t)
+        # This walk owns the write timing of BOTH attributes itself now --
+        # filter both out of _build_code_triples's forward-biased gating.
+        all_triples.extend(
+            t for t in triples if ":introduced-by" not in t and ":modified-in" not in t
+        )
+
+        unchanged_idents = precomputed.get("unchanged_idents", set())
+        for ident in candidate_idents:
+            unchanged_by_ident[ident] = ident in unchanged_idents
 
         new_candidates.extend(set(known_before.keys()) - known_before_snapshot)
         for ident in set(candidate_idents) & known_before_snapshot:
             if _lineage_is_provisional(db, ident):
-                provisional_moves.append(ident)
+                superseded_ident = _entity_introduced_by_query(db, ident)
+                provisional_moves.append((ident, superseded_ident))
+            else:
+                already_authoritative_touched.append(ident)
 
         body_hash_by_ident.update(precomputed.get("body_hashes", {}))
 
     _transact(db, "[" + " ".join(all_triples) + "]", commit_ts_iso, index_con=index_con)
 
-    for ident in new_candidates + provisional_moves:
+    authoritative_modified_triples = [
+        f"[{ident} :modified-in {commit_ident}]"
+        for ident in already_authoritative_touched
+        if not unchanged_by_ident.get(ident, False)
+    ]
+    if authoritative_modified_triples:
+        _transact(
+            db, "[" + " ".join(authoritative_modified_triples) + "]", commit_ts_iso, index_con=index_con,
+        )
+
+    for ident in new_candidates:
         _entity_introduced_by_set_provisional(db, ident, commit_ident, commit_ts_iso, index_con=index_con)
         if ident in body_hash_by_ident:
             _candidate_diff_persist(
                 db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
+            )
+
+    ts_by_commit_ident = {f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata}
+    for ident, superseded_ident in provisional_moves:
+        _entity_introduced_by_set_provisional(db, ident, commit_ident, commit_ts_iso, index_con=index_con)
+        if ident in body_hash_by_ident:
+            _candidate_diff_persist(
+                db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
+            )
+        if superseded_ident is not None and superseded_ident != commit_ident:
+            superseded_ts = ts_by_commit_ident.get(superseded_ident, commit_ts_iso)
+            _transact(
+                db, f"[[{ident} :modified-in {superseded_ident}]]", superseded_ts, index_con=index_con,
             )
 
     _frontier_persist_claim(db, linearization, pos, from_low=False, commit_ts_iso=commit_ts_iso, index_con=index_con)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5225,6 +5225,44 @@ def _candidate_diff_clear(
     _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
 
 
+def _entity_introduced_by_query(db: Any, entity_ident: str) -> Optional[str]:
+    """Return entity_ident's current :introduced-by value (a commit ident
+    string), or None if it has none yet."""
+    raw = _db_execute(db, f"(query [:find ?c :where [{entity_ident} :introduced-by ?c]])")
+    results = json.loads(raw).get("results", [])
+    return results[0][0] if results else None
+
+
+def _entity_introduced_by_set_provisional(
+    db: Any,
+    entity_ident: str,
+    commit_ident: str,
+    commit_ts_iso: str,
+    index_con: Optional[Any] = None,
+) -> None:
+    """Assert or move entity_ident's PROVISIONAL :introduced-by to
+    commit_ident. Never touches an entity whose :introduced-by is already
+    authoritative (a fact exists and _lineage_is_provisional is False) --
+    reverse walk (#222 phase 2b) must never clobber a fact Stream 1 has
+    already confirmed. Idempotent: no-ops the fact write (but still ensures
+    the marker is present) if the current value already equals
+    commit_ident. Query-before-write, retract-then-reassert only if the
+    value genuinely changed -- mirrors _watermark_update's pattern, since
+    re-transacting the same (entity, attribute, value) at a new valid_from
+    creates a duplicate live datom under minigraf's write semantics.
+    """
+    current = _entity_introduced_by_query(db, entity_ident)
+    if current is not None and not _lineage_is_provisional(db, entity_ident):
+        return  # authoritative -- never touch
+    if current == commit_ident:
+        _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
+        return
+    if current is not None:
+        _retract(db, f"[[{entity_ident} :introduced-by {current}]]", index_con=index_con)
+    _transact(db, f"[[{entity_ident} :introduced-by {commit_ident}]]", commit_ts_iso, index_con=index_con)
+    _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
+
+
 _LAST_RUN_KEYWORD_ATTRS = frozenset({":entity-type"})
 _LAST_RUN_NUMERIC_ATTRS = frozenset({":total-ingested"})
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -6420,6 +6420,23 @@ def _precompute_file_triples(
     except Exception:
         unchanged_idents = set()
 
+    # #222 phase 2b: per-entity body hash for every entity present on the
+    # NEW side, keyed the same way unchanged_idents is above -- lets the
+    # reverse-bulk-fill walk persist a candidate-diff record (body hash)
+    # for an entity without needing the raw tree-sitter node itself.
+    # Module-level entries are deliberately excluded: there is no
+    # tree-sitter node to hash for a whole file, and candidate-diff
+    # persistence is function/class/variable/field-only (matching
+    # unchanged_idents' own category scope).
+    body_hashes: Dict[str, str] = {}
+    try:
+        new_nodes_for_hash = new_entity_nodes or {}
+        for category in ("function", "class", "variable", "field"):
+            for name, node in new_nodes_for_hash.get(category, {}).items():
+                body_hashes[_code_ident(category, file_path, name)] = _normalized_body_hash(node)
+    except Exception:
+        body_hashes = {}
+
     return {
         "module_ident": module_ident,
         "module_candidate_triples": module_candidate_triples,
@@ -6431,6 +6448,7 @@ def _precompute_file_triples(
         "field_static_map": field_static_map,
         "resolved_imports": resolved_imports,
         "unchanged_idents": unchanged_idents,
+        "body_hashes": body_hashes,
     }
 
 

--- a/tests/test_frontier_registry.py
+++ b/tests/test_frontier_registry.py
@@ -4,6 +4,7 @@ This module has no DB dependency, so its own real dependency (git) is what
 gets exercised for real here, matching the spirit of
 docs/testing-conventions.md's real-backend rule.
 """
+import itertools
 import os
 import subprocess as _subprocess
 
@@ -157,3 +158,49 @@ class TestFrontierAllocatorClaiming:
         allocator = FrontierAllocator(10, [Interval(0, 4, TAG_AUTHORITATIVE)])
         assert allocator.claim_low() == 5
         assert allocator.intervals() == [Interval(0, 5, TAG_AUTHORITATIVE)]
+
+
+class TestFrontierAllocatorGrownLinearization:
+    """A run that claims from the high end, followed by new commits landing
+    on HEAD, reloads a persisted high interval that no longer reaches the
+    last position -- so claim_high() opens a SECOND provisional interval and
+    _extend has to choose between them. Choosing the first *covering*
+    interval rather than the one adjacent in the direction of growth pins
+    gap_hi forever, which turns _reverse_bulk_fill_walk's `while True` into
+    an unbounded fsync loop (see the 2b review, "never terminates on any
+    incremental re-ingest")."""
+
+    def test_claim_high_strictly_decreases_and_terminates(self):
+        allocator = FrontierAllocator(5, [Interval(1, 2, TAG_PROVISIONAL)])
+        seen = []
+        for _ in range(20):  # bounded so a regression fails instead of hanging
+            pos = allocator.claim_high()
+            if pos is None:
+                break
+            seen.append(pos)
+        assert seen == sorted(set(seen), reverse=True), (
+            f"claim_high() must strictly decrease; got {seen}"
+        )
+        assert allocator.is_gap_empty()
+
+    def test_claim_low_strictly_increases_and_terminates(self):
+        allocator = FrontierAllocator(5, [Interval(2, 3, TAG_AUTHORITATIVE)])
+        seen = []
+        for _ in range(20):
+            pos = allocator.claim_low()
+            if pos is None:
+                break
+            seen.append(pos)
+        assert seen == sorted(set(seen)), f"claim_low() must strictly increase; got {seen}"
+        assert allocator.is_gap_empty()
+
+    def test_same_tag_intervals_coalesce_instead_of_overlapping(self):
+        allocator = FrontierAllocator(5, [Interval(1, 2, TAG_PROVISIONAL)])
+        for _ in range(20):  # bounded: an unbounded loop would hang, not fail
+            if allocator.claim_high() is None:
+                break
+        ivs = allocator.intervals()
+        for a, b in itertools.combinations(ivs, 2):
+            assert a.hi_pos < b.lo_pos or b.hi_pos < a.lo_pos, (
+                f"intervals must stay disjoint, got {ivs}"
+            )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13889,3 +13889,128 @@ class TestFieldClassContainmentE2E:
             )
         }
         assert field_ident not in mod_contains_after
+
+
+class TestReverseFillClaimAndProcess:
+    def _repo_with_evolving_function(self, tmp_path):
+        """Three commits, each genuinely changing auth.py's login() body (not
+        just whitespace -- #221's unchanged-body detection would otherwise
+        suppress :modified-in and complicate the assertions below), plus an
+        unrelated function added at h1/h2 so the file is in each commit's
+        diff for a real reason."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text("def login():\n    return 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text("def login():\n    return 2\n\ndef extra():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h1"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text(
+            "def login():\n    return 3\n\ndef extra():\n    pass\n\ndef more():\n    pass\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h2"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _allocator_and_metadata(self, repo, real_db):
+        import mcp_server
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        return linearization, commit_metadata, allocator
+
+    def test_gap_empty_returns_none_and_writes_nothing(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+        # Drain the gap entirely first (forward-claim everything low).
+        while allocator.claim_low() is not None:
+            pass
+
+        result = mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert result is None
+
+    def test_single_claim_writes_structure_and_provisional_introduced_by(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        claimed_hash = mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert claimed_hash == linearization[-1]  # newest commit (h2) claimed first
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        commit_ident = f":commit/{claimed_hash[:12]}"
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == commit_ident
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        assert mcp_server._candidate_diff_read(real_db, claimed_hash, fn_ident) is not None
+
+    def test_walking_backward_moves_introduced_by_to_the_oldest_commit(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        for _ in range(3):
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        oldest_hash = linearization[0]  # h0
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{oldest_hash[:12]}"
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find (count ?c) :where [{fn_ident} :introduced-by ?c]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+        assert mcp_server._candidate_diff_read(real_db, oldest_hash, fn_ident) is not None
+
+    def test_already_authoritative_entity_only_gets_modified_in(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        # Simulate Stream 1 having already confirmed login() authoritatively
+        # at the oldest commit, before Stream 2 ever runs.
+        mcp_server._transact(
+            real_db, f"[[{fn_ident} :introduced-by :commit/preexisting]]", "2025-01-01T00:00:00Z",
+        )
+
+        claimed_hash = mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        commit_ident = f":commit/{claimed_hash[:12]}"
+
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == ":commit/preexisting"
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :modified-in ?c]])"
+        )
+        assert [commit_ident] in json.loads(raw)["results"]
+
+    def test_frontier_high_interval_advances_by_one(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert bounds is not None
+        _lo_hash, hi_hash = bounds
+        assert hi_hash == linearization[-1]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13967,7 +13967,7 @@ class TestReverseFillClaimAndProcess:
             )
 
         fn_ident = mcp_server._code_ident("function", "auth.py", "login")
-        oldest_hash = linearization[0]  # h0
+        oldest_hash, mid_hash, newest_hash = linearization[0], linearization[1], linearization[2]
         assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{oldest_hash[:12]}"
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
         raw = mcp_server._db_execute(
@@ -13975,6 +13975,48 @@ class TestReverseFillClaimAndProcess:
         )
         assert json.loads(raw)["results"] == [[1]]
         assert mcp_server._candidate_diff_read(real_db, oldest_hash, fn_ident) is not None
+
+        # The converged :modified-in set must match what forward walk would
+        # have produced: every later touch except the true introduction
+        # commit itself (h0 gets none -- see the design spec's corrected
+        # "Per-commit algorithm" section and the final whole-branch
+        # review's Critical finding #1 that this test was added to catch).
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :modified-in ?c]])"
+        )
+        modified_in_commits = {row[0] for row in json.loads(raw)["results"]}
+        assert modified_in_commits == {f":commit/{mid_hash[:12]}", f":commit/{newest_hash[:12]}"}
+
+    def test_two_entities_in_one_commit_get_different_classifications(self, real_db, tmp_path):
+        """A single claimed commit can simultaneously introduce a brand-new
+        entity and add a real touch to an already-authoritative one --
+        the two must not cross-contaminate each other's handling."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization, commit_metadata, allocator = self._allocator_and_metadata(repo, real_db)
+
+        extra_ident = mcp_server._code_ident("function", "auth.py", "extra")
+        # Simulate Stream 1 having already confirmed extra() authoritatively,
+        # before Stream 2 ever runs -- extra() first appears at h1, and this
+        # commit (h2, claimed first) also touches it (its body is identical
+        # at h1/h2, but it still shares the file with a genuinely new touch).
+        mcp_server._transact(
+            real_db, f"[[{extra_ident} :introduced-by :commit/preexisting]]", "2025-01-01T00:00:00Z",
+        )
+
+        claimed_hash = mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        commit_ident = f":commit/{claimed_hash[:12]}"
+
+        more_ident = mcp_server._code_ident("function", "auth.py", "more")
+        # more() is genuinely new at h2 -- first sighting, provisional.
+        assert mcp_server._entity_introduced_by_query(real_db, more_ident) == commit_ident
+        assert mcp_server._lineage_is_provisional(real_db, more_ident) is True
+
+        # extra() stays authoritative and untouched on :introduced-by.
+        assert mcp_server._entity_introduced_by_query(real_db, extra_ident) == ":commit/preexisting"
+        assert mcp_server._lineage_is_provisional(real_db, extra_ident) is False
 
     def test_already_authoritative_entity_only_gets_modified_in(self, real_db, tmp_path):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14014,3 +14014,59 @@ class TestReverseFillClaimAndProcess:
         assert bounds is not None
         _lo_hash, hi_hash = bounds
         assert hi_hash == linearization[-1]
+
+
+class TestReverseBulkFillWalk:
+    def test_walks_until_gap_closes_and_returns_count(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "a.py").write_text("def a(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+        (repo / "b.py").write_text("def b(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h1"], cwd=repo, check=True, capture_output=True)
+        (repo / "c.py").write_text("def c(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h2"], cwd=repo, check=True, capture_output=True)
+
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        count = mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        assert count == 3
+        assert allocator.is_gap_empty() is True
+        fn_ident_a = mcp_server._code_ident("function", "a.py", "a")
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident_a) == f":commit/{linearization[0][:12]}"
+
+    def test_gap_already_empty_returns_zero(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "a.py").write_text("def a(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-02T00:00:00Z")
+        while allocator.claim_low() is not None:
+            pass  # drain the gap forward first
+
+        count = mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert count == 0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14176,6 +14176,216 @@ class TestReverseBulkFillWalkProgressGuard:
         assert "progress" in capsys.readouterr().err.lower()
 
 
+def _assert_no_modified_in_at_or_before_introduction(db, linearization):
+    """Cross-cutting invariant: no entity may carry a :modified-in at a
+    position earlier than, or equal to, its :introduced-by's position.
+
+    Forward walk cannot produce either shape -- _build_code_triples emits
+    :modified-in only on its already-known branch, never at introduction --
+    so both are pure reverse-walk corruption. Positions, never timestamps:
+    committer dates are not monotonic in topological order (this repo's own
+    history has a six-day inversion), which is why build_linearization uses
+    --topo-order in the first place.
+    """
+    import mcp_server
+    pos_by_ident = {f":commit/{h[:12]}": i for i, h in enumerate(linearization)}
+    raw = mcp_server._db_execute(
+        db,
+        "(query [:find ?e ?intro ?mod :where "
+        "[?e :introduced-by ?intro] [?e :modified-in ?mod]])",
+    )
+    violations = []
+    for entity, intro_ident, mod_ident in json.loads(raw)["results"]:
+        intro_pos = pos_by_ident.get(intro_ident)
+        mod_pos = pos_by_ident.get(mod_ident)
+        if intro_pos is None or mod_pos is None:
+            continue
+        if mod_pos <= intro_pos:
+            violations.append((entity, intro_ident, intro_pos, mod_ident, mod_pos))
+    assert not violations, (
+        "entities modified at or before their own introduction: " + repr(violations)
+    )
+
+
+class TestEntityIntroducedBySetProvisionalMonotonicity:
+    def test_refuses_to_move_a_guess_to_a_later_commit(self, real_db):
+        """The helper's contract is 'move the guess DOWN' -- its docstring
+        says reverse walk has reached an *earlier* commit -- but nothing
+        enforced it, so a re-claim of a higher position dragged the guess
+        upward and left :modified-in edges stranded before it."""
+        import mcp_server
+        ident = ":function/f"
+        pos_by = {":commit/c0": 0, ":commit/c1": 1, ":commit/c4": 4}
+        mcp_server._entity_introduced_by_set_provisional(
+            real_db, ident, ":commit/c1", "2026-01-02T00:00:00Z",
+            pos=1, pos_by_commit_ident=pos_by,
+        )
+        mcp_server._entity_introduced_by_set_provisional(
+            real_db, ident, ":commit/c4", "2026-01-05T00:00:00Z",
+            pos=4, pos_by_commit_ident=pos_by,
+        )
+        assert mcp_server._entity_introduced_by_query(real_db, ident) == ":commit/c1"
+
+    def test_still_moves_a_guess_to_an_earlier_commit(self, real_db):
+        import mcp_server
+        ident = ":function/f"
+        pos_by = {":commit/c0": 0, ":commit/c1": 1, ":commit/c4": 4}
+        mcp_server._entity_introduced_by_set_provisional(
+            real_db, ident, ":commit/c4", "2026-01-05T00:00:00Z",
+            pos=4, pos_by_commit_ident=pos_by,
+        )
+        mcp_server._entity_introduced_by_set_provisional(
+            real_db, ident, ":commit/c0", "2026-01-01T00:00:00Z",
+            pos=0, pos_by_commit_ident=pos_by,
+        )
+        assert mcp_server._entity_introduced_by_query(real_db, ident) == ":commit/c0"
+
+
+class TestReverseFillResumeOnGrownLinearization:
+    """The 2b suite never exercised a resume at all -- every test built its
+    allocator from a graph with no persisted frontier. This is the scenario
+    the 2b review reproduced end to end: claim part of a repo, let new
+    commits land, then run again."""
+
+    def _repo(self, tmp_path, n):
+        repo = tmp_path / "repo"
+        if not repo.exists():
+            repo.mkdir()
+            _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(n):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def test_second_run_terminates_and_keeps_lineage_consistent(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = self._repo(tmp_path, 3)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        for _ in range(2):  # claim positions 2 and 1, leaving position 0
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+
+        self._repo(tmp_path, 2)  # two more commits land on HEAD
+        grown = frontier_registry.build_linearization(str(repo))
+        grown_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        assert len(grown) == 5
+        allocator2 = mcp_server._frontier_load(real_db, grown, "2026-01-06T00:00:00Z")
+
+        count = mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), grown, grown_metadata, allocator2,
+        )
+
+        assert count <= len(grown), f"walk re-claimed without progress ({count} commits)"
+        high = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        lo_pos, hi_pos = grown.index(high[0]), grown.index(high[1])
+        assert lo_pos <= hi_pos, f"persisted frontier-high is inverted: {high}"
+        _assert_no_modified_in_at_or_before_introduction(real_db, grown)
+
+    def test_partial_second_run_does_not_drag_the_guess_forward(self, real_db, tmp_path):
+        """The invariant has to hold at every persisted point, not only once
+        a walk runs to exhaustion. A run that stops early -- crash, shutdown,
+        or 2d simply yielding -- leaves whatever state the last claim wrote.
+        Here run 1 leaves login's guess at position 1; run 2 then claims
+        position 4 first, and without a monotonicity guard that DRAGS the
+        guess up to 4 while the retroactive :modified-in lands at 1, i.e. an
+        entity modified three commits before it was introduced."""
+        import mcp_server
+        import frontier_registry
+        repo = self._repo(tmp_path, 3)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        for _ in range(2):
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        login = mcp_server._code_ident("function", "auth.py", "login")
+        assert mcp_server._entity_introduced_by_query(real_db, login) == f":commit/{linearization[1][:12]}"
+
+        self._repo(tmp_path, 2)
+        grown = frontier_registry.build_linearization(str(repo))
+        grown_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator2 = mcp_server._frontier_load(real_db, grown, "2026-01-06T00:00:00Z")
+        for _ in range(2):  # partial: claim positions 4 and 3, then stop
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), grown, grown_metadata, allocator2,
+            )
+
+        _assert_no_modified_in_at_or_before_introduction(real_db, grown)
+        intro = mcp_server._entity_introduced_by_query(real_db, login)
+        assert intro == f":commit/{grown[1][:12]}", (
+            f"guess moved forward to {intro}; it may only ever move earlier"
+        )
+
+
+class TestReverseFillContainsEdges:
+    """Minigraf's EAVT pending index omits value bytes from the key, so
+    several facts sharing (entity, attribute, valid_from) inside ONE
+    transact collapse to the last one. Forward walk splits :contains out
+    for exactly this reason (see _run_ingestion's own one-transact-per-edge
+    loop); 2b batched everything, losing all but one containment edge per
+    parent -- permanently, since no later phase rewrites :contains."""
+
+    def _repo_with_multi_entity_file(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "m.py").write_text(
+            "class Acct:\n"
+            "    bal = 0\n"
+            "    rate = 1\n"
+            "\n"
+            "def a(): pass\n"
+            "def b(): pass\n"
+            "def c(): pass\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _contains(self, db, parent_ident):
+        import mcp_server
+        raw = mcp_server._db_execute(db, f"(query [:find ?c :where [{parent_ident} :contains ?c]])")
+        return {row[0] for row in json.loads(raw)["results"]}
+
+    def test_every_entity_in_a_file_gets_its_containment_edge(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_multi_entity_file(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        module_ident = mcp_server._code_ident("module", "m.py")
+        class_ident = mcp_server._code_ident("class", "m.py", "Acct")
+        expected_module_children = {
+            class_ident,
+            mcp_server._code_ident("field", "m.py", "Acct.bal"),
+            mcp_server._code_ident("field", "m.py", "Acct.rate"),
+            mcp_server._code_ident("function", "m.py", "a"),
+            mcp_server._code_ident("function", "m.py", "b"),
+            mcp_server._code_ident("function", "m.py", "c"),
+        }
+        assert self._contains(real_db, module_ident) == expected_module_children
+        assert self._contains(real_db, class_ident) == {
+            mcp_server._code_ident("field", "m.py", "Acct.bal"),
+            mcp_server._code_ident("field", "m.py", "Acct.rate"),
+        }
+
+
 class TestReverseBulkFillWalk:
     def test_walks_until_gap_closes_and_returns_count(self, real_db, tmp_path):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6006,6 +6006,63 @@ class TestFrontierLoad:
         assert allocator.intervals() == []
 
 
+class TestFrontierLoadNormalisesUnrepresentableIntervals:
+    """The persisted schema holds ONE lo/hi pair per side, which cannot
+    express the post-growth shape (authoritative low region, already-filled
+    high region, then newly-arrived commits above it -- the gap moves ABOVE
+    the high interval). #222 phase 2b1 discards such an interval on load and
+    retracts its facts, so the graph and the allocator agree that the side
+    holds nothing, and the region is simply re-walked (which is safe: the 2b
+    review verified that re-processing an already-processed position is
+    idempotent)."""
+
+    def _seed_high(self, db, lo_hash, hi_hash):
+        import mcp_server
+        facts = [
+            f"[{mcp_server._FRONTIER_HIGH_IDENT} :entity-type :type/ingest-interval]",
+            f"[{mcp_server._FRONTIER_HIGH_IDENT} :tag :provisional]",
+            f'[{mcp_server._FRONTIER_HIGH_IDENT} :lo-hash "{lo_hash}"]',
+            f'[{mcp_server._FRONTIER_HIGH_IDENT} :hi-hash "{hi_hash}"]',
+        ]
+        mcp_server._transact(db, "[" + " ".join(facts) + "]", "2026-01-01T00:00:00Z")
+
+    def test_discards_and_retracts_high_interval_that_no_longer_tops_out(self, real_db):
+        import mcp_server
+        # Run 1 claimed h1..h2 of a 3-commit repo; h3 and h4 have since landed.
+        self._seed_high(real_db, "h1", "h2")
+        grown = ["h0", "h1", "h2", "h3", "h4"]
+
+        allocator = mcp_server._frontier_load(real_db, grown, "2026-01-02T00:00:00Z")
+
+        assert allocator.intervals() == [], "stale high interval must not be reconstructed"
+        assert mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT) is None, (
+            "discarding only in memory leaves the next persist call extending a pair "
+            "the allocator no longer believes in, which re-creates the inverted state"
+        )
+
+    def test_discards_and_retracts_inverted_high_interval(self, real_db):
+        import mcp_server
+        self._seed_high(real_db, "h3", "h1")  # lo above hi: what the old persist path produced
+        linearization = ["h0", "h1", "h2", "h3"]
+
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-02T00:00:00Z")
+
+        assert allocator.intervals() == []
+        assert mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT) is None
+
+    def test_keeps_a_high_interval_that_still_tops_out(self, real_db):
+        import mcp_server
+        linearization = ["h0", "h1", "h2", "h3"]
+        self._seed_high(real_db, "h2", "h3")
+
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-02T00:00:00Z")
+
+        assert allocator.intervals() == [
+            frontier_registry.Interval(2, 3, frontier_registry.TAG_PROVISIONAL)
+        ]
+        assert mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT) == ("h2", "h3")
+
+
 class TestFrontierPersistClaim:
     def test_first_claim_from_low_creates_interval(self, real_db):
         import mcp_server
@@ -14056,6 +14113,67 @@ class TestReverseFillClaimAndProcess:
         assert bounds is not None
         _lo_hash, hi_hash = bounds
         assert hi_hash == linearization[-1]
+
+
+class _NoProgressAllocator:
+    """Stand-in for a FrontierAllocator whose claim_high() stops making
+    progress -- the pre-2b1 behaviour on a grown linearization, where
+    _extend rewrote a stale interval to itself and gap_hi never moved.
+
+    Not a mocked backend (docs/testing-conventions.md): the DB and the git
+    repo in this test are real; only the allocator, a pure in-memory
+    collaborator, is substituted, because after the 2b1 allocator fix no
+    real allocator can reach this state -- which is exactly why the walk
+    still needs its own guard.
+
+    Raises rather than looping forever once called too many times, so a
+    missing guard fails the test instead of hanging the suite.
+    """
+
+    def __init__(self, pos, max_calls=50):
+        self.pos = pos
+        self.calls = 0
+        self.max_calls = max_calls
+
+    def claim_high(self):
+        self.calls += 1
+        if self.calls > self.max_calls:
+            raise AssertionError(
+                f"claim_high() called {self.calls} times without progress -- "
+                "_reverse_bulk_fill_walk has no progress guard"
+            )
+        return self.pos
+
+
+class TestReverseBulkFillWalkProgressGuard:
+    def test_breaks_loudly_when_claim_high_stops_decreasing(self, real_db, tmp_path, capsys):
+        """The walk's loop is unbounded by construction and drives a git
+        subprocess, a tree-sitter parse, a DB write batch and a
+        _db_checkpoint fsync per iteration, inside what 2d intends to run as
+        a background task. It must stop on its own if the allocator ever
+        stops making progress, rather than spinning."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(3):
+            (repo / f"f{i}.py").write_text(f"def f{i}(): pass\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"h{i}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = _NoProgressAllocator(pos=1)
+
+        count = mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        assert allocator.calls < 10, f"walk kept claiming after no progress ({allocator.calls} calls)"
+        assert count >= 1  # the first claim is legitimate work
+        assert "progress" in capsys.readouterr().err.lower()
 
 
 class TestReverseBulkFillWalk:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8586,6 +8586,49 @@ class TestPrecomputeFileTriplesBodyDiff:
         field_ident = mcp_server._code_ident("field", "models.py", "Foo.bar")
         assert field_ident in result["unchanged_idents"]
 
+    def test_body_hashes_populated_for_every_new_side_function(self):
+        import mcp_server
+        parser = self._python_parser()
+        new_nodes = self._all_nodes(parser, b"def login(user):\n    return user.ok\n")
+        extracted = {"functions": ["login"], "classes": [], "imports": []}
+        result = mcp_server._precompute_file_triples(
+            "auth.py", extracted, ":commit/c1", {}, new_entity_nodes=new_nodes,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        assert result["body_hashes"][fn_ident] == mcp_server._normalized_body_hash(new_nodes["function"]["login"])
+
+    def test_body_hashes_match_across_textually_identical_bodies(self):
+        import mcp_server
+        parser = self._python_parser()
+        nodes_a = self._all_nodes(parser, b"def login(user):\n    return user.ok\n")
+        nodes_b = self._all_nodes(parser, b"def login(user):\n\n    return   user.ok\n")
+        extracted = {"functions": ["login"], "classes": [], "imports": []}
+        result_a = mcp_server._precompute_file_triples(
+            "auth.py", extracted, ":commit/c1", {}, new_entity_nodes=nodes_a,
+        )
+        result_b = mcp_server._precompute_file_triples(
+            "auth.py", extracted, ":commit/c2", {}, new_entity_nodes=nodes_b,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        assert result_a["body_hashes"][fn_ident] == result_b["body_hashes"][fn_ident]
+
+    def test_body_hashes_absent_without_new_entity_nodes(self):
+        import mcp_server
+        extracted = {"functions": ["login"], "classes": [], "imports": []}
+        result = mcp_server._precompute_file_triples("auth.py", extracted, ":commit/c1", {})
+        assert result["body_hashes"] == {}
+
+    def test_module_ident_never_appears_in_body_hashes(self):
+        import mcp_server
+        parser = self._python_parser()
+        new_nodes = self._all_nodes(parser, b"def login(user):\n    return user.ok\n")
+        extracted = {"functions": ["login"], "classes": [], "imports": []}
+        result = mcp_server._precompute_file_triples(
+            "auth.py", extracted, ":commit/c1", {}, new_entity_nodes=new_nodes,
+        )
+        module_ident = mcp_server._code_ident("module", "auth.py")
+        assert module_ident not in result["body_hashes"]
+
 
 class TestFieldClassContainment:
     """Fields owned by a real (extracted) class get BOTH module- and

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14241,6 +14241,170 @@ class TestEntityIntroducedBySetProvisionalMonotonicity:
         assert mcp_server._entity_introduced_by_query(real_db, ident) == ":commit/c0"
 
 
+class TestReverseFillCandidateDiffLifecycle:
+    def test_superseded_candidate_diff_records_are_cleared_at_move_time(self, real_db, tmp_path):
+        """2b persisted a candidate-diff record for every (claimed commit,
+        entity) pair, on first sighting and on every move -- so storage grew
+        as O(entity touches), not O(entities), for scratch facts whose own
+        helper docstring says they must not "accumulate unbounded across a
+        full ingest". Only the final, lowest guess is a correct record; the
+        superseded one is stale the moment the guess moves, and 2b has
+        superseded_ident right there in hand."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(6):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        login = mcp_server._code_ident("function", "auth.py", "login")
+        raw = mcp_server._db_execute(
+            real_db,
+            f"(query [:find ?rec :where [?rec :entity-type :type/candidate-diff] "
+            f"[?rec :entity {login}]])",
+        )
+        live_records = json.loads(raw)["results"]
+        assert len(live_records) == 1, (
+            f"one record per live guess, not one per touch; got {len(live_records)}"
+        )
+
+
+class TestReverseFillValidTimeParity:
+    def test_structural_facts_are_re_dated_when_the_guess_moves_earlier(self, real_db, tmp_path):
+        """2b wrote an entity's structural facts once, at the timestamp of
+        the commit where the walk first SIGHTED it, and never re-dated them
+        as the guess moved earlier. That leaves a valid-time window where
+        :introduced-by is live for an entity with no type, name or file --
+        so ":as-of the introduction" answers "this entity did not exist",
+        while ":when was it introduced" answers with that very commit."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(3):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        login = mcp_server._code_ident("function", "auth.py", "login")
+        intro_ts = commit_metadata[0][1]
+        raw = mcp_server._db_execute(
+            real_db, f'(query [:find ?a :valid-at "{intro_ts}" :where [{login} ?a ?v]])'
+        )
+        attrs_at_introduction = {row[0] for row in json.loads(raw)["results"]}
+        assert ":introduced-by" in attrs_at_introduction  # 2b already gets this right
+        assert ":entity-type" in attrs_at_introduction, (
+            "an entity live at its own introduction must carry its structure there too; "
+            f"got only {sorted(attrs_at_introduction)}"
+        )
+        assert ":file" in attrs_at_introduction
+
+
+class TestReverseFillParentEdges:
+    def test_claimed_commits_get_parent_edges(self, real_db, tmp_path):
+        """The bootstrap `ancestor` rule is defined purely over :parent, so
+        without these edges ancestor queries return nothing across the whole
+        reverse-filled region. Forward walk writes them, one transact per
+        parent (a merge commit has two, same EAVT reason as :contains)."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(3):
+            (repo / f"f{i}.py").write_text(f"def f{i}(): pass\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        child = f":commit/{linearization[1][:12]}"
+        parent = f":commit/{linearization[0][:12]}"
+        raw = mcp_server._db_execute(real_db, f"(query [:find ?p :where [{child} :parent ?p]])")
+        assert {row[0] for row in json.loads(raw)["results"]} == {parent}
+
+    def test_root_commit_has_no_parent(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "a.py").write_text("def a(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "c0"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        root = f":commit/{linearization[0][:12]}"
+        raw = mcp_server._db_execute(real_db, f"(query [:find ?p :where [{root} :parent ?p]])")
+        assert json.loads(raw)["results"] == []
+
+
+class TestReverseFillCommitMetadataContract:
+    def test_misaligned_commit_metadata_raises_instead_of_misattributing(self, real_db, tmp_path):
+        """commit_metadata is indexed POSITIONALLY against linearization
+        while _frontier_persist_claim persists linearization[pos], so a
+        watermark-relative list (what _run_ingestion actually builds) makes
+        2b attribute entities to one commit and persist another -- silent,
+        systematic misattribution. 2b is handed a position by an allocator
+        that already claimed it, so it cannot decline: it must raise."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(3):
+            (repo / f"f{i}.py").write_text(f"def f{i}(): pass\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        with pytest.raises(ValueError, match="commit_metadata"):
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata[1:], allocator,
+            )
+
+
 class TestReverseFillResumeOnGrownLinearization:
     """The 2b suite never exercised a resume at all -- every test built its
     allocator from a graph with no persisted frontier. This is the scenario

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6323,6 +6323,65 @@ class TestCandidateDiff:
         assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash1"
 
 
+class TestEntityIntroducedBySetProvisional:
+    def test_query_absent_returns_none(self, real_db):
+        import mcp_server
+        assert mcp_server._entity_introduced_by_query(real_db, ":function/src-auth-py-login") is None
+
+    def test_first_assert_is_provisional(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h2", "2026-01-03T00:00:00Z")
+
+        assert mcp_server._entity_introduced_by_query(db, entity_ident) == ":commit/h2"
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is True
+
+    def test_moving_provisional_value_retracts_old_and_asserts_new(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h2", "2026-01-03T00:00:00Z")
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h0", "2026-01-01T00:00:00Z")
+
+        assert mcp_server._entity_introduced_by_query(db, entity_ident) == ":commit/h0"
+        raw = mcp_server._db_execute(
+            db, f"(query [:find (count ?c) :where [{entity_ident} :introduced-by ?c]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_same_value_twice_is_idempotent(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h1", "2026-01-02T00:00:00Z")
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h1", "2026-01-02T00:00:01Z")
+
+        raw = mcp_server._db_execute(
+            db, f"(query [:find (count ?c) :where [{entity_ident} :introduced-by ?c]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_never_clobbers_an_authoritative_fact(self, real_db):
+        import mcp_server
+        db = real_db
+        entity_ident = ":function/src-auth-py-login"
+
+        # Simulate forward walk (Stream 1) having already confirmed this
+        # entity authoritatively -- a plain _transact, no lineage marker.
+        mcp_server._transact(
+            db, f"[[{entity_ident} :introduced-by :commit/original]]", "2026-01-01T00:00:00Z",
+        )
+
+        mcp_server._entity_introduced_by_set_provisional(db, entity_ident, ":commit/h5", "2026-01-05T00:00:00Z")
+
+        assert mcp_server._entity_introduced_by_query(db, entity_ident) == ":commit/original"
+        assert mcp_server._lineage_is_provisional(db, entity_ident) is False
+
+
 class TestGitCommitsTopoOrder:
     def test_orders_by_topology_not_committer_date(self, git_repo_diamond_clock_skewed):
         import mcp_server


### PR DESCRIPTION
## Summary

Sub-phase 2b of #222's phase 2 ("Streams 1+2 converging"): Stream 2's actual reverse-bulk-fill walk, built on the primitives phase 1 (frontier/interval registry, PR #226) and phase 2a (provisional/authoritative lineage fact model, PR #227) already merged.

- `_entity_introduced_by_query`/`_entity_introduced_by_set_provisional` — the sole writer of provisional `:introduced-by`, never clobbers an already-authoritative fact
- `body_hashes` added to `_precompute_file_triples` (additive) — lets the walk persist a candidate-diff hash without the raw tree-sitter node
- `_reverse_fill_claim_and_process` — the per-commit reverse-fill step: claims one position from the frontier gap's high end, reuses `_extract_commit`/`_build_code_triples` for entity discovery, writes structure + `:modified-in` + provisional `:introduced-by` + candidate-diff records, checkpoints once per commit
- `_reverse_bulk_fill_walk` — thin driving loop over the above until the gap closes

No caller is wired into `_run_ingestion` yet — that's phase 2d. Deletion/rename handling in the reverse direction and `:depends-on` edges are explicitly out of scope for this sub-phase (see the design spec).

Design spec: `docs/superpowers/specs/2026-07-24-reverse-bulk-fill-walk-design.md`
Plan: `docs/superpowers/plans/2026-07-24-reverse-bulk-fill-walk.md`

## Process note

A final whole-branch review caught a real Critical bug: the walk initially reused `_build_code_triples`'s own `:modified-in` emission unchanged, but that gate assumes a forward (oldest→newest) walk — reversed, it missed a real edge at an entity's newest touch and added a spurious one at its true introduction commit. Fixed by having the walk own `:modified-in` explicitly (mirroring how it already owns `:introduced-by`), including a retroactive fact for a superseded provisional guess using *that commit's own* timestamp. The design spec and plan were corrected first, then the fix was transcribed into code/tests and re-reviewed clean. Full history in commits `0ce89f3`/`55dd993`.

## Test plan

- [x] All 4 tasks individually TDD'd and reviewed (spec compliance + code quality), each approved
- [x] Final whole-branch review: found the `:modified-in` bug above, fixed, re-reviewed clean, ready to merge
- [x] `python -m pytest tests/test_mcp_server.py -q` — 608 passed, 120 pre-existing/environmental failures (missing optional tree-sitter language grammars, one unrelated LLM-extraction test), 48 skipped — confirmed via stash comparison that this baseline is unchanged by this branch
- [x] No caller wired into `_run_ingestion` — confirmed via diff inspection at every review stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)