### PR TITLE
Add #222 phase 2c: Stream 1 correction sweep

### DIFF
--- a/docs/superpowers/plans/2026-07-25-stream1-correction-sweep.md
+++ b/docs/superpowers/plans/2026-07-25-stream1-correction-sweep.md
@@ -1,0 +1,1337 @@
+# Stream 1 Correction Sweep (#222 phase 2c) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Stream 1's correction sweep — a post-convergence pass that walks upward through frontier-high's already-claimed territory, converting phase 2b's provisional `:introduced-by` facts to authoritative and correcting 2b's documented `:modified-in` over-assertion, per `docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md`.
+
+**Architecture:** Five new functions added to `mcp_server.py`, split for independent executor scheduling per the spec's "Execution context" section: a cheap DB-reading position selector, a CPU-bound-but-reused extraction call (`_extract_commit`, already exists), a DB-writing per-commit classifier, a synchronous convenience wrapper composing all three, and a driving loop. No caller is wired into `_run_ingestion` — that is phase 2d's job. This branch stacks on `design-222-phase2b-reverse-bulk-fill-walk` (PR #228) and calls its `_entity_introduced_by_query`/`_lineage_is_provisional`/`_candidate_diff_clear`/`_lineage_confirm` directly.
+
+**Tech Stack:** Python 3, minigraf (real backend in tests, no mocks), pytest, real git repos via `subprocess` in test fixtures — matching every existing convention in `tests/test_mcp_server.py`.
+
+## Global Constraints
+
+- Real `MiniGrafDb` in every test — no `MagicMock` of the DB (`docs/testing-conventions.md`). Use the `real_db` fixture (in-memory) unless a test needs state to survive across separate `open()` calls.
+- Every new DB-touching helper takes `index_con: Optional[Any] = None` and forwards it to `_transact`/`_retract`, matching every existing 2a/2b primitive.
+- Every write must be safe to repeat: query-before-write, or (for `:modified-in`) reliant on `commit_ts_iso` matching what the other stream would have used at the same position — never a blind unconditional `_transact` with a fresh/different timestamp.
+- No new module ever gets imported — `sys`, `json`, and all needed `typing` names (`Any, Dict, List, Optional, Sequence, Tuple`) are already imported at the top of `mcp_server.py`; `frontier_registry` is already imported as `import frontier_registry`.
+- Insert all new `mcp_server.py` code in one place: immediately after `_reverse_bulk_fill_walk` (currently ends at line 7437), before `_run_ingestion` (currently starts at line 7440). Re-check the exact line numbers before each edit — earlier tasks in this plan shift them.
+- Append all new tests to `tests/test_mcp_server.py`, after `TestReverseBulkFillWalk` (currently the last class in the file, ending at line 14114/EOF).
+- Every new test class defines its own private repo-building helpers (`_init_repo`, `_commit`, or a `_repo_with_...` builder) rather than reaching for a shared cross-class fixture — this file has no shared helper for that, by established convention (three separate near-identical `_init_repo` methods already exist in different classes).
+
+---
+
+### Task 1: `:ingestion/correction-sweep-through` watermark + log-cap constant
+
+**Files:**
+- Modify: `mcp_server.py` — insert after `_reverse_bulk_fill_walk` (currently ends line 7437).
+- Test: `tests/test_mcp_server.py` — new `TestCorrectionSweepThroughWatermark` class, appended at EOF.
+
+**Interfaces:**
+- Consumes: `_db_execute(db, datalog) -> str` (pre-existing, line 3278), `_transact(db, facts, valid_from, ..., index_con=None) -> str` (pre-existing, line 3532), `_retract(db, facts, ..., index_con=None) -> str` (pre-existing, line 3568), `_edn_escape(s) -> str` (pre-existing, line 4427), `handle_minigraf_audit()` (pre-existing, no-arg, operates on module global `_db`).
+- Produces: `_CORRECTION_SWEEP_THROUGH_IDENT = ":ingestion/correction-sweep-through"`, `_CORRECTION_SWEEP_LOG_CAP = 10`, `_correction_sweep_through_query(db: Any) -> Optional[str]`, `_correction_sweep_through_update(db: Any, commit_hash: str, commit_ts_iso: str, index_con: Optional[Any] = None) -> None`.
+
+This mirrors `_lineage_confirmed_through_query`/`_update` (`mcp_server.py:5080-5128`) exactly — same `:type/ingestion` entity type (already registered in `MINIGRAF_SCHEMA["ingestion"]`, `mcp_server.py:5390-5393`, requiring only `:description` and allowing `:hash` among its optional attrs), same retract-only-if-changed pattern — but with its own ident and its own `:description` string, not a copy of lineage-confirmed-through's (two `:type/ingestion` entities with byte-identical descriptions would both pass audit but be indistinguishable from each other in the fact index and in `minigraf_audit` output).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestCorrectionSweepThroughWatermark:
+    def test_unset_reads_as_none(self, real_db):
+        import mcp_server
+        assert mcp_server._correction_sweep_through_query(real_db) is None
+
+    def test_update_then_query_round_trip(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._correction_sweep_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        assert mcp_server._correction_sweep_through_query(db) == "h1"
+
+        mcp_server._correction_sweep_through_update(db, "h2", "2026-01-02T00:00:00Z")
+        assert mcp_server._correction_sweep_through_query(db) == "h2"
+
+    def test_update_does_not_duplicate_hash_fact(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._correction_sweep_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        mcp_server._correction_sweep_through_update(db, "h2", "2026-01-02T00:00:00Z")
+
+        ident = mcp_server._CORRECTION_SWEEP_THROUGH_IDENT
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_entity_carries_expected_constants_and_survives_audit(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._correction_sweep_through_update(db, "h1", "2026-01-01T00:00:00Z")
+
+        ident = mcp_server._CORRECTION_SWEEP_THROUGH_IDENT
+        raw = mcp_server._db_execute(db, f"(query [:find ?a ?v :where [{ident} ?a ?v]])")
+        attrs = dict(json.loads(raw)["results"])
+        assert attrs[":entity-type"] == ":type/ingestion"
+        assert attrs[":ident"] == ident
+        assert isinstance(attrs[":description"], str) and attrs[":description"]
+
+        result = mcp_server.handle_minigraf_audit()
+        assert result["retracted"] == 0
+        assert mcp_server._correction_sweep_through_query(db) == "h1"
+
+    def test_description_is_distinct_from_lineage_confirmed_through(self, real_db):
+        """Two :type/ingestion watermarks with byte-identical :description
+        strings would both pass audit but be indistinguishable from each
+        other in the fact index and in minigraf_audit output -- this
+        watermark must not just copy lineage-confirmed-through's string."""
+        import mcp_server
+        db = real_db
+        mcp_server._correction_sweep_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_confirmed_through_update(db, "h1", "2026-01-01T00:00:00Z")
+
+        sweep_desc = dict(json.loads(mcp_server._db_execute(
+            db, f"(query [:find ?a ?v :where [{mcp_server._CORRECTION_SWEEP_THROUGH_IDENT} ?a ?v]])"
+        ))["results"])[":description"]
+        lineage_desc = dict(json.loads(mcp_server._db_execute(
+            db, f"(query [:find ?a ?v :where [{mcp_server._LINEAGE_CONFIRMED_THROUGH_IDENT} ?a ?v]])"
+        ))["results"])[":description"]
+        assert sweep_desc != lineage_desc
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepThroughWatermark -v`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_correction_sweep_through_query'` (or similar) on every test.
+
+- [ ] **Step 3: Implement the watermark primitives**
+
+In `mcp_server.py`, immediately after `_reverse_bulk_fill_walk`'s closing (currently ends line 7437, right before `async def _run_ingestion` at line 7440), insert:
+
+```python
+_CORRECTION_SWEEP_THROUGH_IDENT = ":ingestion/correction-sweep-through"
+# Max per-ident skip lines this sweep writes to stderr per run; see the
+# Observability section of the design spec for why this must be
+# caller-threaded state (skipped_so_far), not a module-level counter.
+_CORRECTION_SWEEP_LOG_CAP = 10
+
+
+def _correction_sweep_through_query(db: Any) -> Optional[str]:
+    """Return the hash of the last commit this sweep has itself confirmed/
+    corrected, or None if it has never successfully processed one yet."""
+    raw = _db_execute(
+        db, f"(query [:find ?h :where [{_CORRECTION_SWEEP_THROUGH_IDENT} :hash ?h]])"
+    )
+    results = json.loads(raw).get("results", [])
+    return results[0][0] if results else None
+
+
+def _correction_sweep_through_update(
+    db: Any, commit_hash: str, commit_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Record the last commit this sweep processed. Mirrors
+    _lineage_confirmed_through_update's retract-only-if-changed pattern
+    exactly, at a different ident with its own :description -- tracks this
+    sweep's own progress through frontier-high's territory, independent of
+    lineage-confirmed-through's "contiguous from C0" semantics.
+    """
+    current_raw = _db_execute(
+        db, f"(query [:find ?a ?v :where [{_CORRECTION_SWEEP_THROUGH_IDENT} ?a ?v]])"
+    )
+    current: Dict[str, str] = dict(json.loads(current_raw).get("results", []))
+
+    def _edn(attr: str, value: str) -> str:
+        return value if attr == ":entity-type" else f'"{_edn_escape(value)}"'
+
+    constants = {
+        ":entity-type": ":type/ingestion",
+        ":ident": _CORRECTION_SWEEP_THROUGH_IDENT,
+        ":description": "correction sweep progress watermark",
+    }
+
+    to_retract: List[str] = []
+    to_transact: List[str] = []
+    for attr, value in constants.items():
+        if current.get(attr) == value:
+            continue
+        if attr in current:
+            to_retract.append(f"[{_CORRECTION_SWEEP_THROUGH_IDENT} {attr} {_edn(attr, current[attr])}]")
+        to_transact.append(f"[{_CORRECTION_SWEEP_THROUGH_IDENT} {attr} {_edn(attr, value)}]")
+
+    if ":hash" in current:
+        to_retract.append(f"[{_CORRECTION_SWEEP_THROUGH_IDENT} :hash {_edn(':hash', current[':hash'])}]")
+    to_transact.append(f"[{_CORRECTION_SWEEP_THROUGH_IDENT} :hash {_edn(':hash', commit_hash)}]")
+
+    if to_retract:
+        _retract(db, "[" + " ".join(to_retract) + "]", index_con=index_con)
+    _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepThroughWatermark -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add :ingestion/correction-sweep-through watermark for #222 phase 2c"
+```
+
+---
+
+### Task 2: `_correction_sweep_select_position`
+
+**Files:**
+- Modify: `mcp_server.py` — insert after Task 1's new code.
+- Test: `tests/test_mcp_server.py` — new `TestCorrectionSweepSelectPosition` class, appended at EOF.
+
+**Interfaces:**
+- Consumes: `_frontier_read_bounds(db, ident) -> Optional[Tuple[str, str]]` (pre-existing, line 4917), `_FRONTIER_LOW_IDENT`/`_FRONTIER_HIGH_IDENT` (pre-existing, lines 4913-4914), `_correction_sweep_through_query` (Task 1), `_frontier_load(db, linearization, run_ts_iso, index_con=None) -> FrontierAllocator` (pre-existing, line 4950), `_frontier_persist_claim(db, linearization, pos, from_low, commit_ts_iso, index_con=None) -> None` (pre-existing, line 4982), `_reverse_fill_claim_and_process` (2b, line 7251), `frontier_registry.FrontierAllocator` (`claim_low`, `claim_high`, `is_gap_empty`).
+- Produces: `_correction_sweep_select_position(db: Any, linearization: List[str], commit_metadata: List[Tuple[str, str, str, str]], hash_to_pos: Optional[Dict[str, int]] = None) -> Optional[Tuple[str, str]]`.
+
+This is the gap-closed precondition, the persisted-`:hi-hash` ceiling, and the resume-point logic from the design spec's "Position tracker" section — a pure DB-reading function (no parsing), returning `(commit_hash, commit_ts_iso)` for the next commit to process, or `None` if there is nothing safe to do yet.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestCorrectionSweepSelectPosition:
+    def _init_repo(self, repo):
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _commit(self, repo, filename, content, msg):
+        (repo / filename).write_text(content)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True)
+
+    def _repo_with_n_commits(self, tmp_path, n):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+        for i in range(n):
+            self._commit(repo, f"f{i}.py", f"def f{i}(): pass\n", f"h{i}")
+        return repo
+
+    def _linearization_and_metadata(self, repo):
+        import mcp_server
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        return linearization, commit_metadata
+
+    def _close_gap(self, repo, real_db, linearization, commit_metadata):
+        """Close the gap entirely: claim everything from the low side via a
+        real FrontierAllocator + _frontier_persist_claim (standing in for
+        2d's future ordinary forward walk), then claim the rest from the
+        high side via 2b's real _reverse_fill_claim_and_process."""
+        import mcp_server
+        import frontier_registry
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        while True:
+            pos = allocator.claim_low()
+            if pos is None:
+                break
+            mcp_server._frontier_persist_claim(
+                real_db, linearization, pos, from_low=True,
+                commit_ts_iso=commit_metadata[pos][1],
+            )
+        return allocator
+
+    def test_no_op_when_frontier_high_unclaimed(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")  # seeds frontier-low only
+
+        result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert result is None
+
+    def test_no_op_while_gap_remains_open(self, real_db, tmp_path):
+        """Direct regression test for the race the design spec's "Why
+        confirming requires the gap to already be closed" section
+        describes: claim only from the high side, leaving a non-empty gap
+        below, and assert select_position refuses to hand out a position
+        even though frontier-high has real claimed territory."""
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert allocator.is_gap_empty() is False  # only claimed the newest position so far
+
+        result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert result is None
+
+    def test_returns_frontier_high_lo_hash_once_gap_closed(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        allocator = self._close_gap(repo, real_db, linearization, commit_metadata)
+        assert allocator.is_gap_empty() is True
+
+        result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert result is not None
+        commit_hash, commit_ts_iso = result
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert commit_hash == bounds[0]  # frontier-high's current lo-hash
+        pos = linearization.index(commit_hash)
+        assert commit_ts_iso == commit_metadata[pos][1]
+
+    def test_resumes_from_correction_sweep_through_not_frontier_high_lo_hash(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+
+        first = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert first is not None
+        first_hash, first_ts = first
+        mcp_server._correction_sweep_through_update(real_db, first_hash, first_ts)
+
+        second = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert second is not None
+        second_hash, _second_ts = second
+        assert second_hash != first_hash
+        assert linearization.index(second_hash) == linearization.index(first_hash) + 1
+
+    def test_no_op_once_reached_frontier_high_hi_hash(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+
+        # Walk to exhaustion by hand (Task 5 builds the real driving loop --
+        # this test only needs select_position's own termination).
+        while True:
+            result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+            if result is None:
+                break
+            mcp_server._correction_sweep_through_update(real_db, result[0], result[1])
+
+        assert mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata) is None
+
+    def test_respects_persisted_hi_hash_not_len_linearization(self, real_db, tmp_path):
+        """On an incremental re-ingest, linearization grows but frontier-
+        high's persisted :hi-hash does not move with it -- the ceiling must
+        stop at the persisted hash, not walk into brand-new, unclaimed
+        commits."""
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+        while True:
+            result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+            if result is None:
+                break
+            mcp_server._correction_sweep_through_update(real_db, result[0], result[1])
+
+        # Simulate an incremental re-ingest: more commits land, but neither
+        # stream has claimed them yet.
+        self._commit(repo, "new.py", "def new(): pass\n", "h_new")
+        grown_linearization, grown_commit_metadata = self._linearization_and_metadata(repo)
+        assert len(grown_linearization) == 3
+
+        result = mcp_server._correction_sweep_select_position(
+            real_db, grown_linearization, grown_commit_metadata
+        )
+        assert result is None
+
+    def test_falls_back_to_frontier_high_lo_hash_when_stored_hash_is_stale(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+        mcp_server._correction_sweep_through_update(real_db, "deadbeef_not_in_linearization", "2026-01-01T00:00:00Z")
+
+        result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert result is not None
+        commit_hash, _ts = result
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert commit_hash == bounds[0]
+
+    def test_hash_to_pos_reused_when_passed_in(self, real_db, tmp_path):
+        """hash_to_pos, when supplied, is used as-is rather than rebuilt --
+        pass a deliberately wrong map for an unrelated hash to prove the
+        function trusts the caller's map rather than silently recomputing
+        its own."""
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+        hash_to_pos = {h: i for i, h in enumerate(linearization)}
+
+        result = mcp_server._correction_sweep_select_position(
+            real_db, linearization, commit_metadata, hash_to_pos=hash_to_pos
+        )
+        assert result is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepSelectPosition -v`
+Expected: FAIL with `AttributeError` on every test.
+
+- [ ] **Step 3: Implement `_correction_sweep_select_position`**
+
+Insert after Task 1's code:
+
+```python
+def _correction_sweep_select_position(
+    db: Any,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    hash_to_pos: Optional[Dict[str, int]] = None,
+) -> Optional[Tuple[str, str]]:
+    """Returns (commit_hash, commit_ts_iso) for the next commit this sweep
+    should process, upward through frontier-high's own claimed territory,
+    or None if there is nothing safe to correct yet: the gap is still open
+    (Stream 2 could still descend past a position this call would confirm
+    -- see the design spec's "Why confirming requires the gap to already
+    be closed"), frontier-high hasn't claimed anything yet, a required
+    boundary hash is stale, commit_metadata doesn't match linearization, or
+    the sweep has already reached frontier-high's own :hi-hash.
+
+    DB-bound, parse-free -- must run off the event-loop thread (per the
+    design spec's Execution context) but never on the same executor as
+    _extract_commit, since the two must be independently schedulable.
+
+    hash_to_pos, if omitted, is built fresh from linearization -- callers
+    doing a full sweep should build it once and pass it in instead to
+    avoid rebuilding an N-entry map on every one of a full sweep's N calls.
+    """
+    low_bounds = _frontier_read_bounds(db, _FRONTIER_LOW_IDENT)
+    high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
+    if low_bounds is None or high_bounds is None:
+        return None  # migration hasn't run yet, or Stream 2 hasn't claimed anything
+
+    if hash_to_pos is None:
+        hash_to_pos = {h: i for i, h in enumerate(linearization)}
+
+    if low_bounds[1] not in hash_to_pos or high_bounds[0] not in hash_to_pos:
+        return None  # a boundary hash is stale (rewritten history); nothing safe to do
+
+    if hash_to_pos[low_bounds[1]] + 1 != hash_to_pos[high_bounds[0]]:
+        return None  # gap still open -- Stream 2 may still descend past a position
+                     # this sweep would otherwise confirm
+
+    if high_bounds[1] not in hash_to_pos:
+        return None  # frontier-high's :hi-hash is stale; nothing safe to do
+    ceiling_pos = hash_to_pos[high_bounds[1]]
+
+    through_hash = _correction_sweep_through_query(db)
+    if through_hash is not None and through_hash in hash_to_pos:
+        pos = hash_to_pos[through_hash] + 1
+    else:
+        # Unset (first-ever call), or a stale hash from rewritten/rebased
+        # history -- (re)start from frontier-high's current lo-hash,
+        # mirroring _frontier_load's own precedent of dropping a bound
+        # that no longer resolves rather than erroring.
+        pos = hash_to_pos[high_bounds[0]]  # already validated above
+
+    if pos > ceiling_pos:
+        return None  # reached frontier-high's own :hi-hash; nothing left to correct
+
+    if len(commit_metadata) != len(linearization) or commit_metadata[pos][0] != linearization[pos]:
+        return None  # commit_metadata violates its stated contract -- nothing safe to
+                     # do, rather than an IndexError or a wrong-commit read
+
+    commit_hash, commit_ts_iso, _author, _subject = commit_metadata[pos]
+    return commit_hash, commit_ts_iso
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepSelectPosition -v`
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add _correction_sweep_select_position for #222 phase 2c"
+```
+
+---
+
+### Task 3: `_correction_sweep_apply`
+
+**Files:**
+- Modify: `mcp_server.py` — insert after Task 2's new code.
+- Test: `tests/test_mcp_server.py` — new `TestCorrectionSweepApply` class, appended at EOF.
+
+**Interfaces:**
+- Consumes: `_extract_commit(repo_path, commit_hash, ignore_patterns) -> Tuple[file_results, gitlink_changes, gitmodules_map, renamed_pairs]` (pre-existing, line 6944 — `file_results` is `List[Tuple[status, file_path, extracted, precomputed, old_path]]`; `precomputed` has keys `module_ident`, `function_entries`/`class_entries`/`global_entries`/`field_entries` (each `List[Tuple[ident, name, triples]]`), `unchanged_idents` (`Set[str]`)), `_lineage_is_provisional(db, ident) -> bool` / `_lineage_confirm(db, ident, index_con=None) -> None` (2a, lines 5069/5053), `_candidate_diff_clear(db, commit_hash, ident, index_con=None) -> None` (2a, line 5207), `_db_execute`/`_transact`/`_retract`/`_db_checkpoint` (pre-existing), `_correction_sweep_through_update` (Task 1), `_CORRECTION_SWEEP_LOG_CAP` (Task 1).
+- Produces: `_correction_sweep_apply(db: Any, commit_hash: str, commit_ts_iso: str, file_results: List[tuple], index_con: Optional[Any] = None, skipped_so_far: int = 0) -> int` and `_correction_sweep_log_summary(skipped_events: int) -> None`.
+
+This is the design spec's full three-case per-commit algorithm: confirm a correct provisional guess, fail safe on an ambiguous/wrong one, and reconcile (not merely assert) `:modified-in` for already-authoritative entities — including retracting 2b's documented `:modified-in` over-assertion where this sweep's own parse disagrees. It never calls `_extract_commit` itself (that stays the caller's job, on a different executor) and never writes the commit's own `:type/commit` entity (2b already wrote it for every commit in this sweep's range).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestCorrectionSweepApply:
+    def _init_repo(self, repo):
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _repo_with_evolving_function(self, tmp_path):
+        """Three commits: login() genuinely changes body every commit (h0,
+        h1, h2); extra() is added at h1 and left byte-identical at h2, so
+        #221 marks it unchanged at h2 -- needed for the reconcile-retract
+        test below."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+
+        (repo / "auth.py").write_text("def login():\n    return 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text("def login():\n    return 2\n\ndef extra():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h1"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text(
+            "def login():\n    return 3\n\ndef extra():\n    pass\n\ndef more():\n    pass\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h2"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _extract(self, repo, commit_hash):
+        import mcp_server
+        file_results, _gitlink, _gitmodules, _renamed = mcp_server._extract_commit(str(repo), commit_hash, ())
+        return file_results
+
+    def test_confirms_correct_provisional_guess(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Real reverse walk to the end so login()'s guess settles at h0 --
+        # exactly TestReverseFillClaimAndProcess's own converged-state setup.
+        for _ in range(3):
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        h0_hash, h0_ts = linearization[0], commit_metadata[0][1]
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{h0_hash[:12]}"
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+        file_results = self._extract(repo, h0_hash)
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped == 0
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{h0_hash[:12]}"
+        assert mcp_server._candidate_diff_read(real_db, h0_hash, fn_ident) is None
+
+    def test_does_not_duplicate_commit_metadata(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        for _ in range(3):
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        h0_hash, h0_ts = linearization[0], commit_metadata[0][1]
+        commit_ident = f":commit/{h0_hash[:12]}"
+        before_raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?a ?v :where [{commit_ident} ?a ?v]])"
+        )
+        before = sorted(json.loads(before_raw)["results"])
+
+        file_results = self._extract(repo, h0_hash)
+        mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        after_raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?a ?v :where [{commit_ident} ?a ?v]])"
+        )
+        after = sorted(json.loads(after_raw)["results"])
+        assert after == before
+
+    def test_leaves_entity_untouched_when_guess_points_elsewhere(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        h1_hash = commit_metadata[1][0]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        # Hand-construct a provisional guess pointing at the WRONG commit
+        # for the one this call will visit -- simulating a precondition
+        # violation directly rather than via a real interleaving.
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, f":commit/{h1_hash[:12]}", "2025-01-01T00:00:00Z")
+
+        file_results = self._extract(repo, h0_hash)
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped >= 1
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{h1_hash[:12]}"
+
+    def test_fails_safe_on_duplicate_introduced_by_h0_asserted_first(self, real_db, tmp_path):
+        """Two live :introduced-by facts for one entity (the uncoordinated-
+        forward-walk state the design spec defers to 2d) must be a no-op
+        regardless of which fact minigraf's query returns first -- tested
+        here via physical assertion order, in a sibling test via the
+        opposite order, since row order itself isn't observable/controllable
+        from the test, only the insertion order that produces it."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        h1_hash = commit_metadata[1][0]
+        commit_ident_h0 = f":commit/{h0_hash[:12]}"
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        file_results = self._extract(repo, h0_hash)
+
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {commit_ident_h0}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h1_hash[:12]}]]", "2025-01-02T00:00:00Z")
+        mcp_server._lineage_mark_provisional(real_db, fn_ident, "2025-01-01T00:00:00Z")
+
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped >= 1
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+    def test_fails_safe_on_duplicate_introduced_by_h1_asserted_first(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        h1_hash = commit_metadata[1][0]
+        commit_ident_h0 = f":commit/{h0_hash[:12]}"
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        file_results = self._extract(repo, h0_hash)
+
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h1_hash[:12]}]]", "2025-01-02T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {commit_ident_h0}]]", "2025-01-01T00:00:00Z")
+        mcp_server._lineage_mark_provisional(real_db, fn_ident, "2025-01-01T00:00:00Z")
+
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped >= 1
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+    def test_skips_modified_in_at_own_introduction_commit_on_resumed_sweep(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        commit_ident = f":commit/{h0_hash[:12]}"
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, commit_ident, "2025-01-01T00:00:00Z")
+        file_results = self._extract(repo, h0_hash)
+
+        mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)  # confirms (case 1)
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+
+        # Simulate a resumed sweep re-visiting the same commit (e.g. after a
+        # crash between confirming and advancing correction-sweep-through).
+        mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        raw = mcp_server._db_execute(real_db, f"(query [:find ?c :where [{fn_ident} :modified-in ?c]])")
+        assert [commit_ident] not in json.loads(raw)["results"]
+
+    def test_ordinary_modification_is_idempotent_when_2b_already_agrees(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash = commit_metadata[0][0]
+        h1_hash, h1_ts = commit_metadata[1][0], commit_metadata[1][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        h1_ident = f":commit/{h1_hash[:12]}"
+        # login() is already authoritative at h0, and 2b (or forward walk)
+        # already wrote the correct :modified-in for h1's genuine change.
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h0_hash[:12]}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :modified-in {h1_ident}]]", h1_ts)
+
+        file_results = self._extract(repo, h1_hash)
+        skipped = mcp_server._correction_sweep_apply(real_db, h1_hash, h1_ts, file_results)
+
+        assert skipped == 0
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find (count ?c) :where [{fn_ident} :modified-in {h1_ident}]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_retracts_2b_over_asserted_retroactive_modified_in(self, real_db, tmp_path):
+        """extra() is byte-identical between h1 and h2 (see the fixture
+        docstring), so #221 marks it unchanged at h2 -- but simulate 2b's
+        documented limitation by asserting :modified-in there anyway, then
+        assert this sweep retracts it once it reaches h2 in the ordinary
+        (already-authoritative) path."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h1_hash = commit_metadata[1][0]
+        h2_hash, h2_ts = commit_metadata[2][0], commit_metadata[2][1]
+        extra_ident = mcp_server._code_ident("function", "auth.py", "extra")
+        h1_ident = f":commit/{h1_hash[:12]}"
+        h2_ident = f":commit/{h2_hash[:12]}"
+        mcp_server._transact(real_db, f"[[{extra_ident} :introduced-by {h1_ident}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{extra_ident} :modified-in {h2_ident}]]", h2_ts)  # 2b's over-assertion
+
+        file_results = self._extract(repo, h2_hash)
+        precomputed_unchanged = [
+            precomputed.get("unchanged_idents", set())
+            for _status, _fp, _extracted, precomputed, _old in file_results
+            if precomputed is not None
+        ]
+        assert any(extra_ident in u for u in precomputed_unchanged), (
+            "fixture assumption broken: extra() must read as unchanged at h2"
+        )
+
+        skipped = mcp_server._correction_sweep_apply(real_db, h2_hash, h2_ts, file_results)
+
+        assert skipped == 0
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{extra_ident} :modified-in {h2_ident}]])"
+        )
+        assert json.loads(raw)["results"] == []
+
+    def test_opportunistic_stale_candidate_diff_cleanup(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash = commit_metadata[0][0]
+        h1_hash, h1_ts = commit_metadata[1][0], commit_metadata[1][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h0_hash[:12]}]]", "2025-01-01T00:00:00Z")
+        # An orphaned candidate-diff record from a since-superseded guess.
+        mcp_server._candidate_diff_persist(real_db, h1_hash, fn_ident, "stale-hash", "2025-01-01T00:00:00Z")
+        assert mcp_server._candidate_diff_read(real_db, h1_hash, fn_ident) is not None
+
+        file_results = self._extract(repo, h1_hash)
+        mcp_server._correction_sweep_apply(real_db, h1_hash, h1_ts, file_results)
+
+        assert mcp_server._candidate_diff_read(real_db, h1_hash, fn_ident) is None
+
+    def test_skipped_events_counts_events_not_entities(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        h1_hash, h1_ts = commit_metadata[1][0], commit_metadata[1][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        wrong_ident = f":commit/{commit_metadata[2][0][:12]}"
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, wrong_ident, "2025-01-01T00:00:00Z")
+
+        skipped_h0 = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, self._extract(repo, h0_hash))
+        skipped_h1 = mcp_server._correction_sweep_apply(
+            real_db, h1_hash, h1_ts, self._extract(repo, h1_hash), skipped_so_far=skipped_h0,
+        )
+
+        assert skipped_h0 == 1
+        assert skipped_h1 == 1  # login() is a candidate at h1 too -- second event, same entity
+
+    def test_skip_logging_capped_with_returned_count_uncapped(self, real_db, tmp_path, capsys):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        # 15 synthetic candidate idents in one file entry, each provisional
+        # with a guess pointing elsewhere -- avoids needing 15 real commits
+        # to exercise the logging cap; precomputed's shape is documented in
+        # this task's Interfaces block.
+        n = 15
+        idents = [f":function/synthetic-{i}" for i in range(n)]
+        wrong_ident = ":commit/does-not-matter"
+        for ident in idents:
+            mcp_server._entity_introduced_by_set_provisional(real_db, ident, wrong_ident, "2025-01-01T00:00:00Z")
+        precomputed = {
+            "module_ident": ":module/synthetic",
+            "function_entries": [(ident, ident, []) for ident in idents],
+            "class_entries": [],
+            "global_entries": [],
+            "field_entries": [],
+            "unchanged_idents": set(),
+        }
+        file_results = [("M", "synthetic.py", {}, precomputed, "")]
+
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped == n
+        err = capsys.readouterr().err
+        logged_lines = [line for line in err.splitlines() if "synthetic-" in line]
+        assert len(logged_lines) == mcp_server._CORRECTION_SWEEP_LOG_CAP
+
+    def test_log_cap_is_caller_threaded_not_a_module_global(self, real_db, tmp_path, capsys):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        wrong_ident = f":commit/{commit_metadata[1][0][:12]}"
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, wrong_ident, "2025-01-01T00:00:00Z")
+        file_results = self._extract(repo, h0_hash)
+
+        capsys.readouterr()  # clear
+        mcp_server._correction_sweep_apply(
+            real_db, h0_hash, h0_ts, file_results, skipped_so_far=mcp_server._CORRECTION_SWEEP_LOG_CAP,
+        )
+        assert capsys.readouterr().err == ""  # budget already spent by caller's running total
+
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, wrong_ident, "2025-01-01T00:00:00Z")
+        mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results, skipped_so_far=0)
+        assert "login" in capsys.readouterr().err  # fresh run, budget reset
+
+    def test_correction_sweep_log_summary(self, capsys):
+        import mcp_server
+        mcp_server._correction_sweep_log_summary(0)
+        assert capsys.readouterr().err == ""
+
+        mcp_server._correction_sweep_log_summary(3)
+        err = capsys.readouterr().err
+        assert err.strip() != ""
+        assert "3" in err
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepApply -v`
+Expected: FAIL with `AttributeError` on every test.
+
+- [ ] **Step 3: Implement `_correction_sweep_apply` and `_correction_sweep_log_summary`**
+
+Insert after Task 2's code:
+
+```python
+def _correction_sweep_apply(
+    db: Any,
+    commit_hash: str,
+    commit_ts_iso: str,
+    file_results: List[tuple],
+    index_con: Optional[Any] = None,
+    skipped_so_far: int = 0,
+) -> int:
+    """Reconciles every candidate entity file_results describes for
+    commit_hash, then records progress via _correction_sweep_through_update
+    and checkpoints. Returns skipped_events -- how many candidate idents
+    landed in the fail-safe skip (provisional with an ambiguous/wrong
+    guess, or already-authoritative with an ambiguous introduced-by count),
+    i.e. stayed provisional or unreconciled despite this call visiting
+    their commit.
+
+    Never calls _extract_commit itself (that's the caller's job, on a
+    different executor -- see the design spec's Execution context) and
+    never writes commit_hash's own :type/commit entity (2b already wrote
+    it for every commit in this sweep's range). DB-bound, parse-free.
+
+    skipped_so_far is the driving loop's running total of skipped_events
+    from every previous call this run -- it exists solely to make the
+    stderr log cap (_CORRECTION_SWEEP_LOG_CAP) work across calls without
+    this function holding any state of its own. Deriving the budget from a
+    caller-supplied running total, rather than a module-level counter, is
+    what makes the cap reset per run automatically: this server is
+    long-lived and runs many ingests, and a module counter would burn its
+    budget on the first one and log nothing ever after. The RETURNED count
+    is never capped; only what reaches stderr is.
+
+    Never calls _frontier_persist_claim -- frontier-low is not touched by
+    this sweep.
+    """
+    commit_ident = f":commit/{commit_hash[:12]}"
+    skipped_events = 0
+
+    for status, _file_path, _extracted, precomputed, _old_path in file_results:
+        if status not in ("A", "M"):
+            continue  # "D"/"R" deferred -- matches 2b's own scope cut
+        candidate_idents = (
+            [precomputed["module_ident"]]
+            + [ident for ident, _name, _t in precomputed["function_entries"]]
+            + [ident for ident, _name, _t in precomputed["class_entries"]]
+            + [ident for ident, _name, _t in precomputed["global_entries"]]
+            + [ident for ident, _name, _t in precomputed["field_entries"]]
+        )
+        unchanged_idents = precomputed.get("unchanged_idents", set())
+
+        for ident in candidate_idents:
+            raw = _db_execute(db, f"(query [:find ?c :where [{ident} :introduced-by ?c]])")
+            introduced_by_values = {row[0] for row in json.loads(raw).get("results", [])}
+
+            if _lineage_is_provisional(db, ident):
+                if introduced_by_values == {commit_ident}:
+                    # Case 1: the provisional guess matches this commit --
+                    # confirm. The :introduced-by fact itself is untouched,
+                    # since its value was already correct.
+                    _lineage_confirm(db, ident, index_con=index_con)
+                    _candidate_diff_clear(db, commit_hash, ident, index_con=index_con)
+                else:
+                    # Case 2: guess points elsewhere, or an ambiguous
+                    # (zero/2+) value count -- fail safe, leave untouched.
+                    skipped_events += 1
+                    if skipped_so_far + skipped_events < _CORRECTION_SWEEP_LOG_CAP:
+                        print(
+                            f"[_correction_sweep] {ident} left provisional at {commit_hash} "
+                            f"(introduced-by values: {sorted(introduced_by_values)})",
+                            file=sys.stderr,
+                        )
+            else:
+                # Case 3: already authoritative.
+                if len(introduced_by_values) == 1:
+                    (only_value,) = introduced_by_values
+                    if only_value == commit_ident:
+                        continue  # self-introduction guard: no self-:modified-in
+                    raw2 = _db_execute(db, f"(query [:find ?c :where [{ident} :modified-in ?c]])")
+                    modified_in_values = {row[0] for row in json.loads(raw2).get("results", [])}
+                    already_has_modified_in = commit_ident in modified_in_values
+                    if ident in unchanged_idents:
+                        if already_has_modified_in:
+                            _retract(db, f"[[{ident} :modified-in {commit_ident}]]", index_con=index_con)
+                    else:
+                        if not already_has_modified_in:
+                            _transact(
+                                db, f"[[{ident} :modified-in {commit_ident}]]", commit_ts_iso, index_con=index_con,
+                            )
+                    _candidate_diff_clear(db, commit_hash, ident, index_con=index_con)
+                else:
+                    # Zero or 2+ distinct values -- same duplicate-fact
+                    # risk as case 2 -- skip, left alone rather than
+                    # guessed at.
+                    skipped_events += 1
+                    if skipped_so_far + skipped_events < _CORRECTION_SWEEP_LOG_CAP:
+                        print(
+                            f"[_correction_sweep] {ident} left unreconciled at {commit_hash} "
+                            f"(ambiguous introduced-by values: {sorted(introduced_by_values)})",
+                            file=sys.stderr,
+                        )
+
+    _correction_sweep_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)
+    _db_checkpoint(db)
+    return skipped_events
+
+
+def _correction_sweep_log_summary(skipped_events: int) -> None:
+    """Emit the one-line end-of-sweep summary to stderr if skipped_events
+    is nonzero; no-op otherwise. A named function rather than an inline
+    print in each loop precisely because there are two loops that must say
+    the same thing -- _correction_sweep_walk (Task 5) and 2d's own -- and
+    an operator grepping for this line should not have to know which drove
+    the sweep.
+    """
+    if skipped_events:
+        print(
+            f"[_correction_sweep] {skipped_events} entities left provisional/unreconciled this run",
+            file=sys.stderr,
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepApply -v`
+Expected: 13 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add _correction_sweep_apply (three-case reconciliation) for #222 phase 2c"
+```
+
+---
+
+### Task 4: `_correction_sweep_claim_and_process`
+
+**Files:**
+- Modify: `mcp_server.py` — insert after Task 3's new code.
+- Test: `tests/test_mcp_server.py` — new `TestCorrectionSweepClaimAndProcess` class, appended at EOF.
+
+**Interfaces:**
+- Consumes: `_correction_sweep_select_position` (Task 2), `_extract_commit` (pre-existing), `_correction_sweep_apply` (Task 3).
+- Produces: `_correction_sweep_claim_and_process(db: Any, repo_path: str, linearization: List[str], commit_metadata: List[Tuple[str, str, str, str]], ignore_patterns: Sequence[str] = (), index_con: Optional[Any] = None, hash_to_pos: Optional[Dict[str, int]] = None, skipped_so_far: int = 0) -> Optional[Tuple[str, int]]`.
+
+The synchronous convenience wrapper composing the three pieces above in order, for tests and any caller that doesn't need them on separate executors. **2d must not call this directly** from async code (see the design spec's Execution context) — it fuses the parse and DB phases back together into one function body, exactly the shape that can only be scheduled onto one executor.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestCorrectionSweepClaimAndProcess:
+    def _init_repo(self, repo):
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _commit(self, repo, filename, content, msg):
+        (repo / filename).write_text(content)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True)
+
+    def _repo_with_n_commits(self, tmp_path, n):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+        for i in range(n):
+            self._commit(repo, f"f{i}.py", f"def f{i}(): pass\n", f"h{i}")
+        return repo
+
+    def _linearization_and_metadata(self, repo):
+        import mcp_server
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        return linearization, commit_metadata
+
+    def _close_gap(self, repo, db, linearization, commit_metadata):
+        """db here is any MiniGrafDb instance -- the real_db fixture in
+        most tests, or a manually-created MiniGrafDb.open_in_memory() in
+        the two-graph composition test below."""
+        import mcp_server
+        allocator = mcp_server._frontier_load(db, linearization, "2026-01-04T00:00:00Z")
+        while True:
+            pos = allocator.claim_low()
+            if pos is None:
+                break
+            mcp_server._frontier_persist_claim(
+                db, linearization, pos, from_low=True, commit_ts_iso=commit_metadata[pos][1],
+            )
+        return allocator
+
+    def test_no_op_propagates_from_select_position(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")  # frontier-high unclaimed
+
+        result = mcp_server._correction_sweep_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+        assert result is None
+
+    def test_single_call_round_trip(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+
+        result = mcp_server._correction_sweep_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+        assert result is not None
+        commit_hash, skipped_events = result
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert commit_hash == bounds[0]
+        assert skipped_events == 0
+        assert mcp_server._correction_sweep_through_query(real_db) == commit_hash
+
+    def test_wrapper_is_a_faithful_composition_of_the_three_pieces(self, tmp_path):
+        """Build TWO independent graphs from the same repo fixture (the
+        sweep mutates the state a second run would start from, so this
+        cannot be two passes over one graph). Against the first, call the
+        wrapper; against the second, call the three pieces directly.
+        Assert the resulting graph states are identical. Both dbs are
+        passed explicitly to every call -- none of these functions touch
+        mcp_server's module-global _db -- so this test needs no real_db
+        fixture and no open_db() call, just two independent
+        MiniGrafDb.open_in_memory() instances."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+
+        db_a = MiniGrafDb.open_in_memory()
+        self._close_gap(repo, db_a, linearization, commit_metadata)
+        mcp_server._correction_sweep_claim_and_process(db_a, str(repo), linearization, commit_metadata)
+
+        db_b = MiniGrafDb.open_in_memory()
+        self._close_gap(repo, db_b, linearization, commit_metadata)
+        selected = mcp_server._correction_sweep_select_position(db_b, linearization, commit_metadata)
+        assert selected is not None
+        commit_hash, commit_ts_iso = selected
+        file_results, _, _, _ = mcp_server._extract_commit(str(repo), commit_hash, ())
+        mcp_server._correction_sweep_apply(db_b, commit_hash, commit_ts_iso, file_results)
+
+        query = "(query [:find ?e ?a ?v :where [?e ?a ?v]])"
+        results_a = sorted(json.loads(db_a.execute(query))["results"])
+        results_b = sorted(json.loads(db_b.execute(query))["results"])
+        assert results_a == results_b
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepClaimAndProcess -v`
+Expected: FAIL with `AttributeError`.
+
+- [ ] **Step 3: Implement `_correction_sweep_claim_and_process`**
+
+Insert after Task 3's new code:
+
+```python
+def _correction_sweep_claim_and_process(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+    hash_to_pos: Optional[Dict[str, int]] = None,
+    skipped_so_far: int = 0,
+) -> Optional[Tuple[str, int]]:
+    """Synchronous convenience wrapper composing
+    _correction_sweep_select_position, _extract_commit, and
+    _correction_sweep_apply in order -- for tests and any caller that
+    doesn't need them on separate executors. **2d must not call this
+    directly** from async code: it fuses the CPU-bound parse and the
+    DB-bound writes back into one function body, which can only be
+    scheduled onto one executor as a unit. 2d's real loop should await
+    each of the three pieces on its own executor instead (see the design
+    spec's Execution context).
+
+    Returns (commit_hash, skipped_events), or None if
+    _correction_sweep_select_position found nothing safe to do.
+    skipped_so_far is forwarded to _correction_sweep_apply unchanged (see
+    its docstring for why it exists).
+    """
+    selected = _correction_sweep_select_position(db, linearization, commit_metadata, hash_to_pos)
+    if selected is None:
+        return None
+    commit_hash, commit_ts_iso = selected
+    file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
+        repo_path, commit_hash, ignore_patterns
+    )
+    skipped_events = _correction_sweep_apply(
+        db, commit_hash, commit_ts_iso, file_results,
+        index_con=index_con, skipped_so_far=skipped_so_far,
+    )
+    return commit_hash, skipped_events
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepClaimAndProcess -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add _correction_sweep_claim_and_process wrapper for #222 phase 2c"
+```
+
+---
+
+### Task 5: `_correction_sweep_walk`
+
+**Files:**
+- Modify: `mcp_server.py` — insert after Task 4's new code.
+- Test: `tests/test_mcp_server.py` — new `TestCorrectionSweepWalk` class, appended at EOF.
+
+**Interfaces:**
+- Consumes: `_correction_sweep_claim_and_process` (Task 4), `_correction_sweep_log_summary` (Task 3).
+- Produces: `_correction_sweep_walk(db: Any, repo_path: str, linearization: List[str], commit_metadata: List[Tuple[str, str, str, str]], ignore_patterns: Sequence[str] = (), index_con: Optional[Any] = None) -> Tuple[int, int]`.
+
+Builds `hash_to_pos` once, repeatedly calls `_correction_sweep_claim_and_process` (threading `skipped_so_far` through) until it returns `None`, then calls `_correction_sweep_log_summary`. This is the last piece of #222 phase 2c — no caller is wired into `_run_ingestion` yet (that's phase 2d).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestCorrectionSweepWalk:
+    def _init_repo(self, repo):
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _commit(self, repo, filename, content, msg):
+        (repo / filename).write_text(content)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True)
+
+    def _repo_with_n_commits(self, tmp_path, n):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+        for i in range(n):
+            self._commit(repo, f"f{i}.py", f"def f{i}(): pass\n", f"h{i}")
+        return repo
+
+    def _linearization_and_metadata(self, repo):
+        import mcp_server
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        return linearization, commit_metadata
+
+    def _close_gap_at(self, repo, real_db, linearization, commit_metadata, split_pos):
+        """Close the gap with the low side claiming positions [0, split_pos)
+        and the high side (2b) claiming the rest -- split_pos == len(linearization)
+        closes the whole thing from the low side alone."""
+        import mcp_server
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        for _ in range(split_pos):
+            pos = allocator.claim_low()
+            mcp_server._frontier_persist_claim(
+                real_db, linearization, pos, from_low=True, commit_ts_iso=commit_metadata[pos][1],
+            )
+        while not allocator.is_gap_empty():
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        return allocator
+
+    def test_walks_to_exhaustion_and_returns_counts(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 4)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=0)
+
+        commits_processed, skipped_events = mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+
+        assert commits_processed == 4
+        assert skipped_events == 0
+        assert mcp_server._correction_sweep_through_query(real_db) == linearization[-1]
+
+    def test_returns_zero_zero_when_gap_still_open(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert allocator.is_gap_empty() is False
+
+        result = mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
+        assert result == (0, 0)
+
+    def test_no_op_when_already_fully_swept(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=0)
+        mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
+
+        result = mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
+        assert result == (0, 0)
+
+    def test_frontier_low_and_lineage_confirmed_through_never_touched(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=1)
+
+        low_before = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_LOW_IDENT)
+        lineage_before = mcp_server._lineage_confirmed_through_query(real_db)
+
+        mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
+
+        low_after = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_LOW_IDENT)
+        lineage_after = mcp_server._lineage_confirmed_through_query(real_db)
+        assert low_after == low_before
+        assert lineage_after == lineage_before
+        assert mcp_server._correction_sweep_through_query(real_db) is not None
+
+    def test_full_integration(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 5)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=2)
+
+        commits_processed, skipped_events = mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+
+        assert commits_processed == 3  # the 3 positions the high side claimed
+        assert skipped_events == 0
+        for i in range(5):
+            fn_ident = mcp_server._code_ident("function", f"f{i}.py", f"f{i}")
+            assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        raw = mcp_server._db_execute(real_db, "(query [:find ?e :where [?e :entity-type :type/candidate-diff]])")
+        assert json.loads(raw)["results"] == []
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert mcp_server._correction_sweep_through_query(real_db) == bounds[1]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepWalk -v`
+Expected: FAIL with `AttributeError`.
+
+- [ ] **Step 3: Implement `_correction_sweep_walk`**
+
+Insert after Task 4's new code:
+
+```python
+def _correction_sweep_walk(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> Tuple[int, int]:
+    """Build hash_to_pos once and repeatedly call
+    _correction_sweep_claim_and_process (passing it down, along with the
+    running skipped-events total as skipped_so_far) until that returns
+    None, then call _correction_sweep_log_summary with the final total.
+
+    Returns (commits_processed, skipped_events) -- summed across every
+    call, both 0 both when the gap-closed precondition isn't met yet (the
+    common case early in a run) and when the sweep has already fully
+    caught up to frontier-high's :hi-hash.
+
+    Also a synchronous convenience wrapper, same caveat as
+    _correction_sweep_claim_and_process: 2d should drive the three-step
+    pipeline directly in its own loop, not call this -- but 2d's loop owes
+    the same two things this one does: threading skipped_so_far through
+    every _correction_sweep_apply call, and calling
+    _correction_sweep_log_summary when its own loop ends.
+    """
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+    commits_processed = 0
+    skipped_events = 0
+    while True:
+        result = _correction_sweep_claim_and_process(
+            db, repo_path, linearization, commit_metadata,
+            ignore_patterns=ignore_patterns, index_con=index_con,
+            hash_to_pos=hash_to_pos, skipped_so_far=skipped_events,
+        )
+        if result is None:
+            break
+        _commit_hash, call_skipped = result
+        commits_processed += 1
+        skipped_events += call_skipped
+    _correction_sweep_log_summary(skipped_events)
+    return commits_processed, skipped_events
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepWalk -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Run the full test file to confirm no regressions**
+
+Run: `python -m pytest tests/test_mcp_server.py -v`
+Expected: all tests pass, including every pre-existing phase 1/2a/2b test class.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add _correction_sweep_walk driving loop for #222 phase 2c"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- Watermark + log cap constant → Task 1.
+- Gap-closed precondition, persisted-`:hi-hash` ceiling, resume-from-watermark, stale-hash fallback, `commit_metadata` contract check → Task 2.
+- Full three-case classification (confirm / fail-safe skip / reconcile-with-self-intro-guard), `:type/commit` non-write (implicit — `_correction_sweep_apply` never references commit metadata triples), candidate-diff cleanup (both the case-1 clear and case-3 opportunistic clear), capped+caller-threaded stderr logging, `_correction_sweep_log_summary` → Task 3.
+- Synchronous wrapper composing the three independently-schedulable pieces, proven faithful via the two-graph comparison test → Task 4.
+- Driving loop, `hash_to_pos` built once (not per-call), frontier-low/lineage-confirmed-through untouched, full integration → Task 5.
+- The design spec's "Execution context" section (the actual `await`/executor wiring, and the extraction-pipelining note) is explicitly out of scope for this plan — it's 2d's job; this plan only produces the function *shape* that makes that wiring possible, per the spec itself.
+- The design spec's `ignore_patterns` cross-run consistency caveat and the "wrong provisional guess" reconciliation case are both explicitly deferred in the spec itself (to 2d, or left unresolved) — no task implements them, matching the spec's own scope.
+
+**Placeholder scan:** No task leaves a stub, `pass`, or "implement later" — every task's function is complete and independently correct for its own declared scope (e.g. Task 3's `_correction_sweep_apply` fully implements all three cases in one task, matching how 2b's own plan built `_reverse_fill_claim_and_process`'s full algorithm in a single task).
+
+**Type consistency:** `_correction_sweep_select_position` returns `Optional[Tuple[str, str]]` in Task 2 and is destructured identically (`commit_hash, commit_ts_iso = selected`) in Task 4. `_correction_sweep_apply` returns `int` (Task 3) and is used as `skipped_events = _correction_sweep_apply(...)` in Task 4, then summed in Task 5. `_correction_sweep_claim_and_process` returns `Optional[Tuple[str, int]]` (Task 4) and is destructured as `_commit_hash, call_skipped = result` in Task 5. `skipped_so_far` is threaded as a plain `int` default `0` through Tasks 3→4→5 consistently.

--- a/docs/superpowers/plans/2026-07-25-stream1-correction-sweep.md
+++ b/docs/superpowers/plans/2026-07-25-stream1-correction-sweep.md
@@ -1302,7 +1302,7 @@ def _correction_sweep_walk(
     None, then call _correction_sweep_log_summary with the final total.
 
     Returns (commits_processed, skipped_events) -- summed across every
-    call, both 0 both when the gap-closed precondition isn't met yet (the
+    call, both 0 when the gap-closed precondition isn't met yet (the
     common case early in a run) and when the sweep has already fully
     caught up to frontier-high's :hi-hash.
 

--- a/docs/superpowers/plans/2026-07-25-stream1-correction-sweep.md
+++ b/docs/superpowers/plans/2026-07-25-stream1-correction-sweep.md
@@ -1193,16 +1193,25 @@ class TestCorrectionSweepWalk:
         return allocator
 
     def test_walks_to_exhaustion_and_returns_counts(self, real_db, tmp_path):
+        """split_pos must be >= 1: frontier-low's persisted bounds don't
+        exist in the DB at all until the first claim_low() position is
+        persisted via _frontier_persist_claim(from_low=True, ...) --
+        split_pos=0 never calls that, so _correction_sweep_select_position's
+        `low_bounds is None` precondition check would always fail even
+        though the in-memory allocator's gap does become logically empty
+        via high-side claims alone. With split_pos=1, one position is
+        claimed by the low side (not part of this sweep's own range), so
+        the correction sweep processes the remaining 3 of 4 commits."""
         import mcp_server
         repo = self._repo_with_n_commits(tmp_path, 4)
         linearization, commit_metadata = self._linearization_and_metadata(repo)
-        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=0)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=1)
 
         commits_processed, skipped_events = mcp_server._correction_sweep_walk(
             real_db, str(repo), linearization, commit_metadata,
         )
 
-        assert commits_processed == 4
+        assert commits_processed == 3
         assert skipped_events == 0
         assert mcp_server._correction_sweep_through_query(real_db) == linearization[-1]
 
@@ -1220,10 +1229,12 @@ class TestCorrectionSweepWalk:
         assert result == (0, 0)
 
     def test_no_op_when_already_fully_swept(self, real_db, tmp_path):
+        """split_pos=1, not 0 -- see test_walks_to_exhaustion_and_returns_counts's
+        docstring for why split_pos=0 never persists frontier-low at all."""
         import mcp_server
         repo = self._repo_with_n_commits(tmp_path, 2)
         linearization, commit_metadata = self._linearization_and_metadata(repo)
-        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=0)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=1)
         mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
 
         result = mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)

--- a/docs/superpowers/plans/2026-07-25-stream1-correction-sweep.md
+++ b/docs/superpowers/plans/2026-07-25-stream1-correction-sweep.md
@@ -218,20 +218,26 @@ class TestCorrectionSweepSelectPosition:
         return linearization, commit_metadata
 
     def _close_gap(self, repo, real_db, linearization, commit_metadata):
-        """Close the gap entirely: claim everything from the low side via a
-        real FrontierAllocator + _frontier_persist_claim (standing in for
-        2d's future ordinary forward walk), then claim the rest from the
-        high side via 2b's real _reverse_fill_claim_and_process."""
+        """Claim exactly one position from the low side via a real
+        FrontierAllocator + _frontier_persist_claim (standing in for 2d's
+        future ordinary forward walk), then claim the rest from the high
+        side via 2b's real _reverse_fill_claim_and_process until the gap is
+        empty. Claiming the *whole* gap from the low side alone (an
+        unbounded claim_low() loop) would never touch frontier-high at
+        all -- claim_low() alone can empty the gap without claim_high()
+        ever running, since gap_hi only moves when claim_high() does."""
         import mcp_server
         import frontier_registry
         allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
-        while True:
-            pos = allocator.claim_low()
-            if pos is None:
-                break
+        pos = allocator.claim_low()
+        if pos is not None:
             mcp_server._frontier_persist_claim(
                 real_db, linearization, pos, from_low=True,
                 commit_ts_iso=commit_metadata[pos][1],
+            )
+        while not allocator.is_gap_empty():
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
             )
         return allocator
 
@@ -979,17 +985,29 @@ class TestCorrectionSweepClaimAndProcess:
         return linearization, commit_metadata
 
     def _close_gap(self, repo, db, linearization, commit_metadata):
-        """db here is any MiniGrafDb instance -- the real_db fixture in
-        most tests, or a manually-created MiniGrafDb.open_in_memory() in
-        the two-graph composition test below."""
+        """Claim exactly one position from the low side via a real
+        FrontierAllocator + _frontier_persist_claim (standing in for 2d's
+        future ordinary forward walk), then claim the rest from the high
+        side via 2b's real _reverse_fill_claim_and_process until the gap is
+        empty. Claiming the *whole* gap from the low side alone (an
+        unbounded claim_low() loop) would never touch frontier-high at
+        all -- claim_low() alone can empty the gap without claim_high()
+        ever running, since gap_hi only moves when claim_high() does -- so
+        the low side must stop after a bounded number of claims for
+        frontier-high to end up populated. db here is any MiniGrafDb
+        instance -- the real_db fixture in most tests, or a
+        manually-created MiniGrafDb.open_in_memory() in the two-graph
+        composition test below."""
         import mcp_server
         allocator = mcp_server._frontier_load(db, linearization, "2026-01-04T00:00:00Z")
-        while True:
-            pos = allocator.claim_low()
-            if pos is None:
-                break
+        pos = allocator.claim_low()
+        if pos is not None:
             mcp_server._frontier_persist_claim(
                 db, linearization, pos, from_low=True, commit_ts_iso=commit_metadata[pos][1],
+            )
+        while not allocator.is_gap_empty():
+            mcp_server._reverse_fill_claim_and_process(
+                db, str(repo), linearization, commit_metadata, allocator,
             )
         return allocator
 

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -277,11 +277,24 @@ frontier-high's range entirely, in frontier-low's own territory) belongs —
 that is a different scenario from the one above and remains this sweep's
 own no-op case, not something it can resolve itself.
 
-### Per-commit algorithm
+### Per-commit algorithm (`_correction_sweep_apply`)
 
-For a commit `C` at the sweep's current position (oldest→newest through
-frontier-high's territory), reusing `_extract_commit` for entity discovery
-(direction-agnostic, same as 2b) but **not** `_build_code_triples`:
+**This logic lives in a DB-touching function, `_correction_sweep_apply`,
+that takes `file_results` as a parameter rather than calling
+`_extract_commit` itself** — see "Execution context" below for why: the
+extraction call is CPU-bound and DB-free (process-pool-eligible), while
+everything below is DB-bound, and a single function can't be scheduled onto
+two different executors. `_correction_sweep_select_position` (next section)
+determines `commit_hash`/`commit_ts_iso`; `_extract_commit(repo_path,
+commit_hash, ignore_patterns)` (2b's existing function, unmodified, reused
+for entity discovery exactly as 2b uses it, direction-agnostic) produces
+`file_results` independently; this function reconciles every candidate
+entity `file_results` contains, for the commit `C` its inputs describe.
+`_correction_sweep_claim_and_process` (the synchronous convenience wrapper
+in "Driving functions") composes all three calls for callers that don't
+need them on separate executors — most tests included.
+
+Reuses `_extract_commit`'s output but **not** `_build_code_triples`:
 
 **2c never writes `C`'s own `:type/commit` entity, and never calls
 `_build_code_triples`.** Every commit in the sweep's range was already
@@ -318,9 +331,8 @@ looked up via `ts_by_commit_ident.get(..., commit_ts_iso)`
 current-time read, not a temporal one — cannot detect or correct.
 
 ```python
-file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
-    repo_path, commit_hash, ignore_patterns
-)
+commit_ident = f":commit/{commit_hash[:12]}"
+skipped_events = 0
 for status, file_path, extracted, precomputed, _old_path in file_results:
     if status not in ("A", "M"):
         continue  # "D"/"R" deferred -- see Scope, matches 2b's own cut
@@ -406,7 +418,8 @@ two at once:
    safe (does nothing) rather than confirming an unvalidated or ambiguous
    guess. The entity remains provisional and available for whatever the
    deferred reconciliation (or, for the duplicate-fact case, 2d's own fix)
-   turns out to be.
+   turns out to be. `skipped_events += 1`, and (see "Observability" below)
+   log the ident if this call's log budget isn't yet spent.
 
 3. **Already authoritative** (`not _lineage_is_provisional(db, ident)`;
    confirmed at an earlier position in this same sweep, or — after this
@@ -432,9 +445,10 @@ two at once:
      later touch of an unambiguously-introduced entity — **reconcile
      rather than merely assert**, below.
    - **Zero or two-or-more distinct values**: the same duplicate-fact risk
-     as case 2 — skip, left alone rather than guessed at. This sweep only
-     actively reconciles `:modified-in` when it has an unambiguous single
-     introduction commit to compare `C` against.
+     as case 2 — skip, left alone rather than guessed at (`skipped_events
+     += 1`, same logging budget). This sweep only actively reconciles
+     `:modified-in` when it has an unambiguous single introduction commit
+     to compare `C` against.
 
    The reconcile step is where this sweep corrects 2b's documented
    over-assertion (see Scope), not just re-confirms what's already there —
@@ -481,6 +495,20 @@ two at once:
    special-casing was needed for that cleanup — it falls out of the
    ordinary path once the sweep passes back over those commits.
 
+`_correction_sweep_apply` finishes by recording its own progress and
+checkpointing, after the per-ident loop above has processed every file in
+`file_results`:
+
+```python
+_correction_sweep_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)
+_db_checkpoint(db)
+return skipped_events
+```
+
+Same one-checkpoint-per-commit cadence as 2b. Frontier-low and
+`:ingestion/lineage-confirmed-through` are never touched here (see "Why a
+dedicated watermark" above).
+
 ### Position tracker: `:ingestion/correction-sweep-through`
 
 A new watermark, structurally identical to `:ingestion/lineage-confirmed-
@@ -506,16 +534,25 @@ def _correction_sweep_through_update(
     exactly, at a different ident."""
 ```
 
-`_correction_sweep_claim_and_process` takes an additional optional
-`hash_to_pos: Optional[Dict[str, int]] = None` parameter — if omitted, it
-builds one from `linearization` itself (so the function stays independently
-callable, e.g. from tests, exactly as before); `_correction_sweep_walk`
-builds it **once** and passes it to every call instead. `linearization` is
-fixed for the duration of a run, so rebuilding an `N`-entry map on every one
-of a full sweep's `N` calls (as an earlier draft's snippet did, with no
-caller-side reuse) is pure `O(N²)` waste — `_frontier_load` itself only
-ever builds this map once per run (mcp_server.py:4967), and this sweep
-should match that.
+**This DB-reading logic lives in its own function,
+`_correction_sweep_select_position(db, linearization, commit_metadata,
+hash_to_pos=None) -> Optional[Tuple[str, str]]`** — separate from
+`_correction_sweep_apply` not because it's expensive (it isn't: a handful
+of cheap queries, no parsing) but because its *output* (`commit_hash`) is
+what `_extract_commit` needs as *input*, so it must run, and complete,
+before extraction can even start. See "Execution context" for the
+resulting three-step pipeline; see "Driving functions" for the full
+signature and docstring.
+
+It takes the same optional `hash_to_pos` parameter as the rest of this
+sweep's functions — if omitted, it builds one from `linearization` itself
+(so the function stays independently callable, e.g. from tests, exactly as
+before); `_correction_sweep_walk` builds it **once** and passes it to every
+call instead. `linearization` is fixed for the duration of a run, so
+rebuilding an `N`-entry map on every one of a full sweep's `N` calls (as an
+earlier draft's snippet did, with no caller-side reuse) is pure `O(N²)`
+waste — `_frontier_load` itself only ever builds this map once per run
+(mcp_server.py:4967), and this sweep should match that.
 
 Position selection: first the gap-closed precondition ("Why confirming
 requires the gap to already be closed" above), then the ceiling, then the
@@ -556,6 +593,7 @@ if len(commit_metadata) != len(linearization) or commit_metadata[pos][0] != line
                  # do, rather than an IndexError/wrong-commit read; see the
                  # contract note below
 commit_hash, commit_ts_iso, _author, _subject = commit_metadata[pos]
+return commit_hash, commit_ts_iso
 ```
 
 The contract check above is a real `if`/`return None`, not a bare `assert`:
@@ -668,7 +706,50 @@ why folding into the latter is explicitly deferred to 2d).
 
 ### Driving functions
 
+Four functions, in the three-step data-dependency order "Execution
+context" below explains, plus the convenience wrapper:
+
 ```python
+def _correction_sweep_select_position(
+    db: Any,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    hash_to_pos: Optional[Dict[str, int]] = None,
+) -> Optional[Tuple[str, str]]:
+    """DB-bound, parse-free (see "Position tracker" for the body). Returns
+    (commit_hash, commit_ts_iso) for the next commit this sweep should
+    process, upward through frontier-high's own claimed territory, or None
+    if there is nothing safe to correct yet: the gap is still open (Stream
+    2 could still descend past a position this call would confirm -- see
+    "Why confirming requires the gap to already be closed"), frontier-high
+    hasn't claimed anything yet, a required boundary hash is stale,
+    commit_metadata doesn't match linearization, or the sweep has already
+    reached frontier-high's own :hi-hash. No `allocator` parameter -- reads
+    frontier-low and frontier-high's persisted bounds directly via
+    _frontier_read_bounds and tracks its own progress via
+    _correction_sweep_through_query, not the allocator's claim_low(); see
+    "Why not claim_low()" above. `hash_to_pos`, if omitted, is built fresh
+    from `linearization` -- callers doing a full sweep should build it once
+    and pass it in instead (see _correction_sweep_walk) to avoid rebuilding
+    an N-entry map on every one of a full sweep's N calls."""
+
+def _correction_sweep_apply(
+    db: Any,
+    commit_hash: str,
+    commit_ts_iso: str,
+    file_results: List[tuple],
+    index_con: Optional[Any] = None,
+) -> int:
+    """DB-bound, parse-free (see "Per-commit algorithm" for the body).
+    Reconciles every candidate entity file_results describes for commit_hash
+    per the three-case algorithm, then records progress via
+    _correction_sweep_through_update and checkpoints. Returns
+    skipped_events -- how many candidate idents landed in case 2 or case
+    3's ambiguous-value skip, i.e. stayed provisional or unreconciled
+    despite this call visiting their commit; see "Observability" below for
+    the logging that accompanies each one. Never calls
+    _frontier_persist_claim -- frontier-low is not touched by this sweep."""
+
 def _correction_sweep_claim_and_process(
     db: Any,
     repo_path: str,
@@ -678,32 +759,21 @@ def _correction_sweep_claim_and_process(
     index_con: Optional[Any] = None,
     hash_to_pos: Optional[Dict[str, int]] = None,
 ) -> Optional[Tuple[str, int]]:
-    """Advance the correction sweep by exactly one commit, upward through
-    frontier-high's own claimed territory, and reconcile that commit's
-    entities per the three-case algorithm above. Returns (commit_hash,
-    skipped_count) -- skipped_count is how many candidate idents at this
-    commit landed in case 2 or case 3's ambiguous-value skip, i.e. stayed
-    provisional or unreconciled despite the sweep visiting their commit --
-    or None if there is nothing safe to correct yet: the gap is still open
-    (Stream 2 could still descend past a position this call would confirm
-    -- see "Why confirming requires the gap to already be closed"),
-    frontier-high hasn't claimed anything yet, a required boundary hash is
-    stale, commit_metadata doesn't match linearization, or the sweep has
-    already reached frontier-high's own :hi-hash. Every skip also logs the
-    ident to stderr (`[_correction_sweep] left {ident} provisional/
-    unreconciled at {commit_hash}: ...`), matching `_run_ingestion`'s own
-    stderr-on-skip idiom for unreadable commits -- a run in which every
-    entity failed safe must not look identical to a fully successful one.
-    No `allocator` parameter -- this reads frontier-low and frontier-high's
-    persisted bounds directly via _frontier_read_bounds and tracks its own
-    progress via _correction_sweep_through_query/_update, not the
-    allocator's claim_low(); see "Why not claim_low()" above. Never calls
-    _frontier_persist_claim or _lineage_confirmed_through_update -- neither
-    frontier-low nor lineage-confirmed-through is touched by this sweep.
-    `hash_to_pos`, if omitted, is built fresh from `linearization` --
-    callers doing a full sweep should build it once and pass it in instead
-    (see _correction_sweep_walk) to avoid rebuilding an N-entry map on every
-    one of a full sweep's N calls."""
+    """Synchronous convenience wrapper composing the three calls below in
+    order -- for tests and any caller that doesn't need them on separate
+    executors. **2d must not call this directly**; see "Execution context"
+    for why and what to call instead."""
+    selected = _correction_sweep_select_position(db, linearization, commit_metadata, hash_to_pos)
+    if selected is None:
+        return None
+    commit_hash, commit_ts_iso = selected
+    file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
+        repo_path, commit_hash, ignore_patterns
+    )
+    skipped_events = _correction_sweep_apply(
+        db, commit_hash, commit_ts_iso, file_results, index_con=index_con
+    )
+    return commit_hash, skipped_events
 
 def _correction_sweep_walk(
     db: Any,
@@ -715,60 +785,142 @@ def _correction_sweep_walk(
 ) -> Tuple[int, int]:
     """Build hash_to_pos once and repeatedly call
     _correction_sweep_claim_and_process (passing it down) until that
-    returns None. Returns (commits_processed, entities_left_unreconciled) --
-    both 0 both when the gap-closed precondition isn't met yet (the common
-    case early in a run; callers should not read (0, 0) as "nothing to do,
-    ever") and when the sweep has already fully caught up to frontier-
-    high's :hi-hash. A nonzero entities_left_unreconciled with a nonzero
-    commits_processed is the signal 2d should surface prominently (e.g.
-    through handle_minigraf_ingest_status, mirroring how
-    handle_minigraf_audit returns violation lists rather than only a
-    boolean) -- this sweep's entire product is "these lineage facts are now
-    trustworthy", and silently leaving some provisional is a materially
-    different outcome from a clean run even though both return successfully.
-    No caller in this sub-phase -- 2d wires this into the real concurrent
-    ingestion loop, run only after both the reverse stream and ordinary
-    claim_low()-driven introduction have permanently finished for the run
-    (see "Why confirming requires the gap to already be closed")."""
+    returns None. Returns (commits_processed, skipped_events) -- summed
+    across every call, both 0 both when the gap-closed precondition isn't
+    met yet (the common case early in a run; callers should not read
+    (0, 0) as "nothing to do, ever") and when the sweep has already fully
+    caught up to frontier-high's :hi-hash. `skipped_events` counts skip
+    *events*, not distinct entities -- see "Observability" for the
+    distinction and why a caller wanting a true census should query the
+    graph instead. Also a synchronous convenience wrapper, same caveat as
+    `_correction_sweep_claim_and_process`: 2d should drive the three-step
+    pipeline directly in its own loop, not call this. Run only after both
+    the reverse stream and ordinary claim_low()-driven introduction have
+    permanently finished for the run (see "Why confirming requires the gap
+    to already be closed")."""
 ```
+
+Unlike `_reverse_fill_claim_and_process`'s plain `Optional[str]`, this
+sweep's driving functions return a tuple even on success — the
+observability requirement below has nowhere else to attach the skip count.
+2d, driving both step functions from one loop, needs to unpack accordingly.
 
 ### Execution context
 
-Neither function above may run on the event-loop thread. `_run_ingestion`'s
-whole architecture exists to keep exactly this off it: `_extract_commit`
-(a `git diff-tree`, a `git show` per changed file, and a tree-sitter parse
-of both sides of each) runs on the `ProcessPoolExecutor` because
+Neither `_correction_sweep_select_position` nor `_correction_sweep_apply`
+(nor, transitively, the convenience wrappers above) may run on the
+event-loop thread — but, critically, **they may not run on the *same*
+executor as `_extract_commit` either**, and an earlier draft of this
+section prescribed exactly that contradiction. `_run_ingestion`'s whole
+architecture exists to separate these two concerns: `_extract_commit` (a
+`git diff-tree`, a `git show` per changed file, and a tree-sitter parse of
+both sides of each) runs on the `ProcessPoolExecutor` because
 tree-sitter's GIL-holding C parse was measured to starve the event loop
-(#116), and every `db.execute()`/`checkpoint()` goes through the
-single-worker `write_executor` so an fsync never blocks concurrent
-`call_tool()` requests (mcp_server.py:7440-7466). This sweep's per-commit
-step does both a full `_extract_commit` call and its own
-`_db_execute`/`_transact`/`_retract`/`_db_checkpoint` calls synchronously
-in one function body, exactly the shape that architecture exists to keep
-off the event loop — and, per the terminal-pass consequence above, this
-sweep is the single longest-running phase in the whole ingest, so running
-it inline would be the worst place in the design to get this wrong: no MCP
-request would be served for the duration of a full pass.
+(#116) — and its own docstring calls being DB-free "a hard requirement now
+that this crosses a process boundary, not just a nice property"
+(mcp_server.py:6959-6962) — while every `db.execute()`/`checkpoint()` goes
+through the single-worker `write_executor` so an fsync never blocks
+concurrent `call_tool()` requests (mcp_server.py:7440-7466). A function
+that both parses *and* touches the DB in one body — which
+`_correction_sweep_claim_and_process` is, by construction, since it's the
+wrapper — can only be scheduled onto one executor as a unit; there is no
+way to route "the parse part" to the process pool and "the DB part" to
+`write_executor` once they're fused together in one call. That is exactly
+the shape forward walk deliberately never builds — `_extract_commit`
+crosses the process boundary alone, and the DB bookkeeping lives in
+`_run_ingestion`'s own serial loop, never in the same function.
 
-This spec does not wire the actual `await`/executor calls — that remains
-2d's job, same as the rest of the concurrency wiring — but it does fix the
-function *shape* 2d has to schedule, since that's what determines whether
-2d even *can* schedule it sanely: `_correction_sweep_claim_and_process`
-processes exactly one commit and returns, which is the right granularity
-for cooperative scheduling (2d can `await` between calls, interleaving
-other event-loop work). What 2d must not do is call
-`_correction_sweep_walk` directly from a coroutine with no `await` inside
-its loop (blocks for the entire pass) or route it through
-`run_in_executor(write_executor, _correction_sweep_walk, ...)` as a single
-call (serializes every one of this sweep's parses behind the same thread
-`_run_ingestion` reserves for writes, which is exactly the contention
-`write_executor`'s single-worker design exists to avoid). The natural
-shape, mirroring `_run_ingestion`'s own loop, is 2d awaiting
-`run_in_executor` calls to *each* piece (extraction on the process pool,
-DB operations on `write_executor`) once per commit, with
-`_correction_sweep_claim_and_process` itself staying a plain synchronous
-function ignorant of asyncio, the same role `_extract_commit` and the
-per-commit DB helpers already play for forward walk.
+This is why "Per-commit algorithm" and "Position tracker" factor this
+sweep's step into `_correction_sweep_select_position` and
+`_correction_sweep_apply`, both DB-bound and parse-free, with
+`_extract_commit` called independently between them. 2d's real loop should
+look like `_run_ingestion`'s own shape — awaiting `run_in_executor` calls
+to each piece in turn, once per commit:
+
+```python
+selected = await loop.run_in_executor(
+    write_executor, _correction_sweep_select_position, db, linearization, commit_metadata, hash_to_pos,
+)
+if selected is None:
+    ...  # this sweep has nothing left to do this iteration
+commit_hash, commit_ts_iso = selected
+file_results, _, _, _ = await loop.run_in_executor(
+    extraction_pool, _extract_commit, repo_path, commit_hash, ignore_patterns,
+)
+skipped_events = await loop.run_in_executor(
+    write_executor, _correction_sweep_apply, db, commit_hash, commit_ts_iso, file_results,
+)
+```
+
+— never `_correction_sweep_claim_and_process` or `_correction_sweep_walk`
+themselves from 2d's async code: both are synchronous wrappers that fuse
+the extract and apply phases back together, provided only for tests and
+other callers that genuinely don't care about executor placement.
+`_correction_sweep_select_position`'s own DB reads are cheap (no parsing),
+so routing it through `write_executor` alongside `_correction_sweep_apply`
+is a minor, acceptable serialization — the two are already going to be
+serialized against `_run_ingestion`'s own writes via that same
+single-worker executor regardless, and `_correction_sweep_select_position`
+determining the next `commit_hash` is a genuine data dependency `_extract_commit`
+can't proceed without. `_correction_sweep_apply` processing exactly one
+commit and returning is what makes this cooperative: 2d can `await`
+between each of the three calls, interleaving other event-loop work,
+instead of blocking for a whole pass — which matters more here than
+anywhere else in the design, since per the terminal-pass consequence
+above, this sweep is the single longest-running phase in the whole ingest.
+
+`_reverse_fill_claim_and_process` has the identical parse-and-write
+conflation in one function body (`mcp_server.py:7317-7411`) — this spec
+doesn't fix that (out of scope, and 2b's PR is already merged-pending), but
+2b1, if it addresses 2b's other known issues, should probably split it the
+same way for the same reason.
+
+### Observability
+
+**Logging is capped, not unconditional.** An earlier draft of this design
+said every skip logs its ident to stderr, citing `_run_ingestion`'s own
+skip idiom (mcp_server.py:7612-7616, 8019-8023) as precedent. That
+precedent fires once per *commit*, only on an exceptional failure
+(unreadable commit, failed write) — a different frequency class from this
+sweep's skips, which fire once per *ident* per commit, and whose two
+triggers (a violated gap-closed precondition, or an uncoordinated-forward-
+walk duplicate `:introduced-by`) are systematic once they occur: either can
+make most or all idents skip at *every* commit for the rest of the range.
+Unconditional per-skip logging in that state is millions of lines onto the
+MCP server's own stderr on a large repository. `_correction_sweep_apply`
+therefore logs at most the first 10 skipped idents it encounters across the
+whole run (a simple counter compared against a constant, not a per-call
+budget — 2d's loop calls this function many times), then a single summary
+line once `_correction_sweep_walk` finishes if `skipped_events > 0`. The
+returned count itself stays exact regardless of the logging cap — capping
+only affects what reaches stderr, never what `_correction_sweep_walk`
+returns.
+
+**`skipped_events` counts skip events, not distinct unreconciled
+entities, and only within one pass.** Two gaps between the name and a
+naive reading of the value:
+
+- One `ident` is a candidate at every commit that touches its file, so a
+  single entity stuck in a frequently-touched file inflates the count
+  arbitrarily — it is not a count of *entities*, it is a count of
+  `(ident, commit)` skip events.
+- It only reflects skips *this call/pass observed*. An entity skipped
+  during an earlier, separate partial run is never revisited (the
+  watermark has already advanced past its commits) and is never re-counted
+  by a later run, so a resumed run that itself completes with zero new
+  skips reports `(N, 0)` while the graph still holds provisional entities
+  inside the already-swept range from the earlier run. That is the exact
+  "a run that skipped everything must not look like a clean run" failure
+  the counter exists to prevent, reappearing one level up across separate
+  runs instead of within one.
+
+If 2d (or any consumer) needs a trustworthy answer to "is this range fully
+reconciled *right now*, regardless of how many runs it took," that is a
+graph query, not anything this counter can provide across runs: entities
+introduced within `[frontier-high.lo, frontier-high.:hi-hash]` that still
+carry a live `:type/lineage-marker`. This is exactly what the integration
+test's `_lineage_is_provisional` assertion already checks for a single
+run's fixture.
 
 ### Schema/audit safety, idempotency
 
@@ -902,7 +1054,8 @@ high side, until `allocator.is_gap_empty()`.
   lo-hash again**: close the gap over a range spanning several commits;
   call `_correction_sweep_claim_and_process` once (processes frontier-
   high's lo-hash); call it again; assert it processes the position
-  immediately after the first call's result, not frontier-high's lo-hash
+  immediately after `result[0]` (the first call's returned
+  `(commit_hash, skipped_events)` tuple), not frontier-high's lo-hash
   again — proving the dedicated watermark, not frontier-high's bound,
   drives resumption. (Unlike an earlier draft, this cannot be tested via a
   *further* `claim_high()` after the gap closes — `is_gap_empty()` makes
@@ -944,18 +1097,34 @@ high side, until `allocator.is_gap_empty()`.
   `claim_low()`/`_frontier_persist_claim` from the low side, the rest via
   `_reverse_fill_claim_and_process` from the high side, until
   `allocator.is_gap_empty()`); then run `_correction_sweep_walk` to
-  exhaustion; assert its returned `entities_left_unreconciled` count is `0`,
-  every entity touched within frontier-high's claimed range ends up
-  authoritative (`_lineage_is_provisional` is `False` for all of them), no
+  exhaustion; assert its returned `skipped_events` total is `0`, every
+  entity touched within frontier-high's claimed range ends up authoritative
+  (`_lineage_is_provisional` is `False` for all of them), no
   `:type/candidate-diff` entities remain live, and
   `_correction_sweep_through_query` now equals frontier-high's `:hi-hash` —
   proving the sweep correctly walks all the way through frontier-high's
   claimed territory to its actual persisted ceiling, not the single
   position or the unbounded `len(linearization)` an earlier draft's
   (wrong) bounds would have produced.
-- **`entities_left_unreconciled` counts case-2 skips**: reuse the
-  duplicate-`:introduced-by` fixture from the case-2 multi-value test
-  above; run `_correction_sweep_claim_and_process` over that commit; assert
-  the returned count reflects the skipped entity and that a stderr message
-  naming its ident was emitted — the direct test for the observability fix
-  (a run that skipped everything must not look identical to a clean run).
+- **`skipped_events` counts case-2 skips, one event per `(ident, commit)`
+  pair**: reuse the duplicate-`:introduced-by` fixture from the case-2
+  multi-value test above, arranged so the same stuck entity is also a
+  candidate at a second commit later in the range; run the sweep across
+  both commits; assert `skipped_events` is `2` (not `1`) — pinning that the
+  count is per-event, not per-entity, matching its documented semantics.
+- **Skip logging is capped, with a summary line**: construct a fixture with
+  more than 10 skip-triggering entities across the range; run
+  `_correction_sweep_walk`; assert stderr received at most 10 per-ident
+  lines plus exactly one summary line reporting the total, and that the
+  returned `skipped_events` count still reflects the true (uncapped) total
+  — the test that would fail against a naive implementation that either
+  logs unconditionally or caps the returned count along with the logging.
+- **`_correction_sweep_select_position` and `_correction_sweep_apply` are
+  independently callable and compose correctly**: call
+  `_correction_sweep_select_position` directly against a closed-gap graph,
+  feed its result's `commit_hash` into a real `_extract_commit` call, feed
+  that into `_correction_sweep_apply` directly, and assert the resulting
+  graph state is identical to what `_correction_sweep_claim_and_process`
+  produces for the same starting state — the test that pins the wrapper is
+  a faithful composition of the three independently-schedulable pieces,
+  not a distinct code path that could drift from them.

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -29,12 +29,14 @@ forward stream still owns lineage correctness.
   and writing provisional `:introduced-by` + candidate-diff records for
   every entity it discovers, moving the guess earlier whenever it finds an
   earlier occurrence of the same entity.
-- **2c (this spec)** — Stream 1's correction sweep: walks forward through
-  positions Stream 2 has *already* claimed provisional (tracked via
-  `:ingestion/lineage-confirmed-through` and frontier-high's current
-  boundary — **not** `allocator.claim_low()`, see "Why not `claim_low()`"
-  below), converting the provisional facts 2b wrote into authoritative ones
-  as it reaches them, using 2a's persisted candidate diffs for cheap replay
+- **2c (this spec)** — Stream 1's correction sweep: walks **upward**
+  (oldest→newest) through frontier-high's own already-claimed interval —
+  starting at its current `:lo-hash` and proceeding toward `HEAD` — using a
+  dedicated watermark for its own resumable progress (**not**
+  `:ingestion/lineage-confirmed-through`, and **not** `allocator.claim_low()`;
+  see "Why not `claim_low()`" and "Why a dedicated watermark" below),
+  converting the provisional facts 2b wrote into authoritative ones as it
+  reaches them, using 2a's persisted candidate diffs for cheap replay
   instead of re-parsing.
 - **2d** — the actual concurrency wiring inside `_run_ingestion`: two
   asyncio tasks sharing the frontier allocator and the existing single
@@ -50,31 +52,45 @@ and depends on 2b's exact candidate-diff/provisional-marker write pattern.
 
 In scope:
 
-- A per-commit correction step that advances a position tracker — the
-  commit immediately after `:ingestion/lineage-confirmed-through`, bounded
-  above (inclusive) by frontier-high's *current* `:lo-hash` — and, for
-  every entity touched by that commit's "A"/"M" files, reconciles its
-  lineage per the two-case algorithm below.
-- A thin driving loop that repeats the above until the tracker reaches
-  frontier-high's boundary, advancing `:ingestion/lineage-confirmed-through`
-  per commit. Frontier-low is deliberately never touched by this sweep (see
-  "Why not `claim_low()`" below).
-- Fixing 2b's documented known limitation: a retroactive `:modified-in` fact
-  written when a provisional guess is superseded does not re-check #221's
-  unchanged-body narrowing against the superseded commit's own diff. 2c has
-  both commits' persisted candidate-diff body hashes available and can
-  correct this without re-parsing.
+- A per-commit correction step that advances a dedicated position tracker
+  upward through frontier-high's own claimed interval — starting at its
+  current `:lo-hash` on first use, proceeding toward `HEAD` — and, for every
+  entity touched by that commit's "A"/"M" files, reconciles its lineage per
+  the two-case algorithm below.
+- A thin driving loop that repeats the above until the tracker reaches the
+  end of the linearization. Frontier-low is never touched by this sweep,
+  and neither is `:ingestion/lineage-confirmed-through` (see "Why a
+  dedicated watermark" below) — 2c introduces its own new watermark,
+  `:ingestion/correction-sweep-through`.
 - Opportunistically clearing stale intermediate candidate-diff records left
   behind along a supersession chain (2a's spec flagged this explicitly as
   "2c's job").
+- A guard against re-asserting `:modified-in` at an entity's own
+  introduction commit on a resumed/re-run sweep (see "Per-commit algorithm").
 
-Explicitly deferred (matches 2b's own scope cut):
+Explicitly deferred:
 
 - `:depends-on` edges, deletions ("D"), and renames ("R"). The existing
   `_run_ingestion` loop already has full support for these; this sweep
-  reuses the same `_extract_commit`/`_build_code_triples` entity-discovery
-  path 2b used and keeps the same `if status not in ("A", "M"): continue`
-  guard.
+  reuses the same `_extract_commit` entity-discovery path 2b used and keeps
+  the same `if status not in ("A", "M"): continue` guard.
+- **The "wrong provisional guess" reconciliation case** — an entity whose
+  *true* earliest occurrence lies below frontier-high's own claimed range
+  (in the still-unclaimed gap, or in frontier-low's territory) while Stream
+  2 guessed some commit *within* its own range as the introduction (a
+  rename- or rebirth-spanning-the-gap scenario). An earlier draft of this
+  spec included a reconciliation case for this inside the correction sweep
+  itself; that is wrong and has been removed — see "Why a dedicated
+  watermark, not `lineage-confirmed-through`" below for the proof that a
+  provisional guess pointing
+  anywhere other than the commit currently being visited cannot occur
+  *within* frontier-high's own already-claimed territory, walking
+  oldest-to-newest. The genuine reconciliation belongs to whichever walk
+  processes the entity's true earlier occurrence — an amendment to ordinary
+  forward-walk introduction logic (checking for and correcting a
+  pre-existing provisional guess when it discovers what turns out to be an
+  even-earlier occurrence), or a dedicated concern of 2d. Left as an
+  explicit open item for 2d, not resolved here.
 - Wiring into `_run_ingestion` / real concurrency (2d).
 
 ## Design
@@ -95,24 +111,11 @@ There is no sequence of `claim_low()` calls that returns a position Stream
 2 already claimed — the two streams race to shrink the *same* gap from
 opposite ends, they do not hand off territory to each other.
 
-That means the entire premise of cases 2 and 3 below — Stream 1 "reaching"
-a commit Stream 2 already wrote a provisional guess for — cannot happen via
-`claim_low()`. The positions this sweep needs to revisit are exactly the
-ones **already claimed** by Stream 2 (tagged provisional, `:introduced-by`
-facts already written), which lie in the frontier-high interval, not the
-gap. So the sweep needs its own, entirely separate position tracker, keyed
-off two already-existing watermarks instead of the allocator:
-
-- **Lower bound (exclusive)**: `:ingestion/lineage-confirmed-through`'s
-  current hash — everything up to and including this position is already
-  fully confirmed, by either the original single-stream walk or an earlier
-  pass of this sweep.
-- **Upper bound (inclusive)**: frontier-high's *current* `:lo-hash` (via
-  `_frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)`) — the lowest position
-  Stream 2 has claimed so far. The sweep never walks past this, since
-  anything below it either hasn't been claimed by Stream 2 yet (nothing to
-  correct) or belongs to frontier-low's own territory (never provisional in
-  the first place).
+The positions this sweep needs to revisit are exactly the ones **already
+claimed** by Stream 2 (tagged provisional, `:introduced-by` facts already
+written), which lie in the frontier-high interval, not the gap. So the
+sweep needs its own position tracker, entirely independent of the
+allocator.
 
 This does mean 2c is *not* a drop-in replacement for `claim_low()` as
 Stream 1's single per-commit call site — 2d will need to run both: ordinary
@@ -121,36 +124,89 @@ gap, and this sweep for already-claimed territory above it. That's an
 honest reflection of the allocator's actual semantics rather than a
 convenience this spec can assume away.
 
+### Why a dedicated watermark, not `lineage-confirmed-through`
+
+A second earlier draft of this spec bounded the sweep as `(lineage-
+confirmed-through, frontier-high.lo-hash]` — i.e. lower bound exclusive at
+`lineage-confirmed-through`, upper bound inclusive at frontier-high's
+current `:lo-hash`. That is also wrong, in two compounding ways:
+
+1. **The range pointed at the wrong territory.** `:ingestion/lineage-
+   confirmed-through` is seeded from frontier-**low**'s `:hi-hash`
+   (`_lineage_confirmed_through_migrate`, mcp_server.py:5145-5151) and, per
+   that draft, was advanced by nothing except this sweep. Frontier-high's
+   `:lo-hash` is the *bottom* of Stream 2's claimed interval — the boundary
+   closest to the gap, not deep inside claimed territory. Everything
+   strictly between those two watermarks is the shared **gap**: positions
+   *no* stream has claimed or processed at all. A range bounded this way
+   spans the gap and stops at the single position where frontier-high's
+   claimed territory begins, rather than walking through that territory.
+2. **The bound was backwards even ignoring (1).** The positions where "this
+   entity already has a fact from Stream 2" actually holds are
+   `[frontier-high.lo, N-1]` (`N-1` = the linearization's last position,
+   i.e. `HEAD`) — frontier-high's `:lo-hash` is the correct **floor**, not
+   a ceiling approached from below. `claim_high()` only ever moves
+   frontier-high's `:lo-hash` *down*, extending the interval; its `:hi-hash`
+   is always the fixed top of the linearization (`_extend`'s `from_low=False`
+   branch never touches `existing.hi_pos`). So once Stream 2 has claimed
+   anything at all, positions `[current lo-hash, N-1]` are *all* already
+   claimed and safe to walk — contiguously, with no further bounds-checking
+   needed once the walk starts.
+
+Because of (2), the sweep's own progress cannot be tracked by
+`lineage-confirmed-through` at all: that watermark specifically means "the
+region *contiguous from `C0`* is fully confirmed" (2a's trust predicate,
+below), and folding this sweep's progress into it before the gap is
+actually closed would assert lineage is confirmed through commits nothing
+has ingested yet. So 2c introduces its own watermark,
+`:ingestion/correction-sweep-through`, tracking only "how far *this sweep*
+has walked through frontier-high's own territory," with no claim about
+contiguity from `C0`. Folding the two watermarks together once the gap
+closes (so they describe one contiguous confirmed region again) is 2d's
+job, once it can also make the *ordinary* `claim_low()`-driven walk advance
+`lineage-confirmed-through` for the virgin positions it claims.
+
+**This is also what proves case 2 from an earlier draft (a provisional
+guess pointing at a commit other than the one currently being visited)
+cannot occur inside this sweep's range.** For a commit `C` Stream 2
+claimed, Stream 2 parsed the identical diff (the same invariant the
+per-commit algorithm below relies on) and — per its own per-commit
+algorithm — always moves a candidate's guess *down* to the earliest
+occurrence it has seen. So for any entity `C`'s files touch, Stream 2's
+final persisted guess is necessarily `<= C`'s position, never later. Walking
+`[frontier-high.lo, N-1]` oldest-to-newest, by induction: the sweep reaches
+each entity's true within-range-earliest occurrence *before* any later
+commit that also touches it, because that earliest occurrence's position is
+itself `<= C` for every later `C` — so by the time the sweep would ever
+visit a later `C` for that entity, the entity has already been confirmed
+(case 1, below) at its true earliest position and reads as authoritative,
+not provisional. A guess pointing at some *other*, unvisited commit while
+still provisional is therefore not a state this sweep's own walk can ever
+observe for a commit inside its range — see the "Explicitly deferred"
+bullet above for where that reconciliation actually belongs.
+
 ### Per-commit algorithm
 
-For a commit `C` in the sweep's range (positions processed strictly
-oldest→newest via the position tracker above), reusing the same per-file
-A/M walk `_extract_commit`/`_build_code_triples` that 2b uses for entity
-discovery/parsing (direction-agnostic):
+For a commit `C` at the sweep's current position (oldest→newest through
+frontier-high's territory), reusing `_extract_commit` for entity discovery
+(direction-agnostic, same as 2b) but **not** `_build_code_triples`:
 
-**2c never writes `C`'s own `:type/commit` entity.** Every commit within
-the sweep's range `[lineage-confirmed-through+1, frontier-high's current
-lo-hash]` was, by the range's own definition, already claimed by 2b's
-`claim_high()` and fully processed by `_reverse_fill_claim_and_process` —
-which writes its claimed commit's seven-attribute metadata block
-unconditionally, before its per-file loop even runs (mcp_server.py:7321-7329),
-regardless of whether that commit touches any code entity. So `C`'s commit
-entity is guaranteed to already exist with the correct metadata (including
-the same `:parent`-edge gap 2b itself has — not something 2c introduces or
-needs to fix). Re-`_transact`-ing the same commit attributes here would not
-just be redundant, it would create a duplicate live datom under minigraf's
-write semantics (the same hazard `_watermark_update` and every 2a/2b
-primitive already guards against with query-before-write) — so this sweep
-must not attempt it.
-
-For the same reason, **every candidate entity ident this sweep encounters
-is guaranteed to already have an `:introduced-by` fact.** Stream 2 parses
-the identical diff for `C` via the same `_extract_commit` call when it
-claims `C`, so any entity `C`'s "A"/"M" files touch was necessarily also
-discovered by Stream 2's own processing of `C` and got at least a
-provisional `:introduced-by` (2b's own "no fact yet" branch). There is no
-entity-discovery case symmetric to 2b's "no fact yet" branch for this
-sweep to handle:
+**2c never writes `C`'s own `:type/commit` entity, and never calls
+`_build_code_triples`.** Every commit in the sweep's range was already
+claimed by 2b's `claim_high()` and fully processed by
+`_reverse_fill_claim_and_process`, which writes its claimed commit's
+seven-attribute metadata block unconditionally (mcp_server.py:7321-7329)
+and, for every entity an "A"/"M" file touches, writes either full
+structural triples (first sighting) or nothing but `:introduced-by`
+(2b filters `:modified-in` out of `_build_code_triples`'s own output and
+owns that timing itself) — so by the time this sweep visits `C`, every
+candidate entity ident it will find is *already* structurally complete and
+already has an `:introduced-by` fact. Calling `_build_code_triples` here
+would therefore be dead code: for a *known* entity it emits nothing but
+`:modified-in` (mcp_server.py:6505-6562), which this sweep would then have
+to filter back out anyway, exactly as 2b does for `:introduced-by`. So this
+sweep skips straight to per-ident classification, using `precomputed`
+directly:
 
 ```python
 candidate_idents = (
@@ -160,91 +216,116 @@ candidate_idents = (
     + [ident for ident, _name, _t in precomputed["global_entries"]]
     + [ident for ident, _name, _t in precomputed["field_entries"]]
 )
-known_before = {
-    ident: "known" for ident in candidate_idents
-    if _entity_introduced_by_query(db, ident) is not None
-}
-triples = _build_code_triples(
-    file_path, extracted, commit_ts_iso, known_before, {}, {}, commit_ident,
-    precomputed, {}, {},
-)
-# This sweep owns the write timing of both attributes, same reason 2b does.
-all_triples.extend(t for t in triples if ":introduced-by" not in t and ":modified-in" not in t)
+unchanged_idents = precomputed.get("unchanged_idents", set())
 ```
 
-`known_before` is still built and passed through exactly as shown — it is
-what makes `_build_code_triples` skip re-emitting structural triples
-(`:entity-type`/`:description`/`:file`/`:contains`) for entities 2b already
-wrote structurally, which is real and necessary. It is only the *case
-classification* below that no longer needs a "not in known_before" branch,
-because that branch is unreachable given the invariant above — so, unlike
-2b, this sweep does **not** need a `known_before_snapshot` taken before the
-`_build_code_triples` call: nothing here depends on `known_before`'s
-pre-call membership, only on `_lineage_is_provisional`/
-`_entity_introduced_by_query`, queried independently per ident below.
-
-Each candidate ident then falls into exactly one of two cases:
+Each candidate ident then falls into one of two cases. Every write below
+uses `C`'s own `commit_ts_iso` (the same timestamp 2b itself used when it
+first wrote at `C`) — this equality is load-bearing, not incidental: it is
+what makes any write this sweep re-issues at a position 2b already touched
+land as an idempotent no-op under minigraf's real write semantics (an
+identical `(entity, attribute, value, valid_from)` tuple is a no-op; only a
+*differing* `valid_from` produces a second live datom) rather than a
+duplicate.
 
 1. **Provisional, guess matches this commit**
    (`_lineage_is_provisional(db, ident)` and
-   `_entity_introduced_by_query(db, ident) == commit_ident`) — the expected
-   case once Stream 2 has fully walked the range down to `C`: by
-   construction, Stream 2's final guess for any entity within a range it
-   has completely traversed already equals that entity's true earliest
-   occurrence in that range. Call `_lineage_confirm(db, ident)` (drops the
+   `_entity_introduced_by_query(db, ident) == commit_ident`) — per "Why a
+   dedicated watermark" above, this is the *only* state a provisional
+   entity can be in in this sweep's range once the sweep reaches it: Stream
+   2's guess is guaranteed to already equal its true within-range-earliest
+   occurrence by the time this sweep, walking the same order, gets there.
+   Call `_lineage_confirm(db, ident, index_con=index_con)` (drops the
    marker; the `:introduced-by` fact itself is untouched, since its value
-   was already correct) and `_candidate_diff_clear(db, commit_hash, ident)`.
-   No `:modified-in`.
+   was already correct) and `_candidate_diff_clear(db, commit_hash, ident,
+   index_con=index_con)`. No `:modified-in`.
 
-2. **Provisional, guess points elsewhere**
-   (`_lineage_is_provisional(db, ident)` and
-   `_entity_introduced_by_query(db, ident) != commit_ident`) — the
-   reconciliation case 2a's spec reserved for 2c (rename- or
-   rebirth-spanning-the-gap; out of scope for both 2b and 2c to *detect*
-   structurally, but 2c corrects the resulting lineage once it reaches the
-   entity's real introduction here). Let `guessed_ident` be the current
-   (wrong) value:
-   - Retract `[ident :introduced-by guessed_ident]`, assert
-     `[ident :introduced-by commit_ident]` directly as authoritative (no
-     provisional marker — 2c is ground truth), then `_lineage_confirm(db,
-     ident)` to drop the marker 2b left behind.
-   - Give `guessed_ident` a retroactive `:modified-in` fact using **its
-     own** commit timestamp (looked up from `commit_metadata` via the same
-     `ts_by_commit_ident = {f":commit/{h[:12]}": ts for h, ts, _a, _s in
-     commit_metadata}` mapping 2b's step 3 builds) — **unless both**
-     `_candidate_diff_read(db, guessed_hash, ident)` and
-     `precomputed["body_hashes"].get(ident)` are non-`None` **and** equal,
-     meaning the body was actually unchanged between the two commits. This
-     is the fix for 2b's documented limitation, using the persisted hash
-     instead of re-parsing `guessed_ident`'s own diff. The comparison must
-     fail open (assert `:modified-in` conservatively) whenever either side
-     is `None` — `precomputed["body_hashes"]` deliberately excludes modules
-     (mcp_server.py:6414, function/class/variable/field only) and can be
-     empty on a parse/hash failure, so a bare `==` comparison would treat
-     module idents (and any hash-failure case) as "unchanged" via a
-     `None == None` false positive and wrongly suppress a real edit.
-     `guessed_hash` is recovered directly from `guessed_ident` by stripping
-     its `":commit/"` prefix (`guessed_ident[9:]`) — sufficient because
-     `_candidate_diff_ident` only ever keys on `commit_hash[:12]`, which is
-     exactly what `commit_ident` already truncated to when 2b minted it, so
-     no separate hash→ident reverse lookup is needed.
-   - `_candidate_diff_clear` both `(commit_hash, ident)` and
-     `(guessed_hash, ident)`.
+2. **Already authoritative** (confirmed at an earlier position in this same
+   sweep, or — after this sweep has fully caught up once — simply revisited
+   on a later run) — first check whether `C` *is* this entity's own
+   introduction commit: if `_entity_introduced_by_query(db, ident) ==
+   commit_ident`, skip entirely (no `:modified-in`, no candidate-diff
+   touch). This guard matters for resume-safety: if the process dies after
+   case 1's `_lineage_confirm` but before `_correction_sweep_through_update`
+   persists, a re-run revisits `C` and would otherwise find the
+   now-authoritative entity at its own introduction commit and wrongly
+   assert a self-`:modified-in` — a fact class ordinary forward walk never
+   produces (`_build_code_triples` only emits `:modified-in` on its
+   already-known branch, never at introduction). Otherwise: assert
+   `[ident :modified-in commit_ident]` at `C`'s own `commit_ts_iso`, unless
+   `ident in unchanged_idents` (#221, unmodified this commit). Either way,
+   opportunistically call `_candidate_diff_clear(db, commit_hash, ident,
+   index_con=index_con)` if a record happens to exist for this exact
+   `(commit, ident)` pair — this is what cleans up the *intermediate* stale
+   records 2b's own spec left behind along a supersession chain (guess
+   moves `L3 → L2 → L1 → C`; case 1 clears `C`'s own record when the sweep
+   reaches `C`; each of `L1`/`L2`/`L3` falls into this case when the sweep
+   later reaches them, and each still has its own now-orphaned
+   candidate-diff record from when it was a transient guess). No
+   special-casing was needed for that cleanup — it falls out of the
+   ordinary path once the sweep passes back over those commits.
 
-3. **Already authoritative** (confirmed earlier in this same sweep, or
-   introduced by the original single-stream walk before #222 existed) — the
-   ordinary "already known" case: assert `[ident :modified-in commit_ident]`
-   unless `precomputed["unchanged_idents"]` says the body is provably
-   unchanged this commit (#221, unmodified). Additionally, opportunistically
-   call `_candidate_diff_clear(db, commit_hash, ident)` if a record happens
-   to exist for this exact `(commit, ident)` pair — this is what cleans up
-   the *intermediate* stale records 2b's own spec left behind along a
-   supersession chain (guess moves `L3 → L2 → L1 → C`; case 1 clears `C`'s
-   own record when the sweep reaches `C`; each of `L1`/`L2`/`L3` falls into
-   this case when the sweep later reaches them, and each still has its own
-   now-orphaned candidate-diff record from when it was a transient guess).
-   No special-casing was needed for this — it falls out of the ordinary
-   path once the sweep passes back over those commits.
+### Position tracker: `:ingestion/correction-sweep-through`
+
+A new watermark, structurally identical to `:ingestion/lineage-confirmed-
+through` (`_lineage_confirmed_through_update`'s exact shape: registered
+`:type/ingestion`, same retract-only-if-changed pattern, same required
+`:description` constant) but tracking a different thing — this sweep's own
+progress, independent of contiguity from `C0`:
+
+```python
+_CORRECTION_SWEEP_THROUGH_IDENT = ":ingestion/correction-sweep-through"
+
+def _correction_sweep_through_query(db: Any) -> Optional[str]:
+    """Return the hash of the last commit this sweep has itself confirmed/
+    corrected, or None if it has never successfully processed one yet."""
+
+def _correction_sweep_through_update(
+    db: Any, commit_hash: str, commit_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Record the last commit this sweep processed. Mirrors
+    _lineage_confirmed_through_update's retract-only-if-changed pattern
+    exactly, at a different ident."""
+```
+
+Position selection, handling both ends being possibly absent or stale:
+
+```python
+high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
+if high_bounds is None:
+    return None  # Stream 2 hasn't claimed anything yet -- nothing to correct
+hash_to_pos = {h: i for i, h in enumerate(linearization)}
+through_hash = _correction_sweep_through_query(db)
+if through_hash is not None and through_hash in hash_to_pos:
+    pos = hash_to_pos[through_hash] + 1
+else:
+    # Unset (first-ever call), or a stale hash from rewritten/rebased
+    # history -- (re)start from frontier-high's current lo-hash, mirroring
+    # _frontier_load's own precedent of dropping a bound that no longer
+    # resolves (mcp_server.py:4970-4978) rather than erroring.
+    lo_hash, _hi_hash = high_bounds
+    if lo_hash not in hash_to_pos:
+        return None  # frontier-high itself is stale; nothing safe to do
+    pos = hash_to_pos[lo_hash]
+if pos >= len(linearization):
+    return None  # reached HEAD; nothing left to correct
+commit_hash = linearization[pos]
+commit_ts_iso = next(ts for h, ts, _a, _s in commit_metadata if h == commit_hash)
+```
+
+Once `pos` is known to be `>= frontier-high.lo`'s position at the time this
+call started, the walk needs no further bounds-checking against
+frontier-high for the rest of its run: `[frontier-high.lo, N-1]` only ever
+grows (frontier-high's `:hi-hash` is fixed at `N-1`, and `:lo-hash` only
+moves further down), so every position from the sweep's own resume point
+onward through `N-1` is guaranteed already claimed regardless of how far
+Stream 2 has additionally progressed since.
+
+After processing `C`: `_correction_sweep_through_update(db, commit_hash,
+commit_ts_iso, index_con=index_con)`, then one `_db_checkpoint(db)` call —
+same cadence as 2b. Frontier-low and `:ingestion/lineage-confirmed-through`
+are never touched by this sweep (see "Why a dedicated watermark" above for
+why folding into the latter is explicitly deferred to 2d).
 
 ### Driving functions
 
@@ -257,19 +338,17 @@ def _correction_sweep_claim_and_process(
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
 ) -> Optional[str]:
-    """Advance the correction sweep by exactly one commit past
-    :ingestion/lineage-confirmed-through and reconcile that commit's
+    """Advance the correction sweep by exactly one commit, upward through
+    frontier-high's own claimed territory, and reconcile that commit's
     entities per the two-case algorithm above. Returns the processed
-    commit's hash, or None if the tracker has already reached frontier-
-    high's current lo-hash (nothing left to correct against what Stream 2
-    has claimed so far), or if frontier-high hasn't claimed anything yet.
-    No `allocator` parameter -- this reads frontier-high's persisted bounds
-    directly via _frontier_read_bounds, not the allocator's claim_low(); see
-    "Why not claim_low()" above. Writes are followed by exactly one
-    _db_checkpoint(db) call, after _lineage_confirmed_through_update records
-    the advance -- mirrors _reverse_fill_claim_and_process's
-    one-checkpoint-per-commit cadence. Never calls _frontier_persist_claim:
-    frontier-low is not touched by this sweep."""
+    commit's hash, or None if there is nothing left to correct (frontier-
+    high hasn't claimed anything yet, or the sweep has already reached
+    HEAD). No `allocator` parameter -- this reads frontier-high's persisted
+    bounds directly via _frontier_read_bounds and tracks its own progress
+    via _correction_sweep_through_query/_update, not the allocator's
+    claim_low(); see "Why not claim_low()" above. Never calls
+    _frontier_persist_claim or _lineage_confirmed_through_update -- neither
+    frontier-low nor lineage-confirmed-through is touched by this sweep."""
 
 def _correction_sweep_walk(
     db: Any,
@@ -286,39 +365,22 @@ def _correction_sweep_walk(
     introduction for territory below the gap."""
 ```
 
-### Frontier + watermark advancement
-
-Each processed commit calls `_lineage_confirmed_through_update(db,
-commit_hash, commit_ts_iso, index_con=index_con)` — **and nothing else**.
-Unlike an earlier draft of this spec, `_frontier_persist_claim(...,
-from_low=True, ...)` is never called: `C` already lies inside frontier-
-high's persisted interval (that's the sweep's own range invariant), and
-extending frontier-low's `:hi-hash` onto a position frontier-high's
-`:lo-hash` also covers would make the two persisted intervals overlap —
-`_frontier_load`'s reconstruction has no defined behavior for that (`
-FrontierAllocator._interval_covering` returns whichever interval it checks
-first), and `gap_lo`/`gap_hi` would no longer describe a coherent gap. This
-is exactly the confusion "Why not `claim_low()`" above already ruled out at
-the allocator-call level; not calling `_frontier_persist_claim` here is the
-same rule applied to the lower-level persistence helper directly, since
-nothing stops it from being called with an arbitrary position otherwise.
-`:ingestion/lineage-confirmed-through` is the sole watermark this sweep
-advances, matching 2a's spec: the composed trust predicate it defines
-(`_lineage_is_provisional(entity)` is `False` **and** the entity's
-`:introduced-by` position is `<=` `lineage-confirmed-through`'s position)
-never references frontier-low at all. One `_db_checkpoint(db)` call per
-commit, after the watermark update, same cadence as 2b.
-
 ### Schema/audit safety, idempotency
 
-No new entity types or attributes — 2c is purely a new consumer of 2a's
-already-audited-safe primitives (`_lineage_confirm`/`_candidate_diff_clear`
-already established their own safety in 2a's spec) plus the existing
-`:introduced-by`/`:modified-in` attributes forward walk always used. Every
-write in the two-case algorithm is either a query-before-write primitive
-already built in 2a/2b, or a direct `_transact`/`_retract` pair gated on a
-query result (case 2's direct authoritative assert) — never a blind
-unconditional transact.
+One new entity type, `:ingestion/correction-sweep-through`, reusing the
+already-registered/audited `:type/ingestion` type exactly as
+`:ingestion/lineage-confirmed-through` does — no new schema surface. Case
+1's writes are the same query-before-write primitives 2a/2b already
+established as safe (`_lineage_confirm`, `_candidate_diff_clear`). Case 2's
+`:modified-in` assert, once its guard passes, *is* an unconditional
+`_transact` — it is safe not because of a query-before-write guard but
+because it always uses `C`'s own `commit_ts_iso`, matching what forward
+walk (or 2b, if `C` happens to already carry other facts from it) would
+have used at the same position, so a re-issued write lands as an idempotent
+no-op rather than a duplicate (see "Per-commit algorithm" above). This is
+worth stating plainly rather than leaving implicit, since it is the one
+write in this design that depends on timestamp discipline rather than a
+guard for its safety.
 
 ## Testing
 
@@ -331,71 +393,76 @@ facts:
 
 - **Confirms a correct provisional guess** (case 1): run
   `_reverse_bulk_fill_walk` first so an entity ends up with a provisional
-  `:introduced-by` pointing at its true earliest commit; then run the
-  correction sweep; assert `_lineage_is_provisional` is now `False`, the
-  `:introduced-by` value is unchanged, and the candidate-diff record for
-  that `(commit, entity)` is gone (`_candidate_diff_read` returns `None`).
-- **Does not re-write the claimed commit's metadata**: same setup as above;
-  before running the sweep, capture the claimed commit entity's live facts
-  (`:hash`/`:author`/`:subject`/`:date`) as written by
-  `_reverse_bulk_fill_walk`; run the sweep; assert those facts are
-  byte-for-byte unchanged and, via a raw fact-count query, that no
-  duplicate `:hash`/`:subject`/etc. datom was created — this is the
-  regression test for the bug an earlier draft of this spec would have
-  introduced by unconditionally re-`_transact`-ing commit metadata 2b
-  already wrote.
-- **Reconciles a wrong provisional guess** (case 2): hand-construct a
-  provisional `:introduced-by` pointing at the *wrong* (later) commit for
-  an entity that's also genuinely present at an earlier commit the sweep
-  will reach, simulating the rename/rebirth edge case; run the sweep;
-  assert `:introduced-by` now points at the true earlier commit, is
-  authoritative, and the superseded commit received a retroactive
-  `:modified-in` with its own timestamp.
-- **Skips the retroactive `:modified-in` when the body is unchanged**
-  (case 2's #221 fix): same setup as above, but with matching body hashes
-  persisted at both the superseded and the true-introduction commits;
-  assert no `:modified-in` fact was written for the superseded commit —
-  this is the test that would fail against 2b's own documented limitation
-  if 2c naively reused its unconditional-assert behavior.
-- **Fails open when a body hash is missing** (case 2's fail-open guard):
-  same reconciliation setup as above, but for a *module* ident (which
-  `precomputed["body_hashes"]` never populates) so both the persisted
-  candidate-diff hash and the current body hash are `None`; assert the
-  retroactive `:modified-in` is still written — this is the test that would
-  catch a naive `==` comparison treating the `None == None` case as
-  "unchanged" and wrongly suppressing a real edit.
-- **Ordinary modification of an already-authoritative entity** (case 3): an
-  entity already authoritative (pre-seeded, non-provisional); sweep over a
-  commit that touches it; assert `:modified-in` is added and no lineage
-  marker exists.
-- **Opportunistic stale candidate-diff cleanup** (case 3): pre-seed a stale
+  `:introduced-by` pointing at its true earliest commit within Stream 2's
+  claimed range; then run the correction sweep; assert
+  `_lineage_is_provisional` is now `False`, the `:introduced-by` value is
+  unchanged, and the candidate-diff record for that `(commit, entity)` is
+  gone (`_candidate_diff_read` returns `None`).
+- **Does not duplicate the claimed commit's metadata**: same setup as
+  above; before running the sweep, capture the claimed commit entity's
+  total live fact count and its `:hash`/`:author`/`:subject`/`:date`
+  values as written by `_reverse_bulk_fill_walk`; run the sweep; assert the
+  fact count is unchanged and none of those attributes was re-asserted at a
+  *different* `valid_from` — this is the regression test that can actually
+  distinguish a correct implementation (skips the write, or re-issues it
+  idempotently at the same `commit_ts_iso`) from one that writes it at a
+  different timestamp and produces a second live datom.
+- **Skips `:modified-in` at an entity's own introduction commit on a
+  resumed sweep** (case 2's guard): run the correction sweep once so an
+  entity is confirmed authoritative at its true introduction commit; call
+  `_correction_sweep_claim_and_process` again as if resuming after a crash
+  (i.e. without having advanced `_correction_sweep_through_update` past
+  that commit — construct this directly rather than via the real crash
+  path, mirroring how other resume tests in this codebase re-invoke a step
+  function against pre-set state); assert no `:modified-in` fact was
+  created for that entity at its own introduction commit — this is the
+  test that would fail against a naive implementation of case 2 with no
+  self-introduction guard.
+- **Ordinary modification of an already-authoritative entity** (case 2, the
+  general path): an entity already authoritative at some earlier commit
+  (pre-seeded via a real earlier sweep pass, non-provisional); sweep over a
+  later commit that touches it; assert `:modified-in` is added at that
+  later commit and no lineage marker exists.
+- **Opportunistic stale candidate-diff cleanup** (case 2): pre-seed a stale
   candidate-diff record at a commit for an entity that's already
   authoritative by the time the sweep reaches that commit (simulating an
   orphaned intermediate guess along a supersession chain); assert the sweep
-  clears it even though that commit falls into the ordinary case-3 path.
+  clears it even though that commit falls into the ordinary case-2 path.
 - **No-op when frontier-high hasn't claimed anything yet**: a graph with
   only frontier-low/migration state, no `_reverse_bulk_fill_walk` ever run;
   assert `_correction_sweep_claim_and_process` returns `None` and writes
   nothing.
-- **No-op when the sweep has already caught up**: run
-  `_correction_sweep_walk` to exhaustion over a range Stream 2 has claimed;
+- **Resumes from `correction-sweep-through` on a second call, not from
+  frontier-high's lo-hash again**: run the sweep once (processes frontier-
+  high's then-current lo-hash), then claim one more position via
+  `_reverse_fill_claim_and_process` so frontier-high's lo-hash moves further
+  down; call the correction sweep again; assert it processes the position
+  immediately after where it left off (one above its previous stopping
+  point), not frontier-high's new (lower) lo-hash — proving the dedicated
+  watermark, not frontier-high's current bound, drives resumption.
+- **No-op when the sweep has already reached `HEAD`**: run
+  `_correction_sweep_walk` to exhaustion over the whole claimed range;
   assert a further call to `_correction_sweep_claim_and_process` still
-  returns `None` (lineage-confirmed-through has reached frontier-high's
-  lo-hash) rather than erroring or re-processing the last commit.
-- **Frontier-low is never touched**: capture frontier-low's persisted
-  interval before running `_correction_sweep_walk`; run it; assert
-  frontier-low's persisted `:lo-hash`/`:hi-hash` are byte-for-byte
-  unchanged afterward, while `_lineage_confirmed_through_query` has
-  advanced — the direct regression test for the bug this spec's `claim_low()`
-  draft would have introduced (see "Why not `claim_low()`").
+  returns `None` rather than erroring or re-processing the last commit.
+- **Falls back to frontier-high's current lo-hash when the stored
+  `correction-sweep-through` hash is stale**: seed
+  `:ingestion/correction-sweep-through` with a hash not present in a fresh
+  `linearization` (simulating rewritten/rebased history); assert the sweep
+  restarts from frontier-high's current lo-hash rather than erroring.
+- **Frontier-low and `lineage-confirmed-through` are never touched**:
+  capture frontier-low's persisted interval and
+  `_lineage_confirmed_through_query`'s value before running
+  `_correction_sweep_walk`; run it; assert both are byte-for-byte unchanged
+  afterward, while `_correction_sweep_through_query` has advanced — the
+  direct regression test for the bugs both "Why not `claim_low()`" and "Why
+  a dedicated watermark" describe.
 - **Full integration**: call `_reverse_fill_claim_and_process` a fixed
-  number of times directly (not `_reverse_bulk_fill_walk` to exhaustion —
-  leaving a non-trivial gap below Stream 2's claimed territory, position
-  `P`, is what makes this a meaningful test of the sweep's own bounds, not
-  just its logic) so Stream 2 claims down to `P` but no further; then run
-  `_correction_sweep_walk`; assert every entity touched at or above `P`
-  ends up authoritative (`_lineage_is_provisional` is `False` for all of
-  them), no `:type/candidate-diff` entities remain live, and
-  `_lineage_confirmed_through_query` now equals `P`'s hash — proving the
-  sweep's own upper bound (frontier-high's lo-hash) was respected, not
-  walked past.
+  number of times directly (not `_reverse_bulk_fill_walk` to exhaustion) so
+  Stream 2 claims down to some position `P` within a larger history, then
+  run `_correction_sweep_walk` to exhaustion; assert every entity touched
+  at or above `P` ends up authoritative (`_lineage_is_provisional` is
+  `False` for all of them), no `:type/candidate-diff` entities remain live,
+  and `_correction_sweep_through_query` now equals `HEAD`'s hash — proving
+  the sweep correctly walks all the way through frontier-high's claimed
+  territory, not just the single position an earlier draft's (wrong) bound
+  would have stopped at.

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -29,10 +29,13 @@ forward stream still owns lineage correctness.
   and writing provisional `:introduced-by` + candidate-diff records for
   every entity it discovers, moving the guess earlier whenever it finds an
   earlier occurrence of the same entity.
-- **2c (this spec)** — Stream 1's correction sweep: claims positions via
-  `allocator.claim_low()`, converting the provisional facts 2b wrote into
-  authoritative ones as it reaches them, using 2a's persisted candidate
-  diffs for cheap replay instead of re-parsing.
+- **2c (this spec)** — Stream 1's correction sweep: walks forward through
+  positions Stream 2 has *already* claimed provisional (tracked via
+  `:ingestion/lineage-confirmed-through` and frontier-high's current
+  boundary — **not** `allocator.claim_low()`, see "Why not `claim_low()`"
+  below), converting the provisional facts 2b wrote into authoritative ones
+  as it reaches them, using 2a's persisted candidate diffs for cheap replay
+  instead of re-parsing.
 - **2d** — the actual concurrency wiring inside `_run_ingestion`: two
   asyncio tasks sharing the frontier allocator and the existing single
   write_executor, with fairness so neither starves.
@@ -47,14 +50,15 @@ and depends on 2b's exact candidate-diff/provisional-marker write pattern.
 
 In scope:
 
-- A per-commit correction step that claims one position from the gap's low
-  end (`FrontierAllocator.claim_low()`) and, for every entity touched by
-  that commit's "A"/"M" files, reconciles its lineage per the four-case
-  algorithm below.
-- A thin driving loop that repeats the above until the gap closes and
-  persists each claim via `_frontier_persist_claim`, keeping
-  `:ingestion/lineage-confirmed-through` in lockstep with frontier-low's
-  advancement.
+- A per-commit correction step that advances a position tracker — the
+  commit immediately after `:ingestion/lineage-confirmed-through`, bounded
+  above (inclusive) by frontier-high's *current* `:lo-hash` — and, for
+  every entity touched by that commit's "A"/"M" files, reconciles its
+  lineage per the two-case algorithm below.
+- A thin driving loop that repeats the above until the tracker reaches
+  frontier-high's boundary, advancing `:ingestion/lineage-confirmed-through`
+  per commit. Frontier-low is deliberately never touched by this sweep (see
+  "Why not `claim_low()`" below).
 - Fixing 2b's documented known limitation: a retroactive `:modified-in` fact
   written when a provisional guess is superseded does not re-check #221's
   unchanged-body narrowing against the superseded commit's own diff. 2c has
@@ -75,66 +79,78 @@ Explicitly deferred (matches 2b's own scope cut):
 
 ## Design
 
-### Why `claim_low()`, not a hand-rolled position tracker
+### Why not `claim_low()`
 
-Phase 1's `FrontierAllocator` already models exactly the invariant this
-sweep needs: `claim_low()` returns the next unclaimed position from the low
-end, and returns `None` once the gap is closed (i.e. frontier-low's
-advancing boundary has met frontier-high's current boundary). Using it
-directly means:
+An earlier draft of this spec used `allocator.claim_low()` to drive the
+sweep. That is wrong, and worth recording why: `claim_low()` and
+`claim_high()` partition a *single shared gap* — each call extends its own
+side's interval by exactly the position at that side's edge
+(`frontier_registry.py`'s `gap_lo`/`gap_hi`/`_extend`), and a position
+absorbed into one side's interval is never again returned by the other
+side's claim method. Once Stream 2 has claimed a position via
+`claim_high()`, that position is permanently part of the high (provisional)
+interval; `claim_low()` will only ever hand Stream 1 positions strictly
+below the current gap, which by definition Stream 2 has never touched.
+There is no sequence of `claim_low()` calls that returns a position Stream
+2 already claimed — the two streams race to shrink the *same* gap from
+opposite ends, they do not hand off territory to each other.
 
-- The sweep never walks past ground Stream 2 has actually covered — its
-  termination *is* "reached the point where Stream 2 already provisionally
-  covered ground," expressed through the allocator instead of a manually
-  computed bound.
-- It reuses already-tested machinery (`_frontier_persist_claim`,
-  `FrontierAllocator.claim_low`) instead of introducing a second, parallel
-  notion of "how far has Stream 1 gotten."
-- It sets 2c up to become Stream 1's one true per-commit step in 2d: the
-  four-case algorithm below is a strict generalization of ordinary forward
-  walk (case 1 degenerates to exactly today's `_build_code_triples`
-  introduction path when nothing is provisional), so 2d does not need two
-  separate code paths for "virgin territory" vs. "correcting Stream 2's
-  work" — a single call site suffices once concurrency is wired.
+That means the entire premise of cases 2 and 3 below — Stream 1 "reaching"
+a commit Stream 2 already wrote a provisional guess for — cannot happen via
+`claim_low()`. The positions this sweep needs to revisit are exactly the
+ones **already claimed** by Stream 2 (tagged provisional, `:introduced-by`
+facts already written), which lie in the frontier-high interval, not the
+gap. So the sweep needs its own, entirely separate position tracker, keyed
+off two already-existing watermarks instead of the allocator:
+
+- **Lower bound (exclusive)**: `:ingestion/lineage-confirmed-through`'s
+  current hash — everything up to and including this position is already
+  fully confirmed, by either the original single-stream walk or an earlier
+  pass of this sweep.
+- **Upper bound (inclusive)**: frontier-high's *current* `:lo-hash` (via
+  `_frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)`) — the lowest position
+  Stream 2 has claimed so far. The sweep never walks past this, since
+  anything below it either hasn't been claimed by Stream 2 yet (nothing to
+  correct) or belongs to frontier-low's own territory (never provisional in
+  the first place).
+
+This does mean 2c is *not* a drop-in replacement for `claim_low()` as
+Stream 1's single per-commit call site — 2d will need to run both: ordinary
+`claim_low()`-driven introduction for genuinely virgin territory below the
+gap, and this sweep for already-claimed territory above it. That's an
+honest reflection of the allocator's actual semantics rather than a
+convenience this spec can assume away.
 
 ### Per-commit algorithm
 
-For a claimed commit `C` (positions processed strictly oldest→newest via
-repeated `claim_low()` calls), reusing the same per-file A/M walk
-`_extract_commit`/`_build_code_triples` that 2b uses for entity
+For a commit `C` in the sweep's range (positions processed strictly
+oldest→newest via the position tracker above), reusing the same per-file
+A/M walk `_extract_commit`/`_build_code_triples` that 2b uses for entity
 discovery/parsing (direction-agnostic):
 
-Before any per-file work, `all_triples` is seeded with the claimed commit's
-own `:type/commit` entity — this sweep processes commits `_reverse_fill_claim_and_process`
-never touched (it claims from the *low* end of the gap; 2b only ever claims
-from the high end), so unlike case 3's `guessed_ident` handling, which
-targets a commit 2b already wrote, the commit metadata for `C` itself does
-not exist yet and must be written here, identically to 2b's own shape:
+**2c never writes `C`'s own `:type/commit` entity.** Every commit within
+the sweep's range `[lineage-confirmed-through+1, frontier-high's current
+lo-hash]` was, by the range's own definition, already claimed by 2b's
+`claim_high()` and fully processed by `_reverse_fill_claim_and_process` —
+which writes its claimed commit's seven-attribute metadata block
+unconditionally, before its per-file loop even runs (mcp_server.py:7321-7329),
+regardless of whether that commit touches any code entity. So `C`'s commit
+entity is guaranteed to already exist with the correct metadata (including
+the same `:parent`-edge gap 2b itself has — not something 2c introduces or
+needs to fix). Re-`_transact`-ing the same commit attributes here would not
+just be redundant, it would create a duplicate live datom under minigraf's
+write semantics (the same hazard `_watermark_update` and every 2a/2b
+primitive already guards against with query-before-write) — so this sweep
+must not attempt it.
 
-```python
-all_triples: List[str] = [
-    f"[{commit_ident} :entity-type :type/commit]",
-    f'[{commit_ident} :ident "{commit_ident}"]',
-    f'[{commit_ident} :description "{_edn_escape(subject[:120])}"]',
-    f'[{commit_ident} :hash "{commit_hash}"]',
-    f'[{commit_ident} :author "{_edn_escape(author)}"]',
-    f'[{commit_ident} :subject "{_edn_escape(subject[:200])}"]',
-    f'[{commit_ident} :date "{commit_ts_iso}"]',
-]
-```
-
-`:parent` edges are explicitly deferred, matching 2b's own precedent — 2b's
-`_reverse_fill_claim_and_process` writes the same seven commit attributes
-above and also does not write `:parent` (mcp_server.py:7321-7329). Both
-streams currently leave every commit they claim without a `:parent` edge;
-only ordinary forward walk (`_run_ingestion`, mcp_server.py:7982) writes it
-today. This is a known gap shared by 2b and 2c, not something 2c introduces
-new — 2d must decide how (or whether) to backfill `:parent` for commits
-either stream claims once concurrency is wired, since that's the point at
-which the frontier's authoritative region stops corresponding 1:1 with
-"ordinary forward walk processed it."
-
-Per-file candidate discovery then proceeds:
+For the same reason, **every candidate entity ident this sweep encounters
+is guaranteed to already have an `:introduced-by` fact.** Stream 2 parses
+the identical diff for `C` via the same `_extract_commit` call when it
+claims `C`, so any entity `C`'s "A"/"M" files touch was necessarily also
+discovered by Stream 2's own processing of `C` and got at least a
+provisional `:introduced-by` (2b's own "no fact yet" branch). There is no
+entity-discovery case symmetric to 2b's "no fact yet" branch for this
+sweep to handle:
 
 ```python
 candidate_idents = (
@@ -148,14 +164,6 @@ known_before = {
     ident: "known" for ident in candidate_idents
     if _entity_introduced_by_query(db, ident) is not None
 }
-# Snapshot BEFORE calling _build_code_triples -- it mutates known_before in
-# place (its entity_valid_from parameter), inserting every newly introduced
-# ident as a side effect of building that ident's own structural triples.
-# Classifying case 1 against the post-call dict would therefore find every
-# fresh introduction already "known" and skip its authoritative
-# :introduced-by write entirely. Same reason 2b takes a snapshot
-# (mcp_server.py:7351) before its own equivalent call.
-known_before_snapshot = set(known_before.keys())
 triples = _build_code_triples(
     file_path, extracted, commit_ts_iso, known_before, {}, {}, commit_ident,
     precomputed, {}, {},
@@ -164,20 +172,20 @@ triples = _build_code_triples(
 all_triples.extend(t for t in triples if ":introduced-by" not in t and ":modified-in" not in t)
 ```
 
-Each candidate ident then falls into exactly one of four cases, classified
-against `known_before_snapshot` (never the post-call `known_before`):
+`known_before` is still built and passed through exactly as shown — it is
+what makes `_build_code_triples` skip re-emitting structural triples
+(`:entity-type`/`:description`/`:file`/`:contains`) for entities 2b already
+wrote structurally, which is real and necessary. It is only the *case
+classification* below that no longer needs a "not in known_before" branch,
+because that branch is unreachable given the invariant above — so, unlike
+2b, this sweep does **not** need a `known_before_snapshot` taken before the
+`_build_code_triples` call: nothing here depends on `known_before`'s
+pre-call membership, only on `_lineage_is_provisional`/
+`_entity_introduced_by_query`, queried independently per ident below.
 
-1. **No fact yet** (`ident not in known_before_snapshot`) — neither stream
-   has touched this entity before. This *is* the true chronological
-   introduction, since the sweep walks oldest→newest and nothing earlier
-   claimed it. Assert `[ident :introduced-by commit_ident]` directly via
-   `_transact` — no provisional marker, no candidate-diff record (nothing
-   will ever need to re-check it, since this fact was never a guess). No
-   `:modified-in`. This is exactly what `_build_code_triples`'s own gate
-   would have done unfiltered — 2c only needs to special-case the other
-   three.
+Each candidate ident then falls into exactly one of two cases:
 
-2. **Known, provisional, guess matches this commit**
+1. **Provisional, guess matches this commit**
    (`_lineage_is_provisional(db, ident)` and
    `_entity_introduced_by_query(db, ident) == commit_ident`) — the expected
    case once Stream 2 has fully walked the range down to `C`: by
@@ -188,7 +196,7 @@ against `known_before_snapshot` (never the post-call `known_before`):
    was already correct) and `_candidate_diff_clear(db, commit_hash, ident)`.
    No `:modified-in`.
 
-3. **Known, provisional, guess points elsewhere**
+2. **Provisional, guess points elsewhere**
    (`_lineage_is_provisional(db, ident)` and
    `_entity_introduced_by_query(db, ident) != commit_ident`) — the
    reconciliation case 2a's spec reserved for 2c (rename- or
@@ -223,7 +231,7 @@ against `known_before_snapshot` (never the post-call `known_before`):
    - `_candidate_diff_clear` both `(commit_hash, ident)` and
      `(guessed_hash, ident)`.
 
-4. **Known, authoritative** (confirmed earlier in this same sweep, or
+3. **Already authoritative** (confirmed earlier in this same sweep, or
    introduced by the original single-stream walk before #222 existed) — the
    ordinary "already known" case: assert `[ident :modified-in commit_ident]`
    unless `precomputed["unchanged_idents"]` says the body is provably
@@ -231,12 +239,12 @@ against `known_before_snapshot` (never the post-call `known_before`):
    call `_candidate_diff_clear(db, commit_hash, ident)` if a record happens
    to exist for this exact `(commit, ident)` pair — this is what cleans up
    the *intermediate* stale records 2b's own spec left behind along a
-   supersession chain (guess moves `L3 → L2 → L1 → C`; case 2 clears `C`'s
+   supersession chain (guess moves `L3 → L2 → L1 → C`; case 1 clears `C`'s
    own record when the sweep reaches `C`; each of `L1`/`L2`/`L3` falls into
-   this case 4 when the sweep later reaches them, and each still has its
-   own now-orphaned candidate-diff record from when it was a transient
-   guess). No special-casing was needed for this — it falls out of the
-   ordinary path once the sweep passes back over those commits.
+   this case when the sweep later reaches them, and each still has its own
+   now-orphaned candidate-diff record from when it was a transient guess).
+   No special-casing was needed for this — it falls out of the ordinary
+   path once the sweep passes back over those commits.
 
 ### Driving functions
 
@@ -246,47 +254,60 @@ def _correction_sweep_claim_and_process(
     repo_path: str,
     linearization: List[str],
     commit_metadata: List[Tuple[str, str, str, str]],
-    allocator: "frontier_registry.FrontierAllocator",
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
 ) -> Optional[str]:
-    """Claim one position from the gap's low end and reconcile that
-    commit's entities per the four-case algorithm above. Returns the
-    claimed commit's hash, or None if the gap was already empty (caller's
-    signal to stop). Writes are followed by exactly one _db_checkpoint(db)
-    call, after _frontier_persist_claim and _lineage_confirmed_through_update
-    both record the claim -- mirrors _reverse_fill_claim_and_process's
-    one-checkpoint-per-commit cadence."""
+    """Advance the correction sweep by exactly one commit past
+    :ingestion/lineage-confirmed-through and reconcile that commit's
+    entities per the two-case algorithm above. Returns the processed
+    commit's hash, or None if the tracker has already reached frontier-
+    high's current lo-hash (nothing left to correct against what Stream 2
+    has claimed so far), or if frontier-high hasn't claimed anything yet.
+    No `allocator` parameter -- this reads frontier-high's persisted bounds
+    directly via _frontier_read_bounds, not the allocator's claim_low(); see
+    "Why not claim_low()" above. Writes are followed by exactly one
+    _db_checkpoint(db) call, after _lineage_confirmed_through_update records
+    the advance -- mirrors _reverse_fill_claim_and_process's
+    one-checkpoint-per-commit cadence. Never calls _frontier_persist_claim:
+    frontier-low is not touched by this sweep."""
 
 def _correction_sweep_walk(
     db: Any,
     repo_path: str,
     linearization: List[str],
     commit_metadata: List[Tuple[str, str, str, str]],
-    allocator: "frontier_registry.FrontierAllocator",
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
 ) -> int:
-    """Repeatedly call _correction_sweep_claim_and_process until the gap
-    closes. Returns the count of commits processed. No caller in this
+    """Repeatedly call _correction_sweep_claim_and_process until it returns
+    None. Returns the count of commits processed. No caller in this
     sub-phase -- 2d wires this into the real concurrent ingestion loop
-    alongside the reverse stream."""
+    alongside the reverse stream, and alongside ordinary claim_low()-driven
+    introduction for territory below the gap."""
 ```
 
 ### Frontier + watermark advancement
 
-Each processed commit calls both `_frontier_persist_claim(db, linearization,
-pos, from_low=True, commit_ts_iso=commit_ts_iso, index_con=index_con)` *and*
-`_lineage_confirmed_through_update(db, commit_hash, commit_ts_iso,
-index_con=index_con)` — restoring the lockstep the two watermarks had before
-Stream 2 existed (`_lineage_confirmed_through_migrate` originally seeded
-`lineage-confirmed-through` from frontier-low's boundary precisely because
-they were always advanced together by the single old forward walk). Every
-commit this sweep claims is, by construction, now fully lineage-confirmed,
-so advancing both together is correct and keeps
-`_lineage_confirmed_through_query`'s trust predicate (2a spec, "Migration
-seeding") meaningful without special-casing. One `_db_checkpoint(db)` call
-per commit, after both watermark updates, same cadence as 2b.
+Each processed commit calls `_lineage_confirmed_through_update(db,
+commit_hash, commit_ts_iso, index_con=index_con)` — **and nothing else**.
+Unlike an earlier draft of this spec, `_frontier_persist_claim(...,
+from_low=True, ...)` is never called: `C` already lies inside frontier-
+high's persisted interval (that's the sweep's own range invariant), and
+extending frontier-low's `:hi-hash` onto a position frontier-high's
+`:lo-hash` also covers would make the two persisted intervals overlap —
+`_frontier_load`'s reconstruction has no defined behavior for that (`
+FrontierAllocator._interval_covering` returns whichever interval it checks
+first), and `gap_lo`/`gap_hi` would no longer describe a coherent gap. This
+is exactly the confusion "Why not `claim_low()`" above already ruled out at
+the allocator-call level; not calling `_frontier_persist_claim` here is the
+same rule applied to the lower-level persistence helper directly, since
+nothing stops it from being called with an arbitrary position otherwise.
+`:ingestion/lineage-confirmed-through` is the sole watermark this sweep
+advances, matching 2a's spec: the composed trust predicate it defines
+(`_lineage_is_provisional(entity)` is `False` **and** the entity's
+`:introduced-by` position is `<=` `lineage-confirmed-through`'s position)
+never references frontier-low at all. One `_db_checkpoint(db)` call per
+commit, after the watermark update, same cadence as 2b.
 
 ### Schema/audit safety, idempotency
 
@@ -294,10 +315,10 @@ No new entity types or attributes — 2c is purely a new consumer of 2a's
 already-audited-safe primitives (`_lineage_confirm`/`_candidate_diff_clear`
 already established their own safety in 2a's spec) plus the existing
 `:introduced-by`/`:modified-in` attributes forward walk always used. Every
-write in the four-case algorithm is either a query-before-write primitive
+write in the two-case algorithm is either a query-before-write primitive
 already built in 2a/2b, or a direct `_transact`/`_retract` pair gated on a
-query result (case 1 and case 3's direct authoritative assert) — never a
-blind unconditional transact.
+query result (case 2's direct authoritative assert) — never a blind
+unconditional transact.
 
 ## Testing
 
@@ -308,26 +329,22 @@ a candidate needs a pre-existing provisional state) `_reverse_fill_claim_and_pro
 itself to set that state up realistically rather than hand-constructing
 facts:
 
-- **Fresh introduction, no prior provisional state** (case 1): a two-commit
-  repo with no reverse-walk activity; sweep from the start; assert the
-  entity's `:introduced-by` is asserted directly, no `:type/lineage-marker`
-  companion entity was ever created, and no candidate-diff record exists.
-  Also query the claimed commit itself and assert its `:type/commit` entity
-  was written (`:entity-type`, `:hash`, `:subject`, `:date` at minimum) —
-  this is new 2c-owned behavior (2c claims commits from the low end that 2b
-  never touched, so unlike case 3's `guessed_ident` handling, nothing else
-  has written this commit's metadata first) and a regression that dropped
-  it would still pass every other case-1 assertion while leaving
-  `:introduced-by` pointing at a dangling `:commit/...` ident. Additionally
-  assert no `:parent` fact exists for the claimed commit, documenting the
-  scope cut rather than leaving it untested.
-- **Confirms a correct provisional guess** (case 2): run
+- **Confirms a correct provisional guess** (case 1): run
   `_reverse_bulk_fill_walk` first so an entity ends up with a provisional
   `:introduced-by` pointing at its true earliest commit; then run the
   correction sweep; assert `_lineage_is_provisional` is now `False`, the
   `:introduced-by` value is unchanged, and the candidate-diff record for
   that `(commit, entity)` is gone (`_candidate_diff_read` returns `None`).
-- **Reconciles a wrong provisional guess** (case 3): hand-construct a
+- **Does not re-write the claimed commit's metadata**: same setup as above;
+  before running the sweep, capture the claimed commit entity's live facts
+  (`:hash`/`:author`/`:subject`/`:date`) as written by
+  `_reverse_bulk_fill_walk`; run the sweep; assert those facts are
+  byte-for-byte unchanged and, via a raw fact-count query, that no
+  duplicate `:hash`/`:subject`/etc. datom was created — this is the
+  regression test for the bug an earlier draft of this spec would have
+  introduced by unconditionally re-`_transact`-ing commit metadata 2b
+  already wrote.
+- **Reconciles a wrong provisional guess** (case 2): hand-construct a
   provisional `:introduced-by` pointing at the *wrong* (later) commit for
   an entity that's also genuinely present at an earlier commit the sweep
   will reach, simulating the rename/rebirth edge case; run the sweep;
@@ -335,35 +352,50 @@ facts:
   authoritative, and the superseded commit received a retroactive
   `:modified-in` with its own timestamp.
 - **Skips the retroactive `:modified-in` when the body is unchanged**
-  (case 3's #221 fix): same setup as above, but with matching body hashes
+  (case 2's #221 fix): same setup as above, but with matching body hashes
   persisted at both the superseded and the true-introduction commits;
   assert no `:modified-in` fact was written for the superseded commit —
   this is the test that would fail against 2b's own documented limitation
   if 2c naively reused its unconditional-assert behavior.
-- **Fails open when a body hash is missing** (case 3's fail-open guard):
+- **Fails open when a body hash is missing** (case 2's fail-open guard):
   same reconciliation setup as above, but for a *module* ident (which
   `precomputed["body_hashes"]` never populates) so both the persisted
   candidate-diff hash and the current body hash are `None`; assert the
   retroactive `:modified-in` is still written — this is the test that would
   catch a naive `==` comparison treating the `None == None` case as
   "unchanged" and wrongly suppressing a real edit.
-- **Ordinary modification of an already-authoritative entity** (case 4): an
+- **Ordinary modification of an already-authoritative entity** (case 3): an
   entity already authoritative (pre-seeded, non-provisional); sweep over a
   commit that touches it; assert `:modified-in` is added and no lineage
   marker exists.
-- **Opportunistic stale candidate-diff cleanup** (case 4): pre-seed a stale
+- **Opportunistic stale candidate-diff cleanup** (case 3): pre-seed a stale
   candidate-diff record at a commit for an entity that's already
   authoritative by the time the sweep reaches that commit (simulating an
   orphaned intermediate guess along a supersession chain); assert the sweep
-  clears it even though that commit falls into the ordinary case-4 path.
-- **Gap-empty no-op**: an allocator whose gap is already empty; assert
-  `_correction_sweep_claim_and_process` returns `None` and writes nothing.
-- **`_frontier_persist_claim` + `_lineage_confirmed_through_update`
-  lockstep**: after `_correction_sweep_walk` processes N commits, assert
-  both frontier-low's persisted interval and
-  `_lineage_confirmed_through_query` reflect the same final commit.
-- **Full integration**: run `_reverse_bulk_fill_walk` over a range from
-  `HEAD`, then `_correction_sweep_walk` over the same range from the start;
-  assert every touched entity ends up authoritative
-  (`_lineage_is_provisional` is `False` for all of them) and no
-  `:type/candidate-diff` entities remain live.
+  clears it even though that commit falls into the ordinary case-3 path.
+- **No-op when frontier-high hasn't claimed anything yet**: a graph with
+  only frontier-low/migration state, no `_reverse_bulk_fill_walk` ever run;
+  assert `_correction_sweep_claim_and_process` returns `None` and writes
+  nothing.
+- **No-op when the sweep has already caught up**: run
+  `_correction_sweep_walk` to exhaustion over a range Stream 2 has claimed;
+  assert a further call to `_correction_sweep_claim_and_process` still
+  returns `None` (lineage-confirmed-through has reached frontier-high's
+  lo-hash) rather than erroring or re-processing the last commit.
+- **Frontier-low is never touched**: capture frontier-low's persisted
+  interval before running `_correction_sweep_walk`; run it; assert
+  frontier-low's persisted `:lo-hash`/`:hi-hash` are byte-for-byte
+  unchanged afterward, while `_lineage_confirmed_through_query` has
+  advanced — the direct regression test for the bug this spec's `claim_low()`
+  draft would have introduced (see "Why not `claim_low()`").
+- **Full integration**: call `_reverse_fill_claim_and_process` a fixed
+  number of times directly (not `_reverse_bulk_fill_walk` to exhaustion —
+  leaving a non-trivial gap below Stream 2's claimed territory, position
+  `P`, is what makes this a meaningful test of the sweep's own bounds, not
+  just its logic) so Stream 2 claims down to `P` but no further; then run
+  `_correction_sweep_walk`; assert every entity touched at or above `P`
+  ends up authoritative (`_lineage_is_provisional` is `False` for all of
+  them), no `:type/candidate-diff` entities remain live, and
+  `_lineage_confirmed_through_query` now equals `P`'s hash — proving the
+  sweep's own upper bound (frontier-high's lo-hash) was respected, not
+  walked past.

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -31,7 +31,8 @@ forward stream still owns lineage correctness.
   earlier occurrence of the same entity.
 - **2c (this spec)** — Stream 1's correction sweep: walks **upward**
   (oldest→newest) through frontier-high's own already-claimed interval —
-  starting at its current `:lo-hash` and proceeding toward `HEAD` — using a
+  starting at its current `:lo-hash` and proceeding toward its own
+  persisted `:hi-hash` — using a
   dedicated watermark for its own resumable progress (**not**
   `:ingestion/lineage-confirmed-through`, and **not** `allocator.claim_low()`;
   see "Why not `claim_low()`" and "Why a dedicated watermark" below),
@@ -54,12 +55,14 @@ In scope:
 
 - A per-commit correction step that advances a dedicated position tracker
   upward through frontier-high's own claimed interval — starting at its
-  current `:lo-hash` on first use, proceeding toward `HEAD` — and, for every
+  current `:lo-hash` on first use, proceeding toward its own persisted
+  `:hi-hash` (not necessarily `HEAD`/`len(linearization) - 1` — see the
+  incremental-re-ingest note under "Position tracker") — and, for every
   entity touched by that commit's "A"/"M" files, reconciles its lineage per
-  the two-case algorithm below.
-- A thin driving loop that repeats the above until the tracker reaches the
-  end of the linearization. Frontier-low is never touched by this sweep,
-  and neither is `:ingestion/lineage-confirmed-through` (see "Why a
+  the three-case algorithm below.
+- A thin driving loop that repeats the above until the tracker reaches
+  frontier-high's own persisted `:hi-hash`. Frontier-low is never touched
+  by this sweep, and neither is `:ingestion/lineage-confirmed-through` (see "Why a
   dedicated watermark" below) — 2c introduces its own new watermark,
   `:ingestion/correction-sweep-through`.
 - Opportunistically clearing stale intermediate candidate-diff records left
@@ -166,24 +169,69 @@ closes (so they describe one contiguous confirmed region again) is 2d's
 job, once it can also make the *ordinary* `claim_low()`-driven walk advance
 `lineage-confirmed-through` for the virgin positions it claims.
 
-**This is also what proves case 2 from an earlier draft (a provisional
-guess pointing at a commit other than the one currently being visited)
-cannot occur inside this sweep's range.** For a commit `C` Stream 2
-claimed, Stream 2 parsed the identical diff (the same invariant the
-per-commit algorithm below relies on) and — per its own per-commit
-algorithm — always moves a candidate's guess *down* to the earliest
-occurrence it has seen. So for any entity `C`'s files touch, Stream 2's
-final persisted guess is necessarily `<= C`'s position, never later. Walking
-`[frontier-high.lo, N-1]` oldest-to-newest, by induction: the sweep reaches
-each entity's true within-range-earliest occurrence *before* any later
-commit that also touches it, because that earliest occurrence's position is
-itself `<= C` for every later `C` — so by the time the sweep would ever
-visit a later `C` for that entity, the entity has already been confirmed
-(case 1, below) at its true earliest position and reads as authoritative,
-not provisional. A guess pointing at some *other*, unvisited commit while
-still provisional is therefore not a state this sweep's own walk can ever
-observe for a commit inside its range — see the "Explicitly deferred"
-bullet above for where that reconciliation actually belongs.
+### Why confirming requires the gap to already be closed
+
+A third earlier draft of this design argued that Stream 2's persisted guess
+for any entity `C` touches is always `<= C`'s position, so by induction a
+provisional guess can never point somewhere other than the commit currently
+being visited. That argument silently assumed Stream 2's guess is *final* —
+true only once Stream 2 can never claim another position. During a real
+concurrent run it is not yet final, and the gap between "not yet final" and
+"final" is exactly where this sweep can corrupt data if it runs too early:
+
+1. Sweep visits `C = frontier-high.lo`, confirms entity `E` (case 1):
+   `:introduced-by = C`, provisional marker dropped.
+2. Stream 2 later claims some `C' < C` (a position still below `C` that it
+   had not yet reached) and finds `E` there too. `_reverse_fill_claim_and_process`'s
+   *sole* gate for whether to move a guess is `_lineage_is_provisional`
+   (mcp_server.py:7369-7373) — since this sweep already confirmed `E`, it no
+   longer reads as provisional, so 2b takes its "already authoritative"
+   branch: writes `[E :modified-in C']` and leaves `:introduced-by` at `C`.
+3. `E` now claims it was introduced at `C` while carrying a `:modified-in`
+   edge at the *earlier* commit `C'` — a contradiction ordinary forward walk
+   can never produce — and it reads as fully authoritative, so 2a's trust
+   predicate will trust it as soon as `lineage-confirmed-through` reaches
+   it. Confirming turned a still-correctable provisional guess into
+   uncorrectable (and wrong) ground truth: the deferred reconciliation this
+   spec relies on (see "Explicitly deferred" above) is described in terms
+   of a *pre-existing provisional guess* to correct, and there is no longer
+   one to find.
+
+This is not an exotic interleaving — it is the expected one once 2d runs
+Stream 1 and Stream 2 concurrently, one descending into the gap while this
+sweep ascends through already-claimed territory. **The precondition that
+makes a confirm sound is that no unclaimed position remains below the
+position being confirmed — i.e. the gap is closed:
+`frontier-low.:hi-hash`'s position `+ 1 == frontier-high.:lo-hash`'s
+position** (equivalently, `allocator.is_gap_empty()`, if an allocator were
+available — it is not, so this sweep checks the equivalent condition
+against the two persisted interval bounds directly). Once the gap is
+closed, `claim_high()` can never return another position for the rest of
+this run (`is_gap_empty()` stays `True` — the gap only shrinks), so Stream
+2 is permanently done: its guess for every entity within frontier-high's
+*entire* range is now genuinely final, and the induction argument above
+holds validly. `_correction_sweep_claim_and_process` therefore checks this
+precondition on every call (both bounds are cheap to re-read) and returns
+`None` — nothing safe to correct yet — until it holds.
+
+Given the precondition holds, the induction argument is exactly as before:
+for a commit `C` Stream 2 claimed, Stream 2's final persisted guess for any
+entity `C`'s files touch is necessarily `<= C`'s position (it always moves
+a candidate's guess *down* to the earliest occurrence seen, never up), so
+walking `[frontier-high.lo, N-1]` oldest-to-newest, the sweep reaches each
+entity's true within-range-earliest occurrence before any later commit that
+also touches it. **Even so, the per-commit algorithm below keeps an
+explicit no-op branch for a provisional guess pointing elsewhere, rather
+than treating that state as unreachable** — the precondition is what a
+*correct caller* guarantees, not something the per-ident classification can
+independently verify, and a naive two-branch implementation that assumes
+the state can't happen does something actively harmful if it ever does
+(confirms an entity at a commit that was never validated as its true
+introduction). See "Explicitly deferred" above for where the genuine
+reconciliation (an entity whose true earliest occurrence lies below
+frontier-high's range entirely, in frontier-low's own territory) belongs —
+that is a different scenario from the one above and remains this sweep's
+own no-op case, not something it can resolve itself.
 
 ### Per-commit algorithm
 
@@ -209,17 +257,23 @@ sweep skips straight to per-ident classification, using `precomputed`
 directly:
 
 ```python
-candidate_idents = (
-    [precomputed["module_ident"]]
-    + [ident for ident, _name, _t in precomputed["function_entries"]]
-    + [ident for ident, _name, _t in precomputed["class_entries"]]
-    + [ident for ident, _name, _t in precomputed["global_entries"]]
-    + [ident for ident, _name, _t in precomputed["field_entries"]]
+file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
+    repo_path, commit_hash, ignore_patterns
 )
-unchanged_idents = precomputed.get("unchanged_idents", set())
+for status, file_path, extracted, precomputed, _old_path in file_results:
+    if status not in ("A", "M"):
+        continue  # "D"/"R" deferred -- see Scope, matches 2b's own cut
+    candidate_idents = (
+        [precomputed["module_ident"]]
+        + [ident for ident, _name, _t in precomputed["function_entries"]]
+        + [ident for ident, _name, _t in precomputed["class_entries"]]
+        + [ident for ident, _name, _t in precomputed["global_entries"]]
+        + [ident for ident, _name, _t in precomputed["field_entries"]]
+    )
+    unchanged_idents = precomputed.get("unchanged_idents", set())
 ```
 
-Each candidate ident then falls into one of two cases. Every write below
+Each candidate ident then falls into one of three cases. Every write below
 uses `C`'s own `commit_ts_iso` (the same timestamp 2b itself used when it
 first wrote at `C`) — this equality is load-bearing, not incidental: it is
 what makes any write this sweep re-issues at a position 2b already touched
@@ -240,7 +294,22 @@ duplicate.
    was already correct) and `_candidate_diff_clear(db, commit_hash, ident,
    index_con=index_con)`. No `:modified-in`.
 
-2. **Already authoritative** (confirmed at an earlier position in this same
+2. **Provisional, guess points elsewhere**
+   (`_lineage_is_provisional(db, ident)` and
+   `_entity_introduced_by_query(db, ident) != commit_ident`) — per "Why
+   confirming requires the gap to already be closed" above, a correct
+   caller (the gap-closed precondition holding) means this state should not
+   arise for a commit inside this sweep's range. It is kept as an explicit
+   branch anyway, not folded into case 1's `else`, precisely because
+   "should not arise" is a caller obligation this per-ident classification
+   cannot itself verify: **leave the entity completely untouched** — no
+   `_lineage_confirm`, no `:introduced-by` change, no candidate-diff
+   touch — so that if the precondition is ever violated, this sweep fails
+   safe (does nothing) rather than confirming an unvalidated guess. The
+   entity remains provisional and available for whatever the deferred
+   reconciliation turns out to be.
+
+3. **Already authoritative** (confirmed at an earlier position in this same
    sweep, or — after this sweep has fully caught up once — simply revisited
    on a later run) — first check whether `C` *is* this entity's own
    introduction commit: if `_entity_introduced_by_query(db, ident) ==
@@ -270,7 +339,9 @@ duplicate.
 A new watermark, structurally identical to `:ingestion/lineage-confirmed-
 through` (`_lineage_confirmed_through_update`'s exact shape: registered
 `:type/ingestion`, same retract-only-if-changed pattern, same required
-`:description` constant) but tracking a different thing — this sweep's own
+`:description` *attribute* — but its own distinct string, "correction sweep
+progress watermark," not a copy of lineage-confirmed-through's; see
+"Schema/audit safety" below) but tracking a different thing — this sweep's own
 progress, independent of contiguity from `C0`:
 
 ```python
@@ -288,13 +359,26 @@ def _correction_sweep_through_update(
     exactly, at a different ident."""
 ```
 
-Position selection, handling both ends being possibly absent or stale:
+Position selection: first the gap-closed precondition ("Why confirming
+requires the gap to already be closed" above), then the ceiling, then the
+resume point — each handling its own absent/stale case:
 
 ```python
+low_bounds = _frontier_read_bounds(db, _FRONTIER_LOW_IDENT)
 high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
-if high_bounds is None:
-    return None  # Stream 2 hasn't claimed anything yet -- nothing to correct
+if low_bounds is None or high_bounds is None:
+    return None  # migration hasn't run yet, or Stream 2 hasn't claimed anything
 hash_to_pos = {h: i for i, h in enumerate(linearization)}
+if low_bounds[1] not in hash_to_pos or high_bounds[0] not in hash_to_pos:
+    return None  # a boundary hash is stale (rewritten history); nothing safe to do
+if hash_to_pos[low_bounds[1]] + 1 != hash_to_pos[high_bounds[0]]:
+    return None  # gap still open -- Stream 2 may still descend past a position
+                 # this sweep would otherwise confirm; see the precondition above
+if high_bounds[1] not in hash_to_pos:
+    return None  # frontier-high's :hi-hash is stale -- see the incremental-
+                 # re-ingest note below; nothing safe to do until 2b/2d address it
+ceiling_pos = hash_to_pos[high_bounds[1]]
+
 through_hash = _correction_sweep_through_query(db)
 if through_hash is not None and through_hash in hash_to_pos:
     pos = hash_to_pos[through_hash] + 1
@@ -303,23 +387,68 @@ else:
     # history -- (re)start from frontier-high's current lo-hash, mirroring
     # _frontier_load's own precedent of dropping a bound that no longer
     # resolves (mcp_server.py:4970-4978) rather than erroring.
-    lo_hash, _hi_hash = high_bounds
-    if lo_hash not in hash_to_pos:
-        return None  # frontier-high itself is stale; nothing safe to do
-    pos = hash_to_pos[lo_hash]
-if pos >= len(linearization):
-    return None  # reached HEAD; nothing left to correct
-commit_hash = linearization[pos]
-commit_ts_iso = next(ts for h, ts, _a, _s in commit_metadata if h == commit_hash)
+    pos = hash_to_pos[high_bounds[0]]  # already validated above
+if pos > ceiling_pos:
+    return None  # reached frontier-high's own :hi-hash; nothing left to correct
+commit_hash, commit_ts_iso, _author, _subject = commit_metadata[pos]
+assert commit_hash == linearization[pos]  # see the contract note below
 ```
 
-Once `pos` is known to be `>= frontier-high.lo`'s position at the time this
-call started, the walk needs no further bounds-checking against
-frontier-high for the rest of its run: `[frontier-high.lo, N-1]` only ever
-grows (frontier-high's `:hi-hash` is fixed at `N-1`, and `:lo-hash` only
-moves further down), so every position from the sweep's own resume point
-onward through `N-1` is guaranteed already claimed regardless of how far
-Stream 2 has additionally progressed since.
+`ceiling_pos` reads frontier-high's *persisted* `:hi-hash`
+(`high_bounds[1]`) rather than `len(linearization) - 1`. Those are **not**
+interchangeable across separate runs: within a single run, `claim_high()`'s
+`_extend` never touches `existing.hi_pos`, so the in-memory interval's high
+end genuinely is fixed at the linearization's last position. But on an
+incremental re-ingest, `linearization` is rebuilt fresh and longer while
+`:hi-hash` remains whatever was persisted last time — `_frontier_load`
+reconstructs the high interval as `[pos(lo_hash), pos(hi_hash)]` against
+the *new* linearization (mcp_server.py:4974-4978), so
+`pos(hi_hash) = N_old - 1`, strictly less than `N_new - 1`. Using
+`len(linearization) - 1` as the ceiling would walk the sweep straight into
+`[N_old, N_new - 1]` — brand new commits no stream has claimed yet — and
+every invariant this design relies on would fail there exactly as in the
+gap case above. Stopping at `high_bounds[1]`'s own position avoids this
+regardless of how much the linearization has grown.
+
+**Known dependency, not itself a 2c defect:** `_frontier_persist_claim`
+only updates the moved bound (`:lo-hash` for `claim_high`), never
+`:hi-hash` (mcp_server.py:5012-5014). On an incremental re-ingest, Stream
+2's first `claim_high()` of the new run returns the new `gap_hi`
+(`N_new - 1`, since the reloaded interval no longer reaches the true last
+position) and persists it as the new `:lo-hash`, leaving the persisted
+interval as `[N_new - 1, N_old - 1]` — inverted. This sweep's own ceiling
+check above would then read `high_bounds[1] = N_old - 1` as the ceiling
+while `through_hash`/`high_bounds[0]` sit at `N_new - 1`, well above it —
+`pos > ceiling_pos` immediately, so the sweep silently does nothing rather
+than corrupting anything, but it also makes no progress until 2b or 2d
+fixes the underlying interval-growth handling. Flagged here since 2c is the
+first consumer to read frontier-high's persisted `:lo-hash` as a position
+to walk *from*, which is what exposes it.
+
+`commit_metadata` is assumed **full-history and positionally aligned with
+`linearization`** — the same contract 2b's own tests construct
+(`tests/test_mcp_server.py:13926`, via `_git_commits(repo, None, branch)`)
+and `_reverse_fill_claim_and_process` itself relies on
+(`commit_metadata[pos]`, mcp_server.py:7314). This is *not* what
+`_run_ingestion` currently builds for its own use (a watermark-relative
+list via `_git_commits(repo_path, watermark, branch)`,
+mcp_server.py:7486) — 2d, when it wires this sweep in, must pass the
+full-history list, not `_run_ingestion`'s own watermark-relative one.
+Indexing positionally (`commit_metadata[pos]`) rather than searching by
+hash both matches 2b's convention and avoids a bare `next(...)` with no
+default raising `StopIteration` if the contract is ever violated. Because
+both streams derive `commit_ts_iso` from `_git_commits`'s single
+`strftime("%Y-%m-%dT%H:%M:%SZ")` formatting (mcp_server.py:4130), the two
+streams cannot disagree on the timestamp string for the same commit — this
+is what makes the valid_from-equality argument in "Per-commit algorithm"
+above hold.
+
+Once `pos` is known to be `<= ceiling_pos` at the time this call started,
+the walk needs no further bounds-checking against frontier-high for the
+rest of *this* call — `[frontier-high.lo, ceiling_pos]` is fixed for the
+duration of one call, regardless of how far Stream 2 additionally
+progresses concurrently (its `:lo-hash` can only move further down, never
+past `ceiling_pos`, and `:hi-hash` never moves within a run).
 
 After processing `C`: `_correction_sweep_through_update(db, commit_hash,
 commit_ts_iso, index_con=index_con)`, then one `_db_checkpoint(db)` call —
@@ -340,15 +469,19 @@ def _correction_sweep_claim_and_process(
 ) -> Optional[str]:
     """Advance the correction sweep by exactly one commit, upward through
     frontier-high's own claimed territory, and reconcile that commit's
-    entities per the two-case algorithm above. Returns the processed
-    commit's hash, or None if there is nothing left to correct (frontier-
-    high hasn't claimed anything yet, or the sweep has already reached
-    HEAD). No `allocator` parameter -- this reads frontier-high's persisted
-    bounds directly via _frontier_read_bounds and tracks its own progress
-    via _correction_sweep_through_query/_update, not the allocator's
-    claim_low(); see "Why not claim_low()" above. Never calls
-    _frontier_persist_claim or _lineage_confirmed_through_update -- neither
-    frontier-low nor lineage-confirmed-through is touched by this sweep."""
+    entities per the three-case algorithm above. Returns the processed
+    commit's hash, or None if there is nothing safe to correct yet: the gap
+    is still open (Stream 2 could still descend past a position this call
+    would confirm -- see "Why confirming requires the gap to already be
+    closed"), frontier-high hasn't claimed anything yet, a required
+    boundary hash is stale, or the sweep has already reached frontier-
+    high's own :hi-hash. No `allocator` parameter -- this reads frontier-low
+    and frontier-high's persisted bounds directly via _frontier_read_bounds
+    and tracks its own progress via _correction_sweep_through_query/_update,
+    not the allocator's claim_low(); see "Why not claim_low()" above. Never
+    calls _frontier_persist_claim or _lineage_confirmed_through_update --
+    neither frontier-low nor lineage-confirmed-through is touched by this
+    sweep."""
 
 def _correction_sweep_walk(
     db: Any,
@@ -367,12 +500,17 @@ def _correction_sweep_walk(
 
 ### Schema/audit safety, idempotency
 
-One new entity type, `:ingestion/correction-sweep-through`, reusing the
-already-registered/audited `:type/ingestion` type exactly as
-`:ingestion/lineage-confirmed-through` does — no new schema surface. Case
-1's writes are the same query-before-write primitives 2a/2b already
-established as safe (`_lineage_confirm`, `_candidate_diff_clear`). Case 2's
-`:modified-in` assert, once its guard passes, *is* an unconditional
+`:ingestion/correction-sweep-through` is a new *entity* of the
+already-registered/audited `:type/ingestion` type — the same type
+`:ingestion/lineage-confirmed-through` uses — so no new schema surface.
+Unlike `lineage-confirmed-through`, it gets its own distinct `:description`
+string ("correction sweep progress watermark," not a copy of lineage-
+confirmed-through's) — two `:type/ingestion` entities with byte-identical
+descriptions would both pass audit but be indistinguishable from each
+other in the fact index and in `minigraf_audit` output. Case 1's writes are
+the same query-before-write primitives 2a/2b already established as safe
+(`_lineage_confirm`, `_candidate_diff_clear`). Case 2 writes nothing. Case
+3's `:modified-in` assert, once its guard passes, *is* an unconditional
 `_transact` — it is safe not because of a query-before-write guard but
 because it always uses `C`'s own `commit_ts_iso`, matching what forward
 walk (or 2b, if `C` happens to already carry other facts from it) would
@@ -386,83 +524,123 @@ guard for its safety.
 
 Following `docs/testing-conventions.md` (real `MiniGrafDb`, no mocks), using
 the same `tmp_path / "repo"` real-git-repo fixture pattern already used
-throughout `tests/test_mcp_server.py`'s existing ingestion tests, and (where
-a candidate needs a pre-existing provisional state) `_reverse_fill_claim_and_process`
-itself to set that state up realistically rather than hand-constructing
-facts:
+throughout `tests/test_mcp_server.py`'s existing ingestion tests. Since this
+sweep now requires the gap to be closed before it does anything (see "Why
+confirming requires the gap to already be closed"), most scenarios below
+close it using real functions rather than hand-constructing frontier facts:
+a real `frontier_registry.FrontierAllocator`, `claim_low()` +
+`_frontier_persist_claim(..., from_low=True, ...)` in a loop for the low
+side (standing in for 2d's future ordinary forward walk, which this
+sub-phase doesn't build), and `_reverse_fill_claim_and_process` for the
+high side, until `allocator.is_gap_empty()`.
 
-- **Confirms a correct provisional guess** (case 1): run
-  `_reverse_bulk_fill_walk` first so an entity ends up with a provisional
-  `:introduced-by` pointing at its true earliest commit within Stream 2's
-  claimed range; then run the correction sweep; assert
-  `_lineage_is_provisional` is now `False`, the `:introduced-by` value is
-  unchanged, and the candidate-diff record for that `(commit, entity)` is
-  gone (`_candidate_diff_read` returns `None`).
+- **Sweep is a no-op while the gap remains open** (the precondition itself):
+  claim some positions via `_reverse_fill_claim_and_process` but leave a
+  non-empty gap below them (don't also claim from the low side); call
+  `_correction_sweep_claim_and_process`; assert it returns `None` and
+  writes nothing, even though frontier-high has real provisional facts
+  available to confirm — this is the direct regression test for the race
+  in "Why confirming requires the gap to already be closed": a version of
+  this sweep without the precondition check would confirm here and be
+  wrong the moment Stream 2 claims a still-lower position touching the
+  same entity.
+- **Confirms a correct provisional guess** (case 1): close the gap (as
+  above) so an entity ends up with a provisional `:introduced-by` pointing
+  at its true earliest commit within Stream 2's claimed range; then run
+  the correction sweep; assert `_lineage_is_provisional` is now `False`,
+  the `:introduced-by` value is unchanged, and the candidate-diff record
+  for that `(commit, entity)` is gone (`_candidate_diff_read` returns
+  `None`).
 - **Does not duplicate the claimed commit's metadata**: same setup as
   above; before running the sweep, capture the claimed commit entity's
   total live fact count and its `:hash`/`:author`/`:subject`/`:date`
-  values as written by `_reverse_bulk_fill_walk`; run the sweep; assert the
-  fact count is unchanged and none of those attributes was re-asserted at a
-  *different* `valid_from` — this is the regression test that can actually
-  distinguish a correct implementation (skips the write, or re-issues it
-  idempotently at the same `commit_ts_iso`) from one that writes it at a
-  different timestamp and produces a second live datom.
+  values as written by `_reverse_fill_claim_and_process`; run the sweep;
+  assert the fact count is unchanged and none of those attributes was
+  re-asserted at a *different* `valid_from` — this is the regression test
+  that can actually distinguish a correct implementation (skips the write,
+  or re-issues it idempotently at the same `commit_ts_iso`) from one that
+  writes it at a different timestamp and produces a second live datom.
+- **Leaves an entity untouched when its guess points elsewhere** (case 2,
+  the explicit no-op): with the gap closed, hand-construct a provisional
+  `:introduced-by` pointing at a commit *other* than the one the sweep is
+  about to visit for that same entity (simulating a precondition
+  violation, or the deferred rename/rebirth scenario, directly rather than
+  via a real interleaving); run the sweep over that commit; assert the
+  entity is still provisional, `:introduced-by` is unchanged, and no
+  candidate-diff record was touched — the test that pins "fails safe"
+  rather than "confirms an unvalidated guess."
 - **Skips `:modified-in` at an entity's own introduction commit on a
-  resumed sweep** (case 2's guard): run the correction sweep once so an
-  entity is confirmed authoritative at its true introduction commit; call
-  `_correction_sweep_claim_and_process` again as if resuming after a crash
-  (i.e. without having advanced `_correction_sweep_through_update` past
-  that commit — construct this directly rather than via the real crash
-  path, mirroring how other resume tests in this codebase re-invoke a step
-  function against pre-set state); assert no `:modified-in` fact was
-  created for that entity at its own introduction commit — this is the
-  test that would fail against a naive implementation of case 2 with no
-  self-introduction guard.
-- **Ordinary modification of an already-authoritative entity** (case 2, the
-  general path): an entity already authoritative at some earlier commit
-  (pre-seeded via a real earlier sweep pass, non-provisional); sweep over a
-  later commit that touches it; assert `:modified-in` is added at that
-  later commit and no lineage marker exists.
-- **Opportunistic stale candidate-diff cleanup** (case 2): pre-seed a stale
+  resumed sweep** (case 3's guard): with the gap closed, run the
+  correction sweep once so an entity is confirmed authoritative at its
+  true introduction commit; call `_correction_sweep_claim_and_process`
+  again as if resuming after a crash (i.e. without having advanced
+  `_correction_sweep_through_update` past that commit — construct this
+  directly rather than via the real crash path, mirroring how other resume
+  tests in this codebase re-invoke a step function against pre-set state);
+  assert no `:modified-in` fact was created for that entity at its own
+  introduction commit — this is the test that would fail against a naive
+  implementation of case 3 with no self-introduction guard.
+- **Ordinary modification of an already-authoritative entity** (case 3, the
+  general path): with the gap closed, an entity already authoritative at
+  some earlier commit (pre-seeded via a real earlier sweep pass,
+  non-provisional); sweep over a later commit that touches it; assert
+  `:modified-in` is added at that later commit and no lineage marker
+  exists.
+- **Opportunistic stale candidate-diff cleanup** (case 3): pre-seed a stale
   candidate-diff record at a commit for an entity that's already
   authoritative by the time the sweep reaches that commit (simulating an
   orphaned intermediate guess along a supersession chain); assert the sweep
-  clears it even though that commit falls into the ordinary case-2 path.
+  clears it even though that commit falls into the ordinary case-3 path.
 - **No-op when frontier-high hasn't claimed anything yet**: a graph with
-  only frontier-low/migration state, no `_reverse_bulk_fill_walk` ever run;
-  assert `_correction_sweep_claim_and_process` returns `None` and writes
-  nothing.
-- **Resumes from `correction-sweep-through` on a second call, not from
-  frontier-high's lo-hash again**: run the sweep once (processes frontier-
-  high's then-current lo-hash), then claim one more position via
-  `_reverse_fill_claim_and_process` so frontier-high's lo-hash moves further
-  down; call the correction sweep again; assert it processes the position
-  immediately after where it left off (one above its previous stopping
-  point), not frontier-high's new (lower) lo-hash — proving the dedicated
-  watermark, not frontier-high's current bound, drives resumption.
-- **No-op when the sweep has already reached `HEAD`**: run
-  `_correction_sweep_walk` to exhaustion over the whole claimed range;
+  only frontier-low/migration state, no `_reverse_fill_claim_and_process`
+  ever run; assert `_correction_sweep_claim_and_process` returns `None`
+  and writes nothing.
+- **Resumes from `correction-sweep-through`, not from frontier-high's
+  lo-hash again**: close the gap over a range spanning several commits;
+  call `_correction_sweep_claim_and_process` once (processes frontier-
+  high's lo-hash); call it again; assert it processes the position
+  immediately after the first call's result, not frontier-high's lo-hash
+  again — proving the dedicated watermark, not frontier-high's bound,
+  drives resumption. (Unlike an earlier draft, this cannot be tested via a
+  *further* `claim_high()` after the gap closes — `is_gap_empty()` makes
+  `claim_high()` return `None` forever once closed, which is itself the
+  point of the precondition.)
+- **No-op when the sweep has already reached frontier-high's own
+  `:hi-hash`**: close the gap; run `_correction_sweep_walk` to exhaustion;
   assert a further call to `_correction_sweep_claim_and_process` still
   returns `None` rather than erroring or re-processing the last commit.
+- **Respects frontier-high's persisted `:hi-hash` as the ceiling, not
+  `len(linearization)`**: close the gap and run the sweep to exhaustion
+  against an initial `linearization`; then extend the underlying repo with
+  new commits and rebuild a longer `linearization` (simulating an
+  incremental re-ingest) *without* claiming the new positions via either
+  stream; call the correction sweep again against the longer
+  `linearization`; assert it still returns `None` and does not walk into
+  the newly-added, unclaimed commits — the regression test for the bug an
+  earlier draft's `len(linearization) - 1` ceiling would have produced.
 - **Falls back to frontier-high's current lo-hash when the stored
   `correction-sweep-through` hash is stale**: seed
   `:ingestion/correction-sweep-through` with a hash not present in a fresh
-  `linearization` (simulating rewritten/rebased history); assert the sweep
-  restarts from frontier-high's current lo-hash rather than erroring.
+  `linearization` (simulating rewritten/rebased history), with the gap
+  otherwise closed; assert the sweep restarts from frontier-high's current
+  lo-hash rather than erroring.
 - **Frontier-low and `lineage-confirmed-through` are never touched**:
-  capture frontier-low's persisted interval and
+  close the gap; capture frontier-low's persisted interval and
   `_lineage_confirmed_through_query`'s value before running
   `_correction_sweep_walk`; run it; assert both are byte-for-byte unchanged
   afterward, while `_correction_sweep_through_query` has advanced — the
   direct regression test for the bugs both "Why not `claim_low()`" and "Why
   a dedicated watermark" describe.
-- **Full integration**: call `_reverse_fill_claim_and_process` a fixed
-  number of times directly (not `_reverse_bulk_fill_walk` to exhaustion) so
-  Stream 2 claims down to some position `P` within a larger history, then
-  run `_correction_sweep_walk` to exhaustion; assert every entity touched
-  at or above `P` ends up authoritative (`_lineage_is_provisional` is
-  `False` for all of them), no `:type/candidate-diff` entities remain live,
-  and `_correction_sweep_through_query` now equals `HEAD`'s hash — proving
-  the sweep correctly walks all the way through frontier-high's claimed
-  territory, not just the single position an earlier draft's (wrong) bound
-  would have stopped at.
+- **Full integration**: build a repo with a non-trivial number of commits;
+  close the gap at some meeting point (claim some positions via
+  `claim_low()`/`_frontier_persist_claim` from the low side, the rest via
+  `_reverse_fill_claim_and_process` from the high side, until
+  `allocator.is_gap_empty()`); then run `_correction_sweep_walk` to
+  exhaustion; assert every entity touched within frontier-high's claimed
+  range ends up authoritative (`_lineage_is_provisional` is `False` for all
+  of them), no `:type/candidate-diff` entities remain live, and
+  `_correction_sweep_through_query` now equals frontier-high's `:hi-hash` —
+  proving the sweep correctly walks all the way through frontier-high's
+  claimed territory to its actual persisted ceiling, not the single
+  position or the unbounded `len(linearization)` an earlier draft's
+  (wrong) bounds would have produced.

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -756,7 +756,7 @@ def _correction_sweep_apply(
     from every PREVIOUS call this run, and exists solely to make the stderr
     log cap work across calls without this function holding any state of its
     own: it logs a skipped ident only while
-    `skipped_so_far + skipped_events < _CORRECTION_SWEEP_LOG_CAP` (see
+    `skipped_so_far + skipped_events <= _CORRECTION_SWEEP_LOG_CAP` (see
     "Observability"). Deriving the budget from a caller-supplied running
     total, rather than a module-level counter, is what makes the cap reset
     per run automatically -- this server is long-lived and runs many
@@ -973,7 +973,7 @@ and log nothing for every ingest after, which is precisely the
 "looks clean, isn't" outcome this whole section exists to prevent. So the
 budget is derived from the driving loop's own running total instead:
 `_correction_sweep_apply` takes `skipped_so_far` and logs only while
-`skipped_so_far + skipped_events < _CORRECTION_SWEEP_LOG_CAP`. It resets
+`skipped_so_far + skipped_events <= _CORRECTION_SWEEP_LOG_CAP`. It resets
 per run for free, because each loop starts its total at `0`, and the
 function stays pure enough to test by calling it directly with a chosen
 `skipped_so_far`.

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -564,13 +564,19 @@ resume point — each handling its own absent/stale case:
 ```python
 low_bounds = _frontier_read_bounds(db, _FRONTIER_LOW_IDENT)
 high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
-if low_bounds is None or high_bounds is None:
-    return None  # migration hasn't run yet, or Stream 2 hasn't claimed anything
+if high_bounds is None:
+    return None  # Stream 2 hasn't claimed anything -- nothing to correct
 if hash_to_pos is None:
     hash_to_pos = {h: i for i, h in enumerate(linearization)}
-if low_bounds[1] not in hash_to_pos or high_bounds[0] not in hash_to_pos:
+if high_bounds[0] not in hash_to_pos:
     return None  # a boundary hash is stale (rewritten history); nothing safe to do
-if hash_to_pos[low_bounds[1]] + 1 != hash_to_pos[high_bounds[0]]:
+if low_bounds is None:
+    low_hi_pos = -1  # absent frontier-low == EMPTY low region -- see below
+else:
+    if low_bounds[1] not in hash_to_pos:
+        return None  # a boundary hash is stale (rewritten history)
+    low_hi_pos = hash_to_pos[low_bounds[1]]
+if low_hi_pos + 1 != hash_to_pos[high_bounds[0]]:
     return None  # gap still open -- Stream 2 may still descend past a position
                  # this sweep would otherwise confirm; see the precondition above
 if high_bounds[1] not in hash_to_pos:
@@ -598,6 +604,23 @@ if len(commit_metadata) != len(linearization) or commit_metadata[pos][0] != line
 commit_hash, commit_ts_iso, _author, _subject = commit_metadata[pos]
 return commit_hash, commit_ts_iso
 ```
+
+**An absent frontier-low means an empty low region, not an unknown one.** An
+earlier draft of this snippet returned `None` whenever *either* bound was
+absent, which is wrong for the low side and strands the whole sweep. A fresh
+graph seeds neither side (`_frontier_seed_from_watermark` no-ops without a
+pre-#222 watermark), and frontier-low is created only when the forward stream
+persists its first claim — so if Stream 2 claims the entire history before
+Stream 1 claims anything, the gap is genuinely closed (`is_gap_empty()` is
+`True`, `claim_high()` returns `None` forever) while frontier-low does not
+exist. Treating that as "nothing safe to do" leaves every entity provisional
+permanently, which is total failure of this phase rather than a conservative
+fallback. `low_hi_pos = -1` is the correct reading and is exactly what
+`FrontierAllocator.gap_lo` already does when no interval covers position 0
+(`frontier_registry.py:54-57`): the gap starts at 0, so `high.lo == 0` means it
+is closed. The high side keeps returning `None` when absent, because *there*
+absent genuinely does mean "nothing has been claimed, so there is nothing to
+correct".
 
 The contract check above is a real `if`/`return None`, not a bare `assert`:
 the documented violation this guards against (2d accidentally passing
@@ -1140,6 +1163,21 @@ high side, until `allocator.is_gap_empty()`.
   only frontier-low/migration state, no `_reverse_fill_claim_and_process`
   ever run; assert `_correction_sweep_claim_and_process` returns `None`
   and writes nothing.
+- **Runs when Stream 2 claimed everything and frontier-low never existed**:
+  on a fresh graph (neither side seeded), run `_reverse_fill_claim_and_process`
+  until `is_gap_empty()`, without ever claiming from the low side; assert
+  frontier-low is still absent, frontier-high's `:lo-hash` is
+  `linearization[0]`, and the sweep **does** hand out position 0 rather than
+  refusing — the regression test for reading an absent low side as "unknown"
+  instead of "empty".
+- **No-op when `commit_metadata` violates its alignment contract**: with the
+  gap closed, assert the aligned list yields a position, then that a
+  truncated list (what `_run_ingestion`'s watermark-relative list looks
+  like) and a rotated one (right length, wrong order) both yield `None`.
+  Rotate rather than reverse — reversing an odd-length list leaves the middle
+  element in place, which is exactly the position a one-claim-from-the-low-side
+  fixture leaves the sweep pointing at, so a reversed list slips past the
+  per-position hash check and the test would pass vacuously.
 - **Resumes from `correction-sweep-through`, not from frontier-high's
   lo-hash again**: close the gap over a range spanning several commits;
   call `_correction_sweep_claim_and_process` once (processes frontier-

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -1,0 +1,307 @@
+# Stream 1 Correction Sweep — Design Spec
+
+**Issue:** #222 (Phase 2, sub-phase 2c of 4)
+**Date:** 2026-07-25
+
+## Background
+
+#222's overall design is a converging multi-stream ingestion: a forward-truth
+stream (the existing `_run_ingestion` engine) running concurrently with a
+reverse-bulk-fill stream that provisionally back-fills recent history from
+`HEAD` downward, so recent history is visible almost immediately while the
+forward stream still owns lineage correctness.
+
+- **Phase 1** (merged, PR #226) built `frontier_registry.py`
+  (`Interval`/`FrontierAllocator`/`build_linearization`) plus
+  `mcp_server.py`'s `_frontier_load`/`_frontier_persist_claim` — the shared-gap
+  allocator both streams claim work from.
+- **Phase 2a** (merged, PR #227) built the provisional/authoritative fact
+  model primitives: `_lineage_mark_provisional`/`_lineage_confirm`/
+  `_lineage_is_provisional` (a companion `:type/lineage-marker` entity per
+  tracked entity), `_lineage_confirmed_through_query`/`_update`/`_migrate`
+  (a watermark for "is region X's lineage fully confirmed"), and
+  `_candidate_diff_persist`/`_read`/`_clear` (per-`(commit, entity)`
+  body-hash records so Stream 1 can later confirm/reject a candidate by hash
+  comparison instead of re-parsing).
+- **Phase 2b** (PR #228, not yet merged) built Stream 2's actual
+  reverse-bulk-fill walk (`_reverse_fill_claim_and_process`/
+  `_reverse_bulk_fill_walk`), claiming positions via `allocator.claim_high()`
+  and writing provisional `:introduced-by` + candidate-diff records for
+  every entity it discovers, moving the guess earlier whenever it finds an
+  earlier occurrence of the same entity.
+- **2c (this spec)** — Stream 1's correction sweep: claims positions via
+  `allocator.claim_low()`, converting the provisional facts 2b wrote into
+  authoritative ones as it reaches them, using 2a's persisted candidate
+  diffs for cheap replay instead of re-parsing.
+- **2d** — the actual concurrency wiring inside `_run_ingestion`: two
+  asyncio tasks sharing the frontier allocator and the existing single
+  write_executor, with fairness so neither starves.
+
+Like 2a and 2b, this sub-phase adds functions with **no caller wired into
+`_run_ingestion` yet** — 2d ties everything together into the real commit
+loop. This branch stacks on top of 2b's (`design-222-phase2b-reverse-bulk-fill-walk`,
+PR #228, not yet merged) since 2c calls 2b's `_entity_introduced_by_query`
+and depends on 2b's exact candidate-diff/provisional-marker write pattern.
+
+## Scope (2c only)
+
+In scope:
+
+- A per-commit correction step that claims one position from the gap's low
+  end (`FrontierAllocator.claim_low()`) and, for every entity touched by
+  that commit's "A"/"M" files, reconciles its lineage per the four-case
+  algorithm below.
+- A thin driving loop that repeats the above until the gap closes and
+  persists each claim via `_frontier_persist_claim`, keeping
+  `:ingestion/lineage-confirmed-through` in lockstep with frontier-low's
+  advancement.
+- Fixing 2b's documented known limitation: a retroactive `:modified-in` fact
+  written when a provisional guess is superseded does not re-check #221's
+  unchanged-body narrowing against the superseded commit's own diff. 2c has
+  both commits' persisted candidate-diff body hashes available and can
+  correct this without re-parsing.
+- Opportunistically clearing stale intermediate candidate-diff records left
+  behind along a supersession chain (2a's spec flagged this explicitly as
+  "2c's job").
+
+Explicitly deferred (matches 2b's own scope cut):
+
+- `:depends-on` edges, deletions ("D"), and renames ("R"). The existing
+  `_run_ingestion` loop already has full support for these; this sweep
+  reuses the same `_extract_commit`/`_build_code_triples` entity-discovery
+  path 2b used and keeps the same `if status not in ("A", "M"): continue`
+  guard.
+- Wiring into `_run_ingestion` / real concurrency (2d).
+
+## Design
+
+### Why `claim_low()`, not a hand-rolled position tracker
+
+Phase 1's `FrontierAllocator` already models exactly the invariant this
+sweep needs: `claim_low()` returns the next unclaimed position from the low
+end, and returns `None` once the gap is closed (i.e. frontier-low's
+advancing boundary has met frontier-high's current boundary). Using it
+directly means:
+
+- The sweep never walks past ground Stream 2 has actually covered — its
+  termination *is* "reached the point where Stream 2 already provisionally
+  covered ground," expressed through the allocator instead of a manually
+  computed bound.
+- It reuses already-tested machinery (`_frontier_persist_claim`,
+  `FrontierAllocator.claim_low`) instead of introducing a second, parallel
+  notion of "how far has Stream 1 gotten."
+- It sets 2c up to become Stream 1's one true per-commit step in 2d: the
+  four-case algorithm below is a strict generalization of ordinary forward
+  walk (case 1 degenerates to exactly today's `_build_code_triples`
+  introduction path when nothing is provisional), so 2d does not need two
+  separate code paths for "virgin territory" vs. "correcting Stream 2's
+  work" — a single call site suffices once concurrency is wired.
+
+### Per-commit algorithm
+
+For a claimed commit `C` (positions processed strictly oldest→newest via
+repeated `claim_low()` calls), reusing the same per-file A/M walk
+`_extract_commit`/`_build_code_triples` that 2b uses for entity
+discovery/parsing (direction-agnostic):
+
+```python
+candidate_idents = (
+    [precomputed["module_ident"]]
+    + [ident for ident, _name, _t in precomputed["function_entries"]]
+    + [ident for ident, _name, _t in precomputed["class_entries"]]
+    + [ident for ident, _name, _t in precomputed["global_entries"]]
+    + [ident for ident, _name, _t in precomputed["field_entries"]]
+)
+known_before = {
+    ident: "known" for ident in candidate_idents
+    if _entity_introduced_by_query(db, ident) is not None
+}
+triples = _build_code_triples(
+    file_path, extracted, commit_ts_iso, known_before, {}, {}, commit_ident,
+    precomputed, {}, {},
+)
+# This sweep owns the write timing of both attributes, same reason 2b does.
+all_triples.extend(t for t in triples if ":introduced-by" not in t and ":modified-in" not in t)
+```
+
+Each candidate ident then falls into exactly one of four cases:
+
+1. **No fact yet** (`ident not in known_before`) — neither stream has
+   touched this entity before. This *is* the true chronological
+   introduction, since the sweep walks oldest→newest and nothing earlier
+   claimed it. Assert `[ident :introduced-by commit_ident]` directly via
+   `_transact` — no provisional marker, no candidate-diff record (nothing
+   will ever need to re-check it, since this fact was never a guess). No
+   `:modified-in`. This is exactly what `_build_code_triples`'s own gate
+   would have done unfiltered — 2c only needs to special-case the other
+   three.
+
+2. **Known, provisional, guess matches this commit**
+   (`_lineage_is_provisional(db, ident)` and
+   `_entity_introduced_by_query(db, ident) == commit_ident`) — the expected
+   case once Stream 2 has fully walked the range down to `C`: by
+   construction, Stream 2's final guess for any entity within a range it
+   has completely traversed already equals that entity's true earliest
+   occurrence in that range. Call `_lineage_confirm(db, ident)` (drops the
+   marker; the `:introduced-by` fact itself is untouched, since its value
+   was already correct) and `_candidate_diff_clear(db, commit_hash, ident)`.
+   No `:modified-in`.
+
+3. **Known, provisional, guess points elsewhere**
+   (`_lineage_is_provisional(db, ident)` and
+   `_entity_introduced_by_query(db, ident) != commit_ident`) — the
+   reconciliation case 2a's spec reserved for 2c (rename- or
+   rebirth-spanning-the-gap; out of scope for both 2b and 2c to *detect*
+   structurally, but 2c corrects the resulting lineage once it reaches the
+   entity's real introduction here). Let `guessed_ident` be the current
+   (wrong) value:
+   - Retract `[ident :introduced-by guessed_ident]`, assert
+     `[ident :introduced-by commit_ident]` directly as authoritative (no
+     provisional marker — 2c is ground truth), then `_lineage_confirm(db,
+     ident)` to drop the marker 2b left behind.
+   - Give `guessed_ident` a retroactive `:modified-in` fact using **its
+     own** commit timestamp (looked up from `commit_metadata` via the same
+     `ts_by_commit_ident = {f":commit/{h[:12]}": ts for h, ts, _a, _s in
+     commit_metadata}` mapping 2b's step 3 builds) — **unless**
+     `_candidate_diff_read(db, guessed_hash, ident)`'s persisted body hash
+     equals this commit's freshly-computed body hash for `ident` (from
+     `precomputed["body_hashes"]`), meaning the body was actually unchanged
+     between the two commits. This is the fix for 2b's documented
+     limitation, using the persisted hash instead of re-parsing
+     `guessed_ident`'s own diff. `guessed_hash` is recovered directly from
+     `guessed_ident` by stripping its `":commit/"` prefix (`guessed_ident[9:]`)
+     — sufficient because `_candidate_diff_ident` only ever keys on
+     `commit_hash[:12]`, which is exactly what `commit_ident` already
+     truncated to when 2b minted it, so no separate hash→ident reverse
+     lookup is needed.
+   - `_candidate_diff_clear` both `(commit_hash, ident)` and
+     `(guessed_hash, ident)`.
+
+4. **Known, authoritative** (confirmed earlier in this same sweep, or
+   introduced by the original single-stream walk before #222 existed) — the
+   ordinary "already known" case: assert `[ident :modified-in commit_ident]`
+   unless `precomputed["unchanged_idents"]` says the body is provably
+   unchanged this commit (#221, unmodified). Additionally, opportunistically
+   call `_candidate_diff_clear(db, commit_hash, ident)` if a record happens
+   to exist for this exact `(commit, ident)` pair — this is what cleans up
+   the *intermediate* stale records 2b's own spec left behind along a
+   supersession chain (guess moves `L3 → L2 → L1 → C`; case 2 clears `C`'s
+   own record when the sweep reaches `C`; each of `L1`/`L2`/`L3` falls into
+   this case 4 when the sweep later reaches them, and each still has its
+   own now-orphaned candidate-diff record from when it was a transient
+   guess). No special-casing was needed for this — it falls out of the
+   ordinary path once the sweep passes back over those commits.
+
+### Driving functions
+
+```python
+def _correction_sweep_claim_and_process(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    allocator: "frontier_registry.FrontierAllocator",
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> Optional[str]:
+    """Claim one position from the gap's low end and reconcile that
+    commit's entities per the four-case algorithm above. Returns the
+    claimed commit's hash, or None if the gap was already empty (caller's
+    signal to stop). Writes are followed by exactly one _db_checkpoint(db)
+    call, after _frontier_persist_claim and _lineage_confirmed_through_update
+    both record the claim -- mirrors _reverse_fill_claim_and_process's
+    one-checkpoint-per-commit cadence."""
+
+def _correction_sweep_walk(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    allocator: "frontier_registry.FrontierAllocator",
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> int:
+    """Repeatedly call _correction_sweep_claim_and_process until the gap
+    closes. Returns the count of commits processed. No caller in this
+    sub-phase -- 2d wires this into the real concurrent ingestion loop
+    alongside the reverse stream."""
+```
+
+### Frontier + watermark advancement
+
+Each processed commit calls both `_frontier_persist_claim(db, linearization,
+pos, from_low=True, commit_ts_iso=commit_ts_iso, index_con=index_con)` *and*
+`_lineage_confirmed_through_update(db, commit_hash, commit_ts_iso,
+index_con=index_con)` — restoring the lockstep the two watermarks had before
+Stream 2 existed (`_lineage_confirmed_through_migrate` originally seeded
+`lineage-confirmed-through` from frontier-low's boundary precisely because
+they were always advanced together by the single old forward walk). Every
+commit this sweep claims is, by construction, now fully lineage-confirmed,
+so advancing both together is correct and keeps
+`_lineage_confirmed_through_query`'s trust predicate (2a spec, "Migration
+seeding") meaningful without special-casing. One `_db_checkpoint(db)` call
+per commit, after both watermark updates, same cadence as 2b.
+
+### Schema/audit safety, idempotency
+
+No new entity types or attributes — 2c is purely a new consumer of 2a's
+already-audited-safe primitives (`_lineage_confirm`/`_candidate_diff_clear`
+already established their own safety in 2a's spec) plus the existing
+`:introduced-by`/`:modified-in` attributes forward walk always used. Every
+write in the four-case algorithm is either a query-before-write primitive
+already built in 2a/2b, or a direct `_transact`/`_retract` pair gated on a
+query result (case 1 and case 3's direct authoritative assert) — never a
+blind unconditional transact.
+
+## Testing
+
+Following `docs/testing-conventions.md` (real `MiniGrafDb`, no mocks), using
+the same `tmp_path / "repo"` real-git-repo fixture pattern already used
+throughout `tests/test_mcp_server.py`'s existing ingestion tests, and (where
+a candidate needs a pre-existing provisional state) `_reverse_fill_claim_and_process`
+itself to set that state up realistically rather than hand-constructing
+facts:
+
+- **Fresh introduction, no prior provisional state** (case 1): a two-commit
+  repo with no reverse-walk activity; sweep from the start; assert the
+  entity's `:introduced-by` is asserted directly, no `:type/lineage-marker`
+  companion entity was ever created, and no candidate-diff record exists.
+- **Confirms a correct provisional guess** (case 2): run
+  `_reverse_bulk_fill_walk` first so an entity ends up with a provisional
+  `:introduced-by` pointing at its true earliest commit; then run the
+  correction sweep; assert `_lineage_is_provisional` is now `False`, the
+  `:introduced-by` value is unchanged, and the candidate-diff record for
+  that `(commit, entity)` is gone (`_candidate_diff_read` returns `None`).
+- **Reconciles a wrong provisional guess** (case 3): hand-construct a
+  provisional `:introduced-by` pointing at the *wrong* (later) commit for
+  an entity that's also genuinely present at an earlier commit the sweep
+  will reach, simulating the rename/rebirth edge case; run the sweep;
+  assert `:introduced-by` now points at the true earlier commit, is
+  authoritative, and the superseded commit received a retroactive
+  `:modified-in` with its own timestamp.
+- **Skips the retroactive `:modified-in` when the body is unchanged**
+  (case 3's #221 fix): same setup as above, but with matching body hashes
+  persisted at both the superseded and the true-introduction commits;
+  assert no `:modified-in` fact was written for the superseded commit —
+  this is the test that would fail against 2b's own documented limitation
+  if 2c naively reused its unconditional-assert behavior.
+- **Ordinary modification of an already-authoritative entity** (case 4): an
+  entity already authoritative (pre-seeded, non-provisional); sweep over a
+  commit that touches it; assert `:modified-in` is added and no lineage
+  marker exists.
+- **Opportunistic stale candidate-diff cleanup** (case 4): pre-seed a stale
+  candidate-diff record at a commit for an entity that's already
+  authoritative by the time the sweep reaches that commit (simulating an
+  orphaned intermediate guess along a supersession chain); assert the sweep
+  clears it even though that commit falls into the ordinary case-4 path.
+- **Gap-empty no-op**: an allocator whose gap is already empty; assert
+  `_correction_sweep_claim_and_process` returns `None` and writes nothing.
+- **`_frontier_persist_claim` + `_lineage_confirmed_through_update`
+  lockstep**: after `_correction_sweep_walk` processes N commits, assert
+  both frontier-low's persisted interval and
+  `_lineage_confirmed_through_query` reflect the same final commit.
+- **Full integration**: run `_reverse_bulk_fill_walk` over a range from
+  `HEAD`, then `_correction_sweep_walk` over the same range from the start;
+  assert every touched entity ends up authoritative
+  (`_lineage_is_provisional` is `False` for all of them) and no
+  `:type/candidate-diff` entities remain live.

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -104,6 +104,38 @@ repeated `claim_low()` calls), reusing the same per-file A/M walk
 `_extract_commit`/`_build_code_triples` that 2b uses for entity
 discovery/parsing (direction-agnostic):
 
+Before any per-file work, `all_triples` is seeded with the claimed commit's
+own `:type/commit` entity — this sweep processes commits `_reverse_fill_claim_and_process`
+never touched (it claims from the *low* end of the gap; 2b only ever claims
+from the high end), so unlike case 3's `guessed_ident` handling, which
+targets a commit 2b already wrote, the commit metadata for `C` itself does
+not exist yet and must be written here, identically to 2b's own shape:
+
+```python
+all_triples: List[str] = [
+    f"[{commit_ident} :entity-type :type/commit]",
+    f'[{commit_ident} :ident "{commit_ident}"]',
+    f'[{commit_ident} :description "{_edn_escape(subject[:120])}"]',
+    f'[{commit_ident} :hash "{commit_hash}"]',
+    f'[{commit_ident} :author "{_edn_escape(author)}"]',
+    f'[{commit_ident} :subject "{_edn_escape(subject[:200])}"]',
+    f'[{commit_ident} :date "{commit_ts_iso}"]',
+]
+```
+
+`:parent` edges are explicitly deferred, matching 2b's own precedent — 2b's
+`_reverse_fill_claim_and_process` writes the same seven commit attributes
+above and also does not write `:parent` (mcp_server.py:7321-7329). Both
+streams currently leave every commit they claim without a `:parent` edge;
+only ordinary forward walk (`_run_ingestion`, mcp_server.py:7982) writes it
+today. This is a known gap shared by 2b and 2c, not something 2c introduces
+new — 2d must decide how (or whether) to backfill `:parent` for commits
+either stream claims once concurrency is wired, since that's the point at
+which the frontier's authoritative region stops corresponding 1:1 with
+"ordinary forward walk processed it."
+
+Per-file candidate discovery then proceeds:
+
 ```python
 candidate_idents = (
     [precomputed["module_ident"]]
@@ -116,6 +148,14 @@ known_before = {
     ident: "known" for ident in candidate_idents
     if _entity_introduced_by_query(db, ident) is not None
 }
+# Snapshot BEFORE calling _build_code_triples -- it mutates known_before in
+# place (its entity_valid_from parameter), inserting every newly introduced
+# ident as a side effect of building that ident's own structural triples.
+# Classifying case 1 against the post-call dict would therefore find every
+# fresh introduction already "known" and skip its authoritative
+# :introduced-by write entirely. Same reason 2b takes a snapshot
+# (mcp_server.py:7351) before its own equivalent call.
+known_before_snapshot = set(known_before.keys())
 triples = _build_code_triples(
     file_path, extracted, commit_ts_iso, known_before, {}, {}, commit_ident,
     precomputed, {}, {},
@@ -124,10 +164,11 @@ triples = _build_code_triples(
 all_triples.extend(t for t in triples if ":introduced-by" not in t and ":modified-in" not in t)
 ```
 
-Each candidate ident then falls into exactly one of four cases:
+Each candidate ident then falls into exactly one of four cases, classified
+against `known_before_snapshot` (never the post-call `known_before`):
 
-1. **No fact yet** (`ident not in known_before`) — neither stream has
-   touched this entity before. This *is* the true chronological
+1. **No fact yet** (`ident not in known_before_snapshot`) — neither stream
+   has touched this entity before. This *is* the true chronological
    introduction, since the sweep walks oldest→newest and nothing earlier
    claimed it. Assert `[ident :introduced-by commit_ident]` directly via
    `_transact` — no provisional marker, no candidate-diff record (nothing
@@ -162,18 +203,23 @@ Each candidate ident then falls into exactly one of four cases:
    - Give `guessed_ident` a retroactive `:modified-in` fact using **its
      own** commit timestamp (looked up from `commit_metadata` via the same
      `ts_by_commit_ident = {f":commit/{h[:12]}": ts for h, ts, _a, _s in
-     commit_metadata}` mapping 2b's step 3 builds) — **unless**
-     `_candidate_diff_read(db, guessed_hash, ident)`'s persisted body hash
-     equals this commit's freshly-computed body hash for `ident` (from
-     `precomputed["body_hashes"]`), meaning the body was actually unchanged
-     between the two commits. This is the fix for 2b's documented
-     limitation, using the persisted hash instead of re-parsing
-     `guessed_ident`'s own diff. `guessed_hash` is recovered directly from
-     `guessed_ident` by stripping its `":commit/"` prefix (`guessed_ident[9:]`)
-     — sufficient because `_candidate_diff_ident` only ever keys on
-     `commit_hash[:12]`, which is exactly what `commit_ident` already
-     truncated to when 2b minted it, so no separate hash→ident reverse
-     lookup is needed.
+     commit_metadata}` mapping 2b's step 3 builds) — **unless both**
+     `_candidate_diff_read(db, guessed_hash, ident)` and
+     `precomputed["body_hashes"].get(ident)` are non-`None` **and** equal,
+     meaning the body was actually unchanged between the two commits. This
+     is the fix for 2b's documented limitation, using the persisted hash
+     instead of re-parsing `guessed_ident`'s own diff. The comparison must
+     fail open (assert `:modified-in` conservatively) whenever either side
+     is `None` — `precomputed["body_hashes"]` deliberately excludes modules
+     (mcp_server.py:6414, function/class/variable/field only) and can be
+     empty on a parse/hash failure, so a bare `==` comparison would treat
+     module idents (and any hash-failure case) as "unchanged" via a
+     `None == None` false positive and wrongly suppress a real edit.
+     `guessed_hash` is recovered directly from `guessed_ident` by stripping
+     its `":commit/"` prefix (`guessed_ident[9:]`) — sufficient because
+     `_candidate_diff_ident` only ever keys on `commit_hash[:12]`, which is
+     exactly what `commit_ident` already truncated to when 2b minted it, so
+     no separate hash→ident reverse lookup is needed.
    - `_candidate_diff_clear` both `(commit_hash, ident)` and
      `(guessed_hash, ident)`.
 
@@ -285,6 +331,13 @@ facts:
   assert no `:modified-in` fact was written for the superseded commit —
   this is the test that would fail against 2b's own documented limitation
   if 2c naively reused its unconditional-assert behavior.
+- **Fails open when a body hash is missing** (case 3's fail-open guard):
+  same reconciliation setup as above, but for a *module* ident (which
+  `precomputed["body_hashes"]` never populates) so both the persisted
+  candidate-diff hash and the current body hash are `None`; assert the
+  retroactive `:modified-in` is still written — this is the test that would
+  catch a naive `==` comparison treating the `None == None` case as
+  "unchanged" and wrongly suppressing a real edit.
 - **Ordinary modification of an already-authoritative entity** (case 4): an
   entity already authoritative (pre-seeded, non-provisional); sweep over a
   commit that touches it; assert `:modified-in` is added and no lineage

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -32,22 +32,38 @@ forward stream still owns lineage correctness.
 - **2c (this spec)** — Stream 1's correction sweep: walks **upward**
   (oldest→newest) through frontier-high's own already-claimed interval —
   starting at its current `:lo-hash` and proceeding toward its own
-  persisted `:hi-hash` — using a
-  dedicated watermark for its own resumable progress (**not**
-  `:ingestion/lineage-confirmed-through`, and **not** `allocator.claim_low()`;
-  see "Why not `claim_low()`" and "Why a dedicated watermark" below),
-  converting the provisional facts 2b wrote into authoritative ones as it
-  reaches them, using 2a's persisted candidate diffs for cheap replay
-  instead of re-parsing.
-- **2d** — the actual concurrency wiring inside `_run_ingestion`: two
-  asyncio tasks sharing the frontier allocator and the existing single
-  write_executor, with fairness so neither starves.
+  persisted `:hi-hash` — using a dedicated watermark for its own resumable
+  progress (**not** `:ingestion/lineage-confirmed-through`, and **not**
+  `allocator.claim_low()`; see "Why not `claim_low()`" and "Why a
+  dedicated watermark" below), converting the provisional facts 2b wrote
+  into authoritative ones as it reaches them and correcting 2b's own
+  documented `:modified-in` over-assertion where its own parse disagrees.
+  **This sweep only ever runs once Stream 1 and Stream 2 have both
+  permanently finished for the run** (see "Why confirming requires the gap
+  to already be closed") — it is a third, sequential, post-convergence
+  pass, not a concurrent task alongside the other two.
+- **2d** — the actual concurrency wiring inside `_run_ingestion`. Its task
+  structure is not this spec's to design, but 2c's own precondition already
+  constrains it: it cannot be simply "two asyncio tasks sharing the
+  allocator, with fairness so neither starves" plus this sweep bolted on as
+  a third — this sweep cannot start until both of the other two are
+  finished, so 2d needs a third, sequential phase after the first two
+  converge, not a third concurrent one.
 
 Like 2a and 2b, this sub-phase adds functions with **no caller wired into
 `_run_ingestion` yet** — 2d ties everything together into the real commit
 loop. This branch stacks on top of 2b's (`design-222-phase2b-reverse-bulk-fill-walk`,
 PR #228, not yet merged) since 2c calls 2b's `_entity_introduced_by_query`
 and depends on 2b's exact candidate-diff/provisional-marker write pattern.
+
+**Consequence for phase 2's own value proposition:** recent history becomes
+*visible* as soon as Stream 2 writes it, but every entity Stream 2 touched
+remains provisional — and therefore untrusted by 2a's composed trust
+predicate — until this sweep has walked the *entire* converged range after
+both streams finish. On a large repository that is close to the full
+ingest duration, not a small tail. This isn't a defect in this sweep's own
+logic; it's a real scheduling consequence 2d has to plan around, stated
+here so it isn't discovered only once 2d is being designed.
 
 ## Scope (2c only)
 
@@ -67,9 +83,20 @@ In scope:
   `:ingestion/correction-sweep-through`.
 - Opportunistically clearing stale intermediate candidate-diff records left
   behind along a supersession chain (2a's spec flagged this explicitly as
-  "2c's job").
+  "2c's job"). Candidate-diff records are a pure cleanup obligation for
+  this sweep — nothing in its own classification logic reads one; contrast
+  with an earlier draft, which read persisted hashes to skip re-parsing (a
+  goal that never actually applied once this sweep needed a full
+  `_extract_commit` call for entity discovery regardless).
 - A guard against re-asserting `:modified-in` at an entity's own
   introduction commit on a resumed/re-run sweep (see "Per-commit algorithm").
+- Correcting 2b's documented `:modified-in` over-assertion: when 2b
+  supersedes a provisional guess, it retroactively asserts `:modified-in`
+  at the superseded commit *unconditionally*, without re-checking #221's
+  unchanged-body narrowing against that commit's own diff (2b's own spec,
+  "Known, documented limitation"). This sweep has the real parse in hand
+  for every commit it visits and reconciles the fact to match — see case 3
+  below.
 
 Explicitly deferred:
 
@@ -273,6 +300,30 @@ for status, file_path, extracted, precomputed, _old_path in file_results:
     unchanged_idents = precomputed.get("unchanged_idents", set())
 ```
 
+**Classification reads *all* live `:introduced-by` values for `ident`, not
+just one.** `_entity_introduced_by_query` returns `results[0][0]` — an
+arbitrary row when more than one exists (mcp_server.py:5228-5233). Two live
+`:introduced-by` facts for one entity is a real, reachable state once 2d
+exists: `_run_ingestion` seeds `entity_valid_from` once at startup, 2b's
+writes never enter that in-memory dict, so if ordinary forward walk later
+reaches an entity 2b already introduced, `_build_code_triples` treats it as
+new and asserts a *second* `:introduced-by` at a different commit and a
+different `valid_from` — both survive. Relying on `results[0][0]` would
+make case 1's confirm and case 3's self-introduction guard silently
+order-dependent on which row minigraf happens to return first, which is
+not a documented guarantee anywhere. So this sweep queries the full set:
+
+```python
+raw = _db_execute(db, f"(query [:find ?c :where [{ident} :introduced-by ?c]])")
+introduced_by_values = [row[0] for row in json.loads(raw).get("results", [])]
+```
+
+and every guard below tests `introduced_by_values == [commit_ident]` —
+*exactly one* value, equal to `commit_ident` — never membership
+(`commit_ident in introduced_by_values`) and never the first-row shortcut.
+Zero values or two both fail the equality and fall through to whichever
+branch's `else` is the safe one, below.
+
 Each candidate ident then falls into one of three cases. Every write below
 uses `C`'s own `commit_ts_iso` (the same timestamp 2b itself used when it
 first wrote at `C`) — this equality is load-bearing, not incidental: it is
@@ -282,49 +333,85 @@ identical `(entity, attribute, value, valid_from)` tuple is a no-op; only a
 *differing* `valid_from` produces a second live datom) rather than a
 duplicate.
 
-1. **Provisional, guess matches this commit**
-   (`_lineage_is_provisional(db, ident)` and
-   `_entity_introduced_by_query(db, ident) == commit_ident`) — per "Why a
-   dedicated watermark" above, this is the *only* state a provisional
-   entity can be in in this sweep's range once the sweep reaches it: Stream
-   2's guess is guaranteed to already equal its true within-range-earliest
-   occurrence by the time this sweep, walking the same order, gets there.
-   Call `_lineage_confirm(db, ident, index_con=index_con)` (drops the
-   marker; the `:introduced-by` fact itself is untouched, since its value
-   was already correct) and `_candidate_diff_clear(db, commit_hash, ident,
-   index_con=index_con)`. No `:modified-in`.
+1. **Provisional, guess matches this commit** (`_lineage_is_provisional(db,
+   ident)` and `introduced_by_values == [commit_ident]`) — per "Why
+   confirming requires the gap to already be closed" above, this is the
+   *only* state a provisional entity can be in in this sweep's range once
+   the sweep reaches it: Stream 2's guess is guaranteed to already equal
+   its true within-range-earliest occurrence by the time this sweep,
+   walking the same order, gets there. Call `_lineage_confirm(db, ident,
+   index_con=index_con)` (drops the marker; the `:introduced-by` fact
+   itself is untouched, since its value was already correct) and
+   `_candidate_diff_clear(db, commit_hash, ident, index_con=index_con)`.
+   No `:modified-in`.
 
-2. **Provisional, guess points elsewhere**
-   (`_lineage_is_provisional(db, ident)` and
-   `_entity_introduced_by_query(db, ident) != commit_ident`) — per "Why
-   confirming requires the gap to already be closed" above, a correct
-   caller (the gap-closed precondition holding) means this state should not
-   arise for a commit inside this sweep's range. It is kept as an explicit
-   branch anyway, not folded into case 1's `else`, precisely because
-   "should not arise" is a caller obligation this per-ident classification
-   cannot itself verify: **leave the entity completely untouched** — no
-   `_lineage_confirm`, no `:introduced-by` change, no candidate-diff
-   touch — so that if the precondition is ever violated, this sweep fails
-   safe (does nothing) rather than confirming an unvalidated guess. The
-   entity remains provisional and available for whatever the deferred
-   reconciliation turns out to be.
+2. **Provisional, anything else** (`_lineage_is_provisional(db, ident)` and
+   `introduced_by_values != [commit_ident]` — zero values, `commit_ident`
+   plus at least one other, or a single different value) — the "guess
+   points elsewhere" state per "Why confirming requires the gap to already
+   be closed" above, and now also the duplicate-fact state above: a
+   correct caller (gap-closed precondition, and no stray second
+   `:introduced-by` from an uncoordinated forward walk) means this
+   shouldn't arise for a commit inside this sweep's range, but neither
+   condition is something this per-ident classification can verify itself.
+   **Leave the entity completely untouched** — no `_lineage_confirm`, no
+   `:introduced-by` change, no candidate-diff touch — so this sweep fails
+   safe (does nothing) rather than confirming an unvalidated or ambiguous
+   guess. The entity remains provisional and available for whatever the
+   deferred reconciliation (or, for the duplicate-fact case, 2d's own fix)
+   turns out to be.
 
-3. **Already authoritative** (confirmed at an earlier position in this same
-   sweep, or — after this sweep has fully caught up once — simply revisited
-   on a later run) — first check whether `C` *is* this entity's own
-   introduction commit: if `_entity_introduced_by_query(db, ident) ==
-   commit_ident`, skip entirely (no `:modified-in`, no candidate-diff
-   touch). This guard matters for resume-safety: if the process dies after
-   case 1's `_lineage_confirm` but before `_correction_sweep_through_update`
+3. **Already authoritative** (`not _lineage_is_provisional(db, ident)`;
+   confirmed at an earlier position in this same sweep, or — after this
+   sweep has fully caught up once — simply revisited on a later run) —
+   first, the self-introduction guard: if `introduced_by_values ==
+   [commit_ident]`, `C` *is* this entity's own introduction commit, so skip
+   entirely (no `:modified-in` write or retraction, no candidate-diff
+   touch). This matters for resume-safety: if the process dies after case
+   1's `_lineage_confirm` but before `_correction_sweep_through_update`
    persists, a re-run revisits `C` and would otherwise find the
    now-authoritative entity at its own introduction commit and wrongly
-   assert a self-`:modified-in` — a fact class ordinary forward walk never
+   touch a self-`:modified-in` — a fact class ordinary forward walk never
    produces (`_build_code_triples` only emits `:modified-in` on its
-   already-known branch, never at introduction). Otherwise: assert
-   `[ident :modified-in commit_ident]` at `C`'s own `commit_ts_iso`, unless
-   `ident in unchanged_idents` (#221, unmodified this commit). Either way,
-   opportunistically call `_candidate_diff_clear(db, commit_hash, ident,
-   index_con=index_con)` if a record happens to exist for this exact
+   already-known branch, never at introduction). If `introduced_by_values`
+   is anything else (including zero or 2+ values — the same duplicate-fact
+   risk as case 2, left alone here too rather than guessed at), also skip:
+   this sweep only actively reconciles `:modified-in` when it has an
+   unambiguous single introduction commit to compare `C` against.
+
+   Otherwise, **reconcile rather than merely assert** — this is where this
+   sweep corrects 2b's documented over-assertion (see Scope), not just
+   re-confirms what's already there:
+
+   ```python
+   raw = _db_execute(
+       db, f"(query [:find ?c :where [{ident} :modified-in {commit_ident}]])"
+   )
+   already_has_modified_in = bool(json.loads(raw).get("results", []))
+   if ident in unchanged_idents:
+       if already_has_modified_in:
+           _retract(db, f"[[{ident} :modified-in {commit_ident}]]", index_con=index_con)
+   else:
+       if not already_has_modified_in:
+           _transact(db, f"[[{ident} :modified-in {commit_ident}]]", commit_ts_iso, index_con=index_con)
+   ```
+
+   For the common case — `C` is an ordinary later touch 2b itself already
+   classified as "already authoritative touched" (mcp_server.py:7379-7387,
+   the *same* `unchanged_idents` gate, computed from the identical
+   `_extract_commit` call) — this is provably a no-op: both streams agree,
+   so the fact's presence already matches what this sweep would decide,
+   and the retract/assert branch never fires. Where it actually matters is
+   2b's *retroactive* supersession write (mcp_server.py:7396-7407), which
+   asserts `[ident :modified-in superseded_ident]` unconditionally, with no
+   `#221` check at all — if this sweep's own `unchanged_idents` (computed
+   from its own, potentially more complete, pass over `superseded_ident`'s
+   diff) disagrees, it retracts the over-asserted edge here. This is the
+   only place in the whole design where 2b's known limitation actually gets
+   fixed; everywhere else this sweep's `:modified-in` handling is
+   redundant by construction. Either way, opportunistically call
+   `_candidate_diff_clear(db, commit_hash, ident, index_con=index_con)` if
+   a record happens to exist for this exact
    `(commit, ident)` pair — this is what cleans up the *intermediate* stale
    records 2b's own spec left behind along a supersession chain (guess
    moves `L3 → L2 → L1 → C`; case 1 clears `C`'s own record when the sweep
@@ -359,6 +446,17 @@ def _correction_sweep_through_update(
     exactly, at a different ident."""
 ```
 
+`_correction_sweep_claim_and_process` takes an additional optional
+`hash_to_pos: Optional[Dict[str, int]] = None` parameter — if omitted, it
+builds one from `linearization` itself (so the function stays independently
+callable, e.g. from tests, exactly as before); `_correction_sweep_walk`
+builds it **once** and passes it to every call instead. `linearization` is
+fixed for the duration of a run, so rebuilding an `N`-entry map on every one
+of a full sweep's `N` calls (as an earlier draft's snippet did, with no
+caller-side reuse) is pure `O(N²)` waste — `_frontier_load` itself only
+ever builds this map once per run (mcp_server.py:4967), and this sweep
+should match that.
+
 Position selection: first the gap-closed precondition ("Why confirming
 requires the gap to already be closed" above), then the ceiling, then the
 resume point — each handling its own absent/stale case:
@@ -368,7 +466,8 @@ low_bounds = _frontier_read_bounds(db, _FRONTIER_LOW_IDENT)
 high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
 if low_bounds is None or high_bounds is None:
     return None  # migration hasn't run yet, or Stream 2 hasn't claimed anything
-hash_to_pos = {h: i for i, h in enumerate(linearization)}
+if hash_to_pos is None:
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
 if low_bounds[1] not in hash_to_pos or high_bounds[0] not in hash_to_pos:
     return None  # a boundary hash is stale (rewritten history); nothing safe to do
 if hash_to_pos[low_bounds[1]] + 1 != hash_to_pos[high_bounds[0]]:
@@ -386,13 +485,46 @@ else:
     # Unset (first-ever call), or a stale hash from rewritten/rebased
     # history -- (re)start from frontier-high's current lo-hash, mirroring
     # _frontier_load's own precedent of dropping a bound that no longer
-    # resolves (mcp_server.py:4970-4978) rather than erroring.
+    # resolves (mcp_server.py:4970-4978) rather than erroring. See the
+    # cross-run caveat below for why this rule is only complete within a
+    # single run.
     pos = hash_to_pos[high_bounds[0]]  # already validated above
 if pos > ceiling_pos:
     return None  # reached frontier-high's own :hi-hash; nothing left to correct
+if len(commit_metadata) != len(linearization) or commit_metadata[pos][0] != linearization[pos]:
+    return None  # commit_metadata violates its stated contract -- nothing safe to
+                 # do, rather than an IndexError/wrong-commit read; see the
+                 # contract note below
 commit_hash, commit_ts_iso, _author, _subject = commit_metadata[pos]
-assert commit_hash == linearization[pos]  # see the contract note below
 ```
+
+The contract check above is a real `if`/`return None`, not a bare `assert`:
+the documented violation this guards against (2d accidentally passing
+`_run_ingestion`'s own watermark-relative `commit_metadata`, shorter than
+`linearization`) would make `commit_metadata[pos]` raise `IndexError`
+*before* an `assert` placed after the indexing could ever run, or, for a
+`pos` that happens to still be in range, silently read the wrong commit's
+metadata — and `assert` disappears entirely under `python -O`, which would
+let that silent misread through undetected and quietly break the
+valid_from-equality property every idempotency argument in this design
+depends on. Checking the lengths and the hash *before* indexing, and
+returning `None` like every other unmet precondition in this function,
+keeps the same "nothing safe to do" discipline instead of crashing.
+
+**Cross-run caveat:** `pos = hash_to_pos[through_hash] + 1` assumes no
+position *below* the watermark ever becomes newly claimed after the sweep
+has passed it. That holds within a single run — the gap-closed precondition
+guarantees Stream 2 is permanently finished before this sweep starts, so
+frontier-high's `:lo-hash` is frozen for the rest of the run. It does not
+hold *across* runs once the incremental-re-ingest growth hazard noted below
+is fixed: a later run could then legitimately claim positions below a
+previous run's floor, and this resume rule would skip past them without
+ever confirming their provisional facts or clearing their candidate-diff
+records. Today this is masked — the inverted-interval state produced by
+that same hazard makes `pos > ceiling_pos` and the sweep no-ops instead —
+so this is latent incompleteness, not live corruption. Whoever fixes the
+growth handling should also make this sweep restart from `:lo-hash`
+whenever its position is below `correction-sweep-through`'s.
 
 `ceiling_pos` reads frontier-high's *persisted* `:hi-hash`
 (`high_bounds[1]`) rather than `len(linearization) - 1`. Those are **not**
@@ -466,6 +598,7 @@ def _correction_sweep_claim_and_process(
     commit_metadata: List[Tuple[str, str, str, str]],
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
+    hash_to_pos: Optional[Dict[str, int]] = None,
 ) -> Optional[str]:
     """Advance the correction sweep by exactly one commit, upward through
     frontier-high's own claimed territory, and reconcile that commit's
@@ -474,14 +607,18 @@ def _correction_sweep_claim_and_process(
     is still open (Stream 2 could still descend past a position this call
     would confirm -- see "Why confirming requires the gap to already be
     closed"), frontier-high hasn't claimed anything yet, a required
-    boundary hash is stale, or the sweep has already reached frontier-
-    high's own :hi-hash. No `allocator` parameter -- this reads frontier-low
-    and frontier-high's persisted bounds directly via _frontier_read_bounds
-    and tracks its own progress via _correction_sweep_through_query/_update,
-    not the allocator's claim_low(); see "Why not claim_low()" above. Never
-    calls _frontier_persist_claim or _lineage_confirmed_through_update --
-    neither frontier-low nor lineage-confirmed-through is touched by this
-    sweep."""
+    boundary hash is stale, commit_metadata doesn't match linearization, or
+    the sweep has already reached frontier-high's own :hi-hash. No
+    `allocator` parameter -- this reads frontier-low and frontier-high's
+    persisted bounds directly via _frontier_read_bounds and tracks its own
+    progress via _correction_sweep_through_query/_update, not the
+    allocator's claim_low(); see "Why not claim_low()" above. Never calls
+    _frontier_persist_claim or _lineage_confirmed_through_update -- neither
+    frontier-low nor lineage-confirmed-through is touched by this sweep.
+    `hash_to_pos`, if omitted, is built fresh from `linearization` --
+    callers doing a full sweep should build it once and pass it in instead
+    (see _correction_sweep_walk) to avoid rebuilding an N-entry map on every
+    one of a full sweep's N calls."""
 
 def _correction_sweep_walk(
     db: Any,
@@ -491,11 +628,16 @@ def _correction_sweep_walk(
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
 ) -> int:
-    """Repeatedly call _correction_sweep_claim_and_process until it returns
-    None. Returns the count of commits processed. No caller in this
-    sub-phase -- 2d wires this into the real concurrent ingestion loop
-    alongside the reverse stream, and alongside ordinary claim_low()-driven
-    introduction for territory below the gap."""
+    """Build hash_to_pos once and repeatedly call
+    _correction_sweep_claim_and_process (passing it down) until that
+    returns None. Returns the count of commits processed -- 0 both when the
+    gap-closed precondition isn't met yet (the common case early in a run;
+    callers should not read 0 as "nothing to do, ever") and when the sweep
+    has already fully caught up to frontier-high's :hi-hash. No caller in
+    this sub-phase -- 2d wires this into the real concurrent ingestion
+    loop, run only after both the reverse stream and ordinary
+    claim_low()-driven introduction have permanently finished for the run
+    (see "Why confirming requires the gap to already be closed")."""
 ```
 
 ### Schema/audit safety, idempotency
@@ -510,15 +652,19 @@ descriptions would both pass audit but be indistinguishable from each
 other in the fact index and in `minigraf_audit` output. Case 1's writes are
 the same query-before-write primitives 2a/2b already established as safe
 (`_lineage_confirm`, `_candidate_diff_clear`). Case 2 writes nothing. Case
-3's `:modified-in` assert, once its guard passes, *is* an unconditional
-`_transact` — it is safe not because of a query-before-write guard but
-because it always uses `C`'s own `commit_ts_iso`, matching what forward
-walk (or 2b, if `C` happens to already carry other facts from it) would
-have used at the same position, so a re-issued write lands as an idempotent
-no-op rather than a duplicate (see "Per-commit algorithm" above). This is
-worth stating plainly rather than leaving implicit, since it is the one
-write in this design that depends on timestamp discipline rather than a
-guard for its safety.
+3's `:modified-in` reconciliation is itself query-before-write (it reads
+`already_has_modified_in` before deciding to retract or assert), so its
+retract is never a blind retraction of a possibly-absent fact. The assert
+branch, when it does fire, is still an unconditional `_transact` — it is
+safe not because of the query-before-write guard (that guard decides
+*whether* to write, not what makes a repeat write safe) but because it
+always uses `C`'s own `commit_ts_iso`, matching what forward walk (or 2b,
+if `C` happens to already carry other facts from it) would have used at
+the same position, so a re-issued write lands as an idempotent no-op
+rather than a duplicate (see "Per-commit algorithm" above). This is worth
+stating plainly rather than leaving implicit, since it is the one write in
+this design that depends on timestamp discipline rather than a guard alone
+for its safety.
 
 ## Testing
 
@@ -569,10 +715,21 @@ high side, until `allocator.is_gap_empty()`.
   entity is still provisional, `:introduced-by` is unchanged, and no
   candidate-diff record was touched — the test that pins "fails safe"
   rather than "confirms an unvalidated guess."
+- **Fails safe on a duplicate `:introduced-by`, regardless of row order**
+  (case 2, the multi-value guard): with the gap closed, hand-construct
+  *two* live `:introduced-by` facts for the same entity — one equal to
+  `commit_ident` for the commit the sweep is about to visit, one at a
+  different commit — simulating the uncoordinated-forward-walk state this
+  design defers to 2d; run the sweep over that commit; assert it is a
+  no-op regardless of which fact minigraf's query happens to return first
+  (assert this for both physical insertion orders, since row order is not
+  a documented guarantee) — the test that would fail against a naive
+  `results[0][0]`-based guard, which could confirm on an unvalidated
+  duplicate depending on row order.
 - **Skips `:modified-in` at an entity's own introduction commit on a
-  resumed sweep** (case 3's guard): with the gap closed, run the
-  correction sweep once so an entity is confirmed authoritative at its
-  true introduction commit; call `_correction_sweep_claim_and_process`
+  resumed sweep** (case 3's self-introduction guard): with the gap closed,
+  run the correction sweep once so an entity is confirmed authoritative at
+  its true introduction commit; call `_correction_sweep_claim_and_process`
   again as if resuming after a crash (i.e. without having advanced
   `_correction_sweep_through_update` past that commit — construct this
   directly rather than via the real crash path, mirroring how other resume
@@ -580,12 +737,28 @@ high side, until `allocator.is_gap_empty()`.
   assert no `:modified-in` fact was created for that entity at its own
   introduction commit — this is the test that would fail against a naive
   implementation of case 3 with no self-introduction guard.
-- **Ordinary modification of an already-authoritative entity** (case 3, the
-  general path): with the gap closed, an entity already authoritative at
-  some earlier commit (pre-seeded via a real earlier sweep pass,
-  non-provisional); sweep over a later commit that touches it; assert
-  `:modified-in` is added at that later commit and no lineage marker
-  exists.
+- **Ordinary modification of an already-authoritative entity is a no-op
+  when 2b already agrees** (case 3, the common path): with the gap closed,
+  an entity already authoritative at some earlier commit (pre-seeded via a
+  real earlier sweep pass, non-provisional) genuinely modified at a later
+  commit `C` that 2b itself already classified as "already authoritative
+  touched" (i.e. `_reverse_fill_claim_and_process` already wrote
+  `[entity :modified-in C]` there); sweep over `C`; assert
+  `:modified-in` is present exactly once (raw count, not just presence) —
+  proving the reconciliation is idempotent for the common case, not merely
+  "asserts and happens not to duplicate."
+- **Retracts 2b's over-asserted retroactive `:modified-in`** (case 3, the
+  actual fix): with the gap closed, construct the supersession scenario
+  2b's own known limitation describes — an entity whose provisional guess
+  gets superseded, so 2b retroactively (and unconditionally) writes
+  `[entity :modified-in superseded_commit]` — but arrange for the entity's
+  body to be provably unchanged at `superseded_commit` per this sweep's own
+  `unchanged_idents` (a case 2b's own retroactive write doesn't check);
+  once the sweep, walking forward, reaches `superseded_commit` in case 3's
+  general path, assert the over-asserted `:modified-in` fact has been
+  retracted — this is the regression test for the "case 3's write can only
+  ever be redundant" finding: without the retract branch, this fact stays
+  live forever.
 - **Opportunistic stale candidate-diff cleanup** (case 3): pre-seed a stale
   candidate-diff record at a commit for an entity that's already
   authoritative by the time the sweep reaches that commit (simulating an

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -312,6 +312,15 @@ facts:
   repo with no reverse-walk activity; sweep from the start; assert the
   entity's `:introduced-by` is asserted directly, no `:type/lineage-marker`
   companion entity was ever created, and no candidate-diff record exists.
+  Also query the claimed commit itself and assert its `:type/commit` entity
+  was written (`:entity-type`, `:hash`, `:subject`, `:date` at minimum) —
+  this is new 2c-owned behavior (2c claims commits from the low end that 2b
+  never touched, so unlike case 3's `guessed_ident` handling, nothing else
+  has written this commit's metadata first) and a regression that dropped
+  it would still pass every other case-1 assertion while leaving
+  `:introduced-by` pointing at a dangling `:commit/...` ident. Additionally
+  assert no `:parent` fact exists for the claimed commit, documenting the
+  scope cut rather than leaving it untested.
 - **Confirms a correct provisional guess** (case 2): run
   `_reverse_bulk_fill_walk` first so an entity ends up with a provisional
   `:introduced-by` pointing at its true earliest commit; then run the

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -65,6 +65,23 @@ ingest duration, not a small tail. This isn't a defect in this sweep's own
 logic; it's a real scheduling consequence 2d has to plan around, stated
 here so it isn't discovered only once 2d is being designed.
 
+**Cost:** this sweep calls `_extract_commit` (a `git diff-tree`, a `git
+show` per changed file, and a tree-sitter parse of both sides of each) for
+*every* commit in frontier-high's converged range — duplicating work 2b
+already did over the same commits. For a large converged range that is
+close to a second full extraction pass over the repository, stacked on top
+of the terminal-pass consequence above. This is a deliberate simplicity
+choice, not an oversight: the sweep's classification only strictly needs
+`unchanged_idents` from the parse (which entities `C` touches, and which
+idents to act on, could instead be enumerated from the graph itself — any
+`ident` satisfying `[ident :introduced-by C]` or `[ident :modified-in C]`
+covers everything case 1 and case 3 act on) but `unchanged_idents` is what
+makes the reconcile step in case 3 possible at all, so the parse cannot be
+eliminated outright. A future optimization could enumerate from the graph
+and call `_extract_commit` only when at least one enumerated ident has a
+live `:modified-in` the reconcile step might need to revisit — not adopted
+here, in favor of reusing the same discovery path 2b already established.
+
 ## Scope (2c only)
 
 In scope:
@@ -281,7 +298,24 @@ would therefore be dead code: for a *known* entity it emits nothing but
 `:modified-in` (mcp_server.py:6505-6562), which this sweep would then have
 to filter back out anyway, exactly as 2b does for `:introduced-by`. So this
 sweep skips straight to per-ident classification, using `precomputed`
-directly:
+directly.
+
+**Caveat inherited from 2b, not introduced here:** "already structurally
+complete" assumes 2b's own structural writes are complete and correctly
+timestamped, which a separate review of 2b's own spec found is not
+uniformly true today (2b's `:contains` edges collapse into one batched
+`_transact` rather than the several forward walk deliberately issues, and
+its structural facts keep their first-sighting `valid_from` — later than
+whatever `:introduced-by` a subsequent guess-move settles on, so a query
+`:as-of` the true introduction can return lineage with no structure yet).
+Those are 2b's fixes to make (tracked as "2b1"), not this sweep's — but
+this sweep's case 1 promotes an entity to authoritative based on
+`:introduced-by` alone, so until 2b1 lands, confirming here can promote an
+entity whose structural facts are still incomplete or mistimed. Similarly,
+2b's retroactive `:modified-in` writes can carry a back-dated `valid_from`
+looked up via `ts_by_commit_ident.get(..., commit_ts_iso)`
+(mcp_server.py:7396-7407) that this sweep's case 3 reconciliation — a
+current-time read, not a temporal one — cannot detect or correct.
 
 ```python
 file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
@@ -315,14 +349,21 @@ not a documented guarantee anywhere. So this sweep queries the full set:
 
 ```python
 raw = _db_execute(db, f"(query [:find ?c :where [{ident} :introduced-by ?c]])")
-introduced_by_values = [row[0] for row in json.loads(raw).get("results", [])]
+introduced_by_values = {row[0] for row in json.loads(raw).get("results", [])}
 ```
 
-and every guard below tests `introduced_by_values == [commit_ident]` —
-*exactly one* value, equal to `commit_ident` — never membership
-(`commit_ident in introduced_by_values`) and never the first-row shortcut.
-Zero values or two both fail the equality and fall through to whichever
-branch's `else` is the safe one, below.
+and every guard below tests `introduced_by_values == {commit_ident}` —
+*exactly one distinct* value, equal to `commit_ident` — never membership
+(`commit_ident in introduced_by_values`), never the first-row shortcut, and
+never exact-list equality. The set (not list) comparison matters on its
+own: two live rows with the *same* value (a duplicate that survives
+despite the valid_from-equality idempotency property — e.g. two writes at
+genuinely different `valid_from` that happen to carry an identical value)
+would fail a list-length check but is exactly the single-value case for
+this sweep's purposes; comparing distinct values treats it correctly
+instead of stranding a correctly-guessed entity as provisional forever.
+Zero distinct values or two both fail the equality and fall through to
+whichever branch's `else` is the safe one, below.
 
 Each candidate ident then falls into one of three cases. Every write below
 uses `C`'s own `commit_ts_iso` (the same timestamp 2b itself used when it
@@ -333,8 +374,14 @@ identical `(entity, attribute, value, valid_from)` tuple is a no-op; only a
 *differing* `valid_from` produces a second live datom) rather than a
 duplicate.
 
+This sweep classifies every candidate `ident` by two independent facts:
+whether it's provisional, and how many *distinct* `:introduced-by` values it
+has and what they are. The three cases below are defined so that exactly
+one always applies — no ident falls through all three, and none can match
+two at once:
+
 1. **Provisional, guess matches this commit** (`_lineage_is_provisional(db,
-   ident)` and `introduced_by_values == [commit_ident]`) — per "Why
+   ident)` and `introduced_by_values == {commit_ident}`) — per "Why
    confirming requires the gap to already be closed" above, this is the
    *only* state a provisional entity can be in in this sweep's range once
    the sweep reaches it: Stream 2's guess is guaranteed to already equal
@@ -346,11 +393,11 @@ duplicate.
    No `:modified-in`.
 
 2. **Provisional, anything else** (`_lineage_is_provisional(db, ident)` and
-   `introduced_by_values != [commit_ident]` — zero values, `commit_ident`
-   plus at least one other, or a single different value) — the "guess
-   points elsewhere" state per "Why confirming requires the gap to already
-   be closed" above, and now also the duplicate-fact state above: a
-   correct caller (gap-closed precondition, and no stray second
+   `introduced_by_values != {commit_ident}` — zero distinct values,
+   `commit_ident` plus at least one other, or a single different value) —
+   the "guess points elsewhere" state per "Why confirming requires the gap
+   to already be closed" above, and now also the duplicate-fact state
+   above: a correct caller (gap-closed precondition, and no stray second
    `:introduced-by` from an uncoordinated forward walk) means this
    shouldn't arise for a commit inside this sweep's range, but neither
    condition is something this per-ident classification can verify itself.
@@ -363,31 +410,44 @@ duplicate.
 
 3. **Already authoritative** (`not _lineage_is_provisional(db, ident)`;
    confirmed at an earlier position in this same sweep, or — after this
-   sweep has fully caught up once — simply revisited on a later run) —
-   first, the self-introduction guard: if `introduced_by_values ==
-   [commit_ident]`, `C` *is* this entity's own introduction commit, so skip
-   entirely (no `:modified-in` write or retraction, no candidate-diff
-   touch). This matters for resume-safety: if the process dies after case
-   1's `_lineage_confirm` but before `_correction_sweep_through_update`
-   persists, a re-run revisits `C` and would otherwise find the
-   now-authoritative entity at its own introduction commit and wrongly
-   touch a self-`:modified-in` — a fact class ordinary forward walk never
-   produces (`_build_code_triples` only emits `:modified-in` on its
-   already-known branch, never at introduction). If `introduced_by_values`
-   is anything else (including zero or 2+ values — the same duplicate-fact
-   risk as case 2, left alone here too rather than guessed at), also skip:
-   this sweep only actively reconciles `:modified-in` when it has an
-   unambiguous single introduction commit to compare `C` against.
+   sweep has fully caught up once — simply revisited on a later run),
+   split on `introduced_by_values` into two **non-overlapping**
+   sub-branches (an earlier draft stated these as "self-intro" vs. "anything
+   else, skip", which left no room for the reconcile step to ever run —
+   they must instead partition on the *count* of distinct values, with the
+   value-comparison only deciding *which* of the single-value outcomes
+   applies):
 
-   Otherwise, **reconcile rather than merely assert** — this is where this
-   sweep corrects 2b's documented over-assertion (see Scope), not just
-   re-confirms what's already there:
+   - **Exactly one distinct value**: if it equals `commit_ident`, `C` *is*
+     this entity's own introduction commit — skip entirely (no
+     `:modified-in` write or retraction, no candidate-diff touch). This
+     matters for resume-safety: if the process dies after case 1's
+     `_lineage_confirm` but before `_correction_sweep_through_update`
+     persists, a re-run revisits `C` and would otherwise find the
+     now-authoritative entity at its own introduction commit and wrongly
+     touch a self-`:modified-in` — a fact class ordinary forward walk
+     never produces (`_build_code_triples` only emits `:modified-in` on
+     its already-known branch, never at introduction). If the one distinct
+     value is anything *other* than `commit_ident`, `C` is an ordinary
+     later touch of an unambiguously-introduced entity — **reconcile
+     rather than merely assert**, below.
+   - **Zero or two-or-more distinct values**: the same duplicate-fact risk
+     as case 2 — skip, left alone rather than guessed at. This sweep only
+     actively reconciles `:modified-in` when it has an unambiguous single
+     introduction commit to compare `C` against.
+
+   The reconcile step is where this sweep corrects 2b's documented
+   over-assertion (see Scope), not just re-confirms what's already there —
+   which requires actually checking whether `commit_ident` is among
+   `ident`'s live `:modified-in` values, not a query with an unbound `:find`
+   variable (a bare `[:find ?c :where [ident :modified-in commit_ident]]`
+   never binds `?c` to anything and always returns empty, regardless of
+   whether the fact exists):
 
    ```python
-   raw = _db_execute(
-       db, f"(query [:find ?c :where [{ident} :modified-in {commit_ident}]])"
-   )
-   already_has_modified_in = bool(json.loads(raw).get("results", []))
+   raw = _db_execute(db, f"(query [:find ?c :where [{ident} :modified-in ?c]])")
+   modified_in_values = {row[0] for row in json.loads(raw).get("results", [])}
+   already_has_modified_in = commit_ident in modified_in_values
    if ident in unchanged_idents:
        if already_has_modified_in:
            _retract(db, f"[[{ident} :modified-in {commit_ident}]]", index_con=index_con)
@@ -526,6 +586,24 @@ so this is latent incompleteness, not live corruption. Whoever fixes the
 growth handling should also make this sweep restart from `:lo-hash`
 whenever its position is below `correction-sweep-through`'s.
 
+**`ignore_patterns` must match what 2b used for the same region.** Every
+"2b already wrote a fact for every ident this sweep will find" invariant in
+"Per-commit algorithm" assumes both streams' `_extract_commit(repo_path,
+commit_hash, ignore_patterns)` calls see the same file set.
+`ignore_patterns` comes from `_load_ignore_patterns(repo_path)`, read from
+the working tree once per run (mcp_server.py:7487) — not persisted, and not
+tied to the commit being processed. Within one run this is automatically
+consistent (both streams' calls in that run use the same value); *across*
+runs it is not, if the ignore file changes between the run where 2b claimed
+a region and a later run where this sweep walks it. Newly-ignored files'
+entities are then silently never visited by this sweep (their provisional
+facts and candidate-diff records live forever, uncleared, though nothing is
+corrupted); newly-unignored files yield idents with zero `:introduced-by`
+values, landing harmlessly in case 2's or case 3's skip. Neither corrupts
+data, but both are exactly the kind of silent incompleteness this sweep
+otherwise exists to eliminate — the caller (2d) must pass the same
+`ignore_patterns` the reverse stream used for the region being swept.
+
 `ceiling_pos` reads frontier-high's *persisted* `:hi-hash`
 (`high_bounds[1]`) rather than `len(linearization) - 1`. Those are **not**
 interchangeable across separate runs: within a single run, `claim_high()`'s
@@ -599,17 +677,24 @@ def _correction_sweep_claim_and_process(
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
     hash_to_pos: Optional[Dict[str, int]] = None,
-) -> Optional[str]:
+) -> Optional[Tuple[str, int]]:
     """Advance the correction sweep by exactly one commit, upward through
     frontier-high's own claimed territory, and reconcile that commit's
-    entities per the three-case algorithm above. Returns the processed
-    commit's hash, or None if there is nothing safe to correct yet: the gap
-    is still open (Stream 2 could still descend past a position this call
-    would confirm -- see "Why confirming requires the gap to already be
-    closed"), frontier-high hasn't claimed anything yet, a required
-    boundary hash is stale, commit_metadata doesn't match linearization, or
-    the sweep has already reached frontier-high's own :hi-hash. No
-    `allocator` parameter -- this reads frontier-low and frontier-high's
+    entities per the three-case algorithm above. Returns (commit_hash,
+    skipped_count) -- skipped_count is how many candidate idents at this
+    commit landed in case 2 or case 3's ambiguous-value skip, i.e. stayed
+    provisional or unreconciled despite the sweep visiting their commit --
+    or None if there is nothing safe to correct yet: the gap is still open
+    (Stream 2 could still descend past a position this call would confirm
+    -- see "Why confirming requires the gap to already be closed"),
+    frontier-high hasn't claimed anything yet, a required boundary hash is
+    stale, commit_metadata doesn't match linearization, or the sweep has
+    already reached frontier-high's own :hi-hash. Every skip also logs the
+    ident to stderr (`[_correction_sweep] left {ident} provisional/
+    unreconciled at {commit_hash}: ...`), matching `_run_ingestion`'s own
+    stderr-on-skip idiom for unreadable commits -- a run in which every
+    entity failed safe must not look identical to a fully successful one.
+    No `allocator` parameter -- this reads frontier-low and frontier-high's
     persisted bounds directly via _frontier_read_bounds and tracks its own
     progress via _correction_sweep_through_query/_update, not the
     allocator's claim_low(); see "Why not claim_low()" above. Never calls
@@ -627,18 +712,63 @@ def _correction_sweep_walk(
     commit_metadata: List[Tuple[str, str, str, str]],
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
-) -> int:
+) -> Tuple[int, int]:
     """Build hash_to_pos once and repeatedly call
     _correction_sweep_claim_and_process (passing it down) until that
-    returns None. Returns the count of commits processed -- 0 both when the
-    gap-closed precondition isn't met yet (the common case early in a run;
-    callers should not read 0 as "nothing to do, ever") and when the sweep
-    has already fully caught up to frontier-high's :hi-hash. No caller in
-    this sub-phase -- 2d wires this into the real concurrent ingestion
-    loop, run only after both the reverse stream and ordinary
+    returns None. Returns (commits_processed, entities_left_unreconciled) --
+    both 0 both when the gap-closed precondition isn't met yet (the common
+    case early in a run; callers should not read (0, 0) as "nothing to do,
+    ever") and when the sweep has already fully caught up to frontier-
+    high's :hi-hash. A nonzero entities_left_unreconciled with a nonzero
+    commits_processed is the signal 2d should surface prominently (e.g.
+    through handle_minigraf_ingest_status, mirroring how
+    handle_minigraf_audit returns violation lists rather than only a
+    boolean) -- this sweep's entire product is "these lineage facts are now
+    trustworthy", and silently leaving some provisional is a materially
+    different outcome from a clean run even though both return successfully.
+    No caller in this sub-phase -- 2d wires this into the real concurrent
+    ingestion loop, run only after both the reverse stream and ordinary
     claim_low()-driven introduction have permanently finished for the run
     (see "Why confirming requires the gap to already be closed")."""
 ```
+
+### Execution context
+
+Neither function above may run on the event-loop thread. `_run_ingestion`'s
+whole architecture exists to keep exactly this off it: `_extract_commit`
+(a `git diff-tree`, a `git show` per changed file, and a tree-sitter parse
+of both sides of each) runs on the `ProcessPoolExecutor` because
+tree-sitter's GIL-holding C parse was measured to starve the event loop
+(#116), and every `db.execute()`/`checkpoint()` goes through the
+single-worker `write_executor` so an fsync never blocks concurrent
+`call_tool()` requests (mcp_server.py:7440-7466). This sweep's per-commit
+step does both a full `_extract_commit` call and its own
+`_db_execute`/`_transact`/`_retract`/`_db_checkpoint` calls synchronously
+in one function body, exactly the shape that architecture exists to keep
+off the event loop — and, per the terminal-pass consequence above, this
+sweep is the single longest-running phase in the whole ingest, so running
+it inline would be the worst place in the design to get this wrong: no MCP
+request would be served for the duration of a full pass.
+
+This spec does not wire the actual `await`/executor calls — that remains
+2d's job, same as the rest of the concurrency wiring — but it does fix the
+function *shape* 2d has to schedule, since that's what determines whether
+2d even *can* schedule it sanely: `_correction_sweep_claim_and_process`
+processes exactly one commit and returns, which is the right granularity
+for cooperative scheduling (2d can `await` between calls, interleaving
+other event-loop work). What 2d must not do is call
+`_correction_sweep_walk` directly from a coroutine with no `await` inside
+its loop (blocks for the entire pass) or route it through
+`run_in_executor(write_executor, _correction_sweep_walk, ...)` as a single
+call (serializes every one of this sweep's parses behind the same thread
+`_run_ingestion` reserves for writes, which is exactly the contention
+`write_executor`'s single-worker design exists to avoid). The natural
+shape, mirroring `_run_ingestion`'s own loop, is 2d awaiting
+`run_in_executor` calls to *each* piece (extraction on the process pool,
+DB operations on `write_executor`) once per commit, with
+`_correction_sweep_claim_and_process` itself staying a plain synchronous
+function ignorant of asyncio, the same role `_extract_commit` and the
+per-commit DB helpers already play for forward walk.
 
 ### Schema/audit safety, idempotency
 
@@ -804,16 +934,28 @@ high side, until `allocator.is_gap_empty()`.
   afterward, while `_correction_sweep_through_query` has advanced — the
   direct regression test for the bugs both "Why not `claim_low()`" and "Why
   a dedicated watermark" describe.
-- **Full integration**: build a repo with a non-trivial number of commits;
+- **Full integration**: build a repo with a non-trivial number of commits
+  and a fixture constructed so no entity ever lands in case 2 (no
+  hand-injected ambiguous/duplicate `:introduced-by` state — the fixture
+  this design's other tests use for that scenario is deliberately excluded
+  here, since case 2 leaving its candidate-diff record untouched is
+  by-design behavior, not a bug this test should be asserting against);
   close the gap at some meeting point (claim some positions via
   `claim_low()`/`_frontier_persist_claim` from the low side, the rest via
   `_reverse_fill_claim_and_process` from the high side, until
   `allocator.is_gap_empty()`); then run `_correction_sweep_walk` to
-  exhaustion; assert every entity touched within frontier-high's claimed
-  range ends up authoritative (`_lineage_is_provisional` is `False` for all
-  of them), no `:type/candidate-diff` entities remain live, and
+  exhaustion; assert its returned `entities_left_unreconciled` count is `0`,
+  every entity touched within frontier-high's claimed range ends up
+  authoritative (`_lineage_is_provisional` is `False` for all of them), no
+  `:type/candidate-diff` entities remain live, and
   `_correction_sweep_through_query` now equals frontier-high's `:hi-hash` —
   proving the sweep correctly walks all the way through frontier-high's
   claimed territory to its actual persisted ceiling, not the single
   position or the unbounded `len(linearization)` an earlier draft's
   (wrong) bounds would have produced.
+- **`entities_left_unreconciled` counts case-2 skips**: reuse the
+  duplicate-`:introduced-by` fixture from the case-2 multi-value test
+  above; run `_correction_sweep_claim_and_process` over that commit; assert
+  the returned count reflects the skipped entity and that a stderr message
+  naming its ident was emitted — the direct test for the observability fix
+  (a run that skipped everything must not look identical to a clean run).

--- a/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
+++ b/docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md
@@ -419,7 +419,8 @@ two at once:
    guess. The entity remains provisional and available for whatever the
    deferred reconciliation (or, for the duplicate-fact case, 2d's own fix)
    turns out to be. `skipped_events += 1`, and (see "Observability" below)
-   log the ident if this call's log budget isn't yet spent.
+   log the ident if `skipped_so_far + skipped_events` is still under
+   `_CORRECTION_SWEEP_LOG_CAP`.
 
 3. **Already authoritative** (`not _lineage_is_provisional(db, ident)`;
    confirmed at an earlier position in this same sweep, or — after this
@@ -446,7 +447,7 @@ two at once:
      rather than merely assert**, below.
    - **Zero or two-or-more distinct values**: the same duplicate-fact risk
      as case 2 — skip, left alone rather than guessed at (`skipped_events
-     += 1`, same logging budget). This sweep only actively reconciles
+     += 1`, same log-cap test). This sweep only actively reconciles
      `:modified-in` when it has an unambiguous single introduction commit
      to compare `C` against.
 
@@ -521,6 +522,8 @@ progress, independent of contiguity from `C0`:
 
 ```python
 _CORRECTION_SWEEP_THROUGH_IDENT = ":ingestion/correction-sweep-through"
+# Max per-ident skip lines on stderr per run; see "Observability".
+_CORRECTION_SWEEP_LOG_CAP = 10
 
 def _correction_sweep_through_query(db: Any) -> Optional[str]:
     """Return the hash of the last commit this sweep has itself confirmed/
@@ -739,6 +742,7 @@ def _correction_sweep_apply(
     commit_ts_iso: str,
     file_results: List[tuple],
     index_con: Optional[Any] = None,
+    skipped_so_far: int = 0,
 ) -> int:
     """DB-bound, parse-free (see "Per-commit algorithm" for the body).
     Reconciles every candidate entity file_results describes for commit_hash
@@ -746,9 +750,22 @@ def _correction_sweep_apply(
     _correction_sweep_through_update and checkpoints. Returns
     skipped_events -- how many candidate idents landed in case 2 or case
     3's ambiguous-value skip, i.e. stayed provisional or unreconciled
-    despite this call visiting their commit; see "Observability" below for
-    the logging that accompanies each one. Never calls
-    _frontier_persist_claim -- frontier-low is not touched by this sweep."""
+    despite this call visiting their commit.
+
+    skipped_so_far is the driving loop's running total of skipped_events
+    from every PREVIOUS call this run, and exists solely to make the stderr
+    log cap work across calls without this function holding any state of its
+    own: it logs a skipped ident only while
+    `skipped_so_far + skipped_events < _CORRECTION_SWEEP_LOG_CAP` (see
+    "Observability"). Deriving the budget from a caller-supplied running
+    total, rather than a module-level counter, is what makes the cap reset
+    per run automatically -- this server is long-lived and runs many
+    ingests, and a module counter would burn its budget on the first one and
+    log nothing ever after. The RETURNED count is never capped; only what
+    reaches stderr is.
+
+    Never calls _frontier_persist_claim -- frontier-low is not touched by
+    this sweep."""
 
 def _correction_sweep_claim_and_process(
     db: Any,
@@ -758,11 +775,13 @@ def _correction_sweep_claim_and_process(
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
     hash_to_pos: Optional[Dict[str, int]] = None,
+    skipped_so_far: int = 0,
 ) -> Optional[Tuple[str, int]]:
     """Synchronous convenience wrapper composing the three calls below in
     order -- for tests and any caller that doesn't need them on separate
     executors. **2d must not call this directly**; see "Execution context"
-    for why and what to call instead."""
+    for why and what to call instead. skipped_so_far is forwarded to
+    _correction_sweep_apply unchanged (see its docstring)."""
     selected = _correction_sweep_select_position(db, linearization, commit_metadata, hash_to_pos)
     if selected is None:
         return None
@@ -771,7 +790,8 @@ def _correction_sweep_claim_and_process(
         repo_path, commit_hash, ignore_patterns
     )
     skipped_events = _correction_sweep_apply(
-        db, commit_hash, commit_ts_iso, file_results, index_con=index_con
+        db, commit_hash, commit_ts_iso, file_results,
+        index_con=index_con, skipped_so_far=skipped_so_far,
     )
     return commit_hash, skipped_events
 
@@ -784,20 +804,32 @@ def _correction_sweep_walk(
     index_con: Optional[Any] = None,
 ) -> Tuple[int, int]:
     """Build hash_to_pos once and repeatedly call
-    _correction_sweep_claim_and_process (passing it down) until that
-    returns None. Returns (commits_processed, skipped_events) -- summed
-    across every call, both 0 both when the gap-closed precondition isn't
-    met yet (the common case early in a run; callers should not read
-    (0, 0) as "nothing to do, ever") and when the sweep has already fully
-    caught up to frontier-high's :hi-hash. `skipped_events` counts skip
-    *events*, not distinct entities -- see "Observability" for the
-    distinction and why a caller wanting a true census should query the
-    graph instead. Also a synchronous convenience wrapper, same caveat as
+    _correction_sweep_claim_and_process (passing it down, along with the
+    running skipped-events total as skipped_so_far) until that returns
+    None, then call _correction_sweep_log_summary with the final total.
+    Returns (commits_processed, skipped_events) -- summed across every
+    call, both 0 both when the gap-closed precondition isn't met yet (the
+    common case early in a run; callers should not read (0, 0) as "nothing
+    to do, ever") and when the sweep has already fully caught up to
+    frontier-high's :hi-hash. `skipped_events` counts skip *events*, not
+    distinct entities -- see "Observability" for the distinction and why a
+    caller wanting a true census should query the graph instead. Also a
+    synchronous convenience wrapper, same caveat as
     `_correction_sweep_claim_and_process`: 2d should drive the three-step
-    pipeline directly in its own loop, not call this. Run only after both
-    the reverse stream and ordinary claim_low()-driven introduction have
-    permanently finished for the run (see "Why confirming requires the gap
-    to already be closed")."""
+    pipeline directly in its own loop, not call this -- but 2d's loop owes
+    the same two things this one does, threading skipped_so_far through
+    every _correction_sweep_apply call and calling
+    _correction_sweep_log_summary when its own loop ends. Run only after
+    both the reverse stream and ordinary claim_low()-driven introduction
+    have permanently finished for the run (see "Why confirming requires the
+    gap to already be closed")."""
+
+def _correction_sweep_log_summary(skipped_events: int) -> None:
+    """Emit the one-line end-of-sweep summary to stderr if skipped_events is
+    nonzero; no-op otherwise. A named function rather than an inline print
+    in each loop precisely because there are two loops that must say the
+    same thing -- _correction_sweep_walk and 2d's own -- and an operator
+    grepping for this line should not have to know which drove the sweep."""
 ```
 
 Unlike `_reverse_fill_claim_and_process`'s plain `Optional[str]`, this
@@ -847,9 +879,22 @@ commit_hash, commit_ts_iso = selected
 file_results, _, _, _ = await loop.run_in_executor(
     extraction_pool, _extract_commit, repo_path, commit_hash, ignore_patterns,
 )
-skipped_events = await loop.run_in_executor(
-    write_executor, _correction_sweep_apply, db, commit_hash, commit_ts_iso, file_results,
+skipped_events += await loop.run_in_executor(
+    # NOTE the positional index_con and skipped_so_far: run_in_executor takes
+    # *args only, no keyword arguments, so anything defaulted must be passed
+    # positionally (or bound with functools.partial). Dropping index_con here
+    # is silent and nasty -- the graph writes still land, but the persisted
+    # fact index never sees them, so retracted :modified-in rows stay live in
+    # the index and reconciled entities keep stale rows while the graph itself
+    # is correct.
+    write_executor, _correction_sweep_apply,
+    db, commit_hash, commit_ts_iso, file_results, index_con, skipped_events,
 )
+# ... and once the loop ends, exactly as _correction_sweep_walk does. Called
+# inline, not through an executor: it only writes stderr, touching neither the
+# DB nor a parser -- same as _run_ingestion's own inline skip prints
+# (mcp_server.py:7612-7616).
+_correction_sweep_log_summary(skipped_events)
 ```
 
 — never `_correction_sweep_claim_and_process` or `_correction_sweep_walk`
@@ -868,6 +913,30 @@ between each of the three calls, interleaving other event-loop work,
 instead of blocking for a whole pass — which matters more here than
 anywhere else in the design, since per the terminal-pass consequence
 above, this sweep is the single longest-running phase in the whole ingest.
+
+**2d may pipeline extraction ahead; the apparent serial dependency is only
+apparent.** Read literally, the loop above never overlaps parsing with
+writing — commit `N+1`'s `_correction_sweep_select_position` reads the
+watermark commit `N`'s `_correction_sweep_apply` writes, so the extraction
+pool sits idle during every write and `write_executor` during every parse.
+That would give up exactly the overlap `_run_ingestion` already buys itself
+with its bounded sliding window of look-ahead extractions
+(mcp_server.py:7443-7445), on the longest phase of the run. It isn't
+necessary: once the gap-closed precondition holds, `[pos, ceiling_pos]` is
+fixed for the rest of the run (see "Once `pos` is known…" above), so
+successive positions are just successive integers. 2d is free to call
+`_correction_sweep_select_position` **once**, derive the remaining
+positions locally from `linearization`/`commit_metadata`, and keep a
+sliding window of `_extract_commit` futures in flight — subject to one
+hard constraint: **`_correction_sweep_apply` calls must still happen
+strictly in ascending position order**, since each one advances
+`:ingestion/correction-sweep-through` to its own commit and the watermark's
+crash-resume meaning ("everything up to and including this is swept")
+depends on that ordering. Out-of-order application would let a crash leave
+a watermark above commits that were never applied. The synchronous
+wrappers deliberately don't pipeline — they exist for tests, where the
+overlap buys nothing and the strict select→extract→apply sequence is easier
+to reason about.
 
 `_reverse_fill_claim_and_process` has the identical parse-and-write
 conflation in one function body (`mcp_server.py:7317-7411`) — this spec
@@ -888,13 +957,34 @@ walk duplicate `:introduced-by`) are systematic once they occur: either can
 make most or all idents skip at *every* commit for the rest of the range.
 Unconditional per-skip logging in that state is millions of lines onto the
 MCP server's own stderr on a large repository. `_correction_sweep_apply`
-therefore logs at most the first 10 skipped idents it encounters across the
-whole run (a simple counter compared against a constant, not a per-call
-budget — 2d's loop calls this function many times), then a single summary
-line once `_correction_sweep_walk` finishes if `skipped_events > 0`. The
-returned count itself stays exact regardless of the logging cap — capping
-only affects what reaches stderr, never what `_correction_sweep_walk`
-returns.
+therefore logs at most `_CORRECTION_SWEEP_LOG_CAP` (10) skipped idents
+across the whole run, then the driving loop emits one summary line at the
+end. The returned count itself stays exact regardless of the logging cap —
+capping only affects what reaches stderr, never what any of these functions
+return.
+
+**The cap is caller-threaded state, not a module-level counter.** The cap
+spans calls (`_correction_sweep_apply` runs once per commit), but that
+function is otherwise stateless, and the obvious shortcut — a module global
+— has a specific failure mode: this server is long-lived and
+`handle_minigraf_ingest_git` starts a fresh run per invocation, so an
+unreset global would spend its 10 lines on the first ingest of the process
+and log nothing for every ingest after, which is precisely the
+"looks clean, isn't" outcome this whole section exists to prevent. So the
+budget is derived from the driving loop's own running total instead:
+`_correction_sweep_apply` takes `skipped_so_far` and logs only while
+`skipped_so_far + skipped_events < _CORRECTION_SWEEP_LOG_CAP`. It resets
+per run for free, because each loop starts its total at `0`, and the
+function stays pure enough to test by calling it directly with a chosen
+`skipped_so_far`.
+
+**Both driving loops owe the summary line, not just `_correction_sweep_walk`.**
+An earlier draft attached it to `_correction_sweep_walk` alone — which 2d is
+told not to call (see "Execution context"), so the one operator-facing
+output would have existed only on the test-only path. `_correction_sweep_log_summary(skipped_events)`
+is therefore its own small function that both `_correction_sweep_walk` and
+2d's loop call when their loop ends, so the message is identical whichever
+drove the sweep.
 
 **`skipped_events` counts skip events, not distinct unreconciled
 entities, and only within one pass.** Two gaps between the name and a
@@ -1119,12 +1209,33 @@ high side, until `allocator.is_gap_empty()`.
   returned `skipped_events` count still reflects the true (uncapped) total
   — the test that would fail against a naive implementation that either
   logs unconditionally or caps the returned count along with the logging.
+- **The log cap resets per run, and is not a module-level counter**: run
+  the capped-logging scenario above to exhaustion (spending the whole
+  budget), then run a *second* full sweep in the same process against a
+  fresh graph and fixture; assert the second run logs its own per-ident
+  lines rather than none — the direct regression test for the module-global
+  implementation, which would pass the test above and still go silent for
+  every ingest after the first. Equivalently, at the unit level: call
+  `_correction_sweep_apply` directly with `skipped_so_far=0` and again with
+  `skipped_so_far=_CORRECTION_SWEEP_LOG_CAP`, and assert only the first
+  logs.
+- **`_correction_sweep_log_summary` is emitted by a caller-driven loop, not
+  buried in the walk**: assert `_correction_sweep_walk` calls it, and that
+  calling it directly with a nonzero count emits exactly one line and with
+  `0` emits nothing — pinning that 2d, which must not call
+  `_correction_sweep_walk`, has the same one-call obligation available to
+  it and produces a byte-identical message.
 - **`_correction_sweep_select_position` and `_correction_sweep_apply` are
-  independently callable and compose correctly**: call
-  `_correction_sweep_select_position` directly against a closed-gap graph,
-  feed its result's `commit_hash` into a real `_extract_commit` call, feed
-  that into `_correction_sweep_apply` directly, and assert the resulting
-  graph state is identical to what `_correction_sweep_claim_and_process`
-  produces for the same starting state — the test that pins the wrapper is
-  a faithful composition of the three independently-schedulable pieces,
-  not a distinct code path that could drift from them.
+  independently callable and compose correctly**: build **two independent
+  graphs from the same repo fixture** (the sweep mutates the state a second
+  run would start from, so this cannot be two passes over one graph — and a
+  second pass over an already-swept graph would be testing idempotency,
+  which is a different property). Against the first, call
+  `_correction_sweep_claim_and_process`. Against the second, call
+  `_correction_sweep_select_position` directly, feed its returned
+  `commit_hash` into a real `_extract_commit` call, and feed that into
+  `_correction_sweep_apply` directly. Assert the two resulting graph states
+  are identical — the test that pins the wrapper as a faithful composition
+  of the three independently-schedulable pieces, not a distinct code path
+  that could drift from them once 2d starts calling the pieces and only
+  tests call the wrapper.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7925,6 +7925,45 @@ def _correction_sweep_log_summary(skipped_events: int) -> None:
         )
 
 
+def _correction_sweep_claim_and_process(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+    hash_to_pos: Optional[Dict[str, int]] = None,
+    skipped_so_far: int = 0,
+) -> Optional[Tuple[str, int]]:
+    """Synchronous convenience wrapper composing
+    _correction_sweep_select_position, _extract_commit, and
+    _correction_sweep_apply in order -- for tests and any caller that
+    doesn't need them on separate executors. **2d must not call this
+    directly** from async code: it fuses the CPU-bound parse and the
+    DB-bound writes back into one function body, which can only be
+    scheduled onto one executor as a unit. 2d's real loop should await
+    each of the three pieces on its own executor instead (see the design
+    spec's Execution context).
+
+    Returns (commit_hash, skipped_events), or None if
+    _correction_sweep_select_position found nothing safe to do.
+    skipped_so_far is forwarded to _correction_sweep_apply unchanged (see
+    its docstring for why it exists).
+    """
+    selected = _correction_sweep_select_position(db, linearization, commit_metadata, hash_to_pos)
+    if selected is None:
+        return None
+    commit_hash, commit_ts_iso = selected
+    file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
+        repo_path, commit_hash, ignore_patterns
+    )
+    skipped_events = _correction_sweep_apply(
+        db, commit_hash, commit_ts_iso, file_results,
+        index_con=index_con, skipped_so_far=skipped_so_far,
+    )
+    return commit_hash, skipped_events
+
+
 async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7742,6 +7742,69 @@ def _correction_sweep_through_update(
     _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
 
 
+def _correction_sweep_select_position(
+    db: Any,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    hash_to_pos: Optional[Dict[str, int]] = None,
+) -> Optional[Tuple[str, str]]:
+    """Returns (commit_hash, commit_ts_iso) for the next commit this sweep
+    should process, upward through frontier-high's own claimed territory,
+    or None if there is nothing safe to correct yet: the gap is still open
+    (Stream 2 could still descend past a position this call would confirm
+    -- see the design spec's "Why confirming requires the gap to already
+    be closed"), frontier-high hasn't claimed anything yet, a required
+    boundary hash is stale, commit_metadata doesn't match linearization, or
+    the sweep has already reached frontier-high's own :hi-hash.
+
+    DB-bound, parse-free -- must run off the event-loop thread (per the
+    design spec's Execution context) but never on the same executor as
+    _extract_commit, since the two must be independently schedulable.
+
+    hash_to_pos, if omitted, is built fresh from linearization -- callers
+    doing a full sweep should build it once and pass it in instead to
+    avoid rebuilding an N-entry map on every one of a full sweep's N calls.
+    """
+    low_bounds = _frontier_read_bounds(db, _FRONTIER_LOW_IDENT)
+    high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
+    if low_bounds is None or high_bounds is None:
+        return None  # migration hasn't run yet, or Stream 2 hasn't claimed anything
+
+    if hash_to_pos is None:
+        hash_to_pos = {h: i for i, h in enumerate(linearization)}
+
+    if low_bounds[1] not in hash_to_pos or high_bounds[0] not in hash_to_pos:
+        return None  # a boundary hash is stale (rewritten history); nothing safe to do
+
+    if hash_to_pos[low_bounds[1]] + 1 != hash_to_pos[high_bounds[0]]:
+        return None  # gap still open -- Stream 2 may still descend past a position
+                     # this sweep would otherwise confirm
+
+    if high_bounds[1] not in hash_to_pos:
+        return None  # frontier-high's :hi-hash is stale; nothing safe to do
+    ceiling_pos = hash_to_pos[high_bounds[1]]
+
+    through_hash = _correction_sweep_through_query(db)
+    if through_hash is not None and through_hash in hash_to_pos:
+        pos = hash_to_pos[through_hash] + 1
+    else:
+        # Unset (first-ever call), or a stale hash from rewritten/rebased
+        # history -- (re)start from frontier-high's current lo-hash,
+        # mirroring _frontier_load's own precedent of dropping a bound
+        # that no longer resolves rather than erroring.
+        pos = hash_to_pos[high_bounds[0]]  # already validated above
+
+    if pos > ceiling_pos:
+        return None  # reached frontier-high's own :hi-hash; nothing left to correct
+
+    if len(commit_metadata) != len(linearization) or commit_metadata[pos][0] != linearization[pos]:
+        return None  # commit_metadata violates its stated contract -- nothing safe to
+                     # do, rather than an IndexError or a wrong-commit read
+
+    commit_hash, commit_ts_iso, _author, _subject = commit_metadata[pos]
+    return commit_hash, commit_ts_iso
+
+
 async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7964,6 +7964,49 @@ def _correction_sweep_claim_and_process(
     return commit_hash, skipped_events
 
 
+def _correction_sweep_walk(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> Tuple[int, int]:
+    """Build hash_to_pos once and repeatedly call
+    _correction_sweep_claim_and_process (passing it down, along with the
+    running skipped-events total as skipped_so_far) until that returns
+    None, then call _correction_sweep_log_summary with the final total.
+
+    Returns (commits_processed, skipped_events) -- summed across every
+    call, both 0 both when the gap-closed precondition isn't met yet (the
+    common case early in a run) and when the sweep has already fully
+    caught up to frontier-high's :hi-hash.
+
+    Also a synchronous convenience wrapper, same caveat as
+    _correction_sweep_claim_and_process: 2d should drive the three-step
+    pipeline directly in its own loop, not call this -- but 2d's loop owes
+    the same two things this one does: threading skipped_so_far through
+    every _correction_sweep_apply call, and calling
+    _correction_sweep_log_summary when its own loop ends.
+    """
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+    commits_processed = 0
+    skipped_events = 0
+    while True:
+        result = _correction_sweep_claim_and_process(
+            db, repo_path, linearization, commit_metadata,
+            ignore_patterns=ignore_patterns, index_con=index_con,
+            hash_to_pos=hash_to_pos, skipped_so_far=skipped_events,
+        )
+        if result is None:
+            break
+        _commit_hash, call_skipped = result
+        commits_processed += 1
+        skipped_events += call_skipped
+    _correction_sweep_log_summary(skipped_events)
+    return commits_processed, skipped_events
+
+
 async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7805,6 +7805,134 @@ def _correction_sweep_select_position(
     return commit_hash, commit_ts_iso
 
 
+def _correction_sweep_apply(
+    db: Any,
+    commit_hash: str,
+    commit_ts_iso: str,
+    file_results: List[tuple],
+    index_con: Optional[Any] = None,
+    skipped_so_far: int = 0,
+) -> int:
+    """Reconciles every candidate entity file_results describes for
+    commit_hash, then records progress via _correction_sweep_through_update
+    and checkpoints. Returns skipped_events -- how many candidate idents
+    landed in the fail-safe skip (provisional with an ambiguous/wrong
+    guess, or already-authoritative with an ambiguous introduced-by count),
+    i.e. stayed provisional or unreconciled despite this call visiting
+    their commit.
+
+    Never calls _extract_commit itself (that's the caller's job, on a
+    different executor -- see the design spec's Execution context) and
+    never writes commit_hash's own :type/commit entity (2b already wrote
+    it for every commit in this sweep's range). DB-bound, parse-free.
+
+    skipped_so_far is the driving loop's running total of skipped_events
+    from every previous call this run -- it exists solely to make the
+    stderr log cap (_CORRECTION_SWEEP_LOG_CAP) work across calls without
+    this function holding any state of its own. Deriving the budget from a
+    caller-supplied running total, rather than a module-level counter, is
+    what makes the cap reset per run automatically: this server is
+    long-lived and runs many ingests, and a module counter would burn its
+    budget on the first one and log nothing ever after. The RETURNED count
+    is never capped; only what reaches stderr is.
+
+    Never calls _frontier_persist_claim -- frontier-low is not touched by
+    this sweep.
+    """
+    commit_ident = f":commit/{commit_hash[:12]}"
+    skipped_events = 0
+
+    for status, _file_path, _extracted, precomputed, _old_path in file_results:
+        if status not in ("A", "M"):
+            continue  # "D"/"R" deferred -- matches 2b's own scope cut
+        candidate_idents = (
+            [precomputed["module_ident"]]
+            + [ident for ident, _name, _t in precomputed["function_entries"]]
+            + [ident for ident, _name, _t in precomputed["class_entries"]]
+            + [ident for ident, _name, _t in precomputed["global_entries"]]
+            + [ident for ident, _name, _t in precomputed["field_entries"]]
+        )
+        unchanged_idents = precomputed.get("unchanged_idents", set())
+
+        for ident in candidate_idents:
+            raw = _db_execute(db, f"(query [:find ?c :where [{ident} :introduced-by ?c]])")
+            introduced_by_values = {row[0] for row in json.loads(raw).get("results", [])}
+
+            if _lineage_is_provisional(db, ident):
+                if introduced_by_values == {commit_ident}:
+                    # Case 1: the provisional guess matches this commit --
+                    # confirm. The :introduced-by fact itself is untouched,
+                    # since its value was already correct.
+                    _lineage_confirm(db, ident, index_con=index_con)
+                    _candidate_diff_clear(db, commit_hash, ident, index_con=index_con)
+                else:
+                    # Case 2: guess points elsewhere, or an ambiguous
+                    # (zero/2+) value count -- fail safe, leave untouched.
+                    skipped_events += 1
+                    if skipped_so_far + skipped_events <= _CORRECTION_SWEEP_LOG_CAP:
+                        print(
+                            f"[_correction_sweep] {ident} left provisional at {commit_hash} "
+                            f"(introduced-by values: {sorted(introduced_by_values)})",
+                            file=sys.stderr,
+                        )
+            else:
+                # Case 3: already authoritative.
+                if len(introduced_by_values) == 1:
+                    (only_value,) = introduced_by_values
+                    if only_value == commit_ident:
+                        continue  # self-introduction guard: no self-:modified-in
+                    raw2 = _db_execute(db, f"(query [:find ?c :where [{ident} :modified-in ?c]])")
+                    modified_in_values = {row[0] for row in json.loads(raw2).get("results", [])}
+                    already_has_modified_in = commit_ident in modified_in_values
+                    if ident in unchanged_idents:
+                        if already_has_modified_in:
+                            _retract(db, f"[[{ident} :modified-in {commit_ident}]]", index_con=index_con)
+                    else:
+                        if not already_has_modified_in:
+                            _transact(
+                                db, f"[[{ident} :modified-in {commit_ident}]]", commit_ts_iso, index_con=index_con,
+                            )
+                    _candidate_diff_clear(db, commit_hash, ident, index_con=index_con)
+                elif len(introduced_by_values) == 0:
+                    # Not provisional AND no :introduced-by fact at all --
+                    # neither stream has introduced this entity yet (e.g. a
+                    # symbol that first appears at a commit this sweep
+                    # happens to be visiting before the introducing stream
+                    # has). Nothing to reconcile; silently skip rather than
+                    # treat as an anomaly like the 2+ case below.
+                    continue
+                else:
+                    # 2+ distinct live :introduced-by values -- same
+                    # duplicate-fact risk as case 2 -- skip, left alone
+                    # rather than guessed at.
+                    skipped_events += 1
+                    if skipped_so_far + skipped_events <= _CORRECTION_SWEEP_LOG_CAP:
+                        print(
+                            f"[_correction_sweep] {ident} left unreconciled at {commit_hash} "
+                            f"(ambiguous introduced-by values: {sorted(introduced_by_values)})",
+                            file=sys.stderr,
+                        )
+
+    _correction_sweep_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)
+    _db_checkpoint(db)
+    return skipped_events
+
+
+def _correction_sweep_log_summary(skipped_events: int) -> None:
+    """Emit the one-line end-of-sweep summary to stderr if skipped_events
+    is nonzero; no-op otherwise. A named function rather than an inline
+    print in each loop precisely because there are two loops that must say
+    the same thing -- _correction_sweep_walk (Task 5) and 2d's own -- and
+    an operator grepping for this line should not have to know which drove
+    the sweep.
+    """
+    if skipped_events:
+        print(
+            f"[_correction_sweep] {skipped_events} entities left provisional/unreconciled this run",
+            file=sys.stderr,
+        )
+
+
 async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7893,18 +7893,10 @@ def _correction_sweep_apply(
                                 db, f"[[{ident} :modified-in {commit_ident}]]", commit_ts_iso, index_con=index_con,
                             )
                     _candidate_diff_clear(db, commit_hash, ident, index_con=index_con)
-                elif len(introduced_by_values) == 0:
-                    # Not provisional AND no :introduced-by fact at all --
-                    # neither stream has introduced this entity yet (e.g. a
-                    # symbol that first appears at a commit this sweep
-                    # happens to be visiting before the introducing stream
-                    # has). Nothing to reconcile; silently skip rather than
-                    # treat as an anomaly like the 2+ case below.
-                    continue
                 else:
-                    # 2+ distinct live :introduced-by values -- same
-                    # duplicate-fact risk as case 2 -- skip, left alone
-                    # rather than guessed at.
+                    # Zero or 2+ distinct values -- same duplicate-fact
+                    # risk as case 2 -- skip, left alone rather than
+                    # guessed at.
                     skipped_events += 1
                     if skipped_so_far + skipped_events <= _CORRECTION_SWEEP_LOG_CAP:
                         print(

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7767,16 +7767,32 @@ def _correction_sweep_select_position(
     """
     low_bounds = _frontier_read_bounds(db, _FRONTIER_LOW_IDENT)
     high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
-    if low_bounds is None or high_bounds is None:
-        return None  # migration hasn't run yet, or Stream 2 hasn't claimed anything
+    if high_bounds is None:
+        return None  # Stream 2 hasn't claimed anything -- nothing to correct
 
     if hash_to_pos is None:
         hash_to_pos = {h: i for i, h in enumerate(linearization)}
 
-    if low_bounds[1] not in hash_to_pos or high_bounds[0] not in hash_to_pos:
+    if high_bounds[0] not in hash_to_pos:
         return None  # a boundary hash is stale (rewritten history); nothing safe to do
 
-    if hash_to_pos[low_bounds[1]] + 1 != hash_to_pos[high_bounds[0]]:
+    if low_bounds is None:
+        # An ABSENT frontier-low means an EMPTY low region, not an unknown
+        # one, so its highest claimed position is -1 -- exactly how
+        # FrontierAllocator.gap_lo treats "no interval covers position 0".
+        # A fresh graph seeds neither side, and frontier-low is only created
+        # once the forward stream persists its first claim, so reading
+        # absent as "nothing safe to do" would strand every entity
+        # provisional forever whenever Stream 2 claims the whole history
+        # before Stream 1 claims anything -- reachable in 2d, where the
+        # forward stream does a large preload before its first claim.
+        low_hi_pos = -1
+    else:
+        if low_bounds[1] not in hash_to_pos:
+            return None  # a boundary hash is stale (rewritten history)
+        low_hi_pos = hash_to_pos[low_bounds[1]]
+
+    if low_hi_pos + 1 != hash_to_pos[high_bounds[0]]:
         return None  # gap still open -- Stream 2 may still descend past a position
                      # this sweep would otherwise confirm
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7684,6 +7684,64 @@ def _reverse_bulk_fill_walk(
     return count
 
 
+_CORRECTION_SWEEP_THROUGH_IDENT = ":ingestion/correction-sweep-through"
+# Max per-ident skip lines this sweep writes to stderr per run; see the
+# Observability section of the design spec for why this must be
+# caller-threaded state (skipped_so_far), not a module-level counter.
+_CORRECTION_SWEEP_LOG_CAP = 10
+
+
+def _correction_sweep_through_query(db: Any) -> Optional[str]:
+    """Return the hash of the last commit this sweep has itself confirmed/
+    corrected, or None if it has never successfully processed one yet."""
+    raw = _db_execute(
+        db, f"(query [:find ?h :where [{_CORRECTION_SWEEP_THROUGH_IDENT} :hash ?h]])"
+    )
+    results = json.loads(raw).get("results", [])
+    return results[0][0] if results else None
+
+
+def _correction_sweep_through_update(
+    db: Any, commit_hash: str, commit_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Record the last commit this sweep processed. Mirrors
+    _lineage_confirmed_through_update's retract-only-if-changed pattern
+    exactly, at a different ident with its own :description -- tracks this
+    sweep's own progress through frontier-high's territory, independent of
+    lineage-confirmed-through's "contiguous from C0" semantics.
+    """
+    current_raw = _db_execute(
+        db, f"(query [:find ?a ?v :where [{_CORRECTION_SWEEP_THROUGH_IDENT} ?a ?v]])"
+    )
+    current: Dict[str, str] = dict(json.loads(current_raw).get("results", []))
+
+    def _edn(attr: str, value: str) -> str:
+        return value if attr == ":entity-type" else f'"{_edn_escape(value)}"'
+
+    constants = {
+        ":entity-type": ":type/ingestion",
+        ":ident": _CORRECTION_SWEEP_THROUGH_IDENT,
+        ":description": "correction sweep progress watermark",
+    }
+
+    to_retract: List[str] = []
+    to_transact: List[str] = []
+    for attr, value in constants.items():
+        if current.get(attr) == value:
+            continue
+        if attr in current:
+            to_retract.append(f"[{_CORRECTION_SWEEP_THROUGH_IDENT} {attr} {_edn(attr, current[attr])}]")
+        to_transact.append(f"[{_CORRECTION_SWEEP_THROUGH_IDENT} {attr} {_edn(attr, value)}]")
+
+    if ":hash" in current:
+        to_retract.append(f"[{_CORRECTION_SWEEP_THROUGH_IDENT} :hash {_edn(':hash', current[':hash'])}]")
+    to_transact.append(f"[{_CORRECTION_SWEEP_THROUGH_IDENT} :hash {_edn(':hash', commit_hash)}]")
+
+    if to_retract:
+        _retract(db, "[" + " ".join(to_retract) + "]", index_con=index_con)
+    _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
+
+
 async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7978,7 +7978,7 @@ def _correction_sweep_walk(
     None, then call _correction_sweep_log_summary with the final total.
 
     Returns (commits_processed, skipped_events) -- summed across every
-    call, both 0 both when the gap-closed precondition isn't met yet (the
+    call, both 0 when the gap-closed precondition isn't met yet (the
     common case early in a run) and when the sweep has already fully
     caught up to frontier-high's :hi-hash.
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15322,3 +15322,121 @@ class TestCorrectionSweepClaimAndProcess:
         results_a = sorted(json.loads(db_a.execute(query))["results"])
         results_b = sorted(json.loads(db_b.execute(query))["results"])
         assert results_a == results_b
+
+
+class TestCorrectionSweepWalk:
+    def _init_repo(self, repo):
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _commit(self, repo, filename, content, msg):
+        (repo / filename).write_text(content)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True)
+
+    def _repo_with_n_commits(self, tmp_path, n):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+        for i in range(n):
+            self._commit(repo, f"f{i}.py", f"def f{i}(): pass\n", f"h{i}")
+        return repo
+
+    def _linearization_and_metadata(self, repo):
+        import mcp_server
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        return linearization, commit_metadata
+
+    def _close_gap_at(self, repo, real_db, linearization, commit_metadata, split_pos):
+        """Close the gap with the low side claiming positions [0, split_pos)
+        and the high side (2b) claiming the rest -- split_pos == len(linearization)
+        closes the whole thing from the low side alone."""
+        import mcp_server
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        for _ in range(split_pos):
+            pos = allocator.claim_low()
+            mcp_server._frontier_persist_claim(
+                real_db, linearization, pos, from_low=True, commit_ts_iso=commit_metadata[pos][1],
+            )
+        while not allocator.is_gap_empty():
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        return allocator
+
+    def test_walks_to_exhaustion_and_returns_counts(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 4)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=0)
+
+        commits_processed, skipped_events = mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+
+        assert commits_processed == 4
+        assert skipped_events == 0
+        assert mcp_server._correction_sweep_through_query(real_db) == linearization[-1]
+
+    def test_returns_zero_zero_when_gap_still_open(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert allocator.is_gap_empty() is False
+
+        result = mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
+        assert result == (0, 0)
+
+    def test_no_op_when_already_fully_swept(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=0)
+        mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
+
+        result = mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
+        assert result == (0, 0)
+
+    def test_frontier_low_and_lineage_confirmed_through_never_touched(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=1)
+
+        low_before = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_LOW_IDENT)
+        lineage_before = mcp_server._lineage_confirmed_through_query(real_db)
+
+        mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
+
+        low_after = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_LOW_IDENT)
+        lineage_after = mcp_server._lineage_confirmed_through_query(real_db)
+        assert low_after == low_before
+        assert lineage_after == lineage_before
+        assert mcp_server._correction_sweep_through_query(real_db) is not None
+
+    def test_full_integration(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 5)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=2)
+
+        commits_processed, skipped_events = mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+
+        assert commits_processed == 3  # the 3 positions the high side claimed
+        assert skipped_events == 0
+        for i in range(5):
+            fn_ident = mcp_server._code_ident("function", f"f{i}.py", f"f{i}")
+            assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        raw = mcp_server._db_execute(real_db, "(query [:find ?e :where [?e :entity-type :type/candidate-diff]])")
+        assert json.loads(raw)["results"] == []
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert mcp_server._correction_sweep_through_query(real_db) == bounds[1]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15035,6 +15035,16 @@ class TestCorrectionSweepApply:
         # already wrote the correct :modified-in for h1's genuine change.
         mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h0_hash[:12]}]]", "2025-01-01T00:00:00Z")
         mcp_server._transact(real_db, f"[[{fn_ident} :modified-in {h1_ident}]]", h1_ts)
+        # auth.py's other h1 candidates (the module, and extra() which is
+        # added at h1) are also already-authoritative in any real system --
+        # 2b's real per-commit function assigns :introduced-by to every
+        # candidate it discovers for a commit, including the module ident,
+        # so give both a legitimate single-value authoritative fact here
+        # too, rather than leaving them with zero :introduced-by values.
+        module_ident = mcp_server._code_ident("module", "auth.py")
+        extra_ident = mcp_server._code_ident("function", "auth.py", "extra")
+        mcp_server._transact(real_db, f"[[{module_ident} :introduced-by :commit/{h0_hash[:12]}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{extra_ident} :introduced-by {h1_ident}]]", "2025-01-01T00:00:00Z")
 
         file_results = self._extract(repo, h1_hash)
         skipped = mcp_server._correction_sweep_apply(real_db, h1_hash, h1_ts, file_results)
@@ -15061,6 +15071,17 @@ class TestCorrectionSweepApply:
         h2_ident = f":commit/{h2_hash[:12]}"
         mcp_server._transact(real_db, f"[[{extra_ident} :introduced-by {h1_ident}]]", "2025-01-01T00:00:00Z")
         mcp_server._transact(real_db, f"[[{extra_ident} :modified-in {h2_ident}]]", h2_ts)  # 2b's over-assertion
+        # auth.py's other h2 candidates (the module, login() which changes
+        # every commit, and more() which is added at h2) are also already-
+        # authoritative in any real system -- give each a legitimate
+        # single-value authoritative :introduced-by fact too, rather than
+        # leaving them with zero :introduced-by values.
+        module_ident = mcp_server._code_ident("module", "auth.py")
+        login_ident = mcp_server._code_ident("function", "auth.py", "login")
+        more_ident = mcp_server._code_ident("function", "auth.py", "more")
+        mcp_server._transact(real_db, f"[[{module_ident} :introduced-by :commit/{commit_metadata[0][0][:12]}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{login_ident} :introduced-by :commit/{commit_metadata[0][0][:12]}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{more_ident} :introduced-by {h2_ident}]]", "2025-01-01T00:00:00Z")
 
         file_results = self._extract(repo, h2_hash)
         precomputed_unchanged = [
@@ -15106,6 +15127,15 @@ class TestCorrectionSweepApply:
         fn_ident = mcp_server._code_ident("function", "auth.py", "login")
         wrong_ident = f":commit/{commit_metadata[2][0][:12]}"
         mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, wrong_ident, "2025-01-01T00:00:00Z")
+        # auth.py's other candidates at h0/h1 (the module, and extra() which
+        # is added at h1) are also already-authoritative in any real system
+        # -- give each a legitimate single-value authoritative
+        # :introduced-by fact once, up front, so they don't spuriously
+        # count as skipped at either commit.
+        module_ident = mcp_server._code_ident("module", "auth.py")
+        extra_ident = mcp_server._code_ident("function", "auth.py", "extra")
+        mcp_server._transact(real_db, f"[[{module_ident} :introduced-by :commit/{h0_hash[:12]}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{extra_ident} :introduced-by :commit/{h1_hash[:12]}]]", "2025-01-01T00:00:00Z")
 
         skipped_h0 = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, self._extract(repo, h0_hash))
         skipped_h1 = mcp_server._correction_sweep_apply(
@@ -15129,6 +15159,10 @@ class TestCorrectionSweepApply:
         wrong_ident = ":commit/does-not-matter"
         for ident in idents:
             mcp_server._entity_introduced_by_set_provisional(real_db, ident, wrong_ident, "2025-01-01T00:00:00Z")
+        # The synthetic module ident is also an unconditional candidate --
+        # give it a legitimate single-value authoritative :introduced-by
+        # fact too, so it doesn't spuriously count as a 16th skip.
+        mcp_server._transact(real_db, "[[:module/synthetic :introduced-by :commit/preexisting]]", "2025-01-01T00:00:00Z")
         precomputed = {
             "module_ident": ":module/synthetic",
             "function_entries": [(ident, ident, []) for ident in idents],

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14748,6 +14748,36 @@ class TestCorrectionSweepSelectPosition:
         result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
         assert result is None
 
+    def test_runs_when_stream_2_claimed_everything_and_frontier_low_never_existed(
+        self, real_db, tmp_path
+    ):
+        """A fresh graph seeds neither frontier side, and frontier-low is
+        only created once the forward stream persists its first claim. If
+        Stream 2 claims the whole history before Stream 1 claims anything
+        -- entirely possible in 2d, since the forward stream does a large
+        preload before its first claim -- the gap is genuinely closed
+        (is_gap_empty() is True, claim_high() returns None forever) but
+        frontier-low does not exist. Treating that as "nothing safe to do"
+        strands every entity provisional for good, so an absent frontier-low
+        must read as an EMPTY low region (its hi position is -1), not as an
+        unknown one -- which is exactly what FrontierAllocator.gap_lo
+        already does when no interval covers position 0."""
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        while not allocator.is_gap_empty():
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        assert mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_LOW_IDENT) is None
+        high = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert high[0] == linearization[0]  # Stream 2 reached position 0
+
+        result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert result is not None, "gap is closed; the sweep must not refuse to run"
+        assert result[0] == linearization[0]
+
     def test_returns_frontier_high_lo_hash_once_gap_closed(self, real_db, tmp_path):
         import mcp_server
         repo = self._repo_with_n_commits(tmp_path, 3)
@@ -14834,6 +14864,36 @@ class TestCorrectionSweepSelectPosition:
         commit_hash, _ts = result
         bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
         assert commit_hash == bounds[0]
+
+    def test_no_op_when_commit_metadata_violates_its_alignment_contract(self, real_db, tmp_path):
+        """commit_metadata must be full-history and positionally aligned
+        with linearization (i.e. _git_commits(repo, watermark_hash=None)).
+        _run_ingestion builds a watermark-relative list instead, so a 2d
+        wiring mistake would hand this function a shorter list -- which
+        must return None rather than raise IndexError or, worse, read a
+        different commit's metadata and write facts at the wrong
+        timestamp."""
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+        assert mcp_server._correction_sweep_select_position(
+            real_db, linearization, commit_metadata
+        ) is not None  # aligned metadata works
+
+        truncated = commit_metadata[1:]  # what a watermark-relative list looks like
+        assert mcp_server._correction_sweep_select_position(
+            real_db, linearization, truncated
+        ) is None
+
+        # Right length, wrong order. Rotate rather than reverse: reversing an
+        # odd-length list leaves the middle element in place, and that is
+        # exactly the position _close_gap leaves the sweep pointing at, so a
+        # reversed list would slip past the per-position hash check.
+        misaligned = commit_metadata[1:] + commit_metadata[:1]
+        assert mcp_server._correction_sweep_select_position(
+            real_db, linearization, misaligned
+        ) is None
 
     def test_hash_to_pos_reused_when_passed_in(self, real_db, tmp_path):
         """Smoke test that the hash_to_pos parameter is accepted: passing a
@@ -15096,10 +15156,17 @@ class TestCorrectionSweepApply:
         skipped = mcp_server._correction_sweep_apply(real_db, h2_hash, h2_ts, file_results)
 
         assert skipped == 0
+        # Bind the value and test membership. A query whose :find variable
+        # appears nowhere in :where -- e.g.
+        # [:find ?c :where [extra_ident :modified-in h2_ident]] -- binds ?c
+        # to nothing and returns [] whether or not the fact exists, so
+        # asserting == [] on that form passes even when the retract never
+        # ran. The design spec calls this trap out for exactly this reason.
         raw = mcp_server._db_execute(
-            real_db, f"(query [:find ?c :where [{extra_ident} :modified-in {h2_ident}]])"
+            real_db, f"(query [:find ?c :where [{extra_ident} :modified-in ?c]])"
         )
-        assert json.loads(raw)["results"] == []
+        modified_in_values = {row[0] for row in json.loads(raw)["results"]}
+        assert h2_ident not in modified_in_values
 
     def test_opportunistic_stale_candidate_diff_cleanup(self, real_db, tmp_path):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14850,3 +14850,328 @@ class TestCorrectionSweepSelectPosition:
             real_db, linearization, commit_metadata, hash_to_pos=hash_to_pos
         )
         assert result is not None
+
+
+class TestCorrectionSweepApply:
+    def _init_repo(self, repo):
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _repo_with_evolving_function(self, tmp_path):
+        """Three commits: login() genuinely changes body every commit (h0,
+        h1, h2); extra() is added at h1 and left byte-identical at h2, so
+        #221 marks it unchanged at h2 -- needed for the reconcile-retract
+        test below."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+
+        (repo / "auth.py").write_text("def login():\n    return 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text("def login():\n    return 2\n\ndef extra():\n    pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h1"], cwd=repo, check=True, capture_output=True)
+
+        (repo / "auth.py").write_text(
+            "def login():\n    return 3\n\ndef extra():\n    pass\n\ndef more():\n    pass\n"
+        )
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h2"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _extract(self, repo, commit_hash):
+        import mcp_server
+        file_results, _gitlink, _gitmodules, _renamed = mcp_server._extract_commit(str(repo), commit_hash, ())
+        return file_results
+
+    def test_confirms_correct_provisional_guess(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Real reverse walk to the end so login()'s guess settles at h0 --
+        # exactly TestReverseFillClaimAndProcess's own converged-state setup.
+        for _ in range(3):
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        h0_hash, h0_ts = linearization[0], commit_metadata[0][1]
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{h0_hash[:12]}"
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+        file_results = self._extract(repo, h0_hash)
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped == 0
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{h0_hash[:12]}"
+        assert mcp_server._candidate_diff_read(real_db, h0_hash, fn_ident) is None
+
+    def test_does_not_duplicate_commit_metadata(self, real_db, tmp_path):
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_evolving_function(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        for _ in range(3):
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        h0_hash, h0_ts = linearization[0], commit_metadata[0][1]
+        commit_ident = f":commit/{h0_hash[:12]}"
+        before_raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?a ?v :where [{commit_ident} ?a ?v]])"
+        )
+        before = sorted(json.loads(before_raw)["results"])
+
+        file_results = self._extract(repo, h0_hash)
+        mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        after_raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?a ?v :where [{commit_ident} ?a ?v]])"
+        )
+        after = sorted(json.loads(after_raw)["results"])
+        assert after == before
+
+    def test_leaves_entity_untouched_when_guess_points_elsewhere(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        h1_hash = commit_metadata[1][0]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        # Hand-construct a provisional guess pointing at the WRONG commit
+        # for the one this call will visit -- simulating a precondition
+        # violation directly rather than via a real interleaving.
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, f":commit/{h1_hash[:12]}", "2025-01-01T00:00:00Z")
+
+        file_results = self._extract(repo, h0_hash)
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped >= 1
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{h1_hash[:12]}"
+
+    def test_fails_safe_on_duplicate_introduced_by_h0_asserted_first(self, real_db, tmp_path):
+        """Two live :introduced-by facts for one entity (the uncoordinated-
+        forward-walk state the design spec defers to 2d) must be a no-op
+        regardless of which fact minigraf's query returns first -- tested
+        here via physical assertion order, in a sibling test via the
+        opposite order, since row order itself isn't observable/controllable
+        from the test, only the insertion order that produces it."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        h1_hash = commit_metadata[1][0]
+        commit_ident_h0 = f":commit/{h0_hash[:12]}"
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        file_results = self._extract(repo, h0_hash)
+
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {commit_ident_h0}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h1_hash[:12]}]]", "2025-01-02T00:00:00Z")
+        mcp_server._lineage_mark_provisional(real_db, fn_ident, "2025-01-01T00:00:00Z")
+
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped >= 1
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+    def test_fails_safe_on_duplicate_introduced_by_h1_asserted_first(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        h1_hash = commit_metadata[1][0]
+        commit_ident_h0 = f":commit/{h0_hash[:12]}"
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        file_results = self._extract(repo, h0_hash)
+
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h1_hash[:12]}]]", "2025-01-02T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {commit_ident_h0}]]", "2025-01-01T00:00:00Z")
+        mcp_server._lineage_mark_provisional(real_db, fn_ident, "2025-01-01T00:00:00Z")
+
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped >= 1
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+    def test_skips_modified_in_at_own_introduction_commit_on_resumed_sweep(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        commit_ident = f":commit/{h0_hash[:12]}"
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, commit_ident, "2025-01-01T00:00:00Z")
+        file_results = self._extract(repo, h0_hash)
+
+        mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)  # confirms (case 1)
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+
+        # Simulate a resumed sweep re-visiting the same commit (e.g. after a
+        # crash between confirming and advancing correction-sweep-through).
+        mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        raw = mcp_server._db_execute(real_db, f"(query [:find ?c :where [{fn_ident} :modified-in ?c]])")
+        assert [commit_ident] not in json.loads(raw)["results"]
+
+    def test_ordinary_modification_is_idempotent_when_2b_already_agrees(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash = commit_metadata[0][0]
+        h1_hash, h1_ts = commit_metadata[1][0], commit_metadata[1][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        h1_ident = f":commit/{h1_hash[:12]}"
+        # login() is already authoritative at h0, and 2b (or forward walk)
+        # already wrote the correct :modified-in for h1's genuine change.
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h0_hash[:12]}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :modified-in {h1_ident}]]", h1_ts)
+
+        file_results = self._extract(repo, h1_hash)
+        skipped = mcp_server._correction_sweep_apply(real_db, h1_hash, h1_ts, file_results)
+
+        assert skipped == 0
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find (count ?c) :where [{fn_ident} :modified-in ?c]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_retracts_2b_over_asserted_retroactive_modified_in(self, real_db, tmp_path):
+        """extra() is byte-identical between h1 and h2 (see the fixture
+        docstring), so #221 marks it unchanged at h2 -- but simulate 2b's
+        documented limitation by asserting :modified-in there anyway, then
+        assert this sweep retracts it once it reaches h2 in the ordinary
+        (already-authoritative) path."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h1_hash = commit_metadata[1][0]
+        h2_hash, h2_ts = commit_metadata[2][0], commit_metadata[2][1]
+        extra_ident = mcp_server._code_ident("function", "auth.py", "extra")
+        h1_ident = f":commit/{h1_hash[:12]}"
+        h2_ident = f":commit/{h2_hash[:12]}"
+        mcp_server._transact(real_db, f"[[{extra_ident} :introduced-by {h1_ident}]]", "2025-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{extra_ident} :modified-in {h2_ident}]]", h2_ts)  # 2b's over-assertion
+
+        file_results = self._extract(repo, h2_hash)
+        precomputed_unchanged = [
+            precomputed.get("unchanged_idents", set())
+            for _status, _fp, _extracted, precomputed, _old in file_results
+            if precomputed is not None
+        ]
+        assert any(extra_ident in u for u in precomputed_unchanged), (
+            "fixture assumption broken: extra() must read as unchanged at h2"
+        )
+
+        skipped = mcp_server._correction_sweep_apply(real_db, h2_hash, h2_ts, file_results)
+
+        assert skipped == 0
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{extra_ident} :modified-in {h2_ident}]])"
+        )
+        assert json.loads(raw)["results"] == []
+
+    def test_opportunistic_stale_candidate_diff_cleanup(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash = commit_metadata[0][0]
+        h1_hash, h1_ts = commit_metadata[1][0], commit_metadata[1][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h0_hash[:12]}]]", "2025-01-01T00:00:00Z")
+        # An orphaned candidate-diff record from a since-superseded guess.
+        mcp_server._candidate_diff_persist(real_db, h1_hash, fn_ident, "stale-hash", "2025-01-01T00:00:00Z")
+        assert mcp_server._candidate_diff_read(real_db, h1_hash, fn_ident) is not None
+
+        file_results = self._extract(repo, h1_hash)
+        mcp_server._correction_sweep_apply(real_db, h1_hash, h1_ts, file_results)
+
+        assert mcp_server._candidate_diff_read(real_db, h1_hash, fn_ident) is None
+
+    def test_skipped_events_counts_events_not_entities(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        h1_hash, h1_ts = commit_metadata[1][0], commit_metadata[1][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        wrong_ident = f":commit/{commit_metadata[2][0][:12]}"
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, wrong_ident, "2025-01-01T00:00:00Z")
+
+        skipped_h0 = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, self._extract(repo, h0_hash))
+        skipped_h1 = mcp_server._correction_sweep_apply(
+            real_db, h1_hash, h1_ts, self._extract(repo, h1_hash), skipped_so_far=skipped_h0,
+        )
+
+        assert skipped_h0 == 1
+        assert skipped_h1 == 1  # login() is a candidate at h1 too -- second event, same entity
+
+    def test_skip_logging_capped_with_returned_count_uncapped(self, real_db, tmp_path, capsys):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        # 15 synthetic candidate idents in one file entry, each provisional
+        # with a guess pointing elsewhere -- avoids needing 15 real commits
+        # to exercise the logging cap; precomputed's shape is documented in
+        # this task's Interfaces block.
+        n = 15
+        idents = [f":function/synthetic-{i}" for i in range(n)]
+        wrong_ident = ":commit/does-not-matter"
+        for ident in idents:
+            mcp_server._entity_introduced_by_set_provisional(real_db, ident, wrong_ident, "2025-01-01T00:00:00Z")
+        precomputed = {
+            "module_ident": ":module/synthetic",
+            "function_entries": [(ident, ident, []) for ident in idents],
+            "class_entries": [],
+            "global_entries": [],
+            "field_entries": [],
+            "unchanged_idents": set(),
+        }
+        file_results = [("M", "synthetic.py", {}, precomputed, "")]
+
+        skipped = mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results)
+
+        assert skipped == n
+        err = capsys.readouterr().err
+        logged_lines = [line for line in err.splitlines() if "synthetic-" in line]
+        assert len(logged_lines) == mcp_server._CORRECTION_SWEEP_LOG_CAP
+
+    def test_log_cap_is_caller_threaded_not_a_module_global(self, real_db, tmp_path, capsys):
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        h0_hash, h0_ts = commit_metadata[0][0], commit_metadata[0][1]
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        wrong_ident = f":commit/{commit_metadata[1][0][:12]}"
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, wrong_ident, "2025-01-01T00:00:00Z")
+        file_results = self._extract(repo, h0_hash)
+
+        capsys.readouterr()  # clear
+        mcp_server._correction_sweep_apply(
+            real_db, h0_hash, h0_ts, file_results, skipped_so_far=mcp_server._CORRECTION_SWEEP_LOG_CAP,
+        )
+        assert capsys.readouterr().err == ""  # budget already spent by caller's running total
+
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, wrong_ident, "2025-01-01T00:00:00Z")
+        mcp_server._correction_sweep_apply(real_db, h0_hash, h0_ts, file_results, skipped_so_far=0)
+        assert "login" in capsys.readouterr().err  # fresh run, budget reset
+
+    def test_correction_sweep_log_summary(self, capsys):
+        import mcp_server
+        mcp_server._correction_sweep_log_summary(0)
+        assert capsys.readouterr().err == ""
+
+        mcp_server._correction_sweep_log_summary(3)
+        err = capsys.readouterr().err
+        assert err.strip() != ""
+        assert "3" in err

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14692,45 +14692,33 @@ class TestCorrectionSweepSelectPosition:
         return linearization, commit_metadata
 
     def _close_gap(self, repo, real_db, linearization, commit_metadata):
-        """Close the gap entirely: claim everything from the low side via a
-        real FrontierAllocator + _frontier_persist_claim (standing in for
-        2d's future ordinary forward walk), then claim the rest from the
-        high side via 2b's real _reverse_fill_claim_and_process."""
+        """Close the gap entirely: alternately claim from low and high sides
+        until the gap is empty. The low side uses _frontier_persist_claim
+        (standing in for 2d's future ordinary forward walk), and the high
+        side uses 2b's real _reverse_fill_claim_and_process."""
         import mcp_server
         import frontier_registry
         allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
-        # Manually initialize frontier-high to cover from position 1 to the end
-        # This simulates Stream 2 claiming everything above position 0
-        if len(linearization) > 1:
-            # Initialize frontier-high at the last position
-            mcp_server._frontier_persist_claim(
-                real_db, linearization, len(linearization) - 1, from_low=False,
-                commit_ts_iso=commit_metadata[len(linearization) - 1][1],
-            )
-            # Then expand it down to position 1 by claiming multiple times
-            for pos in range(len(linearization) - 2, 0, -1):
+        # Alternately claim from low and high to close the gap:
+        # - Claim one from low via _frontier_persist_claim
+        # - Then loop _reverse_fill_claim_and_process until gap is closed
+        while not allocator.is_gap_empty():
+            # Claim one position from low
+            pos = allocator.claim_low()
+            if pos is not None:
                 mcp_server._frontier_persist_claim(
-                    real_db, linearization, pos, from_low=False,
+                    real_db, linearization, pos, from_low=True,
                     commit_ts_iso=commit_metadata[pos][1],
                 )
-        # Reload allocator to pick up frontier-high
-        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
-        # Claim everything from the low side
-        while True:
-            pos = allocator.claim_low()
-            if pos is None:
-                break
-            mcp_server._frontier_persist_claim(
-                real_db, linearization, pos, from_low=True,
-                commit_ts_iso=commit_metadata[pos][1],
-            )
-        # Then claim the remaining from high
-        while True:
-            result = mcp_server._reverse_fill_claim_and_process(
-                real_db, str(repo), linearization, commit_metadata, allocator,
-            )
-            if result is None:
-                break
+            # Reload allocator to reflect the low claim
+            allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+            # Then claim from high until gap is closed
+            while not allocator.is_gap_empty():
+                result = mcp_server._reverse_fill_claim_and_process(
+                    real_db, str(repo), linearization, commit_metadata, allocator,
+                )
+                if result is None:
+                    break
         return allocator
 
     def test_no_op_when_frontier_high_unclaimed(self, real_db, tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15209,3 +15209,116 @@ class TestCorrectionSweepApply:
         err = capsys.readouterr().err
         assert err.strip() != ""
         assert "3" in err
+
+
+class TestCorrectionSweepClaimAndProcess:
+    def _init_repo(self, repo):
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _commit(self, repo, filename, content, msg):
+        (repo / filename).write_text(content)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True)
+
+    def _repo_with_n_commits(self, tmp_path, n):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+        for i in range(n):
+            self._commit(repo, f"f{i}.py", f"def f{i}(): pass\n", f"h{i}")
+        return repo
+
+    def _linearization_and_metadata(self, repo):
+        import mcp_server
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        return linearization, commit_metadata
+
+    def _close_gap(self, repo, db, linearization, commit_metadata):
+        """Claim exactly one position from the low side via a real
+        FrontierAllocator + _frontier_persist_claim (standing in for 2d's
+        future ordinary forward walk), then claim the rest from the high
+        side via 2b's real _reverse_fill_claim_and_process until the gap is
+        empty. Claiming the *whole* gap from the low side alone (an
+        unbounded claim_low() loop) would never touch frontier-high at
+        all -- claim_low() alone can empty the gap without claim_high()
+        ever running, since gap_hi only moves when claim_high() does -- so
+        the low side must stop after a bounded number of claims for
+        frontier-high to end up populated. db here is any MiniGrafDb
+        instance -- the real_db fixture in most tests, or a
+        manually-created MiniGrafDb.open_in_memory() in the two-graph
+        composition test below."""
+        import mcp_server
+        allocator = mcp_server._frontier_load(db, linearization, "2026-01-04T00:00:00Z")
+        pos = allocator.claim_low()
+        if pos is not None:
+            mcp_server._frontier_persist_claim(
+                db, linearization, pos, from_low=True, commit_ts_iso=commit_metadata[pos][1],
+            )
+        while not allocator.is_gap_empty():
+            mcp_server._reverse_fill_claim_and_process(
+                db, str(repo), linearization, commit_metadata, allocator,
+            )
+        return allocator
+
+    def test_no_op_propagates_from_select_position(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")  # frontier-high unclaimed
+
+        result = mcp_server._correction_sweep_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+        assert result is None
+
+    def test_single_call_round_trip(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+
+        result = mcp_server._correction_sweep_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+        assert result is not None
+        commit_hash, skipped_events = result
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert commit_hash == bounds[0]
+        assert skipped_events == 0
+        assert mcp_server._correction_sweep_through_query(real_db) == commit_hash
+
+    def test_wrapper_is_a_faithful_composition_of_the_three_pieces(self, tmp_path):
+        """Build TWO independent graphs from the same repo fixture (the
+        sweep mutates the state a second run would start from, so this
+        cannot be two passes over one graph). Against the first, call the
+        wrapper; against the second, call the three pieces directly.
+        Assert the resulting graph states are identical. Both dbs are
+        passed explicitly to every call -- none of these functions touch
+        mcp_server's module-global _db -- so this test needs no real_db
+        fixture and no open_db() call, just two independent
+        MiniGrafDb.open_in_memory() instances."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+
+        db_a = MiniGrafDb.open_in_memory()
+        self._close_gap(repo, db_a, linearization, commit_metadata)
+        mcp_server._correction_sweep_claim_and_process(db_a, str(repo), linearization, commit_metadata)
+
+        db_b = MiniGrafDb.open_in_memory()
+        self._close_gap(repo, db_b, linearization, commit_metadata)
+        selected = mcp_server._correction_sweep_select_position(db_b, linearization, commit_metadata)
+        assert selected is not None
+        commit_hash, commit_ts_iso = selected
+        file_results, _, _, _ = mcp_server._extract_commit(str(repo), commit_hash, ())
+        mcp_server._correction_sweep_apply(db_b, commit_hash, commit_ts_iso, file_results)
+
+        query = "(query [:find ?e ?a ?v :where [?e ?a ?v]])"
+        results_a = sorted(json.loads(db_a.execute(query))["results"])
+        results_b = sorted(json.loads(db_b.execute(query))["results"])
+        assert results_a == results_b

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15371,13 +15371,13 @@ class TestCorrectionSweepWalk:
         import mcp_server
         repo = self._repo_with_n_commits(tmp_path, 4)
         linearization, commit_metadata = self._linearization_and_metadata(repo)
-        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=0)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=1)
 
         commits_processed, skipped_events = mcp_server._correction_sweep_walk(
             real_db, str(repo), linearization, commit_metadata,
         )
 
-        assert commits_processed == 4
+        assert commits_processed == 3
         assert skipped_events == 0
         assert mcp_server._correction_sweep_through_query(real_db) == linearization[-1]
 
@@ -15398,7 +15398,7 @@ class TestCorrectionSweepWalk:
         import mcp_server
         repo = self._repo_with_n_commits(tmp_path, 2)
         linearization, commit_metadata = self._linearization_and_metadata(repo)
-        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=0)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=1)
         mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
 
         result = mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14604,3 +14604,62 @@ class TestReverseBulkFillWalk:
             real_db, str(repo), linearization, commit_metadata, allocator,
         )
         assert count == 0
+
+
+class TestCorrectionSweepThroughWatermark:
+    def test_unset_reads_as_none(self, real_db):
+        import mcp_server
+        assert mcp_server._correction_sweep_through_query(real_db) is None
+
+    def test_update_then_query_round_trip(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._correction_sweep_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        assert mcp_server._correction_sweep_through_query(db) == "h1"
+
+        mcp_server._correction_sweep_through_update(db, "h2", "2026-01-02T00:00:00Z")
+        assert mcp_server._correction_sweep_through_query(db) == "h2"
+
+    def test_update_does_not_duplicate_hash_fact(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._correction_sweep_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        mcp_server._correction_sweep_through_update(db, "h2", "2026-01-02T00:00:00Z")
+
+        ident = mcp_server._CORRECTION_SWEEP_THROUGH_IDENT
+        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :hash ?h]])")
+        assert json.loads(raw)["results"] == [[1]]
+
+    def test_entity_carries_expected_constants_and_survives_audit(self, real_db):
+        import mcp_server
+        db = real_db
+        mcp_server._correction_sweep_through_update(db, "h1", "2026-01-01T00:00:00Z")
+
+        ident = mcp_server._CORRECTION_SWEEP_THROUGH_IDENT
+        raw = mcp_server._db_execute(db, f"(query [:find ?a ?v :where [{ident} ?a ?v]])")
+        attrs = dict(json.loads(raw)["results"])
+        assert attrs[":entity-type"] == ":type/ingestion"
+        assert attrs[":ident"] == ident
+        assert isinstance(attrs[":description"], str) and attrs[":description"]
+
+        result = mcp_server.handle_minigraf_audit()
+        assert result["retracted"] == 0
+        assert mcp_server._correction_sweep_through_query(db) == "h1"
+
+    def test_description_is_distinct_from_lineage_confirmed_through(self, real_db):
+        """Two :type/ingestion watermarks with byte-identical :description
+        strings would both pass audit but be indistinguishable from each
+        other in the fact index and in minigraf_audit output -- this
+        watermark must not just copy lineage-confirmed-through's string."""
+        import mcp_server
+        db = real_db
+        mcp_server._correction_sweep_through_update(db, "h1", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_confirmed_through_update(db, "h1", "2026-01-01T00:00:00Z")
+
+        sweep_desc = dict(json.loads(mcp_server._db_execute(
+            db, f"(query [:find ?a ?v :where [{mcp_server._CORRECTION_SWEEP_THROUGH_IDENT} ?a ?v]])"
+        ))["results"])[":description"]
+        lineage_desc = dict(json.loads(mcp_server._db_execute(
+            db, f"(query [:find ?a ?v :where [{mcp_server._LINEAGE_CONFIRMED_THROUGH_IDENT} ?a ?v]])"
+        ))["results"])[":description"]
+        assert sweep_desc != lineage_desc

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14663,3 +14663,202 @@ class TestCorrectionSweepThroughWatermark:
             db, f"(query [:find ?a ?v :where [{mcp_server._LINEAGE_CONFIRMED_THROUGH_IDENT} ?a ?v]])"
         ))["results"])[":description"]
         assert sweep_desc != lineage_desc
+
+
+class TestCorrectionSweepSelectPosition:
+    def _init_repo(self, repo):
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+    def _commit(self, repo, filename, content, msg):
+        (repo / filename).write_text(content)
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True)
+
+    def _repo_with_n_commits(self, tmp_path, n):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+        for i in range(n):
+            self._commit(repo, f"f{i}.py", f"def f{i}(): pass\n", f"h{i}")
+        return repo
+
+    def _linearization_and_metadata(self, repo):
+        import mcp_server
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        return linearization, commit_metadata
+
+    def _close_gap(self, repo, real_db, linearization, commit_metadata):
+        """Close the gap entirely: claim everything from the low side via a
+        real FrontierAllocator + _frontier_persist_claim (standing in for
+        2d's future ordinary forward walk), then claim the rest from the
+        high side via 2b's real _reverse_fill_claim_and_process."""
+        import mcp_server
+        import frontier_registry
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Manually initialize frontier-high to cover from position 1 to the end
+        # This simulates Stream 2 claiming everything above position 0
+        if len(linearization) > 1:
+            # Initialize frontier-high at the last position
+            mcp_server._frontier_persist_claim(
+                real_db, linearization, len(linearization) - 1, from_low=False,
+                commit_ts_iso=commit_metadata[len(linearization) - 1][1],
+            )
+            # Then expand it down to position 1 by claiming multiple times
+            for pos in range(len(linearization) - 2, 0, -1):
+                mcp_server._frontier_persist_claim(
+                    real_db, linearization, pos, from_low=False,
+                    commit_ts_iso=commit_metadata[pos][1],
+                )
+        # Reload allocator to pick up frontier-high
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Claim everything from the low side
+        while True:
+            pos = allocator.claim_low()
+            if pos is None:
+                break
+            mcp_server._frontier_persist_claim(
+                real_db, linearization, pos, from_low=True,
+                commit_ts_iso=commit_metadata[pos][1],
+            )
+        # Then claim the remaining from high
+        while True:
+            result = mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+            if result is None:
+                break
+        return allocator
+
+    def test_no_op_when_frontier_high_unclaimed(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")  # seeds frontier-low only
+
+        result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert result is None
+
+    def test_no_op_while_gap_remains_open(self, real_db, tmp_path):
+        """Direct regression test for the race the design spec's "Why
+        confirming requires the gap to already be closed" section
+        describes: claim only from the high side, leaving a non-empty gap
+        below, and assert select_position refuses to hand out a position
+        even though frontier-high has real claimed territory."""
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        assert allocator.is_gap_empty() is False  # only claimed the newest position so far
+
+        result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert result is None
+
+    def test_returns_frontier_high_lo_hash_once_gap_closed(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        allocator = self._close_gap(repo, real_db, linearization, commit_metadata)
+        assert allocator.is_gap_empty() is True
+
+        result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert result is not None
+        commit_hash, commit_ts_iso = result
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert commit_hash == bounds[0]  # frontier-high's current lo-hash
+        pos = linearization.index(commit_hash)
+        assert commit_ts_iso == commit_metadata[pos][1]
+
+    def test_resumes_from_correction_sweep_through_not_frontier_high_lo_hash(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+
+        first = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert first is not None
+        first_hash, first_ts = first
+        mcp_server._correction_sweep_through_update(real_db, first_hash, first_ts)
+
+        second = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert second is not None
+        second_hash, _second_ts = second
+        assert second_hash != first_hash
+        assert linearization.index(second_hash) == linearization.index(first_hash) + 1
+
+    def test_no_op_once_reached_frontier_high_hi_hash(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+
+        # Walk to exhaustion by hand (Task 5 builds the real driving loop --
+        # this test only needs select_position's own termination).
+        while True:
+            result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+            if result is None:
+                break
+            mcp_server._correction_sweep_through_update(real_db, result[0], result[1])
+
+        assert mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata) is None
+
+    def test_respects_persisted_hi_hash_not_len_linearization(self, real_db, tmp_path):
+        """On an incremental re-ingest, linearization grows but frontier-
+        high's persisted :hi-hash does not move with it -- the ceiling must
+        stop at the persisted hash, not walk into brand-new, unclaimed
+        commits."""
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+        while True:
+            result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+            if result is None:
+                break
+            mcp_server._correction_sweep_through_update(real_db, result[0], result[1])
+
+        # Simulate an incremental re-ingest: more commits land, but neither
+        # stream has claimed them yet.
+        self._commit(repo, "new.py", "def new(): pass\n", "h_new")
+        grown_linearization, grown_commit_metadata = self._linearization_and_metadata(repo)
+        assert len(grown_linearization) == 3
+
+        result = mcp_server._correction_sweep_select_position(
+            real_db, grown_linearization, grown_commit_metadata
+        )
+        assert result is None
+
+    def test_falls_back_to_frontier_high_lo_hash_when_stored_hash_is_stale(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+        mcp_server._correction_sweep_through_update(real_db, "deadbeef_not_in_linearization", "2026-01-01T00:00:00Z")
+
+        result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
+        assert result is not None
+        commit_hash, _ts = result
+        bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert commit_hash == bounds[0]
+
+    def test_hash_to_pos_reused_when_passed_in(self, real_db, tmp_path):
+        """hash_to_pos, when supplied, is used as-is rather than rebuilt --
+        pass a deliberately wrong map for an unrelated hash to prove the
+        function trusts the caller's map rather than silently recomputing
+        its own."""
+        import mcp_server
+        repo = self._repo_with_n_commits(tmp_path, 2)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap(repo, real_db, linearization, commit_metadata)
+        hash_to_pos = {h: i for i, h in enumerate(linearization)}
+
+        result = mcp_server._correction_sweep_select_position(
+            real_db, linearization, commit_metadata, hash_to_pos=hash_to_pos
+        )
+        assert result is not None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14692,40 +14692,40 @@ class TestCorrectionSweepSelectPosition:
         return linearization, commit_metadata
 
     def _close_gap(self, repo, real_db, linearization, commit_metadata):
-        """Close the gap entirely: alternately claim from low and high sides
-        until the gap is empty. The low side uses _frontier_persist_claim
-        (standing in for 2d's future ordinary forward walk), and the high
-        side uses 2b's real _reverse_fill_claim_and_process."""
+        """Claim exactly one position from the low side via a real
+        FrontierAllocator + _frontier_persist_claim (standing in for 2d's
+        future ordinary forward walk), then claim the rest from the high
+        side via 2b's real _reverse_fill_claim_and_process until the gap is
+        empty. Claiming the *whole* gap from the low side alone (an
+        unbounded claim_low() loop) would never touch frontier-high at
+        all -- claim_low() alone can empty the gap without claim_high()
+        ever running, since gap_hi only moves when claim_high() does -- so
+        the low side must stop after a bounded number of claims for
+        frontier-high to end up populated."""
         import mcp_server
-        import frontier_registry
         allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
-        # Alternately claim from low and high to close the gap:
-        # - Claim one from low via _frontier_persist_claim
-        # - Then loop _reverse_fill_claim_and_process until gap is closed
+        pos = allocator.claim_low()
+        if pos is not None:
+            mcp_server._frontier_persist_claim(
+                real_db, linearization, pos, from_low=True, commit_ts_iso=commit_metadata[pos][1],
+            )
         while not allocator.is_gap_empty():
-            # Claim one position from low
-            pos = allocator.claim_low()
-            if pos is not None:
-                mcp_server._frontier_persist_claim(
-                    real_db, linearization, pos, from_low=True,
-                    commit_ts_iso=commit_metadata[pos][1],
-                )
-            # Reload allocator to reflect the low claim
-            allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
-            # Then claim from high until gap is closed
-            while not allocator.is_gap_empty():
-                result = mcp_server._reverse_fill_claim_and_process(
-                    real_db, str(repo), linearization, commit_metadata, allocator,
-                )
-                if result is None:
-                    break
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
         return allocator
 
     def test_no_op_when_frontier_high_unclaimed(self, real_db, tmp_path):
         import mcp_server
         repo = self._repo_with_n_commits(tmp_path, 2)
         linearization, commit_metadata = self._linearization_and_metadata(repo)
-        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")  # seeds frontier-low only
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Genuinely seed frontier-low (a fresh graph seeds neither side), so
+        # this exercises "frontier-low exists, frontier-high doesn't".
+        pos = allocator.claim_low()
+        mcp_server._frontier_persist_claim(
+            real_db, linearization, pos, from_low=True, commit_ts_iso=commit_metadata[pos][1],
+        )
 
         result = mcp_server._correction_sweep_select_position(real_db, linearization, commit_metadata)
         assert result is None
@@ -14836,10 +14836,10 @@ class TestCorrectionSweepSelectPosition:
         assert commit_hash == bounds[0]
 
     def test_hash_to_pos_reused_when_passed_in(self, real_db, tmp_path):
-        """hash_to_pos, when supplied, is used as-is rather than rebuilt --
-        pass a deliberately wrong map for an unrelated hash to prove the
-        function trusts the caller's map rather than silently recomputing
-        its own."""
+        """Smoke test that the hash_to_pos parameter is accepted: passing a
+        correct, pre-built map still yields a valid result. This does not
+        prove the function trusts the caller's map over recomputing its
+        own -- it would pass identically either way."""
         import mcp_server
         repo = self._repo_with_n_commits(tmp_path, 2)
         linearization, commit_metadata = self._linearization_and_metadata(repo)
@@ -15268,7 +15268,12 @@ class TestCorrectionSweepClaimAndProcess:
         import mcp_server
         repo = self._repo_with_n_commits(tmp_path, 2)
         linearization, commit_metadata = self._linearization_and_metadata(repo)
-        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")  # frontier-high unclaimed
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Genuinely seed frontier-low, leaving frontier-high unclaimed.
+        pos = allocator.claim_low()
+        mcp_server._frontier_persist_claim(
+            real_db, linearization, pos, from_low=True, commit_ts_iso=commit_metadata[pos][1],
+        )
 
         result = mcp_server._correction_sweep_claim_and_process(
             real_db, str(repo), linearization, commit_metadata,


### PR DESCRIPTION
## Summary

Implements #222 phase 2c: Stream 1's correction sweep — the fourth of five planned sub-phases of the converging multi-stream ingestion redesign (issue #222). Stacks on phase 2b (#228, still open) since this sweep calls 2b's `_entity_introduced_by_query`/`_lineage_is_provisional`/etc. and depends on its exact provisional-marker/candidate-diff write pattern. **Please merge #228 first**, or review this PR with that dependency in mind.

- Adds a dedicated `:ingestion/correction-sweep-through` watermark tracking this sweep's own progress, independent of `lineage-confirmed-through`'s "contiguous from C0" semantics.
- Adds `_correction_sweep_select_position`: a pure DB-reading function gated on a genuine correctness precondition — the shared frontier gap must already be closed before any commit can be confirmed, otherwise Stream 2 could still descend past a position this sweep already confirmed and permanently corrupt lineage data. (This was the subject of several review rounds during design — see the design spec's "Why confirming requires the gap to already be closed".)
- Adds `_correction_sweep_apply`: the core three-case reconciliation algorithm (confirm a correct provisional guess / fail-safe skip on anything ambiguous / reconcile `:modified-in` for already-authoritative entities, including retracting phase 2b's documented over-assertion where this sweep's own parse disagrees), plus capped, caller-threaded stderr observability (the log budget resets per run rather than living in a module global, since this is a long-lived server process).
- Adds `_correction_sweep_claim_and_process`: a synchronous convenience wrapper for tests, deliberately **not** meant to be called from real async code — a future phase 2d must call the pieces separately so extraction (CPU-bound, process-pool-eligible) and DB writes (must serialize through the existing write executor) can be scheduled independently.
- Adds `_correction_sweep_walk`: the driving loop.

No caller is wired into `_run_ingestion` yet — that's phase 2d, a separate future sub-phase, matching how phases 1/2a/2b each landed as inert-but-complete infrastructure first.

## Process notes

This went through an unusually long design-review cycle (8 rounds against a cloud reviewer) before implementation — the design doc (`docs/superpowers/specs/2026-07-25-stream1-correction-sweep-design.md`) and plan (`docs/superpowers/plans/2026-07-25-stream1-correction-sweep.md`) are both included and document the reasoning, including two architectural false starts (using the allocator's `claim_low()` directly, and a range that spanned the unclaimed gap rather than Stream 2's actual claimed territory) that were caught and corrected before any code was written.

Implementation surfaced and fixed two further plan-level test-helper bugs (an unbounded `claim_low()` drain that never populated frontier-high; a `split_pos=0` scenario that never persisted frontier-low) — both root-caused in the plan text itself, not worked around ad hoc, so the plan stays an accurate record for future readers.

## Test plan

- [x] All 34 new tests pass across 5 test classes (`TestCorrectionSweepThroughWatermark`, `TestCorrectionSweepSelectPosition`, `TestCorrectionSweepApply`, `TestCorrectionSweepClaimAndProcess`, `TestCorrectionSweepWalk`)
- [x] Full suite run clean relative to baseline: 642 passed, 48 skipped, 120 failed — all 120 pre-existing and unrelated (missing optional tree-sitter grammar modules for some languages, plus one already-known-flaky test), independently verified to reproduce identically on the pre-branch commit
- [x] Each of the 5 implementation tasks individually reviewed and approved
- [x] Final whole-branch review completed (opus): "Ready to merge: Yes" — one Important finding (a test helper that had drifted from its own already-corrected form) and several minor test-hygiene items were found and fixed in one follow-up batch, then re-reviewed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)