### PR TITLE
Add #222 phase 2d: concurrency wiring (Stages A/B into _run_ingestion)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -289,7 +289,9 @@ minigraf_ingest_git(repo_path="/path/to/repo")
 
 Once started, inform the user that ingestion is running in the background and move on — do not poll or wait for completion.
 
-Auto-started at MCP server startup — the server creates a background asyncio task that ingests the resolved default branch immediately. Set `MINIGRAF_NO_AUTO_INGEST=1` to suppress this (useful in eval sandboxes). Incremental: reads the `:ingestion/watermark` entity to determine the last ingested commit, then only processes new commits.
+Auto-started at MCP server startup — the server creates a background asyncio task that ingests the resolved default branch immediately. Set `MINIGRAF_NO_AUTO_INGEST=1` to suppress this (useful in eval sandboxes). Incremental, and resumed from two places, not one: `:ingestion/watermark` says where the authoritative walk resumes, and `:ingestion/correction-sweep-through` says how far lineage has been confirmed. The two differ because a commit becomes *queryable* before its lineage is *final* — history above the watermark is ingested with provisional `:introduced-by` guesses that a later confirmation pass upgrades, so an interrupted run can leave the graph fully queryable with its lineage still being settled.
+
+History is walked by two interleaved streams: one forward from the watermark (authoritative), one backward from HEAD (provisional, so recent history becomes queryable first). `MINIGRAF_INGEST_STREAM_RATIO` sets how many commits each takes per round as `"forward:reverse"` (default `1:1`); `MINIGRAF_INGEST_STREAM_RATIO=1000000:1` is effectively a plain oldest-first walk. A malformed value is ignored with a warning and falls back to the default.
 
 By default, `minigraf_ingest_git` (and the auto-start above) resolve which branch to walk instead of blindly following whatever ref is checked out: `MINIGRAF_GIT_BRANCH` wins if set, otherwise the repo's `main` or `master` branch is auto-detected, falling back to `HEAD` only if neither exists. Pass an explicit `branch` argument to override both — useful for on-demand ingestion of a feature branch without disturbing the pinned default.
 
@@ -315,7 +317,8 @@ aren't populated — a subsequent `minigraf_ingest_git` call will still be
 rejected with "already in progress" during this window, same as `running`.
 `stopped` means a graceful shutdown (session end) paused ingestion between commits —
 not a failure; the next `minigraf_ingest_git` call (or server auto-start)
-resumes from the watermark automatically. `skipped` means another live process
+resumes from the watermark — and from `:ingestion/correction-sweep-through` for
+the confirmation pass — automatically. `skipped` means another live process
 already owns the graph lock (its PID is in `owner_pid`) — this server will not
 attempt ingestion on its own; call `minigraf_ingest_git` again later to retry.
 For `error` and `skipped`, a `stale` field may be present: `stale: true` means the

--- a/docs/superpowers/plans/2026-07-26-concurrency-wiring.md
+++ b/docs/superpowers/plans/2026-07-26-concurrency-wiring.md
@@ -397,7 +397,55 @@ class TestForwardReconcileProvisional:
 Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestForwardReconcileProvisional -q`
 Expected: FAIL with `AttributeError: ... '_forward_reconcile_provisional'`
 
-- [ ] **Step 3: Write the implementation**
+- [ ] **Step 3: Write the shared re-dating helper**
+
+Both this task and `_reverse_apply` (Task 6) re-date an entity's structural
+facts. The `:contains`-one-per-call rule is exactly the kind of invariant that
+rots when duplicated — sub-phase 2b1 exists because a batched `:contains`
+silently dropped five of six containment edges on an ordinary file. One
+implementation, two callers.
+
+```python
+def _re_date_structural_facts(
+    db: Any,
+    structural_triples: List[str],
+    new_ts_iso: str,
+    index_con: Optional[Any] = None,
+) -> None:
+    """Retract and re-assert an entity's structural facts at new_ts_iso.
+
+    Used whenever a provisional :introduced-by guess moves to an earlier
+    commit -- by _reverse_apply when the reverse walk finds an even earlier
+    occurrence, and by _forward_reconcile_provisional when the forward walk
+    reaches the true introduction. In both cases the facts were written at
+    the timestamp of the commit where the entity was first SIGHTED, which is
+    later than the introduction now is, leaving a valid-time window where
+    :introduced-by is live for an entity with no type, name or file -- so
+    ":as-of the introduction" reports it as nonexistent.
+
+    _retract targets live rows regardless of their original valid_from, so
+    this is a straight re-assert at the earlier timestamp.
+
+    :contains is retracted and transacted ONE TRIPLE PER CALL, on both
+    sides. Minigraf's EAVT pending index omits value bytes, so facts sharing
+    (entity, attribute, valid_from) in one call collapse to the last -- see
+    #222 phase 2b1, where this cost five of six containment edges on an
+    ordinary multi-entity file, permanently.
+    """
+    contains = [t for t in structural_triples if ":contains" in t]
+    other = [t for t in structural_triples if ":contains" not in t]
+    if other:
+        _retract(db, "[" + " ".join(other) + "]", index_con=index_con)
+        _transact(db, "[" + " ".join(other) + "]", new_ts_iso, index_con=index_con)
+    for triple in contains:
+        _retract(db, "[" + triple + "]", index_con=index_con)
+        _transact(db, "[" + triple + "]", new_ts_iso, index_con=index_con)
+```
+
+Place it immediately above `_forward_reconcile_provisional`. Task 6 switches
+`_reverse_apply`'s inline copy over to it.
+
+- [ ] **Step 4: Write the implementation**
 
 ```python
 def _forward_reconcile_provisional(
@@ -434,22 +482,13 @@ def _forward_reconcile_provisional(
     if guess_ident is not None:
         _retract(db, f"[[{entity_ident} :introduced-by {guess_ident}]]", index_con=index_con)
 
-    # 2. Re-date structural facts to the true (earlier) introduction. Stream 2
-    # wrote them at the timestamp of the commit where it first SIGHTED the
-    # entity, leaving a valid-time window where :introduced-by is live for an
-    # entity with no type, name or file. _retract targets live rows
-    # regardless of their original valid_from, so this is a straight
-    # re-assert at the earlier timestamp. :contains goes one per call on BOTH
-    # sides (EAVT collision, #222 phase 2b1).
-    structural = [t for t in structural_triples if ":introduced-by" not in t]
-    structural_contains = [t for t in structural if ":contains" in t]
-    structural_other = [t for t in structural if ":contains" not in t]
-    if structural_other:
-        _retract(db, "[" + " ".join(structural_other) + "]", index_con=index_con)
-        _transact(db, "[" + " ".join(structural_other) + "]", true_commit_ts_iso, index_con=index_con)
-    for structural_triple in structural_contains:
-        _retract(db, "[" + structural_triple + "]", index_con=index_con)
-        _transact(db, "[" + structural_triple + "]", true_commit_ts_iso, index_con=index_con)
+    # 2. Re-date structural facts to the true (earlier) introduction.
+    _re_date_structural_facts(
+        db,
+        [t for t in structural_triples if ":introduced-by" not in t],
+        true_commit_ts_iso,
+        index_con=index_con,
+    )
 
     # 3. The entity's lineage is authoritative from here on.
     _lineage_confirm(db, entity_ident, index_con=index_con)
@@ -485,12 +524,12 @@ def _forward_reconcile_provisional(
     return guess_ident
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [ ] **Step 5: Run tests to verify they pass**
 
 Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestForwardReconcileProvisional -q`
 Expected: 7 passed
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add mcp_server.py tests/test_mcp_server.py
@@ -916,6 +955,18 @@ Rename the existing function body to `_reverse_apply` with the signature above, 
 - **Delete** from it: the `pos = allocator.claim_high()` / `if pos is None: return None` lines, and the `_extract_commit` call. `pos` and `file_results` are now parameters.
 - **Keep** in it: the `commit_metadata`/`linearization` length and alignment `ValueError` guards (they must run before any write), everything from `all_triples` onward, `_frontier_persist_claim(..., from_low=False, ...)`, and the single `_db_checkpoint(db)`.
 - Change the return type from `Optional[str]` to `str`.
+- **Replace its inline structural re-dating with `_re_date_structural_facts`** (Task 3). The block to replace is the one inside the `provisional_moves` loop that builds `structural`/`structural_contains`/`structural_other` and retracts+re-transacts them. It becomes:
+
+  ```python
+                _re_date_structural_facts(
+                    db,
+                    [t for t in candidate_triples_by_ident.get(ident, []) if ":introduced-by" not in t],
+                    commit_ts_iso,
+                    index_con=index_con,
+                )
+  ```
+
+  The existing `TestReverseFillContainsEdges` and `TestReverseFillValidTimeParity` classes are what prove this substitution is behaviour-preserving — they must pass unchanged.
 
 Then reduce `_reverse_fill_claim_and_process` to:
 

--- a/docs/superpowers/plans/2026-07-26-concurrency-wiring.md
+++ b/docs/superpowers/plans/2026-07-26-concurrency-wiring.md
@@ -19,7 +19,8 @@
 - **Never call `handle_minigraf_transact` / `handle_minigraf_retract`** from ingestion code. Use internal `_transact` / `_retract`. The public handlers' schema gate rejects `:type/lineage-marker`, `:type/candidate-diff` and `:type/ingest-interval`, all deliberately unregistered in `MINIGRAF_SCHEMA`.
 - **EAVT collision rule:** minigraf's pending index omits value bytes, so facts sharing `(entity, attribute, valid_from)` in ONE `_transact` collapse to the last. `:contains`, `:depends-on` and `:parent` must be transacted **one triple per call**, on the retract side too. Facts differing in entity do not collide.
 - **Positions, never timestamps**, for any ordering comparison. Committer dates are non-monotonic in topological order (this repo's own history has a six-day inversion).
-- **Run the full suite before every commit:** `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`. Baseline on this branch is **968 passing, 0 failing**. The rule for every task is: **zero failures, and the passing count goes up by exactly the number of tests that task added — never down.** Confirm the baseline yourself before starting Task 1 rather than trusting this number; if it differs, use what you measured. Absolute counts are deliberately not restated per-task, because a task that adds one extra test case would otherwise read as a failure.
+- **Always use the project venv: `.venv/bin/python`, never bare `python`.** The system interpreter lacks the optional tree-sitter grammar packages (`tree_sitter_elixir`, and others), which produces ~120 `ModuleNotFoundError` failures that have nothing to do with your change. Every command in this plan that says `python` means `.venv/bin/python`.
+- **Run the full suite before every commit:** `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`. Measured baseline on this branch is **839 passing, 0 failing**. The rule for every task is: **zero failures, and the passing count goes up by exactly the number of tests that task added — never down.** Absolute counts are deliberately not restated per-task, because a task that adds one extra test case would otherwise read as a failure.
 
 ---
 
@@ -67,7 +68,7 @@ class TestParseStreamRatio:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestParseStreamRatio -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestParseStreamRatio -q`
 Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_parse_stream_ratio'`
 
 - [ ] **Step 3: Write the implementation**
@@ -111,7 +112,7 @@ def _parse_stream_ratio(raw: Optional[str]) -> Tuple[int, int]:
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestParseStreamRatio -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestParseStreamRatio -q`
 Expected: 4 passed
 
 - [ ] **Step 5: Commit**
@@ -173,7 +174,7 @@ class TestPreloadProvisionalIdents:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestPreloadProvisionalIdents -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestPreloadProvisionalIdents -q`
 Expected: FAIL with `AttributeError: ... '_preload_provisional_idents'`
 
 - [ ] **Step 3: Write the implementation**
@@ -213,10 +214,10 @@ In `_run_ingestion` at `mcp_server.py:8061-8065`, add `provisional_idents,` as t
 
 - [ ] **Step 5: Run tests to verify they pass**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestPreloadProvisionalIdents -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestPreloadProvisionalIdents -q`
 Expected: 4 passed
 
-Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
 Expected: zero failures, count up by 4. A `ValueError: too many values to unpack` here means Step 4 was missed.
 
 - [ ] **Step 6: Commit**
@@ -393,7 +394,7 @@ class TestForwardReconcileProvisional:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestForwardReconcileProvisional -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestForwardReconcileProvisional -q`
 Expected: FAIL with `AttributeError: ... '_forward_reconcile_provisional'`
 
 - [ ] **Step 3: Write the implementation**
@@ -486,7 +487,7 @@ def _forward_reconcile_provisional(
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestForwardReconcileProvisional -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestForwardReconcileProvisional -q`
 Expected: 7 passed
 
 - [ ] **Step 5: Commit**
@@ -586,7 +587,7 @@ leaving the existing `except`/`finally` handlers at 8594-8612 exactly as they ar
 
 - [ ] **Step 4: Run the full suite**
 
-Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
 Expected: zero failures and **exactly the same count as after Task 3** — this task adds no tests, and the existing suite is the only proof the move was faithful. **Any failure here is an extraction error, not a test problem.** Diff the moved code against `git show HEAD~1:mcp_server.py` rather than adjusting a test.
 
 - [ ] **Step 5: Commit**
@@ -745,7 +746,7 @@ class TestForwardApplyReconcilesProvisional:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestForwardApplyReconcilesProvisional -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestForwardApplyReconcilesProvisional -q`
 Expected: FAIL — `_ForwardWalkState` has no `provisional_idents` field
 
 - [ ] **Step 3: Widen the dataclass**
@@ -822,10 +823,10 @@ def _forward_structural_triples(precomputed: Dict[str, Any], ident: str) -> List
 
 - [ ] **Step 5: Run tests to verify they pass**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestForwardApplyReconcilesProvisional -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestForwardApplyReconcilesProvisional -q`
 Expected: 3 passed
 
-Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
 Expected: zero failures, count up by 3
 
 - [ ] **Step 6: Commit**
@@ -906,7 +907,7 @@ class TestReverseApplySplit:
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestReverseApplySplit -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestReverseApplySplit -q`
 Expected: FAIL with `AttributeError: ... '_reverse_apply'`
 
 - [ ] **Step 3: Perform the split**
@@ -962,10 +963,10 @@ Note the length guard is duplicated deliberately: it must fire **before** `claim
 
 - [ ] **Step 4: Run the tests**
 
-Run: `python -m pytest tests/test_mcp_server.py -k "ReverseFill or ReverseApply" -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py -k "ReverseFill or ReverseApply" -q`
 Expected: all pass, including every pre-existing `TestReverseFill*` test unchanged
 
-Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
 Expected: zero failures, count up by 1
 
 - [ ] **Step 5: Commit**
@@ -1065,7 +1066,7 @@ class TestRoundRobinClaimer:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestRoundRobinClaimer -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestRoundRobinClaimer -q`
 Expected: FAIL with `AttributeError: ... '_RoundRobinClaimer'`
 
 - [ ] **Step 3: Write the implementation**
@@ -1122,7 +1123,7 @@ class _RoundRobinClaimer:
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestRoundRobinClaimer -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestRoundRobinClaimer -q`
 Expected: 8 passed
 
 - [ ] **Step 5: Commit**
@@ -1339,10 +1340,10 @@ Check whether the file already uses `pytest.mark.asyncio` or an explicit `asynci
 
 - [ ] **Step 7: Run the tests**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestStageAInterleave -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestStageAInterleave -q`
 Expected: 5 passed
 
-Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
 Expected: all pass. Existing `_run_ingestion` tests that assumed a watermark-relative commit list may need their *expectations* updated — but only where the change is genuinely the new intended behaviour. If a test fails because lineage is now provisional in the upper region, that is correct and expected; Task 9 is what makes it authoritative again.
 
 - [ ] **Step 8: Commit**
@@ -1470,7 +1471,7 @@ class TestStageBCorrectionSweep:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestStageBCorrectionSweep -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestStageBCorrectionSweep -q`
 Expected: FAIL — `_should_fold_lineage_watermark` undefined, and the completed-run assertions fail because no sweep runs yet
 
 - [ ] **Step 3: Write the fold guard**
@@ -1567,10 +1568,10 @@ In `_run_ingestion`, immediately after the `while pending:` loop ends and before
 
 - [ ] **Step 5: Run the tests**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestStageBCorrectionSweep -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestStageBCorrectionSweep -q`
 Expected: 5 passed
 
-Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
 Expected: all pass
 
 - [ ] **Step 6: Commit**
@@ -1705,7 +1706,7 @@ class TestStagingAndShutdown:
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestStagingAndShutdown -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestStagingAndShutdown -q`
 Expected: FAIL — `KeyError: 'phase'`
 
 - [ ] **Step 3: Add the phase key**
@@ -1722,10 +1723,10 @@ Confirm `_ingest_progress["processed"] += 1` remains where it is — once per dr
 
 - [ ] **Step 4: Run the tests**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestStagingAndShutdown -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestStagingAndShutdown -q`
 Expected: 4 passed
 
-Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
 Expected: all pass
 
 - [ ] **Step 5: Commit**
@@ -1798,7 +1799,7 @@ class TestMultiStreamParityWithForwardOnly:
 
 - [ ] **Step 2: Run it**
 
-Run: `python -m pytest tests/test_mcp_server.py::TestMultiStreamParityWithForwardOnly -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestMultiStreamParityWithForwardOnly -q`
 Expected: PASS
 
 If `:introduced-by` diverges, that is a real bug in Tasks 5/9, not a test to relax. Trace the specific entity: query its `:introduced-by` in both graphs, then check whether it was reconciled (`_preload_provisional_idents` on the multi graph) and whether the sweep visited its guess commit (`_correction_sweep_through_query`).
@@ -1815,7 +1816,7 @@ Add `MINIGRAF_INGEST_STREAM_RATIO` wherever `MINIGRAF_INGEST_WORKERS` is already
 
 - [ ] **Step 4: Run the full suite**
 
-Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
 Expected: all pass, no regressions against the 968 baseline
 
 - [ ] **Step 5: Commit**

--- a/docs/superpowers/plans/2026-07-26-concurrency-wiring.md
+++ b/docs/superpowers/plans/2026-07-26-concurrency-wiring.md
@@ -1,0 +1,1835 @@
+# Concurrency Wiring (#222 phase 2d) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire #222's frontier allocator, reverse-bulk-fill walk and correction sweep into `_run_ingestion` so a real ingest interleaves a forward-truth stream with a recent-first reverse stream, then sweeps the reverse region to authoritative.
+
+**Architecture:** `_run_ingestion` becomes a three-stage driver. Stage A is one coroutine over a single tagged prefetch pipeline — `submit_next()` alternates `allocator.claim_low()` / `claim_high()` by a configurable ratio, submits every `_extract_commit` to the existing `ProcessPoolExecutor`, and dispatches each drained entry by tag to `_forward_apply` or `_reverse_apply` on the existing single-worker `write_executor`. Stage B drives phase 2c's three sweep pieces asynchronously on their correct executors. Stage C is the existing tag/last-run bookkeeping.
+
+**Tech Stack:** Python 3, asyncio, `concurrent.futures` (ProcessPoolExecutor + single-worker ThreadPoolExecutor), `minigraf` (Rust-backed bi-temporal graph DB), tree-sitter, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-concurrency-wiring-design.md` — read it before starting. Every task below implements a section of it.
+
+## Global Constraints
+
+- **Branch:** `design-222-phase2d-concurrency-wiring` (already created, spec already committed as `9439908`). Work in place on this branch — do NOT create a git worktree.
+- **Never write `Fix #222`, `Fixes #222`, `Closes #222` or `Resolves #222` in any commit message.** GitHub treats a closing keyword in *any* branch commit as an auto-close on merge, regardless of PR body. This has already bitten this project twice. Use `#222 phase 2d: ...` phrasing.
+- **Tests are real-backend only** per `docs/testing-conventions.md`: real `MiniGrafDb` via the `real_db` fixture (in-memory) or a real file-backed `MiniGrafDb.open()` against `tmp_path` when state must survive across opens. Never `MagicMock` the DB. Never assert on mock call arguments — always re-query and assert on persisted facts.
+- **All new test classes go in `tests/test_mcp_server.py`**, following the existing class-per-concern idiom (see `TestReverseFillClaimAndProcess` at line 13954 for the fixture pattern).
+- **Never call `handle_minigraf_transact` / `handle_minigraf_retract`** from ingestion code. Use internal `_transact` / `_retract`. The public handlers' schema gate rejects `:type/lineage-marker`, `:type/candidate-diff` and `:type/ingest-interval`, all deliberately unregistered in `MINIGRAF_SCHEMA`.
+- **EAVT collision rule:** minigraf's pending index omits value bytes, so facts sharing `(entity, attribute, valid_from)` in ONE `_transact` collapse to the last. `:contains`, `:depends-on` and `:parent` must be transacted **one triple per call**, on the retract side too. Facts differing in entity do not collide.
+- **Positions, never timestamps**, for any ordering comparison. Committer dates are non-monotonic in topological order (this repo's own history has a six-day inversion).
+- **Run the full suite before every commit:** `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`. Baseline on this branch is **968 passing, 0 failing**. The rule for every task is: **zero failures, and the passing count goes up by exactly the number of tests that task added — never down.** Confirm the baseline yourself before starting Task 1 rather than trusting this number; if it differs, use what you measured. Absolute counts are deliberately not restated per-task, because a task that adds one extra test case would otherwise read as a failure.
+
+---
+
+### Task 1: Stream ratio configuration
+
+**Files:**
+- Modify: `mcp_server.py` (add near the other ingestion env-var reads, around line 8086)
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `_parse_stream_ratio(raw: Optional[str]) -> Tuple[int, int]` returning `(forward_per_round, reverse_per_round)`; module constant `_DEFAULT_STREAM_RATIO = (1, 1)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_mcp_server.py`:
+
+```python
+class TestParseStreamRatio:
+    def test_default_when_unset(self):
+        import mcp_server
+        assert mcp_server._parse_stream_ratio(None) == (1, 1)
+
+    def test_parses_explicit_ratios(self):
+        import mcp_server
+        assert mcp_server._parse_stream_ratio("1:1") == (1, 1)
+        assert mcp_server._parse_stream_ratio("1:3") == (1, 3)
+        assert mcp_server._parse_stream_ratio("3:1") == (3, 1)
+        assert mcp_server._parse_stream_ratio(" 2 : 5 ") == (2, 5)
+
+    def test_malformed_falls_back_to_default_and_logs_once(self, capsys):
+        import mcp_server
+        for bad in ("x", "", "1", "1:2:3", "0:1", "1:0", "-1:2", "a:b", "1.5:2"):
+            assert mcp_server._parse_stream_ratio(bad) == (1, 1), bad
+        err = capsys.readouterr().err
+        # One line per bad value, and each names the offending value.
+        assert err.count("MINIGRAF_INGEST_STREAM_RATIO") == 9
+
+    def test_does_not_raise_on_any_input(self):
+        """A bad env var must never be the reason a repo never ingests --
+        this runs inside a background coroutine with no user in the loop."""
+        import mcp_server
+        assert mcp_server._parse_stream_ratio("\x00\xff") == (1, 1)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestParseStreamRatio -q`
+Expected: FAIL with `AttributeError: module 'mcp_server' has no attribute '_parse_stream_ratio'`
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `mcp_server.py`, immediately above `_run_ingestion`:
+
+```python
+_DEFAULT_STREAM_RATIO = (1, 1)
+
+
+def _parse_stream_ratio(raw: Optional[str]) -> Tuple[int, int]:
+    """Parse MINIGRAF_INGEST_STREAM_RATIO ("F:R") into (forward_per_round,
+    reverse_per_round), falling back to 1:1 on anything malformed.
+
+    Never raises. This is read inside the background ingestion coroutine,
+    where a bad env var must degrade to the default rather than become the
+    reason a repository never ingests at all.
+
+    The ratio trades total work against how fast recent history becomes
+    usable: a commit the forward stream claims is parsed once and is
+    authoritative immediately, while a commit the reverse stream claims is
+    parsed twice (reverse walk, then the correction sweep's own
+    _extract_commit call). Total parse cost is N * (1 + reverse_fraction).
+    """
+    if raw is None:
+        return _DEFAULT_STREAM_RATIO
+    try:
+        forward_str, reverse_str = raw.split(":")
+        forward, reverse = int(forward_str.strip()), int(reverse_str.strip())
+        if forward < 1 or reverse < 1:
+            raise ValueError("both sides must be >= 1")
+        return forward, reverse
+    except Exception as e:
+        print(
+            f"[_run_ingestion] ignoring malformed MINIGRAF_INGEST_STREAM_RATIO "
+            f"{raw!r} ({e}); using {_DEFAULT_STREAM_RATIO[0]}:{_DEFAULT_STREAM_RATIO[1]}",
+            file=sys.stderr,
+        )
+        return _DEFAULT_STREAM_RATIO
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestParseStreamRatio -q`
+Expected: 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add #222 phase 2d: stream ratio configuration"
+```
+
+---
+
+### Task 2: Preload the provisional ident set
+
+**Files:**
+- Modify: `mcp_server.py:6918-6946` (`_load_ingestion_preload_state`), and its single caller's unpack at `mcp_server.py:8061-8065`
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: `_lineage_mark_provisional` (2a), `_LINEAGE_MARKER_ENTITY_TYPE`
+- Produces: `_preload_provisional_idents(db: Any) -> Set[str]`; `_load_ingestion_preload_state` returns a **13**-tuple, with `provisional_idents` appended last
+
+**Why this exists:** the forward walk decides "is this entity new" from the in-memory `entity_valid_from` dict, preloaded once at run start. On a **resumed** run, Stream 2's structural facts from the previous run are already in that dict, so `_build_code_triples` suppresses the introduction entirely and the entity keeps a wrong provisional `:introduced-by` forever. That failure is silent — there is no duplicate fact to notice. This set is what lets Task 5 detect it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestPreloadProvisionalIdents:
+    def test_empty_when_no_markers(self, real_db):
+        import mcp_server
+        assert mcp_server._preload_provisional_idents(real_db) == set()
+
+    def test_returns_every_marked_ident(self, real_db):
+        import mcp_server
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-a", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-b", "2026-01-01T00:00:00Z")
+        assert mcp_server._preload_provisional_idents(real_db) == {":code/fn-a", ":code/fn-b"}
+
+    def test_confirmed_idents_drop_out(self, real_db):
+        """_lineage_confirm retracts the whole companion entity rather than
+        flipping :status, so the set form must agree with the per-ident
+        _lineage_is_provisional check the reconciliation relies on."""
+        import mcp_server
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-a", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-b", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_confirm(real_db, ":code/fn-a")
+        assert mcp_server._preload_provisional_idents(real_db) == {":code/fn-b"}
+        assert mcp_server._lineage_is_provisional(real_db, ":code/fn-a") is False
+
+    def test_load_ingestion_preload_state_returns_it_last(self, real_db, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-a", "2026-01-01T00:00:00Z")
+        result = mcp_server._load_ingestion_preload_state(str(repo))
+        assert len(result) == 13
+        assert result[-1] == {":code/fn-a"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestPreloadProvisionalIdents -q`
+Expected: FAIL with `AttributeError: ... '_preload_provisional_idents'`
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `mcp_server.py` next to the other `_preload_*` functions:
+
+```python
+def _preload_provisional_idents(db: Any) -> Set[str]:
+    """Every tracked ident that currently has a :type/lineage-marker
+    companion entity, i.e. whose :introduced-by is a provisional guess.
+
+    No :status clause is needed: the marker exists ONLY while the entity is
+    provisional -- _lineage_confirm retracts the whole companion entity
+    rather than flipping its :status -- so existence is the test, exactly as
+    _lineage_is_provisional does per-ident. Keeping the two queries the same
+    shape is deliberate: this set is consulted where a per-ident check is
+    too expensive, and the two must never disagree.
+    """
+    raw = _db_execute(
+        db,
+        f"(query [:find ?e :where [?m :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}] [?m :entity ?e]])",
+    )
+    return {row[0] for row in json.loads(raw).get("results", [])}
+```
+
+In `_load_ingestion_preload_state`, add before the `return`:
+
+```python
+    provisional_idents = _preload_provisional_idents(db)
+```
+
+and append `provisional_idents,` as the last element of the returned tuple.
+
+- [ ] **Step 4: Widen the caller's unpack**
+
+In `_run_ingestion` at `mcp_server.py:8061-8065`, add `provisional_idents,` as the last name in the destructuring assignment. It is unused until Task 5 — add `# consumed by _forward_apply (Task 5)` so the unused name is not mistaken for a leftover.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestPreloadProvisionalIdents -q`
+Expected: 4 passed
+
+Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Expected: zero failures, count up by 4. A `ValueError: too many values to unpack` here means Step 4 was missed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add #222 phase 2d: preload the provisional ident set"
+```
+
+---
+
+### Task 3: Forward-introduction reconciliation helper
+
+**Files:**
+- Modify: `mcp_server.py` (add immediately after `_entity_introduced_by_set_provisional`, around line 5320)
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: `_entity_introduced_by_query`, `_lineage_confirm`, `_candidate_diff_clear`, `_transact`, `_retract` (all 2a/2b)
+- Produces:
+  ```python
+  def _forward_reconcile_provisional(
+      db: Any,
+      entity_ident: str,
+      structural_triples: List[str],
+      true_commit_ts_iso: str,
+      ts_by_commit_ident: Dict[str, str],
+      index_con: Optional[Any] = None,
+  ) -> Optional[str]:
+  ```
+  Returns the superseded (guessed) commit ident it reconciled away, or `None` if the entity was not provisional.
+
+**Why:** this is the correctness core of 2d. Without it, an entity alive at `HEAD` but introduced low in history ends up with **two** `:introduced-by` values, which `_correction_sweep_apply` reads as an ambiguous count, hits its case-2 fail-safe on, and leaves provisional forever. It also closes the "wrong provisional guess" case 2c proved it could not handle inside its own walk and left explicitly unowned.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestForwardReconcileProvisional:
+    def _seed_provisional(self, real_db):
+        """An entity Stream 2 discovered at a late commit and guessed wrong."""
+        import mcp_server
+        guess_ident = ":commit/bbbbbbbbbbbb"
+        structural = [
+            ":code/fn-login :entity-type :type/function",
+            ':code/fn-login :name "login"',
+            ":module/auth :contains :code/fn-login",
+        ]
+        structural_triples = [f"[{t}]" for t in structural]
+        mcp_server._transact(
+            real_db, "[" + " ".join(f"[{t}]" for t in structural if ":contains" not in t) + "]",
+            "2026-06-01T00:00:00Z",
+        )
+        mcp_server._transact(
+            real_db, "[[:module/auth :contains :code/fn-login]]", "2026-06-01T00:00:00Z",
+        )
+        mcp_server._transact(
+            real_db, f"[[:code/fn-login :introduced-by {guess_ident}]]", "2026-06-01T00:00:00Z",
+        )
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-login", "2026-06-01T00:00:00Z")
+        mcp_server._candidate_diff_persist(
+            real_db, "bbbbbbbbbbbb" + "0" * 28, ":code/fn-login", "hash-b", "2026-06-01T00:00:00Z",
+        )
+        return guess_ident, structural_triples
+
+    def test_returns_none_and_writes_nothing_when_not_provisional(self, real_db):
+        import mcp_server
+        mcp_server._transact(
+            real_db, "[[:code/fn-x :introduced-by :commit/aaaaaaaaaaaa]]", "2026-01-01T00:00:00Z",
+        )
+        result = mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-x", [], "2026-01-01T00:00:00Z", {},
+        )
+        assert result is None
+        assert mcp_server._entity_introduced_by_query(real_db, ":code/fn-x") == ":commit/aaaaaaaaaaaa"
+
+    def test_retracts_the_provisional_guess(self, real_db):
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        # No :introduced-by left at all -- the caller writes the authoritative
+        # one immediately after, via the normal forward emission path.
+        assert mcp_server._entity_introduced_by_query(real_db, ":code/fn-login") is None
+
+    def test_confirms_the_marker_and_clears_the_candidate_diff(self, real_db):
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        returned = mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        assert returned == guess_ident
+        assert mcp_server._lineage_is_provisional(real_db, ":code/fn-login") is False
+        assert mcp_server._candidate_diff_read(
+            real_db, "bbbbbbbbbbbb" + "0" * 28, ":code/fn-login",
+        ) is None
+
+    def test_writes_modified_in_at_the_guess_commits_own_timestamp(self, real_db):
+        """The guess commit is now known to be a genuine modification rather
+        than the introduction. Dating the edge at the TRUE introduction's
+        timestamp would assert a fact valid before it was true."""
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        raw = mcp_server._db_execute(
+            real_db,
+            '(query [:find ?c :valid-at "2026-06-02T00:00:00Z" '
+            ':where [:code/fn-login :modified-in ?c]])',
+        )
+        assert [row[0] for row in json.loads(raw)["results"]] == [guess_ident]
+        # Not yet true the day BEFORE the guess commit.
+        raw_before = mcp_server._db_execute(
+            real_db,
+            '(query [:find ?c :valid-at "2026-05-31T00:00:00Z" '
+            ':where [:code/fn-login :modified-in ?c]])',
+        )
+        assert json.loads(raw_before)["results"] == []
+
+    def test_re_dates_structural_facts_to_the_true_introduction(self, real_db):
+        """Otherwise there is a valid-time window where :introduced-by is live
+        for an entity with no type, name or file, so an :as-of query at the
+        true introduction reports the entity as nonexistent."""
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        raw = mcp_server._db_execute(
+            real_db,
+            '(query [:find ?n :valid-at "2026-02-01T00:00:00Z" '
+            ':where [:code/fn-login :name ?n]])',
+        )
+        assert [row[0] for row in json.loads(raw)["results"]] == ["login"]
+
+    def test_contains_edge_survives_re_dating(self, real_db):
+        """:contains shares (entity, attribute, valid_from) with any sibling
+        edge, so it must be retracted and re-transacted one triple per call
+        -- batching silently keeps only the last (#222 phase 2b1)."""
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        raw = mcp_server._db_execute(
+            real_db,
+            '(query [:find ?c :valid-at "2026-02-01T00:00:00Z" '
+            ':where [:module/auth :contains ?c]])',
+        )
+        assert [row[0] for row in json.loads(raw)["results"]] == [":code/fn-login"]
+
+    def test_skips_modified_in_when_guess_timestamp_unknown(self, real_db, capsys):
+        """Falling back to the true introduction's timestamp would back-date
+        the edge to before the modification it describes. Skip and say so."""
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z", {},
+        )
+        raw = mcp_server._db_execute(
+            real_db, "(query [:find ?c :where [:code/fn-login :modified-in ?c]])",
+        )
+        assert json.loads(raw)["results"] == []
+        assert "no timestamp in commit_metadata" in capsys.readouterr().err
+        # The rest of the reconciliation still happened.
+        assert mcp_server._lineage_is_provisional(real_db, ":code/fn-login") is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestForwardReconcileProvisional -q`
+Expected: FAIL with `AttributeError: ... '_forward_reconcile_provisional'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+def _forward_reconcile_provisional(
+    db: Any,
+    entity_ident: str,
+    structural_triples: List[str],
+    true_commit_ts_iso: str,
+    ts_by_commit_ident: Dict[str, str],
+    index_con: Optional[Any] = None,
+) -> Optional[str]:
+    """#222 phase 2d: the forward walk has reached entity_ident's TRUE
+    introduction and found a provisional guess left by Stream 2. Clear the
+    guess so the caller's normal authoritative emission is the only
+    :introduced-by fact that survives.
+
+    Returns the superseded guess's commit ident, or None if entity_ident was
+    not provisional (in which case nothing is written at all).
+
+    Deliberately does NOT write the authoritative :introduced-by itself --
+    the caller's ordinary _build_code_triples output does that, so there is
+    exactly one code path that mints an authoritative introduction and this
+    function cannot drift from it.
+
+    Mirrors the supersede path in _reverse_fill_claim_and_process: the same
+    re-dating of structural facts, the same one-transact-per-:contains
+    splitting, and the same refusal to back-date a :modified-in edge whose
+    commit timestamp is unknown.
+    """
+    guess_ident = _entity_introduced_by_query(db, entity_ident)
+    if not _lineage_is_provisional(db, entity_ident):
+        return None
+
+    # 1. Drop the guess. The caller writes the real one immediately after.
+    if guess_ident is not None:
+        _retract(db, f"[[{entity_ident} :introduced-by {guess_ident}]]", index_con=index_con)
+
+    # 2. Re-date structural facts to the true (earlier) introduction. Stream 2
+    # wrote them at the timestamp of the commit where it first SIGHTED the
+    # entity, leaving a valid-time window where :introduced-by is live for an
+    # entity with no type, name or file. _retract targets live rows
+    # regardless of their original valid_from, so this is a straight
+    # re-assert at the earlier timestamp. :contains goes one per call on BOTH
+    # sides (EAVT collision, #222 phase 2b1).
+    structural = [t for t in structural_triples if ":introduced-by" not in t]
+    structural_contains = [t for t in structural if ":contains" in t]
+    structural_other = [t for t in structural if ":contains" not in t]
+    if structural_other:
+        _retract(db, "[" + " ".join(structural_other) + "]", index_con=index_con)
+        _transact(db, "[" + " ".join(structural_other) + "]", true_commit_ts_iso, index_con=index_con)
+    for structural_triple in structural_contains:
+        _retract(db, "[" + structural_triple + "]", index_con=index_con)
+        _transact(db, "[" + structural_triple + "]", true_commit_ts_iso, index_con=index_con)
+
+    # 3. The entity's lineage is authoritative from here on.
+    _lineage_confirm(db, entity_ident, index_con=index_con)
+
+    if guess_ident is None:
+        return None
+
+    # 4. The candidate-diff record is stale the moment the guess moves off it,
+    # and this is the cheapest place to drop it -- guess_ident is right here.
+    _candidate_diff_clear(db, guess_ident[len(":commit/"):], entity_ident, index_con=index_con)
+
+    # 5. The guess commit is now known to be a genuine modification rather
+    # than the introduction, so it earns the :modified-in edge Stream 2
+    # withheld from it. Dated at ITS OWN timestamp, not this commit's.
+    #
+    # This inherits 2b's documented over-assertion: #221's unchanged-body
+    # narrowing cannot be re-checked against the guess commit's own diff,
+    # because only that commit's own parse carries the data. That is already
+    # owned -- the guess commit lies inside frontier-high's territory, so the
+    # correction sweep visits it, finds exactly one :introduced-by (case 3),
+    # and retracts this edge if its own parse says the body was unchanged.
+    guess_ts = ts_by_commit_ident.get(guess_ident)
+    if guess_ts is None:
+        print(
+            f"[_forward_reconcile_provisional] skipping retroactive :modified-in "
+            f"for {entity_ident} at {guess_ident}: no timestamp in commit_metadata",
+            file=sys.stderr,
+        )
+        return guess_ident
+    _transact(
+        db, f"[[{entity_ident} :modified-in {guess_ident}]]", guess_ts, index_con=index_con,
+    )
+    return guess_ident
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestForwardReconcileProvisional -q`
+Expected: 7 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add #222 phase 2d: forward-introduction reconciliation helper"
+```
+
+---
+
+### Task 4: Extract the per-commit forward body (pure move, no behaviour change)
+
+**Files:**
+- Modify: `mcp_server.py:8219-8592` (the `try:` block inside `while pending:`) → new `_forward_apply`; add `_ForwardWalkState` dataclass
+- Test: existing suite must pass **unchanged** — this task adds no new tests
+
+**Interfaces:**
+- Consumes: everything the current inline body consumes
+- Produces:
+  ```python
+  @dataclass
+  class _ForwardWalkState:
+      entity_valid_from: Dict[str, str]
+      entity_descriptions: Dict[str, str]
+      file_entities: Dict[str, list]
+      file_deps: Dict[str, set]
+      dep_valid_from: Dict[tuple, str]
+      pinned_commit_state: Dict[str, tuple]
+      field_class_ident: Dict[str, str]
+      field_static_ident: Dict[str, bool]
+      submodule_paths: Dict[str, str]
+      unresolved_dep_idents: Dict[str, str]
+
+  def _forward_apply(
+      db: Any,
+      repo_path: str,
+      state: "_ForwardWalkState",
+      commit: Tuple[str, str, str, str],          # (hash, ts_iso, author, subject)
+      extracted: Tuple[list, list, dict, list],   # _extract_commit's 4-tuple
+      index_con: Optional[Any] = None,
+  ) -> None:
+  ```
+
+**This is the single largest implementation risk in the phase.** It is a mechanical move, and it must stay one: do not fix, tidy, or restructure anything inside the moved code in this task. The whole point of doing it separately is that the existing 968 tests are the proof it was faithful.
+
+- [ ] **Step 1: Add the dataclass and construct it at the call site**
+
+Add `_ForwardWalkState` (fields exactly as above, in the same order `_load_ingestion_preload_state` returns them) immediately above `_run_ingestion`. In `_run_ingestion`, after the preload unpack, build:
+
+```python
+        state = _ForwardWalkState(
+            entity_valid_from=entity_valid_from,
+            entity_descriptions=entity_descriptions,
+            file_entities=file_entities,
+            file_deps=file_deps,
+            dep_valid_from=dep_valid_from,
+            pinned_commit_state=pinned_commit_state,
+            field_class_ident=field_class_ident,
+            field_static_ident=field_static_ident,
+            submodule_paths=submodule_paths,
+            unresolved_dep_idents=unresolved_dep_idents,
+        )
+```
+
+- [ ] **Step 2: Move the body**
+
+Cut `mcp_server.py:8220-8592` — everything inside the `try:` at 8219, from `add_triples: List[str] = [` through the `_commit_index_writer_safe(index_con)` line — into the new `_forward_apply`, placed immediately after `_reverse_bulk_fill_walk`. Apply exactly these substitutions and no others:
+
+| In the moved code | Becomes |
+|---|---|
+| `await loop.run_in_executor(write_executor, F, *args)` | `F(*args)` — the whole body now runs as ONE submission to `write_executor` instead of ~10 |
+| bare `entity_valid_from`, `entity_descriptions`, `file_entities`, `file_deps`, `dep_valid_from`, `pinned_commit_state`, `field_class_ident`, `field_static_ident`, `submodule_paths`, `unresolved_dep_idents` | `state.<same name>` |
+| `commit_hash`, `commit_ts_iso`, `author`, `subject` | unpacked from `commit` at the top of `_forward_apply` |
+| `extracted_files`, `gitlink_changes`, `gitmodules_map`, `renamed_pairs` | unpacked from `extracted` at the top |
+| `commit_ident` | recomputed at the top: `commit_ident = f":commit/{commit_hash[:12]}"` |
+
+Fusing the ~10 executor submissions into one is **better** for the event loop, not worse: it awaits one future instead of ten round-trips, while the write thread stays busy for the same total time.
+
+- [ ] **Step 3: Call it from the loop**
+
+Replace the excised block at the call site with:
+
+```python
+                    db = await _ensure_db_async()
+                    try:
+                        await loop.run_in_executor(
+                            write_executor, _forward_apply, db, repo_path, state,
+                            (commit_hash, commit_ts_iso, author, subject),
+                            (extracted_files, gitlink_changes, gitmodules_map, renamed_pairs),
+                            index_con,
+                        )
+                    except Exception as e:
+```
+
+leaving the existing `except`/`finally` handlers at 8594-8612 exactly as they are.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Expected: zero failures and **exactly the same count as after Task 3** — this task adds no tests, and the existing suite is the only proof the move was faithful. **Any failure here is an extraction error, not a test problem.** Diff the moved code against `git show HEAD~1:mcp_server.py` rather than adjusting a test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py
+git commit -m "Add #222 phase 2d: extract _forward_apply from _run_ingestion
+
+Pure mechanical move of the per-commit write section, plus a
+_ForwardWalkState dataclass for the ten mutable preload dicts. No
+behaviour change -- the existing suite is the proof. The ten separate
+write_executor submissions become one, which is fewer event-loop
+round-trips for the same write-thread time."
+```
+
+---
+
+### Task 5: Wire reconciliation into the forward walk
+
+**Files:**
+- Modify: `mcp_server.py` (`_ForwardWalkState`, `_forward_apply`, and the `_run_ingestion` construction site)
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: `_forward_reconcile_provisional` (Task 3), `_preload_provisional_idents` (Task 2), `_ForwardWalkState`/`_forward_apply` (Task 4)
+- Produces: `_ForwardWalkState` gains `provisional_idents: Set[str]` and `ts_by_commit_ident: Dict[str, str]`; `_forward_apply` reconciles before emitting
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestForwardApplyReconcilesProvisional:
+    def _repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def login():\n    return 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def login():\n    return 2\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h1"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def test_forward_apply_supersedes_a_provisional_guess(self, real_db, tmp_path):
+        """Stream 2 claimed h1 and guessed login() was introduced there. The
+        forward walk then reaches h0, the TRUE introduction. Exactly one
+        :introduced-by must survive, naming h0, with a confirmed marker."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        # Stream 2 claims the newest commit (h1) and guesses.
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{linearization[1][:12]}"
+
+        # Stream 1 now reaches h0, the true introduction.
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={}, entity_descriptions={}, file_entities={},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents=mcp_server._preload_provisional_idents(real_db),
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(
+            real_db, str(repo), state, commit_metadata[0], extracted,
+        )
+
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :introduced-by ?c]])",
+        )
+        values = {row[0] for row in json.loads(raw)["results"]}
+        assert values == {f":commit/{linearization[0][:12]}"}, "exactly one, naming h0"
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        # h1 is now a genuine modification.
+        raw_mod = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :modified-in ?c]])",
+        )
+        assert f":commit/{linearization[1][:12]}" in {row[0] for row in json.loads(raw_mod)["results"]}
+
+    def test_resumed_run_variant_is_not_suppressed_by_entity_valid_from(self, real_db, tmp_path):
+        """The silent failure mode: on a RESUMED run, Stream 2's structural
+        facts are already in the preloaded entity_valid_from, so
+        _build_code_triples would suppress the introduction entirely and the
+        wrong provisional guess would survive forever."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+
+        # Simulate the resumed-run preload: entity_valid_from ALREADY knows
+        # this entity, because Stream 2 wrote its structural facts last run.
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={fn_ident: "2026-06-01T00:00:00Z"},
+            entity_descriptions={fn_ident: "login"}, file_entities={"auth.py": [fn_ident]},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents={fn_ident},
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(
+            real_db, str(repo), state, commit_metadata[0], extracted,
+        )
+
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :introduced-by ?c]])",
+        )
+        assert {row[0] for row in json.loads(raw)["results"]} == {f":commit/{linearization[0][:12]}"}
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+
+    def test_without_provisional_idents_the_resumed_case_regresses(self, real_db, tmp_path):
+        """Pins that provisional_idents is actually consulted: with it empty,
+        the resumed-run case leaves the wrong guess in place. This is the
+        direct regression test for the silent failure mode."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={fn_ident: "2026-06-01T00:00:00Z"},
+            entity_descriptions={fn_ident: "login"}, file_entities={"auth.py": [fn_ident]},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents=set(),   # the bug
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(
+            real_db, str(repo), state, commit_metadata[0], extracted,
+        )
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{linearization[1][:12]}"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestForwardApplyReconcilesProvisional -q`
+Expected: FAIL — `_ForwardWalkState` has no `provisional_idents` field
+
+- [ ] **Step 3: Widen the dataclass**
+
+Add to `_ForwardWalkState`:
+
+```python
+    provisional_idents: Set[str] = field(default_factory=set)
+    ts_by_commit_ident: Dict[str, str] = field(default_factory=dict)
+```
+
+(`from dataclasses import field` if not already imported.) Populate both in `_run_ingestion`: `provisional_idents=provisional_idents` from Task 2's unpack, and `ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata}` — note this needs the **full-history** `commit_metadata`, which Task 8 introduces; until then build it from the existing `commits` list.
+
+- [ ] **Step 4: Reconcile inside `_forward_apply`**
+
+In the `else:  # A or M or R` branch, immediately **before** the `triples = _build_code_triples(...)` call, add:
+
+```python
+                # #222 phase 2d: an entity Stream 2 already introduced
+                # provisionally is NOT authoritatively introduced, so the
+                # forward walk must treat it as new. Popping it out of
+                # entity_valid_from is what makes _build_code_triples's own
+                # gate (entity_valid_from membership) agree -- deliberately
+                # in preference to widening that function's signature, since
+                # its gate means "is this the introduction" for a forward
+                # walk and nothing else should depend on that meaning.
+                #
+                # It is also semantically right on its own terms: the
+                # valid_from Stream 2 recorded is a wrong guess, and must
+                # never be used as an orig_ts for a close.
+                reconcilable = [
+                    ident for ident in _forward_candidate_idents(precomputed)
+                    if ident in state.provisional_idents
+                ]
+                for ident in reconcilable:
+                    state.entity_valid_from.pop(ident, None)
+                    _forward_reconcile_provisional(
+                        db, ident,
+                        _forward_structural_triples(precomputed, ident),
+                        commit_ts_iso, state.ts_by_commit_ident, index_con=index_con,
+                    )
+                    state.provisional_idents.discard(ident)
+```
+
+Add the two small helpers next to `_forward_apply` (both mirror the candidate-ident and candidate-triple collection `_reverse_fill_claim_and_process` already does, so the three walks agree on what an entity's candidate set is):
+
+```python
+def _forward_candidate_idents(precomputed: Dict[str, Any]) -> List[str]:
+    """Every entity ident a parsed file contributes -- module plus all four
+    child categories. Same collection _reverse_fill_claim_and_process and
+    _correction_sweep_apply perform; kept as one function so the three walks
+    cannot drift on what an entity's candidate set is."""
+    return (
+        [precomputed["module_ident"]]
+        + [ident for ident, _name, _t in precomputed["function_entries"]]
+        + [ident for ident, _name, _t in precomputed["class_entries"]]
+        + [ident for ident, _name, _t in precomputed["global_entries"]]
+        + [ident for ident, _name, _t in precomputed["field_entries"]]
+    )
+
+
+def _forward_structural_triples(precomputed: Dict[str, Any], ident: str) -> List[str]:
+    """ident's own candidate triples, for re-dating. A child's own list
+    carries its [parent :contains child] edge, so re-dating a child re-dates
+    its containment edge with it (#222 phase 2b1)."""
+    if ident == precomputed["module_ident"]:
+        return list(precomputed["module_candidate_triples"])
+    for entries_key in ("function_entries", "class_entries", "global_entries", "field_entries"):
+        for entry_ident, _entry_name, entry_triples in precomputed[entries_key]:
+            if entry_ident == ident:
+                return list(entry_triples)
+    return []
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestForwardApplyReconcilesProvisional -q`
+Expected: 3 passed
+
+Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Expected: zero failures, count up by 3
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add #222 phase 2d: reconcile provisional lineage in the forward walk"
+```
+
+---
+
+### Task 6: Split `_reverse_apply` out of `_reverse_fill_claim_and_process`
+
+**Files:**
+- Modify: `mcp_server.py:7323-7638` (`_reverse_fill_claim_and_process`)
+- Test: existing `TestReverseFill*` classes must pass **unchanged**, plus one new composition test
+
+**Interfaces:**
+- Produces:
+  ```python
+  def _reverse_apply(
+      db: Any,
+      repo_path: str,
+      linearization: List[str],
+      commit_metadata: List[Tuple[str, str, str, str]],
+      pos: int,
+      file_results: List[tuple],
+      index_con: Optional[Any] = None,
+  ) -> str:
+  ```
+  Returns the applied commit's hash. `_reverse_fill_claim_and_process` keeps its signature and becomes `claim_high()` + `_extract_commit()` + `_reverse_apply()`.
+
+**Why:** `_reverse_fill_claim_and_process` calls `_extract_commit` inside its own body. Submitted to `write_executor` — a *thread* — that tree-sitter parse holds the GIL for its whole duration, which is exactly the event-loop starvation #116 introduced the process pool to fix. 2c flagged this conflation and left it (out of scope); 2d cannot.
+
+- [ ] **Step 1: Write the failing composition test**
+
+```python
+class TestReverseApplySplit:
+    def test_split_pieces_compose_to_the_same_graph_as_the_wrapper(self, tmp_path):
+        """Two independent graphs from one repo fixture -- the walk mutates
+        the state a second run would start from, so this cannot be two
+        passes over one graph."""
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def login():\n    return 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+
+        def snapshot(db):
+            raw = mcp_server._db_execute(db, "(query [:find ?e ?a ?v :where [?e ?a ?v]])")
+            return sorted(tuple(row) for row in json.loads(raw)["results"])
+
+        db_a = MiniGrafDb.open(str(tmp_path / "a.graph"))
+        alloc_a = mcp_server._frontier_load(db_a, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            db_a, str(repo), linearization, commit_metadata, alloc_a,
+        )
+
+        db_b = MiniGrafDb.open(str(tmp_path / "b.graph"))
+        alloc_b = mcp_server._frontier_load(db_b, linearization, "2026-01-04T00:00:00Z")
+        pos = alloc_b.claim_high()
+        file_results, _g, _m, _r = mcp_server._extract_commit(str(repo), linearization[pos], ())
+        applied = mcp_server._reverse_apply(
+            db_b, str(repo), linearization, commit_metadata, pos, file_results,
+        )
+        assert applied == linearization[pos]
+        assert snapshot(db_a) == snapshot(db_b)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestReverseApplySplit -q`
+Expected: FAIL with `AttributeError: ... '_reverse_apply'`
+
+- [ ] **Step 3: Perform the split**
+
+Rename the existing function body to `_reverse_apply` with the signature above, then:
+- **Delete** from it: the `pos = allocator.claim_high()` / `if pos is None: return None` lines, and the `_extract_commit` call. `pos` and `file_results` are now parameters.
+- **Keep** in it: the `commit_metadata`/`linearization` length and alignment `ValueError` guards (they must run before any write), everything from `all_triples` onward, `_frontier_persist_claim(..., from_low=False, ...)`, and the single `_db_checkpoint(db)`.
+- Change the return type from `Optional[str]` to `str`.
+
+Then reduce `_reverse_fill_claim_and_process` to:
+
+```python
+def _reverse_fill_claim_and_process(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    allocator: "frontier_registry.FrontierAllocator",
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> Optional[str]:
+    """Synchronous convenience wrapper: claim one position from the gap's
+    high end and process it. Kept for tests and _reverse_bulk_fill_walk.
+
+    **2d must not call this from async code** -- it fuses the CPU-bound
+    tree-sitter parse and the DB-bound writes into one function body, so it
+    can only be scheduled onto one executor as a unit. On write_executor (a
+    thread) that parse holds the GIL for its whole duration, which is
+    exactly the event-loop starvation #116 introduced the process pool to
+    fix. 2d awaits _extract_commit on the process pool and _reverse_apply on
+    write_executor instead. Same caveat 2c's own wrappers carry.
+
+    Returns the claimed commit's hash, or None if the gap was already empty.
+    """
+    if len(commit_metadata) != len(linearization):
+        raise ValueError(
+            "commit_metadata must be full-history and positionally aligned with "
+            f"linearization (got {len(commit_metadata)} entries vs {len(linearization)}); "
+            "pass _git_commits(repo, watermark_hash=None)"
+        )
+    pos = allocator.claim_high()
+    if pos is None:
+        return None
+    file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
+        repo_path, linearization[pos], ignore_patterns
+    )
+    return _reverse_apply(
+        db, repo_path, linearization, commit_metadata, pos, file_results, index_con=index_con,
+    )
+```
+
+Note the length guard is duplicated deliberately: it must fire **before** `claim_high()` consumes a position, and `_reverse_apply` needs its own copy because 2d calls it directly.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `python -m pytest tests/test_mcp_server.py -k "ReverseFill or ReverseApply" -q`
+Expected: all pass, including every pre-existing `TestReverseFill*` test unchanged
+
+Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Expected: zero failures, count up by 1
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add #222 phase 2d: split _reverse_apply from its claim wrapper"
+```
+
+---
+
+### Task 7: The round-robin claim generator
+
+**Files:**
+- Modify: `mcp_server.py` (next to `_parse_stream_ratio`)
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: `frontier_registry.FrontierAllocator`, `_parse_stream_ratio`
+- Produces:
+  ```python
+  class _RoundRobinClaimer:
+      def __init__(self, allocator, forward_per_round: int, reverse_per_round: int): ...
+      def next_claim(self) -> Optional[Tuple[str, int]]:
+          """('fwd'|'rev', pos), or None once the gap is empty."""
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestRoundRobinClaimer:
+    def _claimer(self, total, forward, reverse):
+        import mcp_server, frontier_registry
+        allocator = frontier_registry.FrontierAllocator(total, [])
+        return mcp_server._RoundRobinClaimer(allocator, forward, reverse), allocator
+
+    def _drain(self, claimer):
+        out = []
+        while True:
+            claim = claimer.next_claim()
+            if claim is None:
+                return out
+            out.append(claim)
+
+    def test_one_to_one_alternates(self):
+        claimer, _ = self._claimer(6, 1, 1)
+        assert self._drain(claimer) == [
+            ("fwd", 0), ("rev", 5), ("fwd", 1), ("rev", 4), ("fwd", 2), ("rev", 3),
+        ]
+
+    def test_one_to_three(self):
+        claimer, _ = self._claimer(8, 1, 3)
+        assert self._drain(claimer) == [
+            ("fwd", 0), ("rev", 7), ("rev", 6), ("rev", 5),
+            ("fwd", 1), ("rev", 4), ("rev", 3), ("rev", 2),
+        ]
+
+    def test_three_to_one(self):
+        claimer, _ = self._claimer(8, 3, 1)
+        assert self._drain(claimer) == [
+            ("fwd", 0), ("fwd", 1), ("fwd", 2), ("rev", 7),
+            ("fwd", 3), ("fwd", 4), ("fwd", 5), ("rev", 6),
+        ]
+
+    def test_every_position_claimed_exactly_once(self):
+        for total in (1, 2, 3, 7, 20, 33):
+            for ratio in ((1, 1), (1, 3), (3, 1), (2, 5)):
+                claimer, _ = self._claimer(total, *ratio)
+                claims = self._drain(claimer)
+                positions = [pos for _tag, pos in claims]
+                assert sorted(positions) == list(range(total)), (total, ratio)
+
+    def test_forward_ascending_reverse_descending(self):
+        claimer, _ = self._claimer(20, 2, 3)
+        claims = self._drain(claimer)
+        fwd = [pos for tag, pos in claims if tag == "fwd"]
+        rev = [pos for tag, pos in claims if tag == "rev"]
+        assert fwd == sorted(fwd), "forward state machine requires ascending"
+        assert rev == sorted(rev, reverse=True), "2b's monotonicity guard requires descending"
+
+    def test_empty_linearization_yields_nothing(self):
+        claimer, _ = self._claimer(0, 1, 1)
+        assert claimer.next_claim() is None
+
+    def test_single_position_goes_to_whoever_asks_first(self):
+        claimer, _ = self._claimer(1, 1, 1)
+        assert claimer.next_claim() == ("fwd", 0)
+        assert claimer.next_claim() is None
+
+    def test_pre_drained_gap_yields_nothing_immediately(self):
+        """Resume case: the previous run already covered everything."""
+        claimer, allocator = self._claimer(5, 1, 1)
+        while allocator.claim_low() is not None:
+            pass
+        assert claimer.next_claim() is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestRoundRobinClaimer -q`
+Expected: FAIL with `AttributeError: ... '_RoundRobinClaimer'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+class _RoundRobinClaimer:
+    """#222 phase 2d: hands out positions from the shared gap, alternating
+    forward and reverse by a fixed ratio.
+
+    This IS the fairness mechanism. Because claims are handed out in one
+    deterministic sequence rather than raced between two tasks, starvation
+    is not expressible and the interleave is directly assertable in a test.
+    """
+
+    def __init__(
+        self,
+        allocator: "frontier_registry.FrontierAllocator",
+        forward_per_round: int,
+        reverse_per_round: int,
+    ):
+        self._allocator = allocator
+        self._forward_per_round = forward_per_round
+        self._reverse_per_round = reverse_per_round
+        self._taken_in_phase = 0
+        self._forward_phase = True
+
+    def next_claim(self) -> Optional[Tuple[str, int]]:
+        """('fwd', pos) or ('rev', pos), or None once the gap is empty.
+
+        There is deliberately no "the other side might still have work"
+        fallback: claim_low() and claim_high() both return None on exactly
+        the same condition, is_gap_empty(), so they can only ever return
+        None together. A fallthrough would be dead code reading as if the
+        two frontiers could exhaust independently -- they cannot; they share
+        one gap.
+        """
+        if self._forward_phase:
+            pos = self._allocator.claim_low()
+            tag = "fwd"
+            limit = self._forward_per_round
+        else:
+            pos = self._allocator.claim_high()
+            tag = "rev"
+            limit = self._reverse_per_round
+        if pos is None:
+            return None
+
+        self._taken_in_phase += 1
+        if self._taken_in_phase >= limit:
+            self._taken_in_phase = 0
+            self._forward_phase = not self._forward_phase
+        return tag, pos
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestRoundRobinClaimer -q`
+Expected: 8 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add #222 phase 2d: round-robin claim generator"
+```
+
+---
+
+### Task 8: Stage A — allocator-driven tagged pipeline
+
+**Files:**
+- Modify: `mcp_server.py:8055-8215` (`_run_ingestion`'s setup and `submit_next`/drain loop)
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: `_RoundRobinClaimer` (7), `_forward_apply` (4/5), `_reverse_apply` (6), `_frontier_load`/`_frontier_persist_claim` (1), `frontier_registry.build_linearization`
+- Produces: `_run_ingestion` drives both streams; forward path additionally calls `_frontier_persist_claim(from_low=True)` and `_lineage_confirmed_through_update`
+
+- [ ] **Step 1: Replace the commit source**
+
+In `_run_ingestion`, replace `commits = _git_commits(repo_path, watermark, branch)` with:
+
+```python
+        linearization = frontier_registry.build_linearization(repo_path, branch)
+        # FULL history, positionally aligned with linearization. Both
+        # _reverse_apply and _correction_sweep_select_position index it
+        # positionally, and _reverse_apply raises ValueError on a length
+        # mismatch -- a watermark-relative list is exactly the wrong thing
+        # to hand them.
+        commit_metadata = _git_commits(repo_path, None, branch)
+```
+
+`watermark` is still read by the preload and still used by `_frontier_seed_from_watermark` inside `_frontier_load`; do not delete it.
+
+- [ ] **Step 2: Load the frontier and build the claimer**
+
+After `_ingest_progress` initialisation and after `index_con` is opened (the frontier load writes, so it needs `index_con` and a live `db`):
+
+```python
+            run_ts_iso = datetime.datetime.now(datetime.timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%S.%f"
+            )[:-3] + "Z"
+            db = await _ensure_db_async()
+            allocator = await loop.run_in_executor(
+                write_executor, _frontier_load, db, linearization, run_ts_iso, index_con,
+            )
+            claimer = _RoundRobinClaimer(
+                allocator, *_parse_stream_ratio(os.environ.get("MINIGRAF_INGEST_STREAM_RATIO"))
+            )
+```
+
+- [ ] **Step 3: Make `submit_next` allocator-driven**
+
+Replace the existing `commits_iter`/`submit_next` pair with:
+
+```python
+                pending: Any = deque()
+
+                def submit_next() -> bool:
+                    claim = claimer.next_claim()
+                    if claim is None:
+                        return False
+                    tag, pos = claim
+                    fut = loop.run_in_executor(
+                        executor, _extract_commit, repo_path, linearization[pos], ignore_patterns
+                    )
+                    pending.append((tag, pos, fut))
+                    return True
+```
+
+The drain loop's `popleft` becomes `tag, pos, fut = pending.popleft()`, and `commit_hash, commit_ts_iso, author, subject = commit_metadata[pos]`. The extraction-failure `except` branch is unchanged apart from that unpack.
+
+- [ ] **Step 4: Dispatch by tag**
+
+Replace the single `_forward_apply` call from Task 4 with:
+
+```python
+                    db = await _ensure_db_async()
+                    try:
+                        if tag == "fwd":
+                            await loop.run_in_executor(
+                                write_executor, _forward_apply, db, repo_path, state,
+                                commit_metadata[pos],
+                                (extracted_files, gitlink_changes, gitmodules_map, renamed_pairs),
+                                index_con, linearization, pos,
+                            )
+                        else:
+                            await loop.run_in_executor(
+                                write_executor, _reverse_apply, db, repo_path, linearization,
+                                commit_metadata, pos, extracted_files, index_con,
+                            )
+                    except Exception as e:
+```
+
+- [ ] **Step 5: Persist the forward claim**
+
+Widen `_forward_apply` with `linearization: Optional[List[str]] = None, pos: Optional[int] = None`, and after its existing `_watermark_update` call add:
+
+```python
+    if linearization is not None and pos is not None:
+        _frontier_persist_claim(
+            db, linearization, pos, from_low=True,
+            commit_ts_iso=commit_ts_iso, index_con=index_con,
+        )
+    # The virgin positions this walk claims are authoritative on first write,
+    # so lineage is confirmed contiguously from C0 through here. The sweep
+    # folds its own region in later (Task 9); this watermark must not be
+    # advanced past the forward frontier before that happens.
+    _lineage_confirmed_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)
+```
+
+placed **before** the existing `_db_checkpoint(db)` so one checkpoint still covers the whole commit.
+
+- [ ] **Step 6: Write the tests**
+
+```python
+class TestStageAInterleave:
+    def _repo(self, tmp_path, n_commits=6):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(n_commits):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"h{i}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_both_frontiers_advance_and_meet(self, tmp_path, monkeypatch):
+        """The load-bearing property: a real run must leave frontier-low and
+        frontier-high adjacent, covering every position exactly once."""
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        linearization = frontier_registry.build_linearization(str(repo))
+        low = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_LOW_IDENT)
+        high = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert low is not None and high is not None, "both streams must have claimed"
+        pos = {h: i for i, h in enumerate(linearization)}
+        assert pos[low[0]] == 0
+        assert pos[high[1]] == len(linearization) - 1
+        assert pos[low[1]] + 1 == pos[high[0]], "the two frontiers must be adjacent"
+
+    @pytest.mark.asyncio
+    async def test_forward_heavy_ratio_shifts_the_meeting_point(self, tmp_path, monkeypatch):
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path, n_commits=8)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "3:1")
+
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        linearization = frontier_registry.build_linearization(str(repo))
+        pos = {h: i for i, h in enumerate(linearization)}
+        low = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_LOW_IDENT)
+        # 3:1 over 8 positions -> forward takes 6, reverse takes 2.
+        assert pos[low[1]] == 5
+
+    @pytest.mark.asyncio
+    async def test_watermark_matches_frontier_low_hi(self, tmp_path, monkeypatch):
+        """:ingestion/watermark keeps its contiguous-from-C0 meaning: it is
+        advanced by the forward stream only, never by the reverse one."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        low = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_LOW_IDENT)
+        assert mcp_server._watermark_query(db) == low[1]
+
+    @pytest.mark.asyncio
+    async def test_single_commit_repo(self, tmp_path, monkeypatch):
+        import mcp_server
+        repo = self._repo(tmp_path, n_commits=1)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete"
+
+    @pytest.mark.asyncio
+    async def test_second_run_on_unchanged_repo_is_a_no_op(self, tmp_path, monkeypatch):
+        """Resume with an already-empty gap: Stage A must never begin, not
+        spin or re-process."""
+        import mcp_server
+        repo = self._repo(tmp_path)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete"
+```
+
+Check whether the file already uses `pytest.mark.asyncio` or an explicit `asyncio.run` idiom for the existing `_run_ingestion` tests (see `TestRunIngestionShutdown`) and follow whichever is already there rather than introducing a second style.
+
+- [ ] **Step 7: Run the tests**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestStageAInterleave -q`
+Expected: 5 passed
+
+Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Expected: all pass. Existing `_run_ingestion` tests that assumed a watermark-relative commit list may need their *expectations* updated — but only where the change is genuinely the new intended behaviour. If a test fails because lineage is now provisional in the upper region, that is correct and expected; Task 9 is what makes it authoritative again.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add #222 phase 2d: allocator-driven tagged pipeline (Stage A)"
+```
+
+---
+
+### Task 9: Stage B — asynchronous correction sweep
+
+**Files:**
+- Modify: `mcp_server.py` (`_run_ingestion`, after the Stage A drain loop)
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: `_correction_sweep_select_position`, `_extract_commit`, `_correction_sweep_apply`, `_correction_sweep_log_summary` (all 2c), `_correction_sweep_through_query`, `_frontier_read_bounds`, `_lineage_confirmed_through_update`
+- Produces: nothing new — this is a driver
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestStageBCorrectionSweep:
+    def _repo(self, tmp_path, n_commits=6):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(n_commits):
+            (repo / "auth.py").write_text(
+                f"def login():\n    return {i}\n\ndef helper_{i}():\n    pass\n"
+            )
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"h{i}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_completed_run_leaves_no_provisional_markers(self, tmp_path, monkeypatch):
+        """The headline postcondition of phase 2: after a full ingest,
+        every entity's lineage is authoritative."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        assert mcp_server._preload_provisional_idents(db) == set()
+
+    @pytest.mark.asyncio
+    async def test_no_entity_has_two_introduced_by_values(self, tmp_path, monkeypatch):
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        raw = mcp_server._db_execute(db, "(query [:find ?e ?c :where [?e :introduced-by ?c]])")
+        pairs = [tuple(row) for row in json.loads(raw)["results"]]
+        entities = [e for e, _c in pairs]
+        assert len(entities) == len(set(entities)), f"duplicate :introduced-by: {pairs}"
+
+    @pytest.mark.asyncio
+    async def test_lineage_confirmed_through_reaches_head(self, tmp_path, monkeypatch):
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        linearization = frontier_registry.build_linearization(str(repo))
+        assert mcp_server._lineage_confirmed_through_query(db) == linearization[-1]
+
+    def test_fold_guard_does_not_fire_when_frontier_high_is_absent(self, real_db, tmp_path):
+        """_correction_sweep_select_position returns None for six reasons,
+        only one of which is 'reached the ceiling'. Folding the watermark on
+        any None would claim lineage is confirmed through HEAD in exactly
+        the cases where the sweep did no work at all."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path, n_commits=3)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        # frontier-high never created: forward claimed everything.
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        assert mcp_server._correction_sweep_select_position(
+            real_db, linearization, commit_metadata,
+        ) is None
+        assert mcp_server._should_fold_lineage_watermark(real_db, linearization) is False
+
+    def test_fold_guard_fires_only_when_sweep_reached_the_ceiling(self, real_db, tmp_path):
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path, n_commits=3)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Reverse claims the top two, forward the bottom one -> gap closed.
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        pos = allocator.claim_low()
+        mcp_server._frontier_persist_claim(
+            real_db, linearization, pos, from_low=True,
+            commit_ts_iso=commit_metadata[pos][1],
+        )
+        assert mcp_server._should_fold_lineage_watermark(real_db, linearization) is False
+        mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+        assert mcp_server._should_fold_lineage_watermark(real_db, linearization) is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestStageBCorrectionSweep -q`
+Expected: FAIL — `_should_fold_lineage_watermark` undefined, and the completed-run assertions fail because no sweep runs yet
+
+- [ ] **Step 3: Write the fold guard**
+
+```python
+def _should_fold_lineage_watermark(db: Any, linearization: List[str]) -> bool:
+    """True iff the correction sweep genuinely reached frontier-high's own
+    :hi-hash, so :ingestion/lineage-confirmed-through may be folded forward
+    to it.
+
+    Stage B's loop exit alone must NOT trigger the fold.
+    _correction_sweep_select_position returns None for six different
+    reasons, only one of which is "reached the ceiling": it also returns
+    None when frontier-high is absent, when either boundary hash is stale
+    (rewritten history), when the gap is still open, and when
+    commit_metadata violates its contract. Folding on any None would report
+    lineage as confirmed through HEAD in exactly the situations where the
+    sweep did no work at all.
+    """
+    high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
+    if high_bounds is None:
+        return False
+    through_hash = _correction_sweep_through_query(db)
+    if through_hash is None:
+        return False
+    return through_hash == high_bounds[1] and through_hash in set(linearization)
+```
+
+- [ ] **Step 4: Write the Stage B driver**
+
+In `_run_ingestion`, immediately after the `while pending:` loop ends and before the `if completed_all:` tag/last-run block:
+
+```python
+                # Stage B: the correction sweep. A third, strictly
+                # SEQUENTIAL pass, not a third concurrent task -- claim_low()
+                # and claim_high() partition one shared gap, so no sequence of
+                # forward claims can reach territory the reverse stream
+                # already claimed, and the sweep's own precondition is that
+                # the gap is already closed.
+                #
+                # Drives 2c's three pieces directly on their correct
+                # executors. _correction_sweep_claim_and_process and
+                # _correction_sweep_walk must NOT be used here: both fuse the
+                # CPU-bound parse and the DB-bound writes into one body.
+                if completed_all:
+                    _ingest_progress["phase"] = "sweeping"
+                    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+                    skipped = 0
+                    db = await _ensure_db_async()
+                    try:
+                        while not _shutdown_requested.is_set():
+                            selected = await loop.run_in_executor(
+                                write_executor, _correction_sweep_select_position,
+                                db, linearization, commit_metadata, hash_to_pos,
+                            )
+                            if selected is None:
+                                break
+                            sweep_hash, sweep_ts = selected
+                            try:
+                                sweep_files, _g, _m, _r = await loop.run_in_executor(
+                                    executor, _extract_commit, repo_path, sweep_hash, ignore_patterns,
+                                )
+                                skipped += await loop.run_in_executor(
+                                    write_executor, _correction_sweep_apply,
+                                    db, sweep_hash, sweep_ts, sweep_files, index_con, skipped,
+                                )
+                            except concurrent.futures.process.BrokenProcessPool:
+                                raise
+                            except Exception as e:
+                                # A sweep-step failure aborts Stage B only.
+                                # Stage A's work is already persisted, and the
+                                # next run resumes from the sweep watermark.
+                                print(
+                                    f"[_run_ingestion] correction sweep aborted at {sweep_hash}: {e}",
+                                    file=sys.stderr,
+                                )
+                                completed_all = False
+                                break
+                            await asyncio.sleep(0)  # yield to event loop
+                        if _shutdown_requested.is_set():
+                            completed_all = False
+                        _correction_sweep_log_summary(skipped)
+                        if completed_all and _should_fold_lineage_watermark(db, linearization):
+                            await loop.run_in_executor(
+                                write_executor, _lineage_confirmed_through_update,
+                                db, linearization[-1], commit_metadata[-1][1], index_con,
+                            )
+                            await loop.run_in_executor(write_executor, _db_checkpoint, db)
+                    finally:
+                        _db = None
+```
+
+`hash_to_pos` is built once and threaded in, and `skipped` is threaded through every `_correction_sweep_apply` call — the two obligations 2c's spec places on 2d's own loop. `_correction_sweep_log_summary` is called exactly once so an operator grepping for that line does not have to know which loop drove the sweep.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestStageBCorrectionSweep -q`
+Expected: 5 passed
+
+Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add #222 phase 2d: asynchronous correction sweep (Stage B)"
+```
+
+---
+
+### Task 10: Progress phase, shutdown, and staging discipline
+
+**Files:**
+- Modify: `mcp_server.py` (`_run_ingestion`, `_ingest_progress` initialisation around line 8079)
+- Test: `tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: everything above
+- Produces: `_ingest_progress["phase"]` ∈ `{"converging", "sweeping"}`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestStagingAndShutdown:
+    def _repo(self, tmp_path, n_commits=6):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(n_commits):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"h{i}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_phase_reaches_sweeping_and_processed_never_exceeds_total(self, tmp_path, monkeypatch):
+        """Stage B's commits are re-visits of positions Stage A already
+        counted -- counting them again would push processed past total."""
+        import mcp_server
+        repo = self._repo(tmp_path)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["phase"] == "sweeping"
+        assert mcp_server._ingest_progress["processed"] <= mcp_server._ingest_progress["total"]
+
+    @pytest.mark.asyncio
+    async def test_sweep_does_not_start_before_stage_a_drains(self, tmp_path, monkeypatch):
+        """The sweep's precondition is a CLOSED gap. Stage A pre-claims up to
+        pipeline_depth positions ahead of persisting them, so the in-memory
+        gap can close while commits are still in flight -- the DB-read
+        precondition is what makes this safe, and this test pins it."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+
+        observed = []
+        real_apply = mcp_server._correction_sweep_apply
+
+        def spy(db, *args, **kwargs):
+            observed.append(mcp_server._ingest_progress["phase"])
+            return real_apply(db, *args, **kwargs)
+
+        monkeypatch.setattr(mcp_server, "_correction_sweep_apply", spy)
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert observed, "the sweep must actually have run"
+        assert set(observed) == {"sweeping"}
+
+    @pytest.mark.asyncio
+    async def test_shutdown_during_stage_a_stops_and_resumes(self, tmp_path, monkeypatch):
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path, n_commits=10)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+
+        real_forward = mcp_server._forward_apply
+        calls = {"n": 0}
+
+        def stopping_forward(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                mcp_server._shutdown_requested.set()
+            return real_forward(*args, **kwargs)
+
+        monkeypatch.setattr(mcp_server, "_forward_apply", stopping_forward)
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "stopped"
+        mcp_server._db = None
+
+        # A run stopped in Stage A must NOT claim confirmed lineage at HEAD.
+        db = MiniGrafDb.open(str(graph))
+        linearization = frontier_registry.build_linearization(str(repo))
+        assert mcp_server._lineage_confirmed_through_query(db) != linearization[-1]
+        db = None
+        mcp_server._db = None
+
+        monkeypatch.setattr(mcp_server, "_forward_apply", real_forward)
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete"
+        mcp_server._db = None
+        db2 = MiniGrafDb.open(str(graph))
+        assert mcp_server._preload_provisional_idents(db2) == set()
+        assert mcp_server._lineage_confirmed_through_query(db2) == linearization[-1]
+
+    @pytest.mark.asyncio
+    async def test_neither_sync_wrapper_is_called_from_run_ingestion(self, tmp_path, monkeypatch):
+        """2c and 2b both document that their sync wrappers must not be
+        called from async code -- each fuses a CPU-bound parse with DB-bound
+        writes into one executor-schedulable unit."""
+        import mcp_server
+        repo = self._repo(tmp_path)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+
+        for name in (
+            "_correction_sweep_claim_and_process",
+            "_correction_sweep_walk",
+            "_reverse_bulk_fill_walk",
+            "_reverse_fill_claim_and_process",
+        ):
+            def boom(*a, _n=name, **k):
+                raise AssertionError(f"{_n} must not be called from _run_ingestion")
+            monkeypatch.setattr(mcp_server, name, boom)
+
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestStagingAndShutdown -q`
+Expected: FAIL — `KeyError: 'phase'`
+
+- [ ] **Step 3: Add the phase key**
+
+Next to `_ingest_progress["status"] = "running"` in `_run_ingestion`, add:
+
+```python
+        _ingest_progress["phase"] = "converging"
+```
+
+Stage B already sets it to `"sweeping"` (Task 9, Step 4). Add `"phase": None` to the module-level `_ingest_progress` initialiser so a consumer reading it before any run does not `KeyError`.
+
+Confirm `_ingest_progress["processed"] += 1` remains where it is — once per drained pipeline entry, covering both tags — and that Stage B adds nothing to it.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestStagingAndShutdown -q`
+Expected: 4 passed
+
+Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add #222 phase 2d: progress phase, shutdown, staging discipline"
+```
+
+---
+
+### Task 11: End-to-end parity and documentation
+
+**Files:**
+- Test: `tests/test_mcp_server.py`
+- Modify: `SKILL.md`, `CLAUDE.md` if either documents ingestion behaviour that has changed
+
+**Interfaces:** none — this task only verifies and documents
+
+- [ ] **Step 1: Write the parity test**
+
+```python
+class TestMultiStreamParityWithForwardOnly:
+    @pytest.mark.asyncio
+    async def test_introduced_by_matches_a_forward_only_ingest(self, tmp_path, monkeypatch):
+        """The whole converging design is only worth anything if it lands
+        the same lineage a plain forward walk would. Ratio 1:1 splits the
+        history down the middle, so this exercises the reconciliation, the
+        sweep and the meeting point in one assertion."""
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(8):
+            (repo / "auth.py").write_text(
+                f"def login():\n    return {i}\n\ndef helper_{i}():\n    pass\n"
+            )
+            (repo / "util.py").write_text(f"CONST = {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"h{i}"], cwd=repo, check=True, capture_output=True)
+
+        def introduced_by_map(path):
+            db = MiniGrafDb.open(str(path))
+            raw = mcp_server._db_execute(db, "(query [:find ?e ?c :where [?e :introduced-by ?c]])")
+            return {row[0]: row[1] for row in json.loads(raw)["results"]}
+
+        multi = tmp_path / "multi.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(multi))
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+        multi_map = introduced_by_map(multi)
+        mcp_server._db = None
+
+        # Forward-only: give the forward stream the entire range by making
+        # the reverse side never claim anything.
+        forward_only = tmp_path / "fwd.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(forward_only))
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+        forward_map = introduced_by_map(forward_only)
+
+        assert multi_map == forward_map
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestMultiStreamParityWithForwardOnly -q`
+Expected: PASS
+
+If `:introduced-by` diverges, that is a real bug in Tasks 5/9, not a test to relax. Trace the specific entity: query its `:introduced-by` in both graphs, then check whether it was reconciled (`_preload_provisional_idents` on the multi graph) and whether the sweep visited its guess commit (`_correction_sweep_through_query`).
+
+- [ ] **Step 3: Check the docs**
+
+Grep for ingestion documentation that the new env var or the three-stage behaviour makes stale:
+
+```bash
+grep -rn "MINIGRAF_INGEST\|watermark\|ingest_status\|forward-only" SKILL.md CLAUDE.md README.md 2>/dev/null
+```
+
+Add `MINIGRAF_INGEST_STREAM_RATIO` wherever `MINIGRAF_INGEST_WORKERS` is already documented. If nothing documents ingestion internals, make no change — do not invent a docs section for this.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `python -m pytest tests/test_mcp_server.py tests/test_frontier_registry.py -q`
+Expected: all pass, no regressions against the 968 baseline
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_mcp_server.py SKILL.md CLAUDE.md
+git commit -m "Add #222 phase 2d: end-to-end parity with forward-only ingest"
+```
+
+---
+
+## Wrap-up (after Task 11)
+
+- [ ] Run `superpowers:requesting-code-review` over the whole branch before opening the PR. Every prior sub-phase of #222 had real defects caught by a whole-branch review — 2b's review found three High defects that became sub-phase 2b1, and 2c's spec was revised eight times.
+- [ ] **Audit every commit message on the branch** for `Fix #222` / `Closes #222` / `Resolves #222` before merging: `git log master..HEAD --format=%B | grep -niE "(fix|close|resolve)[sd]? #222"`. Expected: no output.
+- [ ] Open the PR with a body that does **not** contain a closing keyword. #222 stays open until phase 5.
+- [ ] Update the memory file `project_222_multistream_ingestion_phases.md`: mark 2d done, record what 2d actually deferred (the frontier-high→low fold, Stage B pipelining), and note that phase 2 as a whole is complete.

--- a/docs/superpowers/plans/2026-07-26-concurrency-wiring.md
+++ b/docs/superpowers/plans/2026-07-26-concurrency-wiring.md
@@ -1520,10 +1520,56 @@ class TestStageBCorrectionSweep:
         assert mcp_server._should_fold_lineage_watermark(real_db, linearization) is True
 ```
 
+- [ ] **Step 1b: Write the lifecycle-repair tests (AMENDMENT)**
+
+These are the regression tests for the gap Step 3b closes. Each builds a repo where the *newest* commits — the ones the reverse stream claims at a 1:1 ratio — perform a deletion, a rename, and a submodule change, then runs a full `_run_ingestion` and asserts the graph matches what a forward-only ingest produces.
+
+```python
+class TestStageBRepairsLifecycleFacts:
+    """#222 phase 2d: the reverse stream skips D/R files and gitlink changes
+    entirely, so at the default 1:1 ratio the newest half of history loses
+    its deletions, renames and submodule bumps. Stage B applies them."""
+
+    @pytest.mark.asyncio
+    async def test_deletion_in_the_reverse_region_is_closed(self, tmp_path, monkeypatch):
+        """A function deleted in a recent commit must not still read as live
+        at HEAD. Without Stage B's lifecycle pass it stays open forever."""
+
+    @pytest.mark.asyncio
+    async def test_rename_in_the_reverse_region_emits_both_edges(self, tmp_path, monkeypatch):
+        """:renamed-from AND :renamed-to, and the old module closed."""
+
+    @pytest.mark.asyncio
+    async def test_submodule_bump_in_the_reverse_region_updates_pinned_commit(self, tmp_path, monkeypatch):
+        """Gitlink changes are discarded for reverse-claimed commits in
+        Stage A; the sweep must apply them."""
+
+    @pytest.mark.asyncio
+    async def test_entity_born_and_deleted_inside_the_reverse_region(self, tmp_path, monkeypatch):
+        """The case that motivates calling _build_code_triples for its dict
+        side effects on A/M files: the entity is absent from the Stage-A
+        entity_valid_from, so without that bookkeeping its close falls back
+        to the DELETE commit's own timestamp and yields a wrong (often
+        zero-width) valid interval. Assert the entity is live :valid-at a
+        point between its introduction and its deletion."""
+
+    @pytest.mark.asyncio
+    async def test_am_facts_are_not_duplicated_by_the_lifecycle_pass(self, tmp_path, monkeypatch):
+        """lifecycle_only must DISCARD _build_code_triples' output for A/M.
+        Re-transacting the same (entity, attribute, value) under a different
+        valid-from creates a genuinely live duplicate rather than a no-op
+        (#156), so assert exactly one :introduced-by and one :entity-type
+        per entity after a full run."""
+```
+
+Write each test body following the fixture idiom already used by `TestStageAInterleave` and the existing submodule tests (search for `:pinned-commit` for a worked gitlink example). Every one must build a real git repo, run the real `_run_ingestion`, and assert on persisted facts read back from a file-backed `MiniGrafDb`.
+
+The strongest available oracle is differential, and Task 11 already establishes the idiom: ingest the same repo twice, once at the `1:1` default and once forward-only via `MINIGRAF_INGEST_STREAM_RATIO=1000000:1`, and assert the two graphs agree. Prefer that over hand-enumerating expected facts wherever it fits — it is what makes these tests durable against unrelated changes in fact shape.
+
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestStageBCorrectionSweep -q`
-Expected: FAIL — `_should_fold_lineage_watermark` undefined, and the completed-run assertions fail because no sweep runs yet
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestStageBCorrectionSweep tests/test_mcp_server.py::TestStageBRepairsLifecycleFacts -q`
+Expected: FAIL — `_should_fold_lineage_watermark` undefined, `_forward_apply` has no `lifecycle_only` parameter, and the completed-run assertions fail because no sweep runs yet
 
 - [ ] **Step 3: Write the fold guard**
 
@@ -1550,6 +1596,24 @@ def _should_fold_lineage_watermark(db: Any, linearization: List[str]) -> bool:
         return False
     return through_hash == high_bounds[1] and through_hash in set(linearization)
 ```
+
+- [ ] **Step 3b: Add `lifecycle_only` to `_forward_apply` (AMENDMENT — see below)**
+
+**Why this exists.** The Task 8 review confirmed a live regression: `_reverse_apply` and `_correction_sweep_apply` both skip non-`A`/`M` files, and Stage A discards gitlink data for reverse-claimed commits. At the 1:1 default that loses roughly the top half of history's deletions, renames and submodule changes — closed entities stay open, `:renamed-to` is never emitted, removed fields keep satisfying `[?e :static true]`, closed `:depends-on` edges stay live. The original spec out-scoped this as "2b's existing scope cut, unchanged", which was true while every stream was inert and wrong once Stage A made them live. The human's decision: **the correction sweep applies them.**
+
+The sweep is the right home. It already walks the entire reverse region *ascending*, re-parsing each commit — the direction lifecycle attribution requires, and precisely why D/R was intractable for the reverse walk. And at convergence `state` already holds the live-entity picture at the meeting point, because Stage A's forward applies built it.
+
+Apply these facts **fresh**, do not re-run the whole forward body: the reverse stream never wrote D/R or gitlink facts for those commits, so there is nothing to deduplicate against. Re-running the A/M emission instead *would* duplicate — minigraf creates a genuinely live duplicate when the same `(entity, attribute, value)` is re-transacted under a different valid-from (issue #156), so that path must stay owned by `_correction_sweep_apply`.
+
+Widen `_forward_apply` with `lifecycle_only: bool = False`. When true:
+
+- **`"D"` and `"R"` files: process fully, unchanged.** `"R"` includes its `_build_code_triples` emission for the new path — the reverse stream skipped renames entirely, so the new path's entities were never written by anything.
+- **Gitlink changes: process fully, unchanged.**
+- **`"A"` and `"M"` files: call `_build_code_triples` for its dict side effects and DISCARD the returned triples.** Do not transact them. `_correction_sweep_apply` owns those entities' facts.
+
+That last rule is load-bearing and is the part most likely to be dropped as redundant. `state.entity_valid_from` after Stage A covers only positions `0..meeting_point`. An entity *introduced* inside the reverse region is absent from it, so a later deletion of that entity within the same region would close with `orig_ts = entity_valid_from.get(ident, commit_ts_iso)` — falling back to the delete commit's own timestamp and producing a wrong (often zero-width) valid interval. Calling `_build_code_triples` and dropping its output keeps `entity_valid_from`, `entity_descriptions`, `file_entities`, `field_class_ident` and `field_static_ident` current at zero fact cost. Ascending sweep order makes the recorded timestamp the correct earliest one, because `_build_code_triples` only writes `entity_valid_from[ident]` when the ident is not already present.
+
+Also skip `_watermark_update`, `_frontier_persist_claim` and `_lineage_confirmed_through_update` in this mode — Stage B tracks its own progress through `:ingestion/correction-sweep-through`, and the forward frontier must not appear to advance into the reverse region.
 
 - [ ] **Step 4: Write the Stage B driver**
 
@@ -1582,12 +1646,26 @@ In `_run_ingestion`, immediately after the `while pending:` loop ends and before
                                 break
                             sweep_hash, sweep_ts = selected
                             try:
-                                sweep_files, _g, _m, _r = await loop.run_in_executor(
+                                sweep_extracted = await loop.run_in_executor(
                                     executor, _extract_commit, repo_path, sweep_hash, ignore_patterns,
                                 )
+                                sweep_files = sweep_extracted[0]
                                 skipped += await loop.run_in_executor(
                                     write_executor, _correction_sweep_apply,
                                     db, sweep_hash, sweep_ts, sweep_files, index_con, skipped,
+                                )
+                                # Apply the lifecycle facts the reverse stream
+                                # skipped entirely (D/R closes, renames,
+                                # gitlink changes). Fresh writes, not
+                                # re-application -- nothing wrote them for
+                                # these commits. Runs AFTER the A/M
+                                # reconciliation above so an entity's lineage
+                                # is already authoritative before a close in
+                                # the same commit reads its window.
+                                await loop.run_in_executor(
+                                    write_executor, _forward_apply, db, repo_path, state,
+                                    commit_metadata[hash_to_pos[sweep_hash]],
+                                    sweep_extracted, index_con, None, None, True,
                                 )
                             except concurrent.futures.process.BrokenProcessPool:
                                 raise

--- a/docs/superpowers/specs/2026-07-26-concurrency-wiring-design.md
+++ b/docs/superpowers/specs/2026-07-26-concurrency-wiring-design.md
@@ -1,0 +1,491 @@
+# Concurrency Wiring — Design Spec
+
+**Issue:** #222 (Phase 2, sub-phase 2d of 4 — the last one)
+**Date:** 2026-07-26
+
+## Background
+
+#222's overall design is a converging multi-stream ingestion: a forward-truth
+stream (the existing `_run_ingestion` engine) and a reverse-bulk-fill stream
+that provisionally back-fills recent history from `HEAD` downward, so recent
+history becomes visible almost immediately while the forward stream still owns
+lineage correctness.
+
+- **Phase 1** (merged, PR #226) built `frontier_registry.py`
+  (`Interval`/`FrontierAllocator`/`build_linearization`) plus
+  `_frontier_load`/`_frontier_persist_claim`/`_frontier_seed_from_watermark` —
+  the shared-gap allocator both streams claim work from.
+- **Phase 2a** (merged, PR #227) built the provisional/authoritative fact
+  model: `_lineage_mark_provisional`/`_lineage_confirm`/`_lineage_is_provisional`
+  (a companion `:type/lineage-marker` entity per tracked entity),
+  `_lineage_confirmed_through_*`, and `_candidate_diff_persist`/`_read`/`_clear`.
+- **Phase 2b + 2b1** (merged, PR #228) built Stream 2's reverse-bulk-fill walk
+  (`_reverse_fill_claim_and_process`/`_reverse_bulk_fill_walk`) plus the
+  allocator adjacency/coalescing corrections and the EAVT-collision splits.
+- **Phase 2c** (merged, PR #229) built the correction sweep
+  (`_correction_sweep_select_position`/`_correction_sweep_apply` and two
+  synchronous convenience wrappers), which converts 2b's provisional facts to
+  authoritative ones once the gap has closed.
+
+**Every one of those sub-phases is inert against production ingestion.**
+Nothing built so far is called from `_run_ingestion`. 2d is the sub-phase that
+wires all of it in, and is therefore the first point at which #222 delivers any
+user-visible behaviour at all.
+
+### Constraints inherited from the 2b/2c reviews
+
+These were established by review, not preference, and 2d cannot design them
+away:
+
+1. **The correction sweep is terminal and post-convergence.**
+   `FrontierAllocator.claim_low()`/`claim_high()` partition one shared gap: a
+   position claimed by either side is never returned to the other, so no
+   sequence of `claim_low()` calls can reach territory `claim_high()` already
+   claimed. The sweep is a third, strictly sequential pass with its own
+   gap-closed precondition (`frontier-low.hi + 1 == frontier-high.lo`), not a
+   third concurrent task.
+2. **Nothing Stream 2 writes is trusted until that sweep completes.** On a
+   large repo that is close to the full ingest duration, not a small tail.
+3. **The sweep's three pieces must stay independently schedulable**, and
+   neither `_correction_sweep_claim_and_process` nor `_correction_sweep_walk`
+   may be called from async code — both fuse the CPU-bound parse and the
+   DB-bound writes into one function body.
+4. **`commit_metadata` must be full-history**
+   (`_git_commits(repo, watermark_hash=None, branch)`), not `_run_ingestion`'s
+   current watermark-relative list. Both 2b and 2c index it positionally
+   against `linearization`, and 2b raises `ValueError` on a length mismatch.
+
+## Design decisions
+
+### Single interleaved loop, not two asyncio tasks
+
+The issue's own text says "two asyncio tasks in one process", but that framing
+predates knowing how `_run_ingestion` is actually built. Every DB write in this
+server already serialises on `write_executor`, a deliberately
+`max_workers=1` `ThreadPoolExecutor`, and every parse already fans out to a
+`ProcessPoolExecutor`. Two asyncio tasks would therefore contend for the same
+single write thread and gain no throughput whatsoever, while adding:
+
+- a shared `_db` global whose lifecycle is `_db = None` between commits — with
+  two tasks, one clears it mid-commit for the other;
+- nondeterministic interleaving, so the fairness property under test is
+  probabilistic;
+- an explicit fairness mechanism (semaphore/turnstile) that has to be designed,
+  tuned and tested.
+
+Instead, Stage A is **one coroutine over one tagged prefetch pipeline**.
+Fairness *is* the submit order — starvation is not expressible, and the
+interleave is deterministic and directly assertable in a test.
+
+This is a change to the issue's stated mechanism, not to its goal. The
+user-visible property #222 asks for — recent history usable long before the
+ingest finishes — is delivered identically.
+
+### 1:1 default ratio, env-overridable
+
+A commit claimed by Stream 1 is parsed **once** and is authoritative
+immediately. A commit claimed by Stream 2 is parsed **twice**: once by the
+reverse walk, then again by the correction sweep, which calls `_extract_commit`
+rather than reading 2a's candidate-diff hashes (2c's final design deliberately
+dropped the hash-comparison shortcut; the records are now a cleanup obligation
+only). Total parse cost is therefore `N × (1 + reverse_fraction)`.
+
+At 1:1 that is ~1.5N parses with a ~0.5N terminal sweep. `HEAD` itself is
+visible after the first round regardless of ratio — what the ratio controls is
+how *deep* into recent history the reverse stream descends per unit of total
+progress.
+
+`MINIGRAF_INGEST_STREAM_RATIO="F:R"` overrides it (e.g. `"1:3"` to prioritise
+recent-first harder on a large repo, `"3:1"` to minimise total work). A
+malformed or non-positive value logs one line to stderr and falls back to
+`1:1` rather than raising — this is a background ingestion coroutine, and a bad
+env var must not be the reason a repo never ingests.
+
+### Extract the per-commit forward body
+
+`_run_ingestion` is ~630 lines, ~380 of them a single inline per-commit write
+section inside `while pending:`. Interleaving requires that body to be callable
+per-commit, and the tagged pipeline requires the drain loop to dispatch on tag.
+The body is therefore extracted to `_forward_apply`.
+
+That body mutates ten preload dictionaries (`entity_valid_from`,
+`entity_descriptions`, `file_entities`, `file_deps`, `dep_valid_from`,
+`pinned_commit_state`, `field_class_ident`, `field_static_ident`,
+`submodule_paths`, `unresolved_dep_idents`). Passing ten mutable dicts as ten
+parameters is how this function becomes unreviewable, so they are bundled into
+a `_ForwardWalkState` dataclass constructed once from
+`_load_ingestion_preload_state`'s return.
+
+This is a large mechanical diff over already-reviewed code, and the extraction
+itself is the single largest implementation risk in the phase. It is worth it:
+it makes the forward step unit-testable for the first time (today it is
+reachable only through a whole ingestion run), and it cuts the file's worst
+function to a readable driver.
+
+## Architecture
+
+`_run_ingestion` becomes a driver over three sequential stages:
+
+```
+preload state (_load_ingestion_preload_state, + provisional_idents)
+release DB lock
+linearization  = frontier_registry.build_linearization(repo_path, branch)
+commit_metadata = _git_commits(repo_path, None, branch)        # FULL history
+allocator      = _frontier_load(db, linearization, run_ts)     # migrates watermark
+        │
+Stage A ├── interleaved walk: tagged pipeline, until the allocator gap is empty
+        │
+Stage B ├── correction sweep: 2c's three pieces, until select returns None
+        │
+Stage C └── _ingest_tags + _last_run_write   (only if completed_all)
+```
+
+### Stage A — the tagged pipeline
+
+The existing pipeline already pre-submits `pipeline_depth = max_workers * 2`
+extractions to the process pool from a plain iterator. 2d replaces the iterator
+with the allocator:
+
+```python
+def submit_next() -> bool:
+    tag, pos = _next_claim(allocator, round_state)   # "fwd" -> claim_low, "rev" -> claim_high
+    if pos is None:
+        return False                                  # gap empty: BOTH sides are done
+    fut = loop.run_in_executor(
+        executor, _extract_commit, repo_path, linearization[pos], ignore_patterns
+    )
+    pending.append((tag, pos, fut))
+    return True
+```
+
+`_next_claim` walks the `F:R` ratio as a round: `F` forward claims, then `R`
+reverse claims, repeat. There is no "the other side might still have work"
+fallback, and deliberately so: `claim_low()` and `claim_high()` both return
+`None` on exactly the same condition, `is_gap_empty()`, so they can only ever
+return `None` together. A single `None` from whichever side's turn it is
+therefore means the gap is empty and Stage A is finished submitting. A
+fallthrough to the other side would be dead code that reads as if the two
+frontiers could exhaust independently — they cannot; they share one gap.
+
+The drain loop is FIFO, so **relative order within each tag is preserved**:
+forward stays strictly ascending, reverse strictly descending. Both streams
+require exactly that — the forward walk's `_ForwardWalkState` is an ascending
+state machine, and 2b's monotonicity guard and progress guard both assume a
+descending claim sequence.
+
+Each drained entry dispatches on its tag to `_forward_apply` or
+`_reverse_apply`, both of which run on `write_executor` and are DB-bound and
+parse-free.
+
+### Stage B — the correction sweep, driven asynchronously
+
+2c's own docstrings forbid calling `_correction_sweep_claim_and_process` or
+`_correction_sweep_walk` from async code. Stage B therefore drives the three
+pieces directly, each on its correct executor:
+
+```python
+hash_to_pos = {h: i for i, h in enumerate(linearization)}
+skipped = 0
+while not _shutdown_requested.is_set():
+    selected = await loop.run_in_executor(
+        write_executor, _correction_sweep_select_position,
+        db, linearization, commit_metadata, hash_to_pos,
+    )
+    if selected is None:
+        break
+    commit_hash, commit_ts_iso = selected
+    file_results, *_ = await loop.run_in_executor(
+        executor, _extract_commit, repo_path, commit_hash, ignore_patterns,
+    )
+    skipped += await loop.run_in_executor(
+        write_executor, _correction_sweep_apply,
+        db, commit_hash, commit_ts_iso, file_results, index_con, skipped,
+    )
+_correction_sweep_log_summary(skipped)
+```
+
+`hash_to_pos` is built once and threaded through, and `skipped_so_far` is
+threaded through every `_correction_sweep_apply` call — the two obligations
+2c's spec places on 2d's own loop. `_correction_sweep_log_summary` is called
+exactly once at the end so an operator grepping for that line does not have to
+know which loop drove the sweep.
+
+Pipelining `_extract_commit` ahead of `_correction_sweep_apply` is permitted by
+2c provided the `_correction_sweep_apply` calls stay in ascending position
+order. The initial implementation does **not** pipeline: `select_position`
+reads `:ingestion/correction-sweep-through`, which only advances inside
+`_correction_sweep_apply`, so a prefetching version has to predict positions
+rather than select them. That is a real optimisation, and it is deliberately
+out of scope here.
+
+## The correctness core: forward-introduction reconciliation
+
+This is the part that turns 2d from wiring into lineage surgery, and it is not
+optional — without it, essentially every entity alive at `HEAD` but introduced
+low in history ends up with **two** `:introduced-by` values, which
+`_correction_sweep_apply` then reads as an ambiguous count, hits its case-2
+fail-safe on, and leaves provisional forever.
+
+The root cause is an asymmetry between the two streams:
+
+- `_reverse_fill_claim_and_process` determines what it already knows by
+  querying the DB per candidate ident (`_entity_introduced_by_query`), so it
+  sees the forward stream's writes immediately and correctly routes them into
+  its `already_authoritative_touched` branch, which never clobbers.
+- The forward walk determines what it already knows from `entity_valid_from`,
+  an **in-memory dict preloaded once at run start** that never sees Stream 2's
+  writes.
+
+That produces two distinct failure modes:
+
+- **Same run.** The entity is absent from `entity_valid_from`, so
+  `_build_code_triples` emits an authoritative `:introduced-by` on top of
+  Stream 2's provisional one. Two values; detectable.
+- **Resumed run.** Stream 2's structural facts from the previous run *are* in
+  the preload, so `entity_valid_from` contains the entity and
+  `_build_code_triples` suppresses the introduction entirely. The entity keeps
+  a provisional `:introduced-by` pointing at a wrong, far-too-late commit,
+  permanently. This one is silent — there is no duplicate to notice.
+
+### The fix
+
+`_load_ingestion_preload_state` additionally loads `provisional_idents`: the
+set of tracked idents that currently have a `:type/lineage-marker` companion
+entity.
+
+```
+[:find ?e :where [?m :entity-type :type/lineage-marker] [?m :entity ?e]]
+```
+
+No `:status` clause is needed. The marker exists **only** while the entity is
+provisional — `_lineage_confirm` retracts the whole companion entity rather
+than flipping its `:status` — which is the same existence test
+`_lineage_is_provisional` performs per-ident. This is the set form of that
+query, so the preload cannot disagree with the per-ident check the
+reconciliation later relies on.
+
+The forward walk's introduction gate widens from
+*"ident not in `entity_valid_from`"* to *"ident not in `entity_valid_from`
+**or** ident in `provisional_idents`"*.
+
+The gate itself lives in `_build_code_triples`, whose `entity_valid_from`
+membership test means "is this the introduction" only for a forward walk. 2d
+does **not** widen that function's signature. Instead `_forward_apply` pops
+each provisional ident out of `entity_valid_from` before calling
+`_build_code_triples` for that file, which is also the semantically correct
+statement: a provisionally-introduced entity has not been authoritatively
+introduced, and the `valid_from` Stream 2 recorded for it is a wrong guess
+that must not be used as an `orig_ts` for anything.
+
+Then, for each such ident, `_forward_reconcile_provisional` runs **before**
+the normal forward emission:
+
+1. Retract the provisional `[ident :introduced-by <guess_commit>]`.
+2. Retract and re-transact the entity's structural triples at this commit's
+   (true, earlier) timestamp — otherwise there is a valid-time window where
+   `:introduced-by` is live for an entity with no type, name or file, so
+   `:as-of` the true introduction reports it as nonexistent. This is exactly
+   the re-dating `_reverse_fill_claim_and_process` already performs on a
+   provisional move; `:contains` triples go one per `_retract`/`_transact`
+   call, on both sides, for the EAVT-collision reason 2b1 established.
+3. `_lineage_confirm(db, ident)` — flip the marker to authoritative.
+4. `_candidate_diff_clear(db, <guess_commit_hash>, ident)` — the record is
+   stale the moment the guess moves off it, and this is the cheapest place to
+   drop it, mirroring 2b1's own supersede path.
+5. Transact `[ident :modified-in <guess_commit>]` at the **guess commit's own**
+   timestamp, not this commit's. The guess commit is now known to be a genuine
+   modification rather than the introduction, and back-dating the edge to this
+   commit would assert a fact valid before it was true.
+
+Normal forward emission then writes the authoritative `:introduced-by` at the
+true introduction commit, and `entity_valid_from`/`entity_descriptions` are
+populated as they would be for any newly-introduced entity.
+
+Step 5 inherits 2b's documented over-assertion: it cannot check #221's
+unchanged-body narrowing against the guess commit's own diff, because only that
+commit's own parse carries the data. That is already owned and needs no new
+machinery — the guess commit lies inside frontier-high's territory, so Stage B
+visits it, finds exactly one `:introduced-by` (case 3, already authoritative),
+and retracts the `:modified-in` edge if its own parse says the body was
+unchanged there.
+
+This also closes the "wrong provisional guess" reconciliation 2c proved could
+not be handled within its own walk and left explicitly unowned: the correction
+belongs to whichever walk processes the entity's true earlier occurrence, which
+is precisely the forward walk, here.
+
+## Watermarks and persistence
+
+- **`:ingestion/watermark`** — advanced by the forward stream only, once per
+  applied commit, exactly as today. Its meaning is preserved: the forward
+  stream claims contiguously upward from `C0`, so the watermark remains the
+  contiguous-from-`C0` frontier. The reverse stream must never touch it.
+- **`_frontier_persist_claim`** — called once per applied commit,
+  `from_low=True` for forward and `from_low=False` for reverse. New for the
+  forward side; the reverse side already does this inside
+  `_reverse_fill_claim_and_process` and keeps doing it in `_reverse_apply`.
+- **`:ingestion/lineage-confirmed-through`** — advanced by the forward stream
+  per applied commit (the virgin positions it claims are authoritative on
+  first write). It is folded forward to `frontier-high`'s `:hi-hash` when the
+  sweep genuinely completes.
+
+  **Stage B's exit condition alone must not trigger that fold.**
+  `_correction_sweep_select_position` returns `None` for six different
+  reasons, only one of which is "reached the ceiling": it also returns `None`
+  when `frontier-high` is absent, when either boundary hash is stale, when the
+  gap is still open, and when `commit_metadata` violates its contract. Folding
+  the watermark on any `None` would claim lineage is confirmed through `HEAD`
+  in exactly the situations where the sweep did no work at all.
+
+  Stage B therefore performs the fold only on an explicit positive check after
+  its loop ends: re-read `_correction_sweep_through_query(db)` and
+  `_frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)`, and fold only if the
+  former equals the latter's `:hi-hash`. Otherwise the watermark is left where
+  the forward stream put it, which correctly reports the region as
+  unconfirmed.
+- **`:ingestion/correction-sweep-through`** — 2c owns it; Stage B advances it
+  via `_correction_sweep_apply` and 2d does not touch it directly.
+
+The prefetch pipeline pre-claims positions in memory ahead of persisting them,
+so a crash re-walks at most `pipeline_depth` positions on the next run. Every
+write path involved is idempotent, so this costs work and nothing else.
+
+## Termination, degenerate cases, shutdown
+
+**Stage A ends** when `submit_next()` returns `False` (both `claim_low()` and
+`claim_high()` returned `None`) *and* `pending` has drained.
+
+**Stage B ends** when `_correction_sweep_select_position` returns `None`.
+
+The degenerate cases the issue enumerates fall out of this without special
+casing:
+
+| Case | Behaviour |
+|---|---|
+| Gap already empty on resume | `submit_next()` returns `False` on its first call; Stage A does nothing |
+| Empty or single-commit repo | `build_linearization` returns 0 or 1 entries; the allocator handles it, Stage B sees `high_bounds is None` and no-ops |
+| `lo == hi`, one position left | Whichever side's turn it is claims it; the other observes an empty gap. Exactly-once by construction |
+| Forward claimed everything | `frontier-high` is never created, `_correction_sweep_select_position` returns `None` immediately (2c's `high_bounds is None` branch) |
+| Reverse claimed everything | `frontier-low` is never persisted, and 2c's `low_bounds is None` branch reads that as `low_hi_pos = -1` — exactly the case 2c's spec added for 2d |
+| Visibility complete, lineage incomplete | Stage A no-ops on resume, Stage B resumes from `:ingestion/correction-sweep-through` |
+
+**Shutdown.** `_shutdown_requested` is checked between drains in Stage A and
+between steps in Stage B. On a shutdown request: `completed_all = False`, Stage
+C is skipped, status becomes `"stopped"`. The persisted frontier and the sweep
+watermark are what the next run resumes from; no in-memory state is required to
+survive.
+
+Note that a run interrupted during Stage A leaves the frontier-high region
+provisional and the sweep un-run, which is correct and self-describing —
+`:ingestion/lineage-confirmed-through` has not advanced past the forward
+stream's own position, so a consumer can tell.
+
+## Progress reporting
+
+`_ingest_progress` gains a `phase` key: `"converging"` during Stage A,
+`"sweeping"` during Stage B. `processed` counts each **applied** position once
+across both streams; Stage B's commits are re-visits of already-counted
+positions and are not added, or the count would exceed `total`.
+
+That is the whole of 2d's obligation here. The real multi-stream status view —
+per-stream state, visibility coverage versus lineage-authority coverage as two
+distinct completion signals, degenerate states represented explicitly — is
+phase 4's, and this spec deliberately does not pre-empt its shape. 2d owes only
+that the existing single-scalar view does not actively lie.
+
+## Error handling
+
+Unchanged in character from today's per-commit isolation:
+
+- An extraction failure for one commit is logged to stderr and skips that one
+  commit, in whichever stream owns it. The other stream is unaffected.
+- A write failure inside `_forward_apply` or `_reverse_apply` is logged and
+  skips that one commit; the position stays claimed (re-processing is
+  idempotent, and un-claiming would require the allocator to support
+  releasing a position, which it deliberately does not).
+- `BrokenProcessPool` still propagates to the outer handler — it poisons every
+  pending future in the window, both tags, and is not isolable.
+- A failure inside Stage B aborts Stage B only. Stage A's work is already
+  persisted, `completed_all` becomes `False`, and the next run resumes the
+  sweep from its watermark.
+
+## Testing
+
+Real-backend only, per `docs/testing-conventions.md` — real `MiniGrafDb`, real
+git fixture repos, no mocks.
+
+**Ratio and interleave**
+- `MINIGRAF_INGEST_STREAM_RATIO` parses `"1:1"`, `"1:3"`, `"3:1"`; malformed
+  (`"x"`, `"0:1"`, `"1:0"`, `"-1:2"`, unset) falls back to `1:1` and logs once.
+- Under each ratio, the claim sequence over a fixture repo matches the expected
+  interleave exactly — this is the fairness property, and the single-loop
+  design is what makes it deterministically assertable.
+- Every position in the linearization is claimed exactly once, and the union of
+  the two claimed intervals is the whole range with no overlap.
+
+**Reconciliation (the core)**
+- *Same-run variant*: a fixture repo with an entity introduced early and still
+  present at `HEAD`, ingested in one run with a ratio that guarantees Stream 2
+  reaches it first. Assert exactly one `:introduced-by`, that it names the true
+  introduction commit, that the lineage marker is confirmed, that structural
+  facts are live `:as-of` the true introduction, and that the guess commit
+  carries a `:modified-in` edge.
+- *Resumed-run variant*: same repo, but interrupt after Stage A has done some
+  reverse work, then start a second run. Assert the same postconditions —
+  this is the variant that fails silently without `provisional_idents`, so it
+  needs its own test and cannot be folded into the one above.
+- A test asserting `provisional_idents` is actually consulted: with it forced
+  empty, the resumed-run case leaves a provisional marker behind.
+
+**Staging and ordering**
+- Stage B does not start until Stage A has fully drained: assert
+  `:ingestion/correction-sweep-through` is unset while any pipeline entry is
+  outstanding.
+- Stage B's `_correction_sweep_apply` calls occur in ascending position order.
+- Neither `_correction_sweep_claim_and_process` nor `_correction_sweep_walk`
+  nor `_reverse_bulk_fill_walk` is called from `_run_ingestion`.
+
+**Watermarks**
+- `:ingestion/watermark` advances only on forward-applied commits and equals
+  `frontier-low`'s `:hi-hash` at every checkpoint.
+- `:ingestion/lineage-confirmed-through` equals `frontier-high`'s `:hi-hash`
+  after a completed run, and does *not* after a run stopped during Stage A.
+- The fold guard: force each of `_correction_sweep_select_position`'s
+  non-ceiling `None` paths (absent `frontier-high`, stale boundary hash, gap
+  still open) and assert the watermark is **not** folded to `HEAD` in any of
+  them. Without the explicit positive check this passes vacuously on the happy
+  path and lies on every one of these.
+
+**Degenerate and lifecycle**
+- Empty repo, single-commit repo, already-fully-ingested repo (Stage A no-ops,
+  Stage B no-ops), and a resume where visibility is complete but the sweep is
+  not.
+- Shutdown mid-Stage-A: status `"stopped"`, Stage C skipped, and a follow-up
+  run completes correctly from the persisted frontier.
+
+**End-to-end**
+- A full ingest of a real multi-commit fixture repo leaves **zero** provisional
+  lineage markers and no entity with more than one `:introduced-by` value.
+- The resulting graph is equivalent to what a pure forward-only ingest of the
+  same repo produces, for `:introduced-by`. `:modified-in` is compared as a
+  superset-with-explanation rather than equality only if a genuine divergence
+  is found and traced to 2b's documented over-assertion; the expectation is
+  equality, since Stage B is what repairs it.
+
+## Out of scope
+
+- **Stream 3 (tip-liveness)** — phase 3. `Ht` is read once at run start; a
+  branch advancing mid-ingest is not chased.
+- **The multi-stream status view** — phase 4.
+- **Folding a sweep-confirmed frontier-high region into frontier-low** so an
+  incremental re-ingest touches only genuinely new commits — deferred
+  (confirmed with the user). Today's behaviour stands: `_frontier_load`
+  discards and retracts an unrepresentable high interval and that region is
+  re-walked. Correct and terminating, just slower than it needs to be.
+- **`"D"`/`"R"` file handling in the reverse and sweep paths** — 2b's existing
+  scope cut, unchanged. The forward stream handles deletions and renames as it
+  always has.
+- **Pipelining Stage B's extraction** ahead of its apply — permitted by 2c but
+  requires predicting positions rather than selecting them.
+- **Force-push / rebase detection, DAG diamonds, octopus merges, multiple
+  roots** — phase 5.

--- a/docs/superpowers/specs/2026-07-26-concurrency-wiring-design.md
+++ b/docs/superpowers/specs/2026-07-26-concurrency-wiring-design.md
@@ -482,9 +482,36 @@ git fixture repos, no mocks.
   (confirmed with the user). Today's behaviour stands: `_frontier_load`
   discards and retracts an unrepresentable high interval and that region is
   re-walked. Correct and terminating, just slower than it needs to be.
-- **`"D"`/`"R"` file handling in the reverse and sweep paths** — 2b's existing
-  scope cut, unchanged. The forward stream handles deletions and renames as it
-  always has.
+- ~~**`"D"`/`"R"` file handling in the reverse and sweep paths** — 2b's existing
+  scope cut, unchanged.~~ **AMENDED 2026-07-27 — this was wrong, and is now in
+  scope.** Treating it as an unchanged scope cut held only while every stream
+  was inert. Stage A makes them live, and the Task 8 review measured the
+  result: at the 1:1 default, roughly the top half of history loses its
+  deletions, renames and submodule changes — closed entities stay open,
+  `:renamed-to` is never emitted, removed fields keep satisfying
+  `[?e :static true]`, closed `:depends-on` edges stay live — with no pass to
+  repair them. For a graph whose primary use is "what does this codebase look
+  like now", shipping that as the default is not an acceptable scope cut.
+
+  **The correction sweep now applies them** (`_forward_apply(...,
+  lifecycle_only=True)`, called per swept commit after
+  `_correction_sweep_apply`). The sweep is the right home: it already walks the
+  entire reverse region ascending, re-parsing every commit — the direction
+  lifecycle attribution requires, and exactly why D/R was intractable for the
+  reverse walk — and at convergence `state` already holds the live-entity
+  picture at the meeting point.
+
+  These facts are applied **fresh, not re-applied**: the reverse stream never
+  wrote D/R or gitlink facts for those commits, so there is nothing to
+  deduplicate against. The A/M emission stays owned by `_correction_sweep_apply`
+  precisely because re-running it *would* duplicate — minigraf creates a
+  genuinely live duplicate when the same `(entity, attribute, value)` is
+  re-transacted under a different valid-from (#156). In `lifecycle_only` mode
+  `_build_code_triples` is still called for A/M files, but purely for its dict
+  side effects, with its triples discarded: an entity introduced *inside* the
+  reverse region is absent from Stage A's `entity_valid_from`, and without that
+  bookkeeping a later deletion of it closes against the delete commit's own
+  timestamp, yielding a wrong valid interval.
 - **Pipelining Stage B's extraction** ahead of its apply — permitted by 2c but
   requires predicting positions rather than selecting them.
 - **Force-push / rebase detection, DAG diamonds, octopus merges, multiple

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4839,6 +4839,13 @@ def _commit_date_query(db: Any, commit_hash: Optional[str]) -> Optional[str]:
     unlike that function no :db/valid-to filter is needed to pick the live
     row; a re-walked position can re-transact an identical :date under a
     fresh valid-from (#156), but every such row carries the same value.
+
+    Returning None for a NON-EMPTY watermark is not benign: it degrades every
+    caller's resume-position bound back to the unrestricted, pre-fix B1
+    queries (see _load_ingestion_preload_state), which is a correctness
+    regression rather than a slow path. The degradation is therefore
+    announced on stderr instead of failing silently. None for an EMPTY
+    watermark is the ordinary fresh-graph case and stays quiet.
     """
     if not commit_hash:
         return None
@@ -4849,9 +4856,21 @@ def _commit_date_query(db: Any, commit_hash: Optional[str]) -> Optional[str]:
             f":where [:commit/{commit_hash[:12]} :date ?d]])",
         )
         results = json.loads(raw).get("results", [])
-    except Exception:
+    except Exception as e:
+        print(
+            f"[ingest] watermark commit {commit_hash[:12]} :date lookup failed "
+            f"({e}); preloads fall back to unbounded current-graph queries",
+            file=sys.stderr,
+        )
         return None
-    return results[0][0] if results else None
+    if not results:
+        print(
+            f"[ingest] watermark commit {commit_hash[:12]} has no :date fact; "
+            f"preloads fall back to unbounded current-graph queries",
+            file=sys.stderr,
+        )
+        return None
+    return results[0][0]
 
 
 def _iso_to_epoch_ms(ts_iso: Optional[str]) -> Optional[int]:
@@ -5349,8 +5368,9 @@ def _entity_introduced_by_set_provisional(
     introduced. Forward walk cannot produce that shape, nothing in the graph
     or the audit detects it, and it persists.
 
-    Positions, never timestamps: committer dates are not monotonic in
-    topological order (clock skew, rebases), which is why
+    Positions, never timestamps: ingest :date values are AUTHOR dates
+    (_git_commits reads `%at`) and are not monotonic in topological order
+    (clock skew, rebases, cherry-picks), which is why
     build_linearization uses --topo-order at all, so comparing :date values
     would silently mis-order commits. Both parameters default to None, in
     which case the guard is skipped and behaviour is exactly as before --
@@ -6841,12 +6861,34 @@ def _preload_known_entities(
     fresh graph (no watermark) wants.
 
     Known residual, deliberately not papered over: valid-time is populated
-    from COMMITTER dates, which are not monotonic in topological order. An
-    entity introduced at or below the watermark by a commit whose date is
-    later than the watermark commit's own date drops out of this snapshot and
-    is treated as new. That is the second bullet above, in a rarer form; it
-    needs a position-indexed preload (the linearization is not available on
-    this code path) rather than a valid-time one to close completely.
+    from AUTHOR dates -- _git_commits reads `%at`, not `%ct` -- which are not
+    monotonic in topological order, and are MORE inversion-prone than
+    committer dates would be (a rebase, a cherry-pick or a long-lived branch
+    merged late all carry the original author date forward, while rewriting
+    the committer date). So this bound is looser than a committer-date bound,
+    and looser still than a position-indexed one.
+
+    The residual therefore runs in BOTH directions, not just one:
+
+      * a commit at or below the watermark dated LATER than the watermark
+        commit -- its entities drop out of this snapshot and are treated as
+        new, i.e. duplicate introduction (the second bullet above, rarer);
+      * a commit ABOVE the watermark dated EARLIER than the watermark commit
+        -- its entities stay in this snapshot, are absent from the parse of
+        the earlier commit being replayed, and are closed and
+        _forget_closed_entity-purged: B1's original DATA-LOSS mode, surviving
+        in narrow form.
+
+    Both are live on this repository: of 552 watermark positions, 6 (118-123)
+    have a strictly-earlier-dated LATER position, and those later positions
+    (124-128, a side branch authored 2026-04-26/27 landing topologically
+    after the 2026-05-02 merges) are confirmed descendants of 118-123 via
+    `git merge-base --is-ancestor`. Consequence for whoever closes this: the
+    eventual ancestry- or position-indexed filter must REPLACE this
+    valid-time bound, not be unioned with it as an "add-back" -- a union only
+    re-admits the benign duplicate-introduction direction and leaves the
+    data-loss direction wide open. (The linearization is not available on
+    this code path, which is why the bound is expressed in valid-time here.)
 
     external-dependency entities share the module ident namespace and use the
     same "path" attribute as modules, so folding them into this same query
@@ -6921,7 +6963,9 @@ def _preload_known_entities(
     return entity_valid_from, entity_descriptions, file_entities, submodule_paths
 
 
-def _preload_unresolved_dep_idents(db: Any, submodule_paths: Dict[str, str]) -> Dict[str, str]:
+def _preload_unresolved_dep_idents(
+    db: Any, submodule_paths: Dict[str, str], valid_at: Optional[str] = None
+) -> Dict[str, str]:
     """Reload ident -> import_name for every unresolved-import stub (#112).
 
     _preload_known_entities' external-dependency branch requires a :path fact,
@@ -6935,12 +6979,33 @@ def _preload_unresolved_dep_idents(db: Any, submodule_paths: Dict[str, str]) -> 
     find and link any stub created in an earlier run (see the gitlink "add"
     handling in _run_ingestion) — without this, only same-run stubs would
     ever get linked.
+
+    valid_at MUST be the same resume-position bound _preload_known_entities
+    was given (#222 phase 2d review, B1), because submodule_paths is that
+    function's OUTPUT: this query is a minuend and submodule_paths is its
+    subtrahend, so bounding one without the other breaks the subtraction. A
+    real submodule created above the watermark by a prior run's Stage B would
+    drop out of the (bounded) subtrahend while staying in an unbounded
+    minuend, and be misclassified as a stub — reaching
+    state.unresolved_dep_idents, where the replayed gitlink "add" handler's
+    _submodule_path_matches_import check can fire on it (a submodule's
+    :description is `name or path`) and mint a bogus
+    [:module/sub-b :resolves-to :module/sub-a].
+
+    Unlike _preload_field_class_idents, this set has no asymmetry arguing for
+    the unrestricted read: an EXTRA entry is the bogus edge above, while a
+    MISSING one (a stub the reverse stream created above the watermark) is
+    merely a link the forward-only oracle would not have made at that
+    position either.
     """
     unresolved: Dict[str, str] = {}
+    valid_at_clause = f':valid-at "{_edn_escape(valid_at)}" ' if valid_at else ""
     try:
         raw = _db_execute(
             db,
-            "(query [:find ?ident ?desc :where "
+            "(query [:find ?ident ?desc "
+            f"{valid_at_clause}"
+            ":where "
             "[?e :entity-type :type/external-dependency] "
             "[?e :ident ?ident] "
             "[?e :description ?desc]])",
@@ -7224,7 +7289,11 @@ def _load_ingestion_preload_state(repo_path: str) -> tuple:
     # and Stage B's lifecycle pass start there), so the bound is that
     # commit's own :date, read back out of the graph. Wall-clock time would
     # be wrong twice over: it is not the resume position, and ingest
-    # valid-time is denominated in committer dates, not real time.
+    # valid-time is denominated in AUTHOR dates (_git_commits reads `%at`,
+    # not `%ct`), not real time. Author dates invert more readily than
+    # committer dates -- see _preload_known_entities' docstring for the
+    # residual this leaves open in BOTH directions, and for why the eventual
+    # ancestry-indexed fix must replace this bound rather than union with it.
     # No watermark means a fresh graph, where None degrades this to exactly
     # the pre-#222 unrestricted queries rather than to an empty state.
     resume_valid_at = _commit_date_query(db, watermark)
@@ -7239,7 +7308,11 @@ def _load_ingestion_preload_state(repo_path: str) -> tuple:
     pinned_commit_state = _preload_pinned_commits(db, valid_at_ms=resume_valid_at_ms)
     field_class_ident = _preload_field_class_idents(db)
     field_static_ident = _preload_field_static_idents(db)
-    unresolved_dep_idents = _preload_unresolved_dep_idents(db, submodule_paths)
+    # Same bound as _preload_known_entities above, and not optional: this
+    # preload subtracts submodule_paths, which that call already bounded.
+    unresolved_dep_idents = _preload_unresolved_dep_idents(
+        db, submodule_paths, valid_at=resume_valid_at,
+    )
     provisional_idents = _preload_provisional_idents(db)
     return (
         watermark, prior_ingested, entity_valid_from, entity_descriptions,

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -6914,6 +6914,24 @@ def _preload_pinned_commits(db: Any) -> Dict[str, tuple]:
     return pinned
 
 
+def _preload_provisional_idents(db: Any) -> Set[str]:
+    """Every tracked ident that currently has a :type/lineage-marker
+    companion entity, i.e. whose :introduced-by is a provisional guess.
+
+    No :status clause is needed: the marker exists ONLY while the entity is
+    provisional -- _lineage_confirm retracts the whole companion entity
+    rather than flipping its :status -- so existence is the test, exactly as
+    _lineage_is_provisional does per-ident. Keeping the two queries the same
+    shape is deliberate: this set is consulted where a per-ident check is
+    too expensive, and the two must never disagree.
+    """
+    raw = _db_execute(
+        db,
+        f"(query [:find ?e :where [?m :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}] [?m :entity ?e]])",
+    )
+    return {row[0] for row in json.loads(raw).get("results", [])}
+
+
 def _load_ingestion_preload_state(repo_path: str) -> tuple:
     """Open the DB and run every startup preload query for _run_ingestion.
 
@@ -6939,10 +6957,12 @@ def _load_ingestion_preload_state(repo_path: str) -> tuple:
     field_class_ident = _preload_field_class_idents(db)
     field_static_ident = _preload_field_static_idents(db)
     unresolved_dep_idents = _preload_unresolved_dep_idents(db, submodule_paths)
+    provisional_idents = _preload_provisional_idents(db)
     return (
         watermark, prior_ingested, entity_valid_from, entity_descriptions,
         file_entities, file_deps, dep_valid_from, pinned_commit_state,
         field_class_ident, field_static_ident, submodule_paths, unresolved_dep_idents,
+        provisional_idents,
     )
 
 
@@ -8096,6 +8116,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                 watermark, prior_ingested, entity_valid_from, entity_descriptions,
                 file_entities, file_deps, dep_valid_from, pinned_commit_state,
                 field_class_ident, field_static_ident, submodule_paths, unresolved_dep_idents,
+                provisional_idents,  # consumed by _forward_apply (Task 5)
             ) = await loop.run_in_executor(preload_executor, _load_ingestion_preload_state, repo_path)
         # minigraf exposes no explicit close(): the file lock is only released once
         # every reference to the handle is gone — the worker thread's own `db`

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4828,6 +4828,47 @@ def _watermark_query(db: Any) -> Optional[str]:
     return results[0][0] if results else None
 
 
+def _commit_date_query(db: Any, commit_hash: Optional[str]) -> Optional[str]:
+    """Return an already-ingested commit's ISO 8601 :date, or None.
+
+    :any-valid-time is required, not cosmetic: a commit's own facts are
+    transacted at THAT COMMIT's timestamp, which can sit in the future
+    relative to wall-clock time (clock skew, doctored committer dates), so a
+    plain query's implicit "as of now" filter can miss them -- the same
+    reason _total_ingested_query gives. Commit facts are never closed, so
+    unlike that function no :db/valid-to filter is needed to pick the live
+    row; a re-walked position can re-transact an identical :date under a
+    fresh valid-from (#156), but every such row carries the same value.
+    """
+    if not commit_hash:
+        return None
+    try:
+        raw = _db_execute(
+            db,
+            f"(query [:find ?d :any-valid-time "
+            f":where [:commit/{commit_hash[:12]} :date ?d]])",
+        )
+        results = json.loads(raw).get("results", [])
+    except Exception:
+        return None
+    return results[0][0] if results else None
+
+
+def _iso_to_epoch_ms(ts_iso: Optional[str]) -> Optional[int]:
+    """Convert an ingest ISO 8601 timestamp to minigraf's epoch-ms valid-time
+    scale, so it can be compared against the :db/valid-from/:db/valid-to
+    pseudo-attributes. Returns None if ts_iso is absent or unparseable."""
+    if not ts_iso:
+        return None
+    try:
+        parsed = datetime.datetime.fromisoformat(ts_iso.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return int(parsed.timestamp() * 1000)
+
+
 def _total_ingested_query(db: Any) -> int:
     """Return the :total-ingested watermark recorded by the last *completed* run, or 0.
 
@@ -5379,6 +5420,7 @@ def _forward_reconcile_provisional(
     structural_triples: List[str],
     true_commit_ts_iso: str,
     ts_by_commit_ident: Dict[str, str],
+    commit_ident: str,
     index_con: Optional[Any] = None,
 ) -> Optional[str]:
     """#222 phase 2d: the forward walk has reached entity_ident's TRUE
@@ -5395,8 +5437,11 @@ def _forward_reconcile_provisional(
     function cannot drift from it.
 
     Mirrors the supersede path in _reverse_apply: the same re-dating of
-    structural facts (via _re_date_structural_facts), and the same refusal
-    to back-date a :modified-in edge whose commit timestamp is unknown.
+    structural facts (via _re_date_structural_facts), the same refusal to
+    back-date a :modified-in edge whose commit timestamp is unknown, and --
+    what commit_ident is for -- the same refusal to hand the entity a
+    :modified-in edge at its OWN introduction (_reverse_apply's
+    `superseded_ident != commit_ident` guard).
     """
     guess_ident = _entity_introduced_by_query(db, entity_ident)
     if not _lineage_is_provisional(db, entity_ident):
@@ -5425,7 +5470,22 @@ def _forward_reconcile_provisional(
     _candidate_diff_clear(db, guess_ident[len(":commit/"):], entity_ident, index_con=index_con)
 
     # 5. The guess commit is now known to be a genuine modification rather
-    # than the introduction, so it earns the :modified-in edge Stream 2
+    # than the introduction -- UNLESS it is this very commit, which is the
+    # introduction. Stream 2 can guess the right commit and still leave a
+    # provisional marker on it (it claims high-to-low, so the first sighting
+    # of an entity born inside its own region IS that entity's introduction);
+    # the marker then survives whenever the run is interrupted before Stage B
+    # confirms it, and a later run's forward walk re-walks the position after
+    # _frontier_load discards the unrepresentable high interval. Writing the
+    # edge here would assert that the entity was modified at the commit that
+    # created it -- the exact shape _correction_sweep_apply refuses to write
+    # via its own self-introduction guard, and one a forward-only ingest can
+    # never produce. It is also unreachable by the sweep once the position is
+    # forward territory, so it would be permanent.
+    if guess_ident == commit_ident:
+        return guess_ident
+
+    # Otherwise the guess commit earns the :modified-in edge Stream 2
     # withheld from it. Dated at ITS OWN timestamp, not this commit's.
     #
     # This inherits 2b's documented over-assertion: #221's unchanged-body
@@ -6749,10 +6809,44 @@ def _build_code_triples(
     return triples
 
 
-def _preload_known_entities(db: Any, repo_path: str) -> tuple:
+def _preload_known_entities(
+    db: Any, repo_path: str, valid_at: Optional[str] = None
+) -> tuple:
     """Load all existing module/function/class/external-dependency idents from
     the DB, and pre-seed file_entities with all currently tracked files in the
     repo.
+
+    valid_at (#222 phase 2d review, B1) bounds the entity queries to the graph
+    as it stood at the forward walk's RESUME POSITION -- i.e. at the
+    :ingestion/watermark commit's own timestamp -- instead of "now". Before the
+    two-stream ingest, the two were the same thing: the graph never held facts
+    for a commit above the watermark. The reverse stream breaks that. It writes
+    structural facts across the whole frontier-high region, and Stage B's
+    lifecycle pass then applies that region's deletions and renames, so a
+    CURRENT-graph preload hands the resuming forward walk a state describing
+    commits it has not reached yet. Both directions of that mismatch corrupt
+    the graph:
+
+      * an entity born in the reverse region is present in file_entities, is
+        absent from the parse of the (earlier) commit the forward walk is
+        replaying, and so is closed and _forget_closed_entity-purged as a
+        "removed" entity -- with an orig_ts LATER than the close's valid_to,
+        an inverted valid interval;
+      * an entity CLOSED in the reverse region is missing from the state
+        entirely, so replaying an earlier commit that still contains it takes
+        _build_code_triples' introduction branch and mints a second live
+        :introduced-by.
+
+    Passing None restores the pre-#222 behaviour exactly, which is what a
+    fresh graph (no watermark) wants.
+
+    Known residual, deliberately not papered over: valid-time is populated
+    from COMMITTER dates, which are not monotonic in topological order. An
+    entity introduced at or below the watermark by a commit whose date is
+    later than the watermark commit's own date drops out of this snapshot and
+    is treated as new. That is the second bullet above, in a rarer form; it
+    needs a position-indexed preload (the linearization is not available on
+    this code path) rather than a valid-time one to close completely.
 
     external-dependency entities share the module ident namespace and use the
     same "path" attribute as modules, so folding them into this same query
@@ -6792,12 +6886,19 @@ def _preload_known_entities(db: Any, repo_path: str) -> tuple:
     except Exception:
         pass
 
+    # Every clause of the query below is bounded by this one keyword, the
+    # :introduced-by -> :date join included: a commit above the watermark has
+    # a :date fact whose own valid-from is later than valid_at, so the join
+    # simply finds nothing for it.
+    valid_at_clause = f':valid-at "{_edn_escape(valid_at)}" ' if valid_at else ""
+
     for entity_type in ("module", "function", "class", "variable", "field", "external-dependency"):
         path_attr = "path" if entity_type in ("module", "external-dependency") else "file"
         try:
             raw = _db_execute(
                 db,
                 f'(query [:find ?ident ?path ?desc ?date '
+                f'{valid_at_clause}'
                 f':where [?e :entity-type :type/{entity_type}] '
                 f'[?e :ident ?ident] '
                 f'[?e :{path_attr} ?path] '
@@ -6862,6 +6963,16 @@ def _preload_field_class_idents(db: Any) -> Dict[str, str]:
     silently leaked open when a later run closes the field (its module-contains
     edge would still close, but not the class one). Current-time query semantics
     naturally exclude already-closed fields' edges.
+
+    Deliberately NOT bounded to the resume position, unlike the preloads
+    around it (#222 phase 2d review, B1). This is a pure side-table read
+    through .get() at close sites, never a "what existed then" set: an extra
+    entry for a field the forward walk has not reached is inert (nothing
+    looks it up until that field is genuinely closed, at which point the
+    value is right), while a MISSING entry is the leaked-edge bug above. So
+    the failure modes are asymmetric here in the opposite direction, and the
+    unrestricted read is the safer one. _preload_field_static_idents is the
+    same shape and is left alone for the same reason.
     """
     field_class_ident: Dict[str, str] = {}
     try:
@@ -6908,10 +7019,42 @@ def _preload_field_static_idents(db: Any) -> Dict[str, bool]:
 _VALID_TIME_FOREVER_MS = (1 << 63) - 1  # minigraf's i64::MAX "still open" :valid-to sentinel
 
 
+def _valid_time_window_clauses(valid_at_ms: Optional[int]) -> str:
+    """Predicate clauses selecting the facts live at valid_at_ms, for the
+    :any-valid-time preloads that bind ?vf/?vt (#222 phase 2d review, B1).
+
+    valid_at_ms=None keeps the pre-existing "still open right now" test
+    (:valid-to still at the forever sentinel) unchanged. Otherwise the test
+    becomes half-open containment, [?vf, ?vt) ∋ valid_at_ms -- the same
+    boundary rule :valid-at itself uses (a fact starting exactly at the
+    instant is live, one ending exactly at it is not), verified against the
+    backend so the two preload styles cannot disagree at the watermark.
+    The forever sentinel satisfies [(> ?vt valid_at_ms)] for any real
+    timestamp, so still-open facts stay in.
+    """
+    if valid_at_ms is None:
+        return f"[(= ?vt {_VALID_TIME_FOREVER_MS})]"
+    return f"[(<= ?vf {valid_at_ms})] [(> ?vt {valid_at_ms})]"
+
+
 def _preload_known_deps(
-    db: Any, file_entities: Dict[str, List[str]]
+    db: Any, file_entities: Dict[str, List[str]], valid_at_ms: Optional[int] = None
 ) -> tuple:
     """Reload file_deps/dep_valid_from from durable :depends-on facts.
+
+    valid_at_ms is _preload_known_entities' valid_at on minigraf's epoch-ms
+    valid-time scale, and means the same thing: the graph as it stood at the
+    forward walk's resume position (#222 phase 2d review, B1). :depends-on is
+    never written by the reverse stream, but Stage B's lifecycle pass calls
+    _forward_apply(lifecycle_only=True), whose dep_add_triples are NOT gated
+    on that flag -- so a completed two-stream run does leave :depends-on edges
+    above the watermark, and a current-time reload would hand them to a
+    resuming forward walk that then closes them at an earlier commit. This
+    query cannot express the bound as :valid-at, because the
+    :db/valid-from/:db/valid-to pseudo-attributes it needs only bind under
+    :any-valid-time; the equivalent is stated directly as
+    [valid_from, valid_to) containing valid_at_ms, which is exactly
+    :valid-at's own half-open semantics.
 
     Mirrors _preload_known_entities, but :depends-on facts have no
     :introduced-by-style companion edge to a commit's :date, so the
@@ -6964,7 +7107,7 @@ def _preload_known_deps(
             "[?src :depends-on ?dep] "
             "[?src :db/valid-from ?vf] "
             "[?src :db/valid-to ?vt] "
-            f"[(= ?vt {_VALID_TIME_FOREVER_MS})]])"
+            f"{_valid_time_window_clauses(valid_at_ms)}])"
         )
         rows = json.loads(raw).get("results", [])
     except Exception:
@@ -6984,10 +7127,15 @@ def _preload_known_deps(
     return file_deps, dep_valid_from
 
 
-def _preload_pinned_commits(db: Any) -> Dict[str, tuple]:
+def _preload_pinned_commits(db: Any, valid_at_ms: Optional[int] = None) -> Dict[str, tuple]:
     """Reload each external-dependency entity's current :pinned-commit value
     and the timestamp it was set at, mirroring _preload_known_deps's per-fact
     :any-valid-time pattern for :depends-on.
+
+    valid_at_ms carries the same resume-position bound, for the same reason:
+    Stage B's lifecycle pass runs the gitlink handling over the reverse
+    region, so a completed two-stream run can leave a bump recorded above the
+    watermark (#222 phase 2d review, B1).
 
     Needed because :pinned-commit is bi-temporally closed and reopened on
     every bump (see _run_ingestion's gitlink handling) — without this, the
@@ -7013,7 +7161,7 @@ def _preload_pinned_commits(db: Any) -> Dict[str, tuple]:
             "[?e :pinned-commit ?sha] "
             "[?e :db/valid-from ?vf] "
             "[?e :db/valid-to ?vt] "
-            f"[(= ?vt {_VALID_TIME_FOREVER_MS})]])"
+            f"{_valid_time_window_clauses(valid_at_ms)}])"
         )
         rows = json.loads(raw).get("results", [])
     except Exception:
@@ -7037,6 +7185,12 @@ def _preload_provisional_idents(db: Any) -> Set[str]:
     _lineage_is_provisional does per-ident. Keeping the two queries the same
     shape is deliberate: this set is consulted where a per-ident check is
     too expensive, and the two must never disagree.
+
+    Deliberately NOT bounded to the resume position the way the mutable walk
+    state is (#222 phase 2d review, B1). This set is the reconciliation
+    AUTHORITY: its whole job is to name the entities the reverse stream
+    introduced above the watermark, so restricting it to the watermark's
+    valid-time would empty it of exactly the rows it exists to carry.
     """
     raw = _db_execute(
         db,
@@ -7063,10 +7217,26 @@ def _load_ingestion_preload_state(repo_path: str) -> tuple:
     """
     db = _db if _db is not None else _open_db_at_with_extended_retry(_graph_path or _get_graph_path())
     watermark = _watermark_query(db)
+    # #222 phase 2d review, B1: the MUTABLE walk state must describe the graph
+    # at the forward walk's resume position, not "now" -- see
+    # _preload_known_entities' valid_at docstring for what goes wrong
+    # otherwise. The resume position IS the watermark (both the forward walk
+    # and Stage B's lifecycle pass start there), so the bound is that
+    # commit's own :date, read back out of the graph. Wall-clock time would
+    # be wrong twice over: it is not the resume position, and ingest
+    # valid-time is denominated in committer dates, not real time.
+    # No watermark means a fresh graph, where None degrades this to exactly
+    # the pre-#222 unrestricted queries rather than to an empty state.
+    resume_valid_at = _commit_date_query(db, watermark)
+    resume_valid_at_ms = _iso_to_epoch_ms(resume_valid_at)
     prior_ingested = _count_commit_entities(db)
-    entity_valid_from, entity_descriptions, file_entities, submodule_paths = _preload_known_entities(db, repo_path)
-    file_deps, dep_valid_from = _preload_known_deps(db, file_entities)
-    pinned_commit_state = _preload_pinned_commits(db)
+    entity_valid_from, entity_descriptions, file_entities, submodule_paths = _preload_known_entities(
+        db, repo_path, valid_at=resume_valid_at,
+    )
+    file_deps, dep_valid_from = _preload_known_deps(
+        db, file_entities, valid_at_ms=resume_valid_at_ms,
+    )
+    pinned_commit_state = _preload_pinned_commits(db, valid_at_ms=resume_valid_at_ms)
     field_class_ident = _preload_field_class_idents(db)
     field_static_ident = _preload_field_static_idents(db)
     unresolved_dep_idents = _preload_unresolved_dep_idents(db, submodule_paths)
@@ -8086,7 +8256,8 @@ def _forward_apply(
                     )
                 _forward_reconcile_provisional(
                     db, ident, structural_triples_by_ident[ident],
-                    commit_ts_iso, state.ts_by_commit_ident, index_con=index_con,
+                    commit_ts_iso, state.ts_by_commit_ident, commit_ident,
+                    index_con=index_con,
                 )
             for ident in candidate_in_set:
                 state.provisional_idents.discard(ident)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7845,6 +7845,8 @@ def _forward_apply(
     commit: Tuple[str, str, str, str],
     extracted: Tuple[list, list, dict, list],
     index_con: Optional[Any] = None,
+    linearization: Optional[List[str]] = None,
+    pos: Optional[int] = None,
 ) -> None:
     """Apply one commit's forward-walk writes.
 
@@ -7854,6 +7856,12 @@ def _forward_apply(
     `run_in_executor(write_executor, ...)` submissions the inline body used
     became direct calls, and the caller submits this whole function to
     write_executor once instead.
+
+    linearization/pos are the allocator's view of this commit. When both are
+    supplied (Stage A's forward stream always does), this also persists the
+    frontier-low claim and advances the lineage-confirmed-through watermark;
+    both default to None so the existing tests that call this function with a
+    bare commit tuple stay valid.
     """
     commit_hash, commit_ts_iso, author, subject = commit
     extracted_files, gitlink_changes, gitmodules_map, renamed_pairs = extracted
@@ -8292,6 +8300,16 @@ def _forward_apply(
         pass  # non-fatal; parent edges are best-effort
 
     _watermark_update(db, commit_hash, commit_ts_iso, reason, index_con)
+    if linearization is not None and pos is not None:
+        _frontier_persist_claim(
+            db, linearization, pos, from_low=True,
+            commit_ts_iso=commit_ts_iso, index_con=index_con,
+        )
+    # The virgin positions this walk claims are authoritative on first write,
+    # so lineage is confirmed contiguously from C0 through here. The sweep
+    # folds its own region in later (Task 9); this watermark must not be
+    # advanced past the forward frontier before that happens.
+    _lineage_confirmed_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)
     _db_checkpoint(db)
     _commit_index_writer_safe(index_con)
 
@@ -8826,7 +8844,13 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
         # the global here is enough to release the lock.
         _db = None  # release file lock while enumerating commits
 
-        commits = _git_commits(repo_path, watermark, branch)
+        linearization = frontier_registry.build_linearization(repo_path, branch)
+        # FULL history, positionally aligned with linearization. Both
+        # _reverse_apply and _correction_sweep_select_position index it
+        # positionally, and _reverse_apply raises ValueError on a length
+        # mismatch -- a watermark-relative list is exactly the wrong thing
+        # to hand them.
+        commit_metadata = _git_commits(repo_path, None, branch)
         ignore_patterns = _load_ignore_patterns(repo_path)
         state = _ForwardWalkState(
             entity_valid_from=entity_valid_from,
@@ -8840,16 +8864,16 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
             submodule_paths=submodule_paths,
             unresolved_dep_idents=unresolved_dep_idents,
             provisional_idents=provisional_idents,
-            # Task 8 introduces the full-history commit_metadata this should
-            # really be built from; until then, the existing (post-watermark)
-            # commits list is what's available here.
-            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commits},
+            # Full-history, so a resumed run's retroactive :modified-in for a
+            # guess commit at or below the watermark still finds a timestamp
+            # (a post-watermark-only map would silently skip it).
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
         )
         repo_total_result = _subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
             cwd=repo_path, capture_output=True, text=True,
         )
-        repo_total = int(repo_total_result.stdout.strip()) if repo_total_result.returncode == 0 else len(commits)
+        repo_total = int(repo_total_result.stdout.strip()) if repo_total_result.returncode == 0 else len(commit_metadata)
         _ingest_progress["total"] = repo_total
         _ingest_progress["status"] = "running"
         _ingest_progress["processed"] = prior_ingested
@@ -8899,6 +8923,23 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
         index_path = fact_index.index_path_for(_graph_path or _get_graph_path())
         index_con = await loop.run_in_executor(write_executor, _open_index_writer_safe, index_path)
 
+        # #222 phase 2d: the two streams share one gap. _frontier_load WRITES
+        # (one-time watermark->interval migration, plus the lineage-marker
+        # migration), so it needs a live db and index_con and must run on
+        # write_executor rather than inline on the event-loop thread.
+        run_ts_iso = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S.%f"
+        )[:-3] + "Z"
+        db = await _ensure_db_async()
+        allocator = await loop.run_in_executor(
+            write_executor, _frontier_load, db, linearization, run_ts_iso, index_con,
+        )
+        db = None
+        _db = None
+        claimer = _RoundRobinClaimer(
+            allocator, *_parse_stream_ratio(os.environ.get("MINIGRAF_INGEST_STREAM_RATIO"))
+        )
+
         try:
             # Extraction (git show + tree-sitter parse + triple construction) runs
             # in real OS processes, not threads (#116): tree-sitter's C parse holds
@@ -8921,18 +8962,30 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                 max_workers=max_workers, mp_context=mp_context
             )
             try:
-                commits_iter = iter(commits)
                 pending: Any = deque()
 
+                # #222 phase 2d: positions come from the shared-gap claimer,
+                # not a plain commit iterator, and each pipeline entry carries
+                # the tag of the stream that claimed it. Extraction is stream-
+                # agnostic (every position goes to the same process pool); only
+                # the write half below dispatches on the tag.
+                #
+                # The pipeline is FIFO, and that is what preserves the ordering
+                # each stream requires: claims are handed out in one
+                # deterministic sequence, appended in that sequence and popped
+                # in it, so "fwd" positions reach _forward_apply strictly
+                # ascending (its state machine's precondition) and "rev"
+                # positions reach _reverse_apply strictly descending (its
+                # monotonicity and progress guards' precondition).
                 def submit_next() -> bool:
-                    try:
-                        commit = next(commits_iter)
-                    except StopIteration:
+                    claim = claimer.next_claim()
+                    if claim is None:
                         return False
+                    tag, pos = claim
                     fut = loop.run_in_executor(
-                        executor, _extract_commit, repo_path, commit[0], ignore_patterns
+                        executor, _extract_commit, repo_path, linearization[pos], ignore_patterns
                     )
-                    pending.append((commit, fut))
+                    pending.append((tag, pos, fut))
                     return True
 
                 for _ in range(pipeline_depth):
@@ -8944,7 +8997,8 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                         completed_all = False
                         break
 
-                    (commit_hash, commit_ts_iso, author, subject), fut = pending.popleft()
+                    tag, pos, fut = pending.popleft()
+                    commit_hash, commit_ts_iso, author, subject = commit_metadata[pos]
                     # renamed_pairs (Task 9's 4th _extract_commit return element) is
                     # unpacked here but not yet consumed — Task 10 wires it into
                     # :renamed-from/:renamed-to triple emission for functions/classes.
@@ -8987,12 +9041,18 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                     # Acquire DB fresh each commit — never hold across yield
                     db = await _ensure_db_async()
                     try:
-                        await loop.run_in_executor(
-                            write_executor, _forward_apply, db, repo_path, state,
-                            (commit_hash, commit_ts_iso, author, subject),
-                            (extracted_files, gitlink_changes, gitmodules_map, renamed_pairs),
-                            index_con,
-                        )
+                        if tag == "fwd":
+                            await loop.run_in_executor(
+                                write_executor, _forward_apply, db, repo_path, state,
+                                commit_metadata[pos],
+                                (extracted_files, gitlink_changes, gitmodules_map, renamed_pairs),
+                                index_con, linearization, pos,
+                            )
+                        else:
+                            await loop.run_in_executor(
+                                write_executor, _reverse_apply, db, repo_path, linearization,
+                                commit_metadata, pos, extracted_files, index_con,
+                            )
 
                     except Exception as e:
                         # Ordinary per-commit write failure (malformed EDN, a

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -102,6 +102,7 @@ _ingest_task: Optional[asyncio.Task] = None
 _ingest_progress: Dict[str, Any] = {
     "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
     "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+    "phase": None,
 }
 _shutdown_requested = asyncio.Event()
 
@@ -9000,6 +9001,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
         repo_total = int(repo_total_result.stdout.strip()) if repo_total_result.returncode == 0 else len(commit_metadata)
         _ingest_progress["total"] = repo_total
         _ingest_progress["status"] = "running"
+        _ingest_progress["phase"] = "converging"
         _ingest_progress["processed"] = prior_ingested
         _ingest_progress["prior_ingested"] = prior_ingested
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -23,7 +23,7 @@ import sys
 import threading
 import time
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
@@ -7829,7 +7829,7 @@ def _forward_apply(
 
     Moved verbatim out of _run_ingestion's `while pending:` loop (issue #222
     phase 2d) so a single commit's write section can be driven per-commit by
-    the two-stream interleave. Purely synchronous: the ~10 individual
+    the two-stream interleave. Purely synchronous: the eight individual
     `run_in_executor(write_executor, ...)` submissions the inline body used
     became direct calls, and the caller submits this whole function to
     write_executor once instead.
@@ -7921,6 +7921,30 @@ def _forward_apply(
                     state.field_static_ident,
                 )
             previous_idents = set(state.file_entities.get(file_path, []))
+            # #222 phase 2d: an entity Stream 2 already introduced
+            # provisionally is NOT authoritatively introduced, so the
+            # forward walk must treat it as new. Popping it out of
+            # entity_valid_from is what makes _build_code_triples's own
+            # gate (entity_valid_from membership) agree -- deliberately
+            # in preference to widening that function's signature, since
+            # its gate means "is this the introduction" for a forward
+            # walk and nothing else should depend on that meaning.
+            #
+            # It is also semantically right on its own terms: the
+            # valid_from Stream 2 recorded is a wrong guess, and must
+            # never be used as an orig_ts for a close.
+            reconcilable = [
+                ident for ident in _forward_candidate_idents(precomputed)
+                if ident in state.provisional_idents
+            ]
+            for ident in reconcilable:
+                state.entity_valid_from.pop(ident, None)
+                _forward_reconcile_provisional(
+                    db, ident,
+                    _forward_structural_triples(precomputed, ident),
+                    commit_ts_iso, state.ts_by_commit_ident, index_con=index_con,
+                )
+                state.provisional_idents.discard(ident)
             triples = _build_code_triples(
                 file_path, extracted, commit_ts_iso, state.entity_valid_from,
                 state.entity_descriptions, state.file_entities, commit_ident, precomputed,
@@ -8202,6 +8226,33 @@ def _forward_apply(
     _watermark_update(db, commit_hash, commit_ts_iso, reason, index_con)
     _db_checkpoint(db)
     _commit_index_writer_safe(index_con)
+
+
+def _forward_candidate_idents(precomputed: Dict[str, Any]) -> List[str]:
+    """Every entity ident a parsed file contributes -- module plus all four
+    child categories. Same collection _reverse_fill_claim_and_process and
+    _correction_sweep_apply perform; kept as one function so the three walks
+    cannot drift on what an entity's candidate set is."""
+    return (
+        [precomputed["module_ident"]]
+        + [ident for ident, _name, _t in precomputed["function_entries"]]
+        + [ident for ident, _name, _t in precomputed["class_entries"]]
+        + [ident for ident, _name, _t in precomputed["global_entries"]]
+        + [ident for ident, _name, _t in precomputed["field_entries"]]
+    )
+
+
+def _forward_structural_triples(precomputed: Dict[str, Any], ident: str) -> List[str]:
+    """ident's own candidate triples, for re-dating. A child's own list
+    carries its [parent :contains child] edge, so re-dating a child re-dates
+    its containment edge with it (#222 phase 2b1)."""
+    if ident == precomputed["module_ident"]:
+        return list(precomputed["module_candidate_triples"])
+    for entries_key in ("function_entries", "class_entries", "global_entries", "field_entries"):
+        for entry_ident, _entry_name, entry_triples in precomputed[entries_key]:
+            if entry_ident == ident:
+                return list(entry_triples)
+    return []
 
 
 _CORRECTION_SWEEP_THROUGH_IDENT = ":ingestion/correction-sweep-through"
@@ -8596,6 +8647,8 @@ class _ForwardWalkState:
     field_static_ident: Dict[str, bool]
     submodule_paths: Dict[str, str]
     unresolved_dep_idents: Dict[str, str]
+    provisional_idents: Set[str] = field(default_factory=set)
+    ts_by_commit_ident: Dict[str, str] = field(default_factory=dict)
 
 
 async def _run_ingestion(repo_path: str, branch: str) -> None:
@@ -8639,6 +8692,14 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                 field_class_ident, field_static_ident, submodule_paths, unresolved_dep_idents,
                 provisional_idents,  # consumed by _forward_apply (Task 5)
             ) = await loop.run_in_executor(preload_executor, _load_ingestion_preload_state, repo_path)
+        # minigraf exposes no explicit close(): the file lock is only released once
+        # every reference to the handle is gone — the worker thread's own `db`
+        # local already went out of scope when it returned above, so clearing
+        # the global here is enough to release the lock.
+        _db = None  # release file lock while enumerating commits
+
+        commits = _git_commits(repo_path, watermark, branch)
+        ignore_patterns = _load_ignore_patterns(repo_path)
         state = _ForwardWalkState(
             entity_valid_from=entity_valid_from,
             entity_descriptions=entity_descriptions,
@@ -8650,15 +8711,12 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
             field_static_ident=field_static_ident,
             submodule_paths=submodule_paths,
             unresolved_dep_idents=unresolved_dep_idents,
+            provisional_idents=provisional_idents,
+            # Task 8 introduces the full-history commit_metadata this should
+            # really be built from; until then, the existing (post-watermark)
+            # commits list is what's available here.
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commits},
         )
-        # minigraf exposes no explicit close(): the file lock is only released once
-        # every reference to the handle is gone — the worker thread's own `db`
-        # local already went out of scope when it returned above, so clearing
-        # the global here is enough to release the lock.
-        _db = None  # release file lock while enumerating commits
-
-        commits = _git_commits(repo_path, watermark, branch)
-        ignore_patterns = _load_ignore_patterns(repo_path)
         repo_total_result = _subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
             cwd=repo_path, capture_output=True, text=True,
@@ -8797,10 +8855,6 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
 
                     last_hash = commit_hash
                     _ingest_progress["current_commit"] = commit_hash
-                    reason = f"git:{commit_hash} {author}: {subject}"
-
-                    # Build commit entity ident from first 12 chars of hash
-                    commit_ident = f":commit/{commit_hash[:12]}"
 
                     # Acquire DB fresh each commit — never hold across yield
                     db = await _ensure_db_async()

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -23,6 +23,7 @@ import sys
 import threading
 import time
 from collections import deque
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
@@ -7816,6 +7817,393 @@ def _reverse_bulk_fill_walk(
     return count
 
 
+def _forward_apply(
+    db: Any,
+    repo_path: str,
+    state: "_ForwardWalkState",
+    commit: Tuple[str, str, str, str],
+    extracted: Tuple[list, list, dict, list],
+    index_con: Optional[Any] = None,
+) -> None:
+    """Apply one commit's forward-walk writes.
+
+    Moved verbatim out of _run_ingestion's `while pending:` loop (issue #222
+    phase 2d) so a single commit's write section can be driven per-commit by
+    the two-stream interleave. Purely synchronous: the ~10 individual
+    `run_in_executor(write_executor, ...)` submissions the inline body used
+    became direct calls, and the caller submits this whole function to
+    write_executor once instead.
+    """
+    commit_hash, commit_ts_iso, author, subject = commit
+    extracted_files, gitlink_changes, gitmodules_map, renamed_pairs = extracted
+    commit_ident = f":commit/{commit_hash[:12]}"
+    reason = f"git:{commit_hash} {author}: {subject}"
+
+    add_triples: List[str] = [
+        f"[{commit_ident} :entity-type :type/commit]",
+        f'[{commit_ident} :ident "{commit_ident}"]',
+        f'[{commit_ident} :description "{_edn_escape(subject[:120])}"]',
+        f'[{commit_ident} :hash "{commit_hash}"]',
+        f'[{commit_ident} :author "{_edn_escape(author)}"]',
+        f'[{commit_ident} :subject "{_edn_escape(subject[:200])}"]',
+        f'[{commit_ident} :date "{commit_ts_iso}"]',
+    ]
+    close_items: List[tuple] = []  # (triples, original_ts_iso)
+    dep_add_triples: List[str] = []  # :depends-on triples to transact individually
+    # Old paths of files renamed this commit (R status). Their
+    # unmatched child entities / dependency edges are closed in a
+    # final pass after renamed_pairs is consumed (see below).
+    renamed_old_paths: set = set()
+
+    for status, file_path, extracted, precomputed, old_path in extracted_files:
+        if status == "D":
+            # Close module and all known child entities for this file.
+            # Iterate a copy: _forget_closed_entity mutates
+            # state.file_entities[file_path] in place as it purges.
+            idents = list(state.file_entities.get(file_path, [_code_ident("module", file_path)]))
+            module_ident = _code_ident("module", file_path)
+            for ident in idents:
+                orig_ts = state.entity_valid_from.get(ident, commit_ts_iso)
+                desc = state.entity_descriptions.get(ident, "")
+                close_items.append(
+                    (_build_close_triples(
+                        ident, desc, module_ident,
+                        state.field_class_ident.get(ident),
+                        close_entity_type=True, file_value=file_path,
+                        is_static=state.field_static_ident.get(ident),
+                    ), orig_ts)
+                )
+                _forget_closed_entity(
+                    ident, file_path, state.entity_valid_from,
+                    state.entity_descriptions, state.field_class_ident, state.file_entities,
+                    state.field_static_ident,
+                )
+            # Whole file is gone: drop its (now-empty) state.file_entities key
+            # so nothing stale lingers under this path (matches state.file_deps).
+            state.file_entities.pop(file_path, None)
+            # Close all :depends-on edges for the deleted module
+            for dep_ident in state.file_deps.get(file_path, set()):
+                orig_ts = state.dep_valid_from.get((module_ident, dep_ident), commit_ts_iso)
+                close_items.append(
+                    ([f"[{module_ident} :depends-on {dep_ident}]"], orig_ts)
+                )
+            state.file_deps.pop(file_path, None)
+        else:  # A or M or R
+            if status == "R" and old_path:
+                renamed_old_paths.add(old_path)
+                old_module_ident = _code_ident("module", old_path)
+                new_module_ident = _code_ident("module", file_path)
+                add_triples.append(f"[{new_module_ident} :renamed-from {old_module_ident}]")
+                # :renamed-to is a brand-new fact that becomes
+                # true at the rename commit and stays true forever
+                # after — it must be transacted open-ended (like
+                # :renamed-from), NOT closed with the old entity's
+                # historical valid window via _ingest_close.
+                add_triples.append(f"[{old_module_ident} :renamed-to {new_module_ident}]")
+                old_desc = state.entity_descriptions.get(old_module_ident, old_path)
+                orig_ts = state.entity_valid_from.get(old_module_ident, commit_ts_iso)
+                close_items.append((
+                    _build_close_triples(
+                        old_module_ident, old_desc, old_module_ident,
+                        close_entity_type=True, file_value=old_path,
+                    ),
+                    orig_ts,
+                ))
+                # Purge the closed old module. Its remaining child
+                # entities under old_path are closed+purged by the
+                # renamed_old_paths pass below, which also pops the
+                # whole state.file_entities[old_path] key — so only the
+                # scalar dicts and the module's own list slot need
+                # dropping here.
+                _forget_closed_entity(
+                    old_module_ident, old_path, state.entity_valid_from,
+                    state.entity_descriptions, state.field_class_ident, state.file_entities,
+                    state.field_static_ident,
+                )
+            previous_idents = set(state.file_entities.get(file_path, []))
+            triples = _build_code_triples(
+                file_path, extracted, commit_ts_iso, state.entity_valid_from,
+                state.entity_descriptions, state.file_entities, commit_ident, precomputed,
+                state.field_class_ident, state.field_static_ident,
+            )
+            add_triples.extend(triples)
+            # Detect entities removed from a modified file.
+            # _build_code_triples only appends to state.file_entities, never removes.
+            # Compare previous idents against the idents derivable from the
+            # current extraction to find what was deleted.
+            if status == "M":
+                module_ident = _code_ident("module", file_path)
+                current_extracted_idents: set = {module_ident}
+                for fn_ident, _fn_name, _fn_triples in precomputed["function_entries"]:
+                    current_extracted_idents.add(fn_ident)
+                for cls_ident, _cls_name, _cls_triples in precomputed["class_entries"]:
+                    current_extracted_idents.add(cls_ident)
+                # Globals and fields are tracked in state.file_entities too
+                # (see _build_code_triples): omitting them here would
+                # make every still-present global/field look "removed"
+                # on any later edit and wrongly close it (#113).
+                for gvar_ident, _gvar_name, _gvar_triples in precomputed["global_entries"]:
+                    current_extracted_idents.add(gvar_ident)
+                for field_ident, _field_name, _field_triples in precomputed["field_entries"]:
+                    current_extracted_idents.add(field_ident)
+                removed_idents = previous_idents - current_extracted_idents
+                # An in-place rename (old->new in the same file) is
+                # closed with :renamed-to linkage by the renamed_pairs
+                # loop below; exclude those old idents here so they are
+                # not ALSO closed as a plain removal (double close).
+                same_file_renamed_old_idents = {
+                    _code_ident(cat, o_file, o_name)
+                    for cat, o_file, o_name, _n_file, _n_name in renamed_pairs
+                    if o_file == file_path
+                }
+                removed_idents -= same_file_renamed_old_idents
+                for ident in removed_idents:
+                    orig_ts = state.entity_valid_from.get(ident, commit_ts_iso)
+                    desc = state.entity_descriptions.get(ident, "")
+                    close_items.append(
+                        (_build_close_triples(
+                            ident, desc, module_ident,
+                            state.field_class_ident.get(ident),
+                            close_entity_type=True, file_value=file_path,
+                            is_static=state.field_static_ident.get(ident),
+                        ), orig_ts)
+                    )
+                    # File survives (M), only this child was removed:
+                    # purge just this ident from the file's list.
+                    _forget_closed_entity(
+                        ident, file_path, state.entity_valid_from,
+                        state.entity_descriptions, state.field_class_ident, state.file_entities,
+                        state.field_static_ident,
+                    )
+            # Compute dep edges for this file and diff against previous.
+            # Resolution itself already happened in _extract_commit
+            # (precomputed["resolved_imports"]) against that commit's
+            # own git-ls-tree state — nothing left to resolve here.
+            module_ident = _code_ident("module", file_path)
+            current_deps: set = set()
+            for import_name, dep_ident, is_resolved in precomputed["resolved_imports"]:
+                if dep_ident != module_ident:
+                    current_deps.add(dep_ident)
+                    is_relative = import_name.startswith(".")
+                    if not is_resolved and not is_relative and dep_ident not in state.entity_valid_from:
+                        add_triples.extend([
+                            f"[{dep_ident} :entity-type :type/external-dependency]",
+                            f'[{dep_ident} :ident "{_edn_escape(dep_ident)}"]',
+                            f'[{dep_ident} :description "{_edn_escape(import_name)}"]',
+                        ])
+                        state.entity_valid_from[dep_ident] = commit_ts_iso
+                        state.entity_descriptions[dep_ident] = import_name
+                        state.unresolved_dep_idents[dep_ident] = import_name
+                        # #112: an already-known submodule may be the real
+                        # target this unresolvable import was reaching for
+                        # (submodule directories are never in state.file_entities,
+                        # so any import into one always falls through here).
+                        for sub_ident, sub_path in state.submodule_paths.items():
+                            if _submodule_path_matches_import(sub_path, import_name):
+                                add_triples.append(f"[{dep_ident} :resolves-to {sub_ident}]")
+            previous_deps = state.file_deps.get(file_path, set())
+            for dep_ident in current_deps - previous_deps:
+                dep_add_triples.append(f"[{module_ident} :depends-on {dep_ident}]")
+                state.dep_valid_from[(module_ident, dep_ident)] = commit_ts_iso
+            if status == "M":
+                for dep_ident in previous_deps - current_deps:
+                    orig_ts = state.dep_valid_from.get((module_ident, dep_ident), commit_ts_iso)
+                    close_items.append(
+                        ([f"[{module_ident} :depends-on {dep_ident}]"], orig_ts)
+                    )
+            state.file_deps[file_path] = current_deps
+
+    # Function/class rename linkage (Task 9's renamed_pairs).
+    # Module-level linkage is handled separately per-file
+    # above (Task 5) since it comes from git's own -M
+    # detection, not this commit-wide matcher.
+    for category, old_file, old_name, new_file, new_name in renamed_pairs:
+        old_ident = _code_ident(category, old_file, old_name)
+        new_ident = _code_ident(category, new_file, new_name)
+        add_triples.append(f"[{new_ident} :renamed-from {old_ident}]")
+        # :renamed-to becomes true at the rename commit and stays
+        # open-ended thereafter — transact it via the add path, do
+        # NOT fold it into the old entity's _ingest_close window.
+        add_triples.append(f"[{old_ident} :renamed-to {new_ident}]")
+        old_desc = state.entity_descriptions.get(old_ident, old_name)
+        old_module_ident = _code_ident("module", old_file)
+        orig_ts = state.entity_valid_from.get(old_ident, commit_ts_iso)
+        close_items.append((
+            _build_close_triples(
+                old_ident, old_desc, old_module_ident,
+                state.field_class_ident.get(old_ident),
+                close_entity_type=True, file_value=old_file,
+                is_static=state.field_static_ident.get(old_ident),
+            ),
+            orig_ts,
+        ))
+        _forget_closed_entity(
+            old_ident, old_file, state.entity_valid_from,
+            state.entity_descriptions, state.field_class_ident, state.file_entities,
+            state.field_static_ident,
+        )
+
+    # A file rename (R status) only closes the old MODULE above.
+    # Child entities and dependency edges under the old path are
+    # closed here as plain removals UNLESS the matcher established
+    # a rename continuity edge for them (handled with :renamed-to
+    # by the loop above). This runs after renamed_pairs is fully
+    # consumed so those confirmed renames can be excluded; without
+    # it, unmatched old children/deps leak open forever under the
+    # old path while new ones open under the new path.
+    if renamed_old_paths:
+        renamed_covered_idents = {
+            _code_ident(cat, o_file, o_name)
+            for cat, o_file, o_name, _n_file, _n_name in renamed_pairs
+        }
+        for r_old_path in renamed_old_paths:
+            r_old_module_ident = _code_ident("module", r_old_path)
+            # Iterate a copy: _forget_closed_entity mutates
+            # state.file_entities[r_old_path] in place as it purges.
+            for ident in list(state.file_entities.get(r_old_path, [])):
+                if ident == r_old_module_ident:
+                    continue  # already closed+purged by the R block above
+                if ident in renamed_covered_idents:
+                    continue  # already closed+purged with :renamed-to linkage
+                orig_ts = state.entity_valid_from.get(ident, commit_ts_iso)
+                desc = state.entity_descriptions.get(ident, "")
+                close_items.append(
+                    (_build_close_triples(
+                        ident, desc, r_old_module_ident,
+                        state.field_class_ident.get(ident),
+                        close_entity_type=True, file_value=r_old_path,
+                        is_static=state.field_static_ident.get(ident),
+                    ), orig_ts)
+                )
+                _forget_closed_entity(
+                    ident, r_old_path, state.entity_valid_from,
+                    state.entity_descriptions, state.field_class_ident, state.file_entities,
+                    state.field_static_ident,
+                )
+            # Whole old path is gone (renamed away): drop the key so
+            # no stale ident lingers to be re-discovered by a later
+            # commit that reuses this path (e.g. a shim at old_path).
+            state.file_entities.pop(r_old_path, None)
+            for dep_ident in state.file_deps.get(r_old_path, set()):
+                orig_ts = state.dep_valid_from.get((r_old_module_ident, dep_ident), commit_ts_iso)
+                close_items.append(
+                    ([f"[{r_old_module_ident} :depends-on {dep_ident}]"], orig_ts)
+                )
+            state.file_deps.pop(r_old_path, None)
+
+    # Process gitlink changes (submodule add/bump/remove).
+    # The "remove" case's interaction with the ordinary per-file module-open
+    # logic (elsewhere in this loop) is only sound because real submodule paths
+    # are extensionless (no tree-sitter parser matches them, so no module is
+    # ever opened for a bare gitlink path) — a gitlink path that happened to
+    # carry a recognized source extension is an untested, unreachable-in-practice edge case.
+    for kind, sha, path in gitlink_changes:
+        ext_ident = _code_ident("module", path)
+        if kind == "add":
+            info = gitmodules_map.get(path, {})
+            name = info.get("name", "")
+            url = info.get("url", "")
+            description = name or path
+            ext_triples = [
+                f"[{ext_ident} :entity-type :type/external-dependency]",
+                f'[{ext_ident} :ident "{_edn_escape(ext_ident)}"]',
+                f'[{ext_ident} :description "{_edn_escape(description)}"]',
+                f'[{ext_ident} :path "{_edn_escape(path)}"]',
+                f'[{ext_ident} :pinned-commit "{_edn_escape(sha)}"]',
+                f"[{ext_ident} :introduced-by {commit_ident}]",
+            ]
+            if name:
+                ext_triples.append(f'[{ext_ident} :submodule-name "{_edn_escape(name)}"]')
+            if url:
+                ext_triples.append(f'[{ext_ident} :submodule-url "{_edn_escape(url)}"]')
+            add_triples.extend(ext_triples)
+            state.entity_valid_from[ext_ident] = commit_ts_iso
+            state.entity_descriptions[ext_ident] = description
+            state.pinned_commit_state[ext_ident] = (sha, commit_ts_iso)
+            state.submodule_paths[ext_ident] = path
+            # #112: link any pre-existing unresolved-import stub whose
+            # import path reaches into this submodule — the ordering in
+            # the issue's own repro (stub created before the submodule
+            # was ever added), which the per-import check above can't
+            # catch since the submodule wasn't known yet at that time.
+            for stub_ident, import_name in state.unresolved_dep_idents.items():
+                if _submodule_path_matches_import(path, import_name):
+                    add_triples.append(f"[{stub_ident} :resolves-to {ext_ident}]")
+        elif kind == "bump":
+            old_sha, orig_ts = state.pinned_commit_state.get(ext_ident, (None, commit_ts_iso))
+            if old_sha is not None:
+                close_items.append(
+                    ([f'[{ext_ident} :pinned-commit "{_edn_escape(old_sha)}"]'], orig_ts)
+                )
+            add_triples.append(f'[{ext_ident} :pinned-commit "{_edn_escape(sha)}"]')
+            add_triples.append(f"[{ext_ident} :modified-in {commit_ident}]")
+            state.pinned_commit_state[ext_ident] = (sha, commit_ts_iso)
+        else:  # "remove"
+            orig_ts = state.entity_valid_from.get(ext_ident, commit_ts_iso)
+            desc = state.entity_descriptions.get(ext_ident, "")
+            close_items.append(
+                (_build_close_triples(
+                    ext_ident, desc, ext_ident,
+                    entity_type_kw=":type/external-dependency",
+                    file_value=path,
+                ), orig_ts)
+            )
+            # Submodule removed: purge lifecycle state so a later
+            # re-add at the same path is treated as genuinely new.
+            # (Submodule paths aren't tracked in state.file_entities, so the
+            # path arg is a no-op there, but pass it for consistency.)
+            _forget_closed_entity(
+                ext_ident, path, state.entity_valid_from,
+                state.entity_descriptions, state.field_class_ident, state.file_entities,
+            )
+            old_sha, pin_orig_ts = state.pinned_commit_state.pop(ext_ident, (None, commit_ts_iso))
+            if old_sha is not None:
+                close_items.append(
+                    ([f'[{ext_ident} :pinned-commit "{_edn_escape(old_sha)}"]'], pin_orig_ts)
+                )
+
+    # Split :contains triples out before batching.  Minigraf's EAVT
+    # pending index lacks value bytes in the key, so batching multiple
+    # [module :contains fn] facts in one transact silently drops all
+    # but the last.  Each :contains triple gets its own transact so
+    # they receive distinct tx_counts and avoid the index collision.
+    contains_triples = [t for t in add_triples if ":contains" in t]
+    other_triples = [t for t in add_triples if ":contains" not in t]
+    _ingest_transact(db, other_triples, commit_ts_iso, reason, index_con)
+    for ct in contains_triples:
+        _ingest_transact(db, [ct], commit_ts_iso, reason, index_con)
+    # :depends-on triples transacted individually — same EAVT collision risk
+    # as :contains when multiple deps share the same source module
+    for dt in dep_add_triples:
+        _ingest_transact(db, [dt], commit_ts_iso, reason, index_con)
+    for close_triples, orig_ts in close_items:
+        _ingest_close(db, close_triples, orig_ts, commit_ts_iso, reason, index_con)
+
+    # Ingest :parent edges — one transact per parent to avoid EAVT
+    # collision for merge commits (which have two parent hashes).
+    # Routed through _transact (not a raw _db_execute call) so the
+    # edge also lands in the persisted fact index -- see #118 review
+    # finding: this call site used to build its own raw (transact
+    # ...) string and bypass the index choke point entirely.
+    try:
+        for parent_hash in _git_parent_hashes(repo_path, commit_hash):
+            parent_ident = f":commit/{parent_hash[:12]}"
+            _transact(
+                db,
+                f'[[{commit_ident} :parent {parent_ident}]]',
+                commit_ts_iso,
+                None,
+                None,
+                index_con,
+            )
+    except Exception:
+        pass  # non-fatal; parent edges are best-effort
+
+    _watermark_update(db, commit_hash, commit_ts_iso, reason, index_con)
+    _db_checkpoint(db)
+    _commit_index_writer_safe(index_con)
+
+
 _CORRECTION_SWEEP_THROUGH_IDENT = ":ingestion/correction-sweep-through"
 # Max per-ident skip lines this sweep writes to stderr per run; see the
 # Observability section of the design spec for why this must be
@@ -8189,6 +8577,27 @@ def _parse_stream_ratio(raw: Optional[str]) -> Tuple[int, int]:
         return _DEFAULT_STREAM_RATIO
 
 
+@dataclass
+class _ForwardWalkState:
+    """The forward walk's ten mutable preload dicts, threaded as one object.
+
+    Held by reference, not by value: _forward_apply mutates these in place
+    exactly as the inline loop body it was extracted from did (issue #222
+    phase 2d).
+    """
+
+    entity_valid_from: Dict[str, str]
+    entity_descriptions: Dict[str, str]
+    file_entities: Dict[str, list]
+    file_deps: Dict[str, set]
+    dep_valid_from: Dict[tuple, str]
+    pinned_commit_state: Dict[str, tuple]
+    field_class_ident: Dict[str, str]
+    field_static_ident: Dict[str, bool]
+    submodule_paths: Dict[str, str]
+    unresolved_dep_idents: Dict[str, str]
+
+
 async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 
@@ -8230,6 +8639,18 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                 field_class_ident, field_static_ident, submodule_paths, unresolved_dep_idents,
                 provisional_idents,  # consumed by _forward_apply (Task 5)
             ) = await loop.run_in_executor(preload_executor, _load_ingestion_preload_state, repo_path)
+        state = _ForwardWalkState(
+            entity_valid_from=entity_valid_from,
+            entity_descriptions=entity_descriptions,
+            file_entities=file_entities,
+            file_deps=file_deps,
+            dep_valid_from=dep_valid_from,
+            pinned_commit_state=pinned_commit_state,
+            field_class_ident=field_class_ident,
+            field_static_ident=field_static_ident,
+            submodule_paths=submodule_paths,
+            unresolved_dep_idents=unresolved_dep_idents,
+        )
         # minigraf exposes no explicit close(): the file lock is only released once
         # every reference to the handle is gone — the worker thread's own `db`
         # local already went out of scope when it returned above, so clearing
@@ -8384,379 +8805,12 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                     # Acquire DB fresh each commit — never hold across yield
                     db = await _ensure_db_async()
                     try:
-                        add_triples: List[str] = [
-                            f"[{commit_ident} :entity-type :type/commit]",
-                            f'[{commit_ident} :ident "{commit_ident}"]',
-                            f'[{commit_ident} :description "{_edn_escape(subject[:120])}"]',
-                            f'[{commit_ident} :hash "{commit_hash}"]',
-                            f'[{commit_ident} :author "{_edn_escape(author)}"]',
-                            f'[{commit_ident} :subject "{_edn_escape(subject[:200])}"]',
-                            f'[{commit_ident} :date "{commit_ts_iso}"]',
-                        ]
-                        close_items: List[tuple] = []  # (triples, original_ts_iso)
-                        dep_add_triples: List[str] = []  # :depends-on triples to transact individually
-                        # Old paths of files renamed this commit (R status). Their
-                        # unmatched child entities / dependency edges are closed in a
-                        # final pass after renamed_pairs is consumed (see below).
-                        renamed_old_paths: set = set()
-
-                        for status, file_path, extracted, precomputed, old_path in extracted_files:
-                            if status == "D":
-                                # Close module and all known child entities for this file.
-                                # Iterate a copy: _forget_closed_entity mutates
-                                # file_entities[file_path] in place as it purges.
-                                idents = list(file_entities.get(file_path, [_code_ident("module", file_path)]))
-                                module_ident = _code_ident("module", file_path)
-                                for ident in idents:
-                                    orig_ts = entity_valid_from.get(ident, commit_ts_iso)
-                                    desc = entity_descriptions.get(ident, "")
-                                    close_items.append(
-                                        (_build_close_triples(
-                                            ident, desc, module_ident,
-                                            field_class_ident.get(ident),
-                                            close_entity_type=True, file_value=file_path,
-                                            is_static=field_static_ident.get(ident),
-                                        ), orig_ts)
-                                    )
-                                    _forget_closed_entity(
-                                        ident, file_path, entity_valid_from,
-                                        entity_descriptions, field_class_ident, file_entities,
-                                        field_static_ident,
-                                    )
-                                # Whole file is gone: drop its (now-empty) file_entities key
-                                # so nothing stale lingers under this path (matches file_deps).
-                                file_entities.pop(file_path, None)
-                                # Close all :depends-on edges for the deleted module
-                                for dep_ident in file_deps.get(file_path, set()):
-                                    orig_ts = dep_valid_from.get((module_ident, dep_ident), commit_ts_iso)
-                                    close_items.append(
-                                        ([f"[{module_ident} :depends-on {dep_ident}]"], orig_ts)
-                                    )
-                                file_deps.pop(file_path, None)
-                            else:  # A or M or R
-                                if status == "R" and old_path:
-                                    renamed_old_paths.add(old_path)
-                                    old_module_ident = _code_ident("module", old_path)
-                                    new_module_ident = _code_ident("module", file_path)
-                                    add_triples.append(f"[{new_module_ident} :renamed-from {old_module_ident}]")
-                                    # :renamed-to is a brand-new fact that becomes
-                                    # true at the rename commit and stays true forever
-                                    # after — it must be transacted open-ended (like
-                                    # :renamed-from), NOT closed with the old entity's
-                                    # historical valid window via _ingest_close.
-                                    add_triples.append(f"[{old_module_ident} :renamed-to {new_module_ident}]")
-                                    old_desc = entity_descriptions.get(old_module_ident, old_path)
-                                    orig_ts = entity_valid_from.get(old_module_ident, commit_ts_iso)
-                                    close_items.append((
-                                        _build_close_triples(
-                                            old_module_ident, old_desc, old_module_ident,
-                                            close_entity_type=True, file_value=old_path,
-                                        ),
-                                        orig_ts,
-                                    ))
-                                    # Purge the closed old module. Its remaining child
-                                    # entities under old_path are closed+purged by the
-                                    # renamed_old_paths pass below, which also pops the
-                                    # whole file_entities[old_path] key — so only the
-                                    # scalar dicts and the module's own list slot need
-                                    # dropping here.
-                                    _forget_closed_entity(
-                                        old_module_ident, old_path, entity_valid_from,
-                                        entity_descriptions, field_class_ident, file_entities,
-                                        field_static_ident,
-                                    )
-                                previous_idents = set(file_entities.get(file_path, []))
-                                triples = _build_code_triples(
-                                    file_path, extracted, commit_ts_iso, entity_valid_from,
-                                    entity_descriptions, file_entities, commit_ident, precomputed,
-                                    field_class_ident, field_static_ident,
-                                )
-                                add_triples.extend(triples)
-                                # Detect entities removed from a modified file.
-                                # _build_code_triples only appends to file_entities, never removes.
-                                # Compare previous idents against the idents derivable from the
-                                # current extraction to find what was deleted.
-                                if status == "M":
-                                    module_ident = _code_ident("module", file_path)
-                                    current_extracted_idents: set = {module_ident}
-                                    for fn_ident, _fn_name, _fn_triples in precomputed["function_entries"]:
-                                        current_extracted_idents.add(fn_ident)
-                                    for cls_ident, _cls_name, _cls_triples in precomputed["class_entries"]:
-                                        current_extracted_idents.add(cls_ident)
-                                    # Globals and fields are tracked in file_entities too
-                                    # (see _build_code_triples): omitting them here would
-                                    # make every still-present global/field look "removed"
-                                    # on any later edit and wrongly close it (#113).
-                                    for gvar_ident, _gvar_name, _gvar_triples in precomputed["global_entries"]:
-                                        current_extracted_idents.add(gvar_ident)
-                                    for field_ident, _field_name, _field_triples in precomputed["field_entries"]:
-                                        current_extracted_idents.add(field_ident)
-                                    removed_idents = previous_idents - current_extracted_idents
-                                    # An in-place rename (old->new in the same file) is
-                                    # closed with :renamed-to linkage by the renamed_pairs
-                                    # loop below; exclude those old idents here so they are
-                                    # not ALSO closed as a plain removal (double close).
-                                    same_file_renamed_old_idents = {
-                                        _code_ident(cat, o_file, o_name)
-                                        for cat, o_file, o_name, _n_file, _n_name in renamed_pairs
-                                        if o_file == file_path
-                                    }
-                                    removed_idents -= same_file_renamed_old_idents
-                                    for ident in removed_idents:
-                                        orig_ts = entity_valid_from.get(ident, commit_ts_iso)
-                                        desc = entity_descriptions.get(ident, "")
-                                        close_items.append(
-                                            (_build_close_triples(
-                                                ident, desc, module_ident,
-                                                field_class_ident.get(ident),
-                                                close_entity_type=True, file_value=file_path,
-                                                is_static=field_static_ident.get(ident),
-                                            ), orig_ts)
-                                        )
-                                        # File survives (M), only this child was removed:
-                                        # purge just this ident from the file's list.
-                                        _forget_closed_entity(
-                                            ident, file_path, entity_valid_from,
-                                            entity_descriptions, field_class_ident, file_entities,
-                                            field_static_ident,
-                                        )
-                                # Compute dep edges for this file and diff against previous.
-                                # Resolution itself already happened in _extract_commit
-                                # (precomputed["resolved_imports"]) against that commit's
-                                # own git-ls-tree state — nothing left to resolve here.
-                                module_ident = _code_ident("module", file_path)
-                                current_deps: set = set()
-                                for import_name, dep_ident, is_resolved in precomputed["resolved_imports"]:
-                                    if dep_ident != module_ident:
-                                        current_deps.add(dep_ident)
-                                        is_relative = import_name.startswith(".")
-                                        if not is_resolved and not is_relative and dep_ident not in entity_valid_from:
-                                            add_triples.extend([
-                                                f"[{dep_ident} :entity-type :type/external-dependency]",
-                                                f'[{dep_ident} :ident "{_edn_escape(dep_ident)}"]',
-                                                f'[{dep_ident} :description "{_edn_escape(import_name)}"]',
-                                            ])
-                                            entity_valid_from[dep_ident] = commit_ts_iso
-                                            entity_descriptions[dep_ident] = import_name
-                                            unresolved_dep_idents[dep_ident] = import_name
-                                            # #112: an already-known submodule may be the real
-                                            # target this unresolvable import was reaching for
-                                            # (submodule directories are never in file_entities,
-                                            # so any import into one always falls through here).
-                                            for sub_ident, sub_path in submodule_paths.items():
-                                                if _submodule_path_matches_import(sub_path, import_name):
-                                                    add_triples.append(f"[{dep_ident} :resolves-to {sub_ident}]")
-                                previous_deps = file_deps.get(file_path, set())
-                                for dep_ident in current_deps - previous_deps:
-                                    dep_add_triples.append(f"[{module_ident} :depends-on {dep_ident}]")
-                                    dep_valid_from[(module_ident, dep_ident)] = commit_ts_iso
-                                if status == "M":
-                                    for dep_ident in previous_deps - current_deps:
-                                        orig_ts = dep_valid_from.get((module_ident, dep_ident), commit_ts_iso)
-                                        close_items.append(
-                                            ([f"[{module_ident} :depends-on {dep_ident}]"], orig_ts)
-                                        )
-                                file_deps[file_path] = current_deps
-
-                        # Function/class rename linkage (Task 9's renamed_pairs).
-                        # Module-level linkage is handled separately per-file
-                        # above (Task 5) since it comes from git's own -M
-                        # detection, not this commit-wide matcher.
-                        for category, old_file, old_name, new_file, new_name in renamed_pairs:
-                            old_ident = _code_ident(category, old_file, old_name)
-                            new_ident = _code_ident(category, new_file, new_name)
-                            add_triples.append(f"[{new_ident} :renamed-from {old_ident}]")
-                            # :renamed-to becomes true at the rename commit and stays
-                            # open-ended thereafter — transact it via the add path, do
-                            # NOT fold it into the old entity's _ingest_close window.
-                            add_triples.append(f"[{old_ident} :renamed-to {new_ident}]")
-                            old_desc = entity_descriptions.get(old_ident, old_name)
-                            old_module_ident = _code_ident("module", old_file)
-                            orig_ts = entity_valid_from.get(old_ident, commit_ts_iso)
-                            close_items.append((
-                                _build_close_triples(
-                                    old_ident, old_desc, old_module_ident,
-                                    field_class_ident.get(old_ident),
-                                    close_entity_type=True, file_value=old_file,
-                                    is_static=field_static_ident.get(old_ident),
-                                ),
-                                orig_ts,
-                            ))
-                            _forget_closed_entity(
-                                old_ident, old_file, entity_valid_from,
-                                entity_descriptions, field_class_ident, file_entities,
-                                field_static_ident,
-                            )
-
-                        # A file rename (R status) only closes the old MODULE above.
-                        # Child entities and dependency edges under the old path are
-                        # closed here as plain removals UNLESS the matcher established
-                        # a rename continuity edge for them (handled with :renamed-to
-                        # by the loop above). This runs after renamed_pairs is fully
-                        # consumed so those confirmed renames can be excluded; without
-                        # it, unmatched old children/deps leak open forever under the
-                        # old path while new ones open under the new path.
-                        if renamed_old_paths:
-                            renamed_covered_idents = {
-                                _code_ident(cat, o_file, o_name)
-                                for cat, o_file, o_name, _n_file, _n_name in renamed_pairs
-                            }
-                            for r_old_path in renamed_old_paths:
-                                r_old_module_ident = _code_ident("module", r_old_path)
-                                # Iterate a copy: _forget_closed_entity mutates
-                                # file_entities[r_old_path] in place as it purges.
-                                for ident in list(file_entities.get(r_old_path, [])):
-                                    if ident == r_old_module_ident:
-                                        continue  # already closed+purged by the R block above
-                                    if ident in renamed_covered_idents:
-                                        continue  # already closed+purged with :renamed-to linkage
-                                    orig_ts = entity_valid_from.get(ident, commit_ts_iso)
-                                    desc = entity_descriptions.get(ident, "")
-                                    close_items.append(
-                                        (_build_close_triples(
-                                            ident, desc, r_old_module_ident,
-                                            field_class_ident.get(ident),
-                                            close_entity_type=True, file_value=r_old_path,
-                                            is_static=field_static_ident.get(ident),
-                                        ), orig_ts)
-                                    )
-                                    _forget_closed_entity(
-                                        ident, r_old_path, entity_valid_from,
-                                        entity_descriptions, field_class_ident, file_entities,
-                                        field_static_ident,
-                                    )
-                                # Whole old path is gone (renamed away): drop the key so
-                                # no stale ident lingers to be re-discovered by a later
-                                # commit that reuses this path (e.g. a shim at old_path).
-                                file_entities.pop(r_old_path, None)
-                                for dep_ident in file_deps.get(r_old_path, set()):
-                                    orig_ts = dep_valid_from.get((r_old_module_ident, dep_ident), commit_ts_iso)
-                                    close_items.append(
-                                        ([f"[{r_old_module_ident} :depends-on {dep_ident}]"], orig_ts)
-                                    )
-                                file_deps.pop(r_old_path, None)
-
-                        # Process gitlink changes (submodule add/bump/remove).
-                        # The "remove" case's interaction with the ordinary per-file module-open
-                        # logic (elsewhere in this loop) is only sound because real submodule paths
-                        # are extensionless (no tree-sitter parser matches them, so no module is
-                        # ever opened for a bare gitlink path) — a gitlink path that happened to
-                        # carry a recognized source extension is an untested, unreachable-in-practice edge case.
-                        for kind, sha, path in gitlink_changes:
-                            ext_ident = _code_ident("module", path)
-                            if kind == "add":
-                                info = gitmodules_map.get(path, {})
-                                name = info.get("name", "")
-                                url = info.get("url", "")
-                                description = name or path
-                                ext_triples = [
-                                    f"[{ext_ident} :entity-type :type/external-dependency]",
-                                    f'[{ext_ident} :ident "{_edn_escape(ext_ident)}"]',
-                                    f'[{ext_ident} :description "{_edn_escape(description)}"]',
-                                    f'[{ext_ident} :path "{_edn_escape(path)}"]',
-                                    f'[{ext_ident} :pinned-commit "{_edn_escape(sha)}"]',
-                                    f"[{ext_ident} :introduced-by {commit_ident}]",
-                                ]
-                                if name:
-                                    ext_triples.append(f'[{ext_ident} :submodule-name "{_edn_escape(name)}"]')
-                                if url:
-                                    ext_triples.append(f'[{ext_ident} :submodule-url "{_edn_escape(url)}"]')
-                                add_triples.extend(ext_triples)
-                                entity_valid_from[ext_ident] = commit_ts_iso
-                                entity_descriptions[ext_ident] = description
-                                pinned_commit_state[ext_ident] = (sha, commit_ts_iso)
-                                submodule_paths[ext_ident] = path
-                                # #112: link any pre-existing unresolved-import stub whose
-                                # import path reaches into this submodule — the ordering in
-                                # the issue's own repro (stub created before the submodule
-                                # was ever added), which the per-import check above can't
-                                # catch since the submodule wasn't known yet at that time.
-                                for stub_ident, import_name in unresolved_dep_idents.items():
-                                    if _submodule_path_matches_import(path, import_name):
-                                        add_triples.append(f"[{stub_ident} :resolves-to {ext_ident}]")
-                            elif kind == "bump":
-                                old_sha, orig_ts = pinned_commit_state.get(ext_ident, (None, commit_ts_iso))
-                                if old_sha is not None:
-                                    close_items.append(
-                                        ([f'[{ext_ident} :pinned-commit "{_edn_escape(old_sha)}"]'], orig_ts)
-                                    )
-                                add_triples.append(f'[{ext_ident} :pinned-commit "{_edn_escape(sha)}"]')
-                                add_triples.append(f"[{ext_ident} :modified-in {commit_ident}]")
-                                pinned_commit_state[ext_ident] = (sha, commit_ts_iso)
-                            else:  # "remove"
-                                orig_ts = entity_valid_from.get(ext_ident, commit_ts_iso)
-                                desc = entity_descriptions.get(ext_ident, "")
-                                close_items.append(
-                                    (_build_close_triples(
-                                        ext_ident, desc, ext_ident,
-                                        entity_type_kw=":type/external-dependency",
-                                        file_value=path,
-                                    ), orig_ts)
-                                )
-                                # Submodule removed: purge lifecycle state so a later
-                                # re-add at the same path is treated as genuinely new.
-                                # (Submodule paths aren't tracked in file_entities, so the
-                                # path arg is a no-op there, but pass it for consistency.)
-                                _forget_closed_entity(
-                                    ext_ident, path, entity_valid_from,
-                                    entity_descriptions, field_class_ident, file_entities,
-                                )
-                                old_sha, pin_orig_ts = pinned_commit_state.pop(ext_ident, (None, commit_ts_iso))
-                                if old_sha is not None:
-                                    close_items.append(
-                                        ([f'[{ext_ident} :pinned-commit "{_edn_escape(old_sha)}"]'], pin_orig_ts)
-                                    )
-
-                        # Split :contains triples out before batching.  Minigraf's EAVT
-                        # pending index lacks value bytes in the key, so batching multiple
-                        # [module :contains fn] facts in one transact silently drops all
-                        # but the last.  Each :contains triple gets its own transact so
-                        # they receive distinct tx_counts and avoid the index collision.
-                        contains_triples = [t for t in add_triples if ":contains" in t]
-                        other_triples = [t for t in add_triples if ":contains" not in t]
                         await loop.run_in_executor(
-                            write_executor, _ingest_transact, db, other_triples, commit_ts_iso, reason, index_con
+                            write_executor, _forward_apply, db, repo_path, state,
+                            (commit_hash, commit_ts_iso, author, subject),
+                            (extracted_files, gitlink_changes, gitmodules_map, renamed_pairs),
+                            index_con,
                         )
-                        for ct in contains_triples:
-                            await loop.run_in_executor(
-                                write_executor, _ingest_transact, db, [ct], commit_ts_iso, reason, index_con
-                            )
-                        # :depends-on triples transacted individually — same EAVT collision risk
-                        # as :contains when multiple deps share the same source module
-                        for dt in dep_add_triples:
-                            await loop.run_in_executor(
-                                write_executor, _ingest_transact, db, [dt], commit_ts_iso, reason, index_con
-                            )
-                        for close_triples, orig_ts in close_items:
-                            await loop.run_in_executor(
-                                write_executor, _ingest_close, db, close_triples, orig_ts, commit_ts_iso, reason, index_con
-                            )
-
-                        # Ingest :parent edges — one transact per parent to avoid EAVT
-                        # collision for merge commits (which have two parent hashes).
-                        # Routed through _transact (not a raw _db_execute call) so the
-                        # edge also lands in the persisted fact index -- see #118 review
-                        # finding: this call site used to build its own raw (transact
-                        # ...) string and bypass the index choke point entirely.
-                        try:
-                            for parent_hash in _git_parent_hashes(repo_path, commit_hash):
-                                parent_ident = f":commit/{parent_hash[:12]}"
-                                await loop.run_in_executor(
-                                    write_executor,
-                                    _transact,
-                                    db,
-                                    f'[[{commit_ident} :parent {parent_ident}]]',
-                                    commit_ts_iso,
-                                    None,
-                                    None,
-                                    index_con,
-                                )
-                        except Exception:
-                            pass  # non-fatal; parent edges are best-effort
-
-                        await loop.run_in_executor(write_executor, _watermark_update, db, commit_hash, commit_ts_iso, reason, index_con)
-                        await loop.run_in_executor(write_executor, _db_checkpoint, db)
-                        await loop.run_in_executor(write_executor, _commit_index_writer_safe, index_con)
 
                     except Exception as e:
                         # Ordinary per-commit write failure (malformed EDN, a

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7933,17 +7933,64 @@ def _forward_apply(
             # It is also semantically right on its own terms: the
             # valid_from Stream 2 recorded is a wrong guess, and must
             # never be used as an orig_ts for a close.
-            reconcilable = [
+            #
+            # state.provisional_idents is a PRELOAD SNAPSHOT (see
+            # _preload_provisional_idents), not the authority -- by the
+            # time this commit is reached, the entity may already have
+            # been confirmed authoritative in the DB (reconciled earlier
+            # in this same forward pass, or by a previous run's
+            # correction sweep) without the in-memory set knowing.
+            # Trusting the set alone would still pop entity_valid_from and
+            # hand the ident to _build_code_triples as "new" even though
+            # _forward_reconcile_provisional no-ops on an already-
+            # authoritative entity (see its own provisional check) --
+            # minting a SECOND :introduced-by alongside the authoritative
+            # one already there. That is exactly the two-value ambiguity
+            # _correction_sweep_apply fails safe on and never resolves,
+            # reintroduced through this door. So the set is kept only as
+            # a cheap prefilter; the DB (_lineage_is_provisional) is the
+            # authority actually consulted before an ident is treated as
+            # reconcilable. Every candidate that was in the set is
+            # evicted below regardless of whether it survives that
+            # check -- a stale entry left in place would be retried, and
+            # fail the same way, on every later commit that touches the
+            # entity.
+            candidate_in_set = [
                 ident for ident in _forward_candidate_idents(precomputed)
                 if ident in state.provisional_idents
             ]
+            reconcilable = [
+                ident for ident in candidate_in_set
+                if _lineage_is_provisional(db, ident)
+            ]
+            # Built once per file rather than scanned per ident (matches
+            # _reverse_fill_claim_and_process's candidate_triples_by_ident
+            # precedent) -- a per-ident linear scan here is O(n^2) per file
+            # once there is more than one reconcilable entity.
+            structural_triples_by_ident = (
+                _forward_structural_triples_by_ident(precomputed) if reconcilable else {}
+            )
             for ident in reconcilable:
                 state.entity_valid_from.pop(ident, None)
+                if ident not in structural_triples_by_ident:
+                    # Unreachable in normal operation: _forward_candidate_idents
+                    # and _forward_structural_triples_by_ident scan the same
+                    # five sources. If they ever desynchronize, failing loudly
+                    # beats a silent [] -- that would let
+                    # _forward_reconcile_provisional retract the guess and
+                    # confirm lineage while skipping the re-dating, stranding
+                    # structural facts at the wrong valid-time.
+                    raise RuntimeError(
+                        f"_forward_structural_triples_by_ident has no entry for "
+                        f"{ident!r}, but it came from _forward_candidate_idents, "
+                        "which scans the same five sources -- the two have "
+                        "desynchronized"
+                    )
                 _forward_reconcile_provisional(
-                    db, ident,
-                    _forward_structural_triples(precomputed, ident),
+                    db, ident, structural_triples_by_ident[ident],
                     commit_ts_iso, state.ts_by_commit_ident, index_con=index_con,
                 )
+            for ident in candidate_in_set:
                 state.provisional_idents.discard(ident)
             triples = _build_code_triples(
                 file_path, extracted, commit_ts_iso, state.entity_valid_from,
@@ -8230,9 +8277,11 @@ def _forward_apply(
 
 def _forward_candidate_idents(precomputed: Dict[str, Any]) -> List[str]:
     """Every entity ident a parsed file contributes -- module plus all four
-    child categories. Same collection _reverse_fill_claim_and_process and
-    _correction_sweep_apply perform; kept as one function so the three walks
-    cannot drift on what an entity's candidate set is."""
+    child categories. Mirrors the identical collection kept inline in
+    _reverse_fill_claim_and_process (its own local `candidate_idents`) and in
+    _correction_sweep_apply (same name, same construction) -- those two are
+    NOT wired to call this helper (considered and declined, #222 phase 2d
+    Task 5 review), so all three must be kept in sync by hand."""
     return (
         [precomputed["module_ident"]]
         + [ident for ident, _name, _t in precomputed["function_entries"]]
@@ -8242,17 +8291,24 @@ def _forward_candidate_idents(precomputed: Dict[str, Any]) -> List[str]:
     )
 
 
-def _forward_structural_triples(precomputed: Dict[str, Any], ident: str) -> List[str]:
-    """ident's own candidate triples, for re-dating. A child's own list
-    carries its [parent :contains child] edge, so re-dating a child re-dates
-    its containment edge with it (#222 phase 2b1)."""
-    if ident == precomputed["module_ident"]:
-        return list(precomputed["module_candidate_triples"])
+def _forward_structural_triples_by_ident(precomputed: Dict[str, Any]) -> Dict[str, List[str]]:
+    """Every candidate ident's own structural triples, for re-dating, built
+    once per file instead of scanned per ident (#222 phase 2d Task 5 fix --
+    the previous per-ident linear scan was O(n^2) per file once more than one
+    entity needed reconciling). Matches the existing precedent in
+    _reverse_fill_claim_and_process's candidate_triples_by_ident, which
+    builds the same shape of dict from the same five sources.
+
+    A child's own list carries its [parent :contains child] edge, so
+    re-dating a child re-dates its containment edge with it (#222 phase
+    2b1)."""
+    by_ident: Dict[str, List[str]] = {
+        precomputed["module_ident"]: list(precomputed["module_candidate_triples"]),
+    }
     for entries_key in ("function_entries", "class_entries", "global_entries", "field_entries"):
         for entry_ident, _entry_name, entry_triples in precomputed[entries_key]:
-            if entry_ident == ident:
-                return list(entry_triples)
-    return []
+            by_ident[entry_ident] = list(entry_triples)
+    return by_ident
 
 
 _CORRECTION_SWEEP_THROUGH_IDENT = ":ingestion/correction-sweep-through"

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7847,6 +7847,7 @@ def _forward_apply(
     index_con: Optional[Any] = None,
     linearization: Optional[List[str]] = None,
     pos: Optional[int] = None,
+    lifecycle_only: bool = False,
 ) -> None:
     """Apply one commit's forward-walk writes.
 
@@ -7862,13 +7863,53 @@ def _forward_apply(
     frontier-low claim and advances the lineage-confirmed-through watermark;
     both default to None so the existing tests that call this function with a
     bare commit tuple stay valid.
+
+    lifecycle_only (#222 phase 2d, Stage B) restricts this to the facts the
+    REVERSE stream never wrote for a commit in frontier-high's territory --
+    deletions, renames, dependency-edge churn and gitlink changes -- while
+    leaving that commit's "A"/"M" entity facts alone. It is not a re-run of
+    the forward body: nothing wrote D/R or gitlink facts for these commits,
+    so there is nothing to deduplicate against, whereas re-running the A/M
+    emission WOULD duplicate (minigraf mints a genuinely live duplicate when
+    the same (entity, attribute, value) is re-transacted at a different
+    valid-from -- issue #156). Concretely, when true:
+
+    * The commit's own :type/commit entity and its :parent edges are skipped
+      -- _reverse_apply already wrote both for every commit in this range
+      (the same reason _correction_sweep_apply gives for not writing them).
+    * "D" files, "R" files and gitlink changes are processed unchanged. "R"
+      keeps its _build_code_triples emission for the NEW path: the reverse
+      stream skipped renames entirely, so nothing ever wrote those entities.
+    * "A"/"M" files still CALL _build_code_triples, and its returned triples
+      are DISCARDED. This looks redundant and is not: state.entity_valid_from
+      after Stage A covers only positions 0..meeting_point, so an entity
+      introduced INSIDE the reverse region is absent from it and a later
+      deletion of that entity within the same region would close with
+      orig_ts falling back to the delete commit's own timestamp -- a wrong,
+      often zero-width valid interval. Calling the function and dropping its
+      output keeps entity_valid_from / entity_descriptions / file_entities /
+      field_class_ident / field_static_ident current at zero fact cost, and
+      the sweep's ascending order makes the recorded timestamp the correct
+      EARLIEST one (_build_code_triples only writes entity_valid_from[ident]
+      when the ident is not already present).
+    * Provisional-lineage reconciliation is skipped for "A"/"M" --
+      _correction_sweep_apply owns those entities' lineage and has already
+      run for this commit. It is still performed for an "R" file's new path,
+      where the reverse stream may hold a provisional guess at a LATER
+      commit that this rename supersedes; there the DB is consulted
+      directly, because state.provisional_idents is a run-start preload
+      snapshot and is empty on a fresh ingest.
+    * _watermark_update, _frontier_persist_claim and
+      _lineage_confirmed_through_update are skipped. Stage B tracks its own
+      progress through :ingestion/correction-sweep-through, and the forward
+      frontier must not appear to advance into the reverse region.
     """
     commit_hash, commit_ts_iso, author, subject = commit
     extracted_files, gitlink_changes, gitmodules_map, renamed_pairs = extracted
     commit_ident = f":commit/{commit_hash[:12]}"
     reason = f"git:{commit_hash} {author}: {subject}"
 
-    add_triples: List[str] = [
+    add_triples: List[str] = [] if lifecycle_only else [
         f"[{commit_ident} :entity-type :type/commit]",
         f'[{commit_ident} :ident "{commit_ident}"]',
         f'[{commit_ident} :description "{_edn_escape(subject[:120])}"]',
@@ -7984,14 +8025,34 @@ def _forward_apply(
             # check -- a stale entry left in place would be retried, and
             # fail the same way, on every later commit that touches the
             # entity.
-            candidate_in_set = [
-                ident for ident in _forward_candidate_idents(precomputed)
-                if ident in state.provisional_idents
-            ]
-            reconcilable = [
-                ident for ident in candidate_in_set
-                if _lineage_is_provisional(db, ident)
-            ]
+            #
+            # lifecycle_only (Stage B): _correction_sweep_apply owns "A"/"M"
+            # lineage and has already run for this very commit, so
+            # reconciling here would mint a second :introduced-by behind its
+            # back. An "R" file's NEW path is the one case that still needs
+            # it -- nothing wrote those entities in Stage A, so the reverse
+            # stream's provisional guess (if any) sits at a LATER commit that
+            # this rename supersedes. state.provisional_idents cannot be the
+            # prefilter there: it is a run-start snapshot, empty on a fresh
+            # ingest, and the guess was made during this same run.
+            if lifecycle_only:
+                candidate_in_set = []
+                reconcilable = (
+                    [
+                        ident for ident in _forward_candidate_idents(precomputed)
+                        if _lineage_is_provisional(db, ident)
+                    ]
+                    if status == "R" else []
+                )
+            else:
+                candidate_in_set = [
+                    ident for ident in _forward_candidate_idents(precomputed)
+                    if ident in state.provisional_idents
+                ]
+                reconcilable = [
+                    ident for ident in candidate_in_set
+                    if _lineage_is_provisional(db, ident)
+                ]
             # Built once per file rather than scanned per ident (matches
             # _reverse_fill_claim_and_process's candidate_triples_by_ident
             # precedent) -- a per-ident linear scan here is O(n^2) per file
@@ -8026,7 +8087,12 @@ def _forward_apply(
                 state.entity_descriptions, state.file_entities, commit_ident, precomputed,
                 state.field_class_ident, state.field_static_ident,
             )
-            add_triples.extend(triples)
+            # lifecycle_only: called for its dict side effects, output
+            # DISCARDED for "A"/"M" (see this function's docstring). "R" keeps
+            # it -- the reverse stream skipped renames entirely, so nothing
+            # ever wrote the new path's entities.
+            if not lifecycle_only or status == "R":
+                add_triples.extend(triples)
             # Detect entities removed from a modified file.
             # _build_code_triples only appends to state.file_entities, never removes.
             # Compare previous idents against the idents derivable from the
@@ -8285,31 +8351,41 @@ def _forward_apply(
     # edge also lands in the persisted fact index -- see #118 review
     # finding: this call site used to build its own raw (transact
     # ...) string and bypass the index choke point entirely.
-    try:
-        for parent_hash in _git_parent_hashes(repo_path, commit_hash):
-            parent_ident = f":commit/{parent_hash[:12]}"
-            _transact(
-                db,
-                f'[[{commit_ident} :parent {parent_ident}]]',
-                commit_ts_iso,
-                None,
-                None,
-                index_con,
-            )
-    except Exception:
-        pass  # non-fatal; parent edges are best-effort
+    # lifecycle_only: _reverse_apply already wrote this commit's :parent
+    # edges (and its :type/commit entity, skipped at the top of this
+    # function) for every commit in frontier-high's territory.
+    if not lifecycle_only:
+        try:
+            for parent_hash in _git_parent_hashes(repo_path, commit_hash):
+                parent_ident = f":commit/{parent_hash[:12]}"
+                _transact(
+                    db,
+                    f'[[{commit_ident} :parent {parent_ident}]]',
+                    commit_ts_iso,
+                    None,
+                    None,
+                    index_con,
+                )
+        except Exception:
+            pass  # non-fatal; parent edges are best-effort
 
-    _watermark_update(db, commit_hash, commit_ts_iso, reason, index_con)
-    if linearization is not None and pos is not None:
-        _frontier_persist_claim(
-            db, linearization, pos, from_low=True,
-            commit_ts_iso=commit_ts_iso, index_con=index_con,
-        )
-    # The virgin positions this walk claims are authoritative on first write,
-    # so lineage is confirmed contiguously from C0 through here. The sweep
-    # folds its own region in later (Task 9); this watermark must not be
-    # advanced past the forward frontier before that happens.
-    _lineage_confirmed_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)
+    # lifecycle_only: Stage B tracks its own progress through
+    # :ingestion/correction-sweep-through (written by _correction_sweep_apply),
+    # and none of these three watermarks may advance into the reverse region --
+    # :ingestion/watermark and :ingestion/lineage-confirmed-through both mean
+    # "contiguous from C0", and frontier-low belongs to the forward stream.
+    if not lifecycle_only:
+        _watermark_update(db, commit_hash, commit_ts_iso, reason, index_con)
+        if linearization is not None and pos is not None:
+            _frontier_persist_claim(
+                db, linearization, pos, from_low=True,
+                commit_ts_iso=commit_ts_iso, index_con=index_con,
+            )
+        # The virgin positions this walk claims are authoritative on first write,
+        # so lineage is confirmed contiguously from C0 through here. The sweep
+        # folds its own region in later (Task 9); this watermark must not be
+        # advanced past the forward frontier before that happens.
+        _lineage_confirmed_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)
     _db_checkpoint(db)
     _commit_index_writer_safe(index_con)
 
@@ -8689,6 +8765,29 @@ def _correction_sweep_walk(
         skipped_events += call_skipped
     _correction_sweep_log_summary(skipped_events)
     return commits_processed, skipped_events
+
+
+def _should_fold_lineage_watermark(db: Any, linearization: List[str]) -> bool:
+    """True iff the correction sweep genuinely reached frontier-high's own
+    :hi-hash, so :ingestion/lineage-confirmed-through may be folded forward
+    to it.
+
+    Stage B's loop exit alone must NOT trigger the fold.
+    _correction_sweep_select_position returns None for six different
+    reasons, only one of which is "reached the ceiling": it also returns
+    None when frontier-high is absent, when either boundary hash is stale
+    (rewritten history), when the gap is still open, and when
+    commit_metadata violates its contract. Folding on any None would report
+    lineage as confirmed through HEAD in exactly the situations where the
+    sweep did no work at all.
+    """
+    high_bounds = _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT)
+    if high_bounds is None:
+        return False
+    through_hash = _correction_sweep_through_query(db)
+    if through_hash is None:
+        return False
+    return through_hash == high_bounds[1] and through_hash in set(linearization)
 
 
 _DEFAULT_STREAM_RATIO = (1, 1)
@@ -9076,6 +9175,84 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
 
                     _ingest_progress["processed"] += 1
                     await asyncio.sleep(0)  # yield to event loop
+
+                # Stage B: the correction sweep. A third, strictly
+                # SEQUENTIAL pass, not a third concurrent task -- claim_low()
+                # and claim_high() partition one shared gap, so no sequence of
+                # forward claims can reach territory the reverse stream
+                # already claimed, and the sweep's own precondition is that
+                # the gap is already closed.
+                #
+                # Drives 2c's three pieces directly on their correct
+                # executors. _correction_sweep_claim_and_process and
+                # _correction_sweep_walk must NOT be used here: both fuse the
+                # CPU-bound parse and the DB-bound writes into one body.
+                if completed_all:
+                    _ingest_progress["phase"] = "sweeping"
+                    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+                    skipped = 0
+                    db = await _ensure_db_async()
+                    try:
+                        while not _shutdown_requested.is_set():
+                            selected = await loop.run_in_executor(
+                                write_executor, _correction_sweep_select_position,
+                                db, linearization, commit_metadata, hash_to_pos,
+                            )
+                            if selected is None:
+                                break
+                            sweep_hash, sweep_ts = selected
+                            try:
+                                sweep_extracted = await loop.run_in_executor(
+                                    executor, _extract_commit, repo_path, sweep_hash, ignore_patterns,
+                                )
+                                sweep_files = sweep_extracted[0]
+                                skipped += await loop.run_in_executor(
+                                    write_executor, _correction_sweep_apply,
+                                    db, sweep_hash, sweep_ts, sweep_files, index_con, skipped,
+                                )
+                                # Apply the lifecycle facts the reverse stream
+                                # skipped entirely (D/R closes, renames,
+                                # dependency-edge churn, gitlink changes).
+                                # Fresh writes, not re-application -- nothing
+                                # wrote them for these commits. Runs AFTER the
+                                # A/M reconciliation above so an entity's
+                                # lineage is already authoritative before a
+                                # close in the same commit reads its window.
+                                await loop.run_in_executor(
+                                    write_executor, _forward_apply, db, repo_path, state,
+                                    commit_metadata[hash_to_pos[sweep_hash]],
+                                    sweep_extracted, index_con, None, None, True,
+                                )
+                            except concurrent.futures.process.BrokenProcessPool:
+                                raise
+                            except Exception as e:
+                                # A sweep-step failure aborts Stage B only.
+                                # Stage A's work is already persisted, and the
+                                # next run resumes from the sweep watermark.
+                                print(
+                                    f"[_run_ingestion] correction sweep aborted at {sweep_hash}: {e}",
+                                    file=sys.stderr,
+                                )
+                                completed_all = False
+                                break
+                            await asyncio.sleep(0)  # yield to event loop
+                        if _shutdown_requested.is_set():
+                            completed_all = False
+                        _correction_sweep_log_summary(skipped)
+                        # DB-bound like everything else here, so it runs on
+                        # write_executor rather than inline on the event loop.
+                        should_fold = completed_all and await loop.run_in_executor(
+                            write_executor, _should_fold_lineage_watermark, db, linearization,
+                        )
+                        if should_fold:
+                            await loop.run_in_executor(
+                                write_executor, _lineage_confirmed_through_update,
+                                db, linearization[-1], commit_metadata[-1][1], index_con,
+                            )
+                            await loop.run_in_executor(write_executor, _db_checkpoint, db)
+                    finally:
+                        _db = None
+                        db = None
 
                 # Call _ingest_tags and _last_run_write before closing index_con
                 # so they use the batched connection instead of opening new ones

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5335,6 +5335,118 @@ def _entity_introduced_by_set_provisional(
     _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
 
 
+def _re_date_structural_facts(
+    db: Any,
+    structural_triples: List[str],
+    new_ts_iso: str,
+    index_con: Optional[Any] = None,
+) -> None:
+    """Retract and re-assert an entity's structural facts at new_ts_iso.
+
+    Used whenever a provisional :introduced-by guess moves to an earlier
+    commit -- by _reverse_apply when the reverse walk finds an even earlier
+    occurrence, and by _forward_reconcile_provisional when the forward walk
+    reaches the true introduction. In both cases the facts were written at
+    the timestamp of the commit where the entity was first SIGHTED, which is
+    later than the introduction now is, leaving a valid-time window where
+    :introduced-by is live for an entity with no type, name or file -- so
+    ":as-of the introduction" reports it as nonexistent.
+
+    _retract targets live rows regardless of their original valid_from, so
+    this is a straight re-assert at the earlier timestamp.
+
+    :contains is retracted and transacted ONE TRIPLE PER CALL, on both
+    sides. Minigraf's EAVT pending index omits value bytes, so facts sharing
+    (entity, attribute, valid_from) in one call collapse to the last -- see
+    #222 phase 2b1, where this cost five of six containment edges on an
+    ordinary multi-entity file, permanently.
+    """
+    contains = [t for t in structural_triples if ":contains" in t]
+    other = [t for t in structural_triples if ":contains" not in t]
+    if other:
+        _retract(db, "[" + " ".join(other) + "]", index_con=index_con)
+        _transact(db, "[" + " ".join(other) + "]", new_ts_iso, index_con=index_con)
+    for triple in contains:
+        _retract(db, "[" + triple + "]", index_con=index_con)
+        _transact(db, "[" + triple + "]", new_ts_iso, index_con=index_con)
+
+
+def _forward_reconcile_provisional(
+    db: Any,
+    entity_ident: str,
+    structural_triples: List[str],
+    true_commit_ts_iso: str,
+    ts_by_commit_ident: Dict[str, str],
+    index_con: Optional[Any] = None,
+) -> Optional[str]:
+    """#222 phase 2d: the forward walk has reached entity_ident's TRUE
+    introduction and found a provisional guess left by Stream 2. Clear the
+    guess so the caller's normal authoritative emission is the only
+    :introduced-by fact that survives.
+
+    Returns the superseded guess's commit ident, or None if entity_ident was
+    not provisional (in which case nothing is written at all).
+
+    Deliberately does NOT write the authoritative :introduced-by itself --
+    the caller's ordinary _build_code_triples output does that, so there is
+    exactly one code path that mints an authoritative introduction and this
+    function cannot drift from it.
+
+    Mirrors the supersede path in _reverse_fill_claim_and_process: the same
+    re-dating of structural facts, the same one-transact-per-:contains
+    splitting, and the same refusal to back-date a :modified-in edge whose
+    commit timestamp is unknown.
+    """
+    guess_ident = _entity_introduced_by_query(db, entity_ident)
+    if not _lineage_is_provisional(db, entity_ident):
+        return None
+
+    # 1. Drop the guess. The caller writes the real one immediately after.
+    if guess_ident is not None:
+        _retract(db, f"[[{entity_ident} :introduced-by {guess_ident}]]", index_con=index_con)
+
+    # 2. Re-date structural facts to the true (earlier) introduction.
+    _re_date_structural_facts(
+        db,
+        [t for t in structural_triples if ":introduced-by" not in t],
+        true_commit_ts_iso,
+        index_con=index_con,
+    )
+
+    # 3. The entity's lineage is authoritative from here on.
+    _lineage_confirm(db, entity_ident, index_con=index_con)
+
+    if guess_ident is None:
+        return None
+
+    # 4. The candidate-diff record is stale the moment the guess moves off it,
+    # and this is the cheapest place to drop it -- guess_ident is right here.
+    _candidate_diff_clear(db, guess_ident[len(":commit/"):], entity_ident, index_con=index_con)
+
+    # 5. The guess commit is now known to be a genuine modification rather
+    # than the introduction, so it earns the :modified-in edge Stream 2
+    # withheld from it. Dated at ITS OWN timestamp, not this commit's.
+    #
+    # This inherits 2b's documented over-assertion: #221's unchanged-body
+    # narrowing cannot be re-checked against the guess commit's own diff,
+    # because only that commit's own parse carries the data. That is already
+    # owned -- the guess commit lies inside frontier-high's territory, so the
+    # correction sweep visits it, finds exactly one :introduced-by (case 3),
+    # and retracts this edge if its own parse says the body was unchanged.
+    guess_ts = ts_by_commit_ident.get(guess_ident)
+    if guess_ts is None:
+        print(
+            f"[_forward_reconcile_provisional] skipping retroactive :modified-in "
+            f"for {entity_ident} at {guess_ident}: no timestamp in commit_metadata",
+            file=sys.stderr,
+        )
+        return guess_ident
+    _transact(
+        db, f"[[{entity_ident} :modified-in {guess_ident}]]", guess_ts, index_con=index_con,
+    )
+    return guess_ident
+
+
 _LAST_RUN_KEYWORD_ATTRS = frozenset({":entity-type"})
 _LAST_RUN_NUMERIC_ATTRS = frozenset({":total-ingested"})
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5393,10 +5393,9 @@ def _forward_reconcile_provisional(
     exactly one code path that mints an authoritative introduction and this
     function cannot drift from it.
 
-    Mirrors the supersede path in _reverse_fill_claim_and_process: the same
-    re-dating of structural facts, the same one-transact-per-:contains
-    splitting, and the same refusal to back-date a :modified-in edge whose
-    commit timestamp is unknown.
+    Mirrors the supersede path in _reverse_apply: the same re-dating of
+    structural facts (via _re_date_structural_facts), and the same refusal
+    to back-date a :modified-in edge whose commit timestamp is unknown.
     """
     guess_ident = _entity_introduced_by_query(db, entity_ident)
     if not _lineage_is_provisional(db, entity_ident):
@@ -7453,36 +7452,43 @@ def _extract_commit(
     return results, gitlink_changes, gitmodules_map, renamed_pairs
 
 
-def _reverse_fill_claim_and_process(
+def _reverse_apply(
     db: Any,
     repo_path: str,
     linearization: List[str],
     commit_metadata: List[Tuple[str, str, str, str]],
-    allocator: "frontier_registry.FrontierAllocator",
-    ignore_patterns: Sequence[str] = (),
+    pos: int,
+    file_results: List[tuple],
     index_con: Optional[Any] = None,
-) -> Optional[str]:
-    """#222 phase 2b: claim exactly one position from the gap's high end
-    (allocator.claim_high()) and process that one commit -- structural
-    facts, :modified-in edges, provisional :introduced-by, and candidate-diff
-    records for every entity the commit's "A"/"M" files touch. "D"/"R"
-    files are skipped entirely (deletions and renames are out of scope for
-    this sub-phase -- see the design spec).
+) -> str:
+    """#222 phase 2b: apply one already-claimed, already-extracted commit --
+    structural facts, :modified-in edges, provisional :introduced-by, and
+    candidate-diff records for every entity the commit's "A"/"M" files
+    touch. "D"/"R" files are skipped entirely (deletions and renames are
+    out of scope for this sub-phase -- see the design spec).
 
-    Reuses _extract_commit/_build_code_triples unchanged for entity
-    discovery/parsing (direction-agnostic). BOTH :introduced-by and
-    :modified-in are filtered out of _build_code_triples's own output and
-    written by this function instead -- _build_code_triples's gate for
-    both attributes is entity_valid_from membership, which for forward
-    walk coincides with "is this the introduction commit" but for reverse
-    walk does not: the first commit reverse walk sees an entity at is the
-    newest touch (not the introduction), and the commit where reverse walk
-    finally stops finding an even-earlier occurrence (the true
-    introduction) is by then already "known" from later, already-visited
-    commits. Reusing _build_code_triples's :modified-in emission verbatim
-    would misclassify both ends. See the design spec's "Per-commit
-    algorithm" section (revised after the final whole-branch review found
-    this defect) for the full derivation.
+    Split out of _reverse_fill_claim_and_process's single body (#222 phase
+    2d): `pos` (from allocator.claim_high()) and `file_results` (from
+    _extract_commit) are now supplied by the caller instead of produced
+    here, so the CPU-bound tree-sitter parse and these DB-bound writes can
+    be scheduled onto separate executors. See
+    _reverse_fill_claim_and_process's own docstring for why that split
+    matters and who is responsible for driving each half.
+
+    Reuses _build_code_triples unchanged for entity discovery/parsing
+    (direction-agnostic). BOTH :introduced-by and :modified-in are filtered
+    out of _build_code_triples's own output and written by this function
+    instead -- _build_code_triples's gate for both attributes is
+    entity_valid_from membership, which for forward walk coincides with
+    "is this the introduction commit" but for reverse walk does not: the
+    first commit reverse walk sees an entity at is the newest touch (not
+    the introduction), and the commit where reverse walk finally stops
+    finding an even-earlier occurrence (the true introduction) is by then
+    already "known" from later, already-visited commits. Reusing
+    _build_code_triples's :modified-in emission verbatim would misclassify
+    both ends. See the design spec's "Per-commit algorithm" section
+    (revised after the final whole-branch review found this defect) for
+    the full derivation.
 
     :introduced-by: a newly-discovered entity's guess is asserted via
     _entity_introduced_by_set_provisional and gets no :modified-in yet
@@ -7514,12 +7520,11 @@ def _reverse_fill_claim_and_process(
     an intermediate draft of 2c's spec dropped the case entirely, leaving it
     briefly owned by nobody (see the 2b review).
 
-    Returns the claimed commit's hash, or None if the gap was already
-    empty (allocator.claim_high() returned None) -- caller's signal to
-    stop. Writes for one commit are followed by exactly one
-    _db_checkpoint(db) call, after _frontier_persist_claim records the
-    claim -- mirrors _run_ingestion's one-checkpoint-per-commit cadence
-    (see the design spec's "Resume-safety / atomicity boundary" section).
+    Returns the applied commit's hash. Writes for one commit are followed
+    by exactly one _db_checkpoint(db) call, after _frontier_persist_claim
+    records the claim -- mirrors _run_ingestion's one-checkpoint-per-commit
+    cadence (see the design spec's "Resume-safety / atomicity boundary"
+    section).
     """
     # commit_metadata is indexed POSITIONALLY against linearization below,
     # while _frontier_persist_claim persists linearization[pos] -- so a
@@ -7527,20 +7532,16 @@ def _reverse_fill_claim_and_process(
     # persist another: silent, systematic misattribution. _run_ingestion
     # builds a watermark-relative list for its own use
     # (_git_commits(repo, watermark, branch)), which is exactly the wrong
-    # thing to hand this function. Checked before claim_high() so a bad call
-    # does not consume a position. This raises rather than returning None
-    # (2c's mirror-image guard returns None) because 2c selects its own
-    # position and can decline, whereas this walk has been handed one.
+    # thing to hand this function. _reverse_fill_claim_and_process checks
+    # this before claim_high() so a bad call does not consume a position;
+    # this copy is duplicated here because 2d calls _reverse_apply directly,
+    # after already claiming pos itself.
     if len(commit_metadata) != len(linearization):
         raise ValueError(
             "commit_metadata must be full-history and positionally aligned with "
             f"linearization (got {len(commit_metadata)} entries vs {len(linearization)}); "
             "pass _git_commits(repo, watermark_hash=None)"
         )
-
-    pos = allocator.claim_high()
-    if pos is None:
-        return None
 
     commit_hash, commit_ts_iso, author, subject = commit_metadata[pos]
     if commit_hash != linearization[pos]:
@@ -7549,10 +7550,6 @@ def _reverse_fill_claim_and_process(
             f"{linearization[pos]}: the two must be positionally aligned"
         )
     commit_ident = f":commit/{commit_hash[:12]}"
-
-    file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
-        repo_path, commit_hash, ignore_patterns
-    )
 
     all_triples: List[str] = [
         f"[{commit_ident} :entity-type :type/commit]",
@@ -7673,7 +7670,7 @@ def _reverse_fill_claim_and_process(
         intro_pos = pos_by_commit_ident.get(intro_ident) if intro_ident is not None else None
         if intro_pos is not None and pos <= intro_pos:
             print(
-                f"[_reverse_fill_claim_and_process] skipping :modified-in for {ident} at "
+                f"[_reverse_apply] skipping :modified-in for {ident} at "
                 f"position {pos}: not later than its introduction {intro_ident} "
                 f"(position {intro_pos})",
                 file=sys.stderr,
@@ -7708,32 +7705,17 @@ def _reverse_fill_claim_and_process(
             superseded_pos = pos_by_commit_ident.get(superseded_ident)
             if superseded_pos is None or superseded_pos > pos:
                 # The move happened: this commit is genuinely earlier.
-                #
                 # Re-date the entity's structural facts to match (#222 phase
-                # 2b1). They were written at the timestamp of the commit
+                # 2b1) -- see _re_date_structural_facts's own docstring for
+                # why (they were written at the timestamp of the commit
                 # where the walk first SIGHTED the entity, which is later
-                # than the guess now is -- leaving a valid-time window where
-                # :introduced-by is live for an entity with no type, name or
-                # file, so ":as-of the introduction" says it did not exist.
-                # _retract targets live rows regardless of their original
-                # valid_from, so this is a straight re-assert at the earlier
-                # timestamp. :contains goes one per call for the same EAVT
-                # reason as above, on the retract side too (see
-                # _ingest_close's docstring).
-                structural = [
-                    t for t in candidate_triples_by_ident.get(ident, [])
-                    if ":introduced-by" not in t
-                ]
-                structural_contains = [t for t in structural if ":contains" in t]
-                structural_other = [t for t in structural if ":contains" not in t]
-                if structural_other:
-                    _retract(db, "[" + " ".join(structural_other) + "]", index_con=index_con)
-                    _transact(
-                        db, "[" + " ".join(structural_other) + "]", commit_ts_iso, index_con=index_con,
-                    )
-                for structural_triple in structural_contains:
-                    _retract(db, "[" + structural_triple + "]", index_con=index_con)
-                    _transact(db, "[" + structural_triple + "]", commit_ts_iso, index_con=index_con)
+                # than the guess now is).
+                _re_date_structural_facts(
+                    db,
+                    [t for t in candidate_triples_by_ident.get(ident, []) if ":introduced-by" not in t],
+                    commit_ts_iso,
+                    index_con=index_con,
+                )
 
                 # The superseded candidate-diff record is stale the moment
                 # the guess moves off it, and this is the cheapest place to
@@ -7756,7 +7738,7 @@ def _reverse_fill_claim_and_process(
                 # to before the modification it describes -- a fact asserted
                 # valid before it was true. Skip and say so instead.
                 print(
-                    f"[_reverse_fill_claim_and_process] skipping retroactive :modified-in "
+                    f"[_reverse_apply] skipping retroactive :modified-in "
                     f"for {ident} at {superseded_ident}: no timestamp in commit_metadata",
                     file=sys.stderr,
                 )
@@ -7768,6 +7750,45 @@ def _reverse_fill_claim_and_process(
     _frontier_persist_claim(db, linearization, pos, from_low=False, commit_ts_iso=commit_ts_iso, index_con=index_con)
     _db_checkpoint(db)
     return commit_hash
+
+
+def _reverse_fill_claim_and_process(
+    db: Any,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: List[Tuple[str, str, str, str]],
+    allocator: "frontier_registry.FrontierAllocator",
+    ignore_patterns: Sequence[str] = (),
+    index_con: Optional[Any] = None,
+) -> Optional[str]:
+    """Synchronous convenience wrapper: claim one position from the gap's
+    high end and process it. Kept for tests and _reverse_bulk_fill_walk.
+
+    **2d must not call this from async code** -- it fuses the CPU-bound
+    tree-sitter parse and the DB-bound writes into one function body, so it
+    can only be scheduled onto one executor as a unit. On write_executor (a
+    thread) that parse holds the GIL for its whole duration, which is
+    exactly the event-loop starvation #116 introduced the process pool to
+    fix. 2d awaits _extract_commit on the process pool and _reverse_apply on
+    write_executor instead. Same caveat 2c's own wrappers carry.
+
+    Returns the claimed commit's hash, or None if the gap was already empty.
+    """
+    if len(commit_metadata) != len(linearization):
+        raise ValueError(
+            "commit_metadata must be full-history and positionally aligned with "
+            f"linearization (got {len(commit_metadata)} entries vs {len(linearization)}); "
+            "pass _git_commits(repo, watermark_hash=None)"
+        )
+    pos = allocator.claim_high()
+    if pos is None:
+        return None
+    file_results, _gitlink_changes, _gitmodules_map, _renamed_pairs = _extract_commit(
+        repo_path, linearization[pos], ignore_patterns
+    )
+    return _reverse_apply(
+        db, repo_path, linearization, commit_metadata, pos, file_results, index_con=index_con,
+    )
 
 
 def _reverse_bulk_fill_walk(
@@ -8278,7 +8299,8 @@ def _forward_apply(
 def _forward_candidate_idents(precomputed: Dict[str, Any]) -> List[str]:
     """Every entity ident a parsed file contributes -- module plus all four
     child categories. Mirrors the identical collection kept inline in
-    _reverse_fill_claim_and_process (its own local `candidate_idents`) and in
+    _reverse_apply (its own local `candidate_idents`, moved verbatim out of
+    _reverse_fill_claim_and_process by #222 phase 2d Task 6) and in
     _correction_sweep_apply (same name, same construction) -- those two are
     NOT wired to call this helper (considered and declined, #222 phase 2d
     Task 5 review), so all three must be kept in sync by hand."""
@@ -8296,8 +8318,9 @@ def _forward_structural_triples_by_ident(precomputed: Dict[str, Any]) -> Dict[st
     once per file instead of scanned per ident (#222 phase 2d Task 5 fix --
     the previous per-ident linear scan was O(n^2) per file once more than one
     entity needed reconciling). Matches the existing precedent in
-    _reverse_fill_claim_and_process's candidate_triples_by_ident, which
-    builds the same shape of dict from the same five sources.
+    _reverse_apply's candidate_triples_by_ident (moved verbatim out of
+    _reverse_fill_claim_and_process by #222 phase 2d Task 6), which builds
+    the same shape of dict from the same five sources.
 
     A child's own list carries its [parent :contains child] edge, so
     re-dating a child re-dates its containment edge with it (#222 phase

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -8707,6 +8707,55 @@ def _parse_stream_ratio(raw: Optional[str]) -> Tuple[int, int]:
         return _DEFAULT_STREAM_RATIO
 
 
+class _RoundRobinClaimer:
+    """#222 phase 2d: hands out positions from the shared gap, alternating
+    forward and reverse by a fixed ratio.
+
+    This IS the fairness mechanism. Because claims are handed out in one
+    deterministic sequence rather than raced between two tasks, starvation
+    is not expressible and the interleave is directly assertable in a test.
+    """
+
+    def __init__(
+        self,
+        allocator: "frontier_registry.FrontierAllocator",
+        forward_per_round: int,
+        reverse_per_round: int,
+    ):
+        self._allocator = allocator
+        self._forward_per_round = forward_per_round
+        self._reverse_per_round = reverse_per_round
+        self._taken_in_phase = 0
+        self._forward_phase = True
+
+    def next_claim(self) -> Optional[Tuple[str, int]]:
+        """('fwd', pos) or ('rev', pos), or None once the gap is empty.
+
+        There is deliberately no "the other side might still have work"
+        fallback: claim_low() and claim_high() both return None on exactly
+        the same condition, is_gap_empty(), so they can only ever return
+        None together. A fallthrough would be dead code reading as if the
+        two frontiers could exhaust independently -- they cannot; they share
+        one gap.
+        """
+        if self._forward_phase:
+            pos = self._allocator.claim_low()
+            tag = "fwd"
+            limit = self._forward_per_round
+        else:
+            pos = self._allocator.claim_high()
+            tag = "rev"
+            limit = self._reverse_per_round
+        if pos is None:
+            return None
+
+        self._taken_in_phase += 1
+        if self._taken_in_phase >= limit:
+            self._taken_in_phase = 0
+            self._forward_phase = not self._forward_phase
+        return tag, pos
+
+
 @dataclass
 class _ForwardWalkState:
     """The forward walk's ten mutable preload dicts, threaded as one object.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -8036,7 +8036,6 @@ def _forward_apply(
             # prefilter there: it is a run-start snapshot, empty on a fresh
             # ingest, and the guess was made during this same run.
             if lifecycle_only:
-                candidate_in_set = []
                 reconcilable = (
                     [
                         ident for ident in _forward_candidate_idents(precomputed)
@@ -8044,6 +8043,14 @@ def _forward_apply(
                     ]
                     if status == "R" else []
                 )
+                # The eviction invariant above still holds here, it just has a
+                # different source: the preload snapshot is not the prefilter in
+                # this mode, so what must leave the set is exactly what was
+                # reconciled. Leaving these behind (the eviction loop's `[]` in
+                # an earlier revision) meant an R-file ident reconciled during
+                # Stage B stayed in state.provisional_idents and would be
+                # retried by every later commit touching the entity.
+                candidate_in_set = list(reconcilable)
             else:
                 candidate_in_set = [
                     ident for ident in _forward_candidate_idents(precomputed)
@@ -8572,6 +8579,7 @@ def _correction_sweep_apply(
     file_results: List[tuple],
     index_con: Optional[Any] = None,
     skipped_so_far: int = 0,
+    update_watermark: bool = True,
 ) -> int:
     """Reconciles every candidate entity file_results describes for
     commit_hash, then records progress via _correction_sweep_through_update
@@ -8598,6 +8606,22 @@ def _correction_sweep_apply(
 
     Never calls _frontier_persist_claim -- frontier-low is not touched by
     this sweep.
+
+    update_watermark=False suppresses BOTH the trailing
+    _correction_sweep_through_update and the _db_checkpoint that follows it,
+    handing both back to the caller. Only a caller that does MORE per-commit
+    work after this returns should pass False -- 2d's Stage B, which follows
+    every call with _forward_apply(..., lifecycle_only=True) to write the
+    D/R/gitlink facts the reverse stream skipped. If the watermark advanced
+    here, a failure in that lifecycle pass would leave
+    :ingestion/correction-sweep-through naming a commit whose deletions,
+    renames and gitlink changes were never written, and the next run's
+    _correction_sweep_select_position would resume at through + 1 and skip
+    it permanently. Deferring the watermark (and the checkpoint that
+    durably records it) to after the lifecycle pass makes the whole
+    per-commit unit atomic with respect to resume, and keeps the
+    one-checkpoint-per-commit cadence intact. The default True preserves the
+    2c behaviour for every caller that does nothing after this returns.
     """
     commit_ident = f":commit/{commit_hash[:12]}"
     skipped_events = 0
@@ -8665,8 +8689,9 @@ def _correction_sweep_apply(
                             file=sys.stderr,
                         )
 
-    _correction_sweep_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)
-    _db_checkpoint(db)
+    if update_watermark:
+        _correction_sweep_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)
+        _db_checkpoint(db)
     return skipped_events
 
 
@@ -9206,9 +9231,15 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                     executor, _extract_commit, repo_path, sweep_hash, ignore_patterns,
                                 )
                                 sweep_files = sweep_extracted[0]
+                                # update_watermark=False: this commit is only
+                                # half-processed until the lifecycle pass below
+                                # also lands, so the sweep watermark (and its
+                                # checkpoint) is deferred to after it -- see
+                                # _correction_sweep_apply's own docstring.
                                 skipped += await loop.run_in_executor(
                                     write_executor, _correction_sweep_apply,
                                     db, sweep_hash, sweep_ts, sweep_files, index_con, skipped,
+                                    False,
                                 )
                                 # Apply the lifecycle facts the reverse stream
                                 # skipped entirely (D/R closes, renames,
@@ -9223,12 +9254,25 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                     commit_metadata[hash_to_pos[sweep_hash]],
                                     sweep_extracted, index_con, None, None, True,
                                 )
+                                # Both halves landed -- only now is this commit
+                                # genuinely swept, so only now may the watermark
+                                # name it. Same one-checkpoint-per-commit cadence
+                                # _correction_sweep_apply had when it owned this.
+                                await loop.run_in_executor(
+                                    write_executor, _correction_sweep_through_update,
+                                    db, sweep_hash, sweep_ts, index_con,
+                                )
+                                await loop.run_in_executor(write_executor, _db_checkpoint, db)
                             except concurrent.futures.process.BrokenProcessPool:
                                 raise
                             except Exception as e:
                                 # A sweep-step failure aborts Stage B only.
-                                # Stage A's work is already persisted, and the
-                                # next run resumes from the sweep watermark.
+                                # Stage A's work is already persisted, and this
+                                # commit's watermark was never advanced (see
+                                # update_watermark=False above), so the next
+                                # run's _correction_sweep_select_position
+                                # re-selects THIS commit and reprocesses it from
+                                # the start -- nothing is silently skipped.
                                 print(
                                     f"[_run_ingestion] correction sweep aborted at {sweep_hash}: {e}",
                                     file=sys.stderr,
@@ -9279,6 +9323,12 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                 await loop.run_in_executor(write_executor, _close_index_writer_safe, index_con)
                 await loop.run_in_executor(write_executor, executor.shutdown)
 
+            # "phase" describes what a RUNNING ingest is currently doing, so
+            # it must not outlive the run: leaving Stage B's "sweeping" in
+            # place made a finished run report {"status": "complete", "phase":
+            # "sweeping"} forever. Cleared on every terminal path below, not
+            # just this one.
+            _ingest_progress["phase"] = None
             if completed_all:
                 _ingest_progress["status"] = "complete"
             else:
@@ -9290,6 +9340,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
         # write_executor is already shut down by the inner finally above by the
         # time we get here (it runs on any exit from that try, including this
         # exception propagating through it) — nothing left to clean up.
+        _ingest_progress["phase"] = None
         _ingest_progress["status"] = "error"
         _ingest_progress["error"] = str(e)
         _ingest_progress["error_at"] = _now_utc_ms()
@@ -9309,6 +9360,7 @@ async def handle_minigraf_ingest_git(
     # and losing (#108).
     holder_pid = _live_lock_holder_pid(_graph_path or _get_graph_path())
     if holder_pid is not None:
+        _ingest_progress["phase"] = None
         _ingest_progress["status"] = "skipped"
         _ingest_progress["owner_pid"] = holder_pid
         return {
@@ -9333,6 +9385,7 @@ async def handle_minigraf_ingest_git(
     _ingest_progress = {
         "status": "starting", "processed": 0, "total": 0, "prior_ingested": 0,
         "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+        "phase": None,
     }
     _ingest_task = asyncio.create_task(_run_ingestion(repo, branch or _default_git_branch(repo)))
     return {"ok": True, "job_id": "git-ingest", "message": f"Ingestion started for {repo}"}
@@ -9729,6 +9782,7 @@ async def main() -> None:
     _ingest_progress = {
         "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
         "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+        "phase": None,
     }
     if not os.environ.get("MINIGRAF_NO_AUTO_INGEST"):
         # Proactive check-before-attempt: if another live process already

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -8023,6 +8023,40 @@ def _correction_sweep_walk(
     return commits_processed, skipped_events
 
 
+_DEFAULT_STREAM_RATIO = (1, 1)
+
+
+def _parse_stream_ratio(raw: Optional[str]) -> Tuple[int, int]:
+    """Parse MINIGRAF_INGEST_STREAM_RATIO ("F:R") into (forward_per_round,
+    reverse_per_round), falling back to 1:1 on anything malformed.
+
+    Never raises. This is read inside the background ingestion coroutine,
+    where a bad env var must degrade to the default rather than become the
+    reason a repository never ingests at all.
+
+    The ratio trades total work against how fast recent history becomes
+    usable: a commit the forward stream claims is parsed once and is
+    authoritative immediately, while a commit the reverse stream claims is
+    parsed twice (reverse walk, then the correction sweep's own
+    _extract_commit call). Total parse cost is N * (1 + reverse_fraction).
+    """
+    if raw is None:
+        return _DEFAULT_STREAM_RATIO
+    try:
+        forward_str, reverse_str = raw.split(":")
+        forward, reverse = int(forward_str.strip()), int(reverse_str.strip())
+        if forward < 1 or reverse < 1:
+            raise ValueError("both sides must be >= 1")
+        return forward, reverse
+    except Exception as e:
+        print(
+            f"[_run_ingestion] ignoring malformed MINIGRAF_INGEST_STREAM_RATIO "
+            f"{raw!r} ({e}); using {_DEFAULT_STREAM_RATIO[0]}:{_DEFAULT_STREAM_RATIO[1]}",
+            file=sys.stderr,
+        )
+        return _DEFAULT_STREAM_RATIO
+
+
 async def _run_ingestion(repo_path: str, branch: str) -> None:
     """Background coroutine: walk git history and ingest code structure.
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15773,6 +15773,91 @@ class TestForwardApplyReconcilesProvisional:
         )
         assert f":commit/{linearization[1][:12]}" in {row[0] for row in json.loads(raw_mod)["results"]}
 
+        # The module ident is provisional too (Stream 2 guessed it at h1
+        # alongside login()) and exercises the distinct module-ident branch
+        # of the reconciliation block/lookup -- not just the function-entry
+        # branch. Same exactly-one-survivor, same confirmed marker.
+        module_ident = mcp_server._code_ident("module", "auth.py")
+        raw_module = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{module_ident} :introduced-by ?c]])",
+        )
+        module_values = {row[0] for row in json.loads(raw_module)["results"]}
+        assert module_values == {f":commit/{linearization[0][:12]}"}, "exactly one, naming h0"
+        assert mcp_server._lineage_is_provisional(real_db, module_ident) is False
+
+    def test_forward_apply_does_not_duplicate_for_a_stale_provisional_snapshot_entry(
+        self, real_db, tmp_path,
+    ):
+        """FIX 1 regression (#222 phase 2d Task 5 review): state.provisional_idents
+        is a preload SNAPSHOT, not the authority. If something else (e.g. the
+        correction sweep) already confirmed an entity authoritative in the DB
+        after the snapshot was taken, the snapshot can still list it as
+        provisional. The forward walk must consult the DB
+        (_lineage_is_provisional) before treating the ident as reconcilable --
+        popping it out of entity_valid_from unconditionally would make
+        _build_code_triples mint a SECOND :introduced-by on top of the
+        existing authoritative one, while _forward_reconcile_provisional
+        (itself DB-backed) no-ops on an already-confirmed entity and never
+        retracts the duplicate. Without the fix this yields two
+        :introduced-by values; with it, exactly one survives."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        # Stream 2 claims h1 and guesses login() was introduced there.
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+        # Take the preload snapshot while the entity is still genuinely
+        # provisional...
+        provisional_snapshot = mcp_server._preload_provisional_idents(real_db)
+        assert fn_ident in provisional_snapshot
+
+        # ...then simulate something else confirming it authoritative in the
+        # DB afterward (the snapshot is now stale for this ident, though the
+        # existing :introduced-by fact itself is untouched).
+        mcp_server._lineage_confirm(real_db, fn_ident)
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        existing_raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :introduced-by ?c]])",
+        )
+        assert {row[0] for row in json.loads(existing_raw)["results"]} == {
+            f":commit/{linearization[1][:12]}"
+        }
+
+        # entity_valid_from already knows this entity (mirrors the resumed-run
+        # shape) so an unconditional pop would matter.
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={fn_ident: "2026-06-01T00:00:00Z"},
+            entity_descriptions={fn_ident: "login"}, file_entities={"auth.py": [fn_ident]},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents=provisional_snapshot,  # stale: still lists fn_ident
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(
+            real_db, str(repo), state, commit_metadata[0], extracted,
+        )
+
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :introduced-by ?c]])",
+        )
+        values = {row[0] for row in json.loads(raw)["results"]}
+        assert values == {f":commit/{linearization[1][:12]}"}, (
+            "exactly one :introduced-by must survive -- a stale snapshot "
+            "entry must not cause a second one to be minted"
+        )
+        # The stale entry must be evicted, or it would be retried (and fail
+        # the same way) on every later commit that touches this entity.
+        assert fn_ident not in state.provisional_idents
+
     def test_resumed_run_variant_is_not_suppressed_by_entity_valid_from(self, real_db, tmp_path):
         """The silent failure mode: on a RESUMED run, Stream 2's structural
         facts are already in the preloaded entity_valid_from, so

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8161,6 +8161,11 @@ class TestIngestionWrites:
 
         monkeypatch.setattr(mcp_server, "_watermark_query", lambda db: "abc123")
         monkeypatch.setattr(mcp_server, "_git_commits", lambda repo, watermark, branch: [])
+        # #222 phase 2d: which commits get walked is now driven by
+        # build_linearization, not by _git_commits, so simulating an
+        # empty history has to stub both. tmp_path is not a git repo, and
+        # build_linearization runs `git log` with check=True.
+        monkeypatch.setattr(frontier_registry, "build_linearization", lambda repo, branch="HEAD": [])
 
         last_run_calls = []
         monkeypatch.setattr(
@@ -9140,6 +9145,13 @@ class TestRunIngestion:
     @pytest.mark.asyncio
     async def test_watermark_updated_after_each_commit(self, real_db, git_repo, monkeypatch):
         import mcp_server
+        # #222 phase 2d: :ingestion/watermark keeps its "contiguous from C0"
+        # meaning and is advanced by the FORWARD stream only -- the reverse
+        # stream never touches it. Pin the ratio forward-only so the forward
+        # stream claims both of git_repo's commits, which is what makes
+        # "one watermark write per commit" the property under test rather
+        # than a statement about the 1:1 split.
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
         mcp_server._ingest_progress = {
             "status": "idle", "processed": 0, "total": 0,
             "current_commit": "", "error": None,
@@ -9696,6 +9708,7 @@ class TestRunIngestionCommitFaultIsolation:
         import mcp_server
 
         real_git_commits = mcp_server._git_commits
+        real_build_linearization = frontier_registry.build_linearization
 
         def poisoned_git_commits(repo_path, watermark_hash, branch="HEAD"):
             # Inject a commit hash that was never actually created in this
@@ -9706,7 +9719,17 @@ class TestRunIngestionCommitFaultIsolation:
             poisoned = commits[:1] + [("deadbeef" * 5, "2026-01-01T00:00:00Z", "x@x.com", "POISONED")] + commits[1:]
             return poisoned
 
+        # #222 phase 2d: _run_ingestion extracts linearization[pos] and reads
+        # commit_metadata[pos], so the poison has to be injected at the SAME
+        # position in both lists -- injecting it into _git_commits alone would
+        # just misalign the two and trip _reverse_apply's alignment guard
+        # instead of exercising the extraction-failure path this test is about.
+        def poisoned_linearization(repo_path, branch="HEAD"):
+            hashes = real_build_linearization(repo_path, branch)
+            return hashes[:1] + ["deadbeef" * 5] + hashes[1:]
+
         monkeypatch.setattr(mcp_server, "_git_commits", poisoned_git_commits)
+        monkeypatch.setattr(frontier_registry, "build_linearization", poisoned_linearization)
         mcp_server._ingest_progress = {
             "status": "idle", "processed": 0, "total": 0,
             "current_commit": "", "error": None,
@@ -9724,13 +9747,21 @@ class TestRunIngestionCommitFaultIsolation:
         import fact_index
 
         real_git_commits = mcp_server._git_commits
+        real_build_linearization = frontier_registry.build_linearization
 
         def poisoned_git_commits(repo_path, watermark_hash, branch="HEAD"):
             commits = real_git_commits(repo_path, watermark_hash, branch)
             poisoned = [commits[0], ("deadbeef" * 5, "2026-01-01T00:00:00Z", "x@x.com", "POISONED")] + commits[1:]
             return poisoned
 
+        # See the sibling test above: the poison must land at the same
+        # position in both the linearization and commit_metadata.
+        def poisoned_linearization(repo_path, branch="HEAD"):
+            hashes = real_build_linearization(repo_path, branch)
+            return [hashes[0], "deadbeef" * 5] + hashes[1:]
+
         monkeypatch.setattr(mcp_server, "_git_commits", poisoned_git_commits)
+        monkeypatch.setattr(frontier_registry, "build_linearization", poisoned_linearization)
         mcp_server._ingest_progress = {
             "status": "idle", "processed": 0, "total": 0,
             "current_commit": "", "error": None,
@@ -9816,10 +9847,19 @@ class TestRunIngestionBatchedIndexWrites:
         one final flush-on-close) once batched. The gap between those two
         numbers is what would grow unboundedly on a 1M-fact repo if this
         regressed back to per-triple commits.
+
+        #222 phase 2d: the ratio is pinned forward-only so both of the
+        fixture's commits go through _forward_apply. _reverse_apply
+        (phase 2b, merged) checkpoints the graph per commit but does not
+        call _commit_index_writer_safe, so a reverse-claimed commit
+        contributes no per-commit index commit -- counting a mix would make
+        this assertion a statement about the stream split rather than about
+        batching.
         """
         import mcp_server
         import fact_index
 
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
         commit_calls = []
         open_calls = []
         original_open_writer = fact_index.open_writer
@@ -11393,6 +11433,21 @@ class TestClosedEntityLifecyclePurge:
         timestamp, widening its valid window across the span it was closed for.
     """
 
+    @pytest.fixture(autouse=True)
+    def _forward_only_ratio(self, monkeypatch):
+        """#222 phase 2d: pin ingestion to the forward stream.
+
+        These tests are about the FORWARD walk's close/purge semantics for
+        deleted and renamed paths. "D"/"R" file handling in the reverse-fill
+        and correction-sweep paths is explicitly out of scope for phase 2
+        (docs/superpowers/specs/2026-07-26-concurrency-wiring-design.md,
+        "Out of scope"), so at the default 1:1 ratio the reverse stream would
+        claim the very commit that performs the deletion/rename and skip it.
+        Pinning the ratio forward-only keeps these tests measuring the
+        behaviour they were written to measure.
+        """
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
+
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "",
                 "error": None, "prior_ingested": 0}
@@ -11467,6 +11522,14 @@ class TestClosedEntityLifecyclePurge:
 
 class TestRunIngestionBitemporalClose:
     """Integration tests verifying bi-temporal correctness of entity lifecycle handling."""
+
+    @pytest.fixture(autouse=True)
+    def _forward_only_ratio(self, monkeypatch):
+        """#222 phase 2d: pin ingestion to the forward stream -- see the
+        identically-named fixture on TestClosedEntityLifecyclePurge for the
+        rationale. Every test in this class turns on a deletion or a rename,
+        which only the forward walk handles."""
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
 
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
@@ -12427,6 +12490,15 @@ class TestTransactValidTimeArgumentOrder:
 class TestRunIngestionBitemporalDeps:
     """Tests verifying that :depends-on edges are written/closed bi-temporally in the commit loop."""
 
+    @pytest.fixture(autouse=True)
+    def _forward_only_ratio(self, monkeypatch):
+        """#222 phase 2d: pin ingestion to the forward stream -- see the
+        identically-named fixture on TestClosedEntityLifecyclePurge.
+        :depends-on edge lifecycle (and its close on a removed import) is
+        forward-walk-owned; the reverse-fill path does not write or close
+        dependency edges."""
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
+
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
 
@@ -13112,6 +13184,15 @@ class TestResolveModuleImportRelative:
 class TestRunIngestionGitlinks:
     """End-to-end tests for submodule add/bump/remove/flip via _run_ingestion."""
 
+    @pytest.fixture(autouse=True)
+    def _forward_only_ratio(self, monkeypatch):
+        """#222 phase 2d: pin ingestion to the forward stream -- see the
+        identically-named fixture on TestClosedEntityLifecyclePurge.
+        _reverse_apply consumes only _extract_commit's file_results and
+        discards its gitlink_changes/gitmodules_map, so submodule
+        add/bump/remove handling is forward-walk-only."""
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
+
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
 
@@ -13408,6 +13489,14 @@ class TestSubmoduleDependencyLinking:
     Verified against the REAL minigraf backend (no mock), since the fix reads
     back existing external-dependency rows via a DB query at gitlink-add time.
     """
+
+    @pytest.fixture(autouse=True)
+    def _forward_only_ratio(self, monkeypatch):
+        """#222 phase 2d: pin ingestion to the forward stream -- see the
+        identically-named fixture on TestRunIngestionGitlinks. The
+        :resolves-to linking under test runs in the forward walk's gitlink
+        handling, which the reverse-fill path does not perform."""
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
 
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
@@ -16031,3 +16120,105 @@ class TestRoundRobinClaimer:
         while allocator.claim_low() is not None:
             pass
         assert claimer.next_claim() is None
+
+
+class TestStageAInterleave:
+    """#222 phase 2d Task 8: _run_ingestion driven by the shared-gap claimer.
+
+    Real on-disk graph throughout (docs/testing-conventions.md Pattern 2):
+    _run_ingestion releases and reopens the DB between every commit, which an
+    in-memory store cannot survive.
+    """
+
+    def _repo(self, tmp_path, n_commits=6):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        # -b master explicitly: init.defaultBranch is machine-configurable, and
+        # every test below passes "master" to _run_ingestion.
+        _subprocess.run(["git", "init", "-b", "master"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(n_commits):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"h{i}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_both_frontiers_advance_and_meet(self, tmp_path, monkeypatch):
+        """The load-bearing property: a real run must leave frontier-low and
+        frontier-high adjacent, covering every position exactly once."""
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        linearization = frontier_registry.build_linearization(str(repo))
+        low = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_LOW_IDENT)
+        high = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_HIGH_IDENT)
+        assert low is not None and high is not None, "both streams must have claimed"
+        pos = {h: i for i, h in enumerate(linearization)}
+        assert pos[low[0]] == 0
+        assert pos[high[1]] == len(linearization) - 1
+        assert pos[low[1]] + 1 == pos[high[0]], "the two frontiers must be adjacent"
+
+    @pytest.mark.asyncio
+    async def test_forward_heavy_ratio_shifts_the_meeting_point(self, tmp_path, monkeypatch):
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path, n_commits=8)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "3:1")
+
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        linearization = frontier_registry.build_linearization(str(repo))
+        pos = {h: i for i, h in enumerate(linearization)}
+        low = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_LOW_IDENT)
+        # 3:1 over 8 positions -> forward takes 6, reverse takes 2.
+        assert pos[low[1]] == 5
+
+    @pytest.mark.asyncio
+    async def test_watermark_matches_frontier_low_hi(self, tmp_path, monkeypatch):
+        """:ingestion/watermark keeps its contiguous-from-C0 meaning: it is
+        advanced by the forward stream only, never by the reverse one."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        low = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_LOW_IDENT)
+        assert mcp_server._watermark_query(db) == low[1]
+
+    @pytest.mark.asyncio
+    async def test_single_commit_repo(self, tmp_path, monkeypatch):
+        import mcp_server
+        repo = self._repo(tmp_path, n_commits=1)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete"
+
+    @pytest.mark.asyncio
+    async def test_second_run_on_unchanged_repo_is_a_no_op(self, tmp_path, monkeypatch):
+        """Resume with an already-empty gap: Stage A must never begin, not
+        spin or re-process."""
+        import mcp_server
+        repo = self._repo(tmp_path)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15964,3 +15964,70 @@ class TestForwardApplyReconcilesProvisional:
         )
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
         assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{linearization[1][:12]}"
+
+
+class TestRoundRobinClaimer:
+    def _claimer(self, total, forward, reverse):
+        import mcp_server, frontier_registry
+        allocator = frontier_registry.FrontierAllocator(total, [])
+        return mcp_server._RoundRobinClaimer(allocator, forward, reverse), allocator
+
+    def _drain(self, claimer):
+        out = []
+        while True:
+            claim = claimer.next_claim()
+            if claim is None:
+                return out
+            out.append(claim)
+
+    def test_one_to_one_alternates(self):
+        claimer, _ = self._claimer(6, 1, 1)
+        assert self._drain(claimer) == [
+            ("fwd", 0), ("rev", 5), ("fwd", 1), ("rev", 4), ("fwd", 2), ("rev", 3),
+        ]
+
+    def test_one_to_three(self):
+        claimer, _ = self._claimer(8, 1, 3)
+        assert self._drain(claimer) == [
+            ("fwd", 0), ("rev", 7), ("rev", 6), ("rev", 5),
+            ("fwd", 1), ("rev", 4), ("rev", 3), ("rev", 2),
+        ]
+
+    def test_three_to_one(self):
+        claimer, _ = self._claimer(8, 3, 1)
+        assert self._drain(claimer) == [
+            ("fwd", 0), ("fwd", 1), ("fwd", 2), ("rev", 7),
+            ("fwd", 3), ("fwd", 4), ("fwd", 5), ("rev", 6),
+        ]
+
+    def test_every_position_claimed_exactly_once(self):
+        for total in (1, 2, 3, 7, 20, 33):
+            for ratio in ((1, 1), (1, 3), (3, 1), (2, 5)):
+                claimer, _ = self._claimer(total, *ratio)
+                claims = self._drain(claimer)
+                positions = [pos for _tag, pos in claims]
+                assert sorted(positions) == list(range(total)), (total, ratio)
+
+    def test_forward_ascending_reverse_descending(self):
+        claimer, _ = self._claimer(20, 2, 3)
+        claims = self._drain(claimer)
+        fwd = [pos for tag, pos in claims if tag == "fwd"]
+        rev = [pos for tag, pos in claims if tag == "rev"]
+        assert fwd == sorted(fwd), "forward state machine requires ascending"
+        assert rev == sorted(rev, reverse=True), "2b's monotonicity guard requires descending"
+
+    def test_empty_linearization_yields_nothing(self):
+        claimer, _ = self._claimer(0, 1, 1)
+        assert claimer.next_claim() is None
+
+    def test_single_position_goes_to_whoever_asks_first(self):
+        claimer, _ = self._claimer(1, 1, 1)
+        assert claimer.next_claim() == ("fwd", 0)
+        assert claimer.next_claim() is None
+
+    def test_pre_drained_gap_yields_nothing_immediately(self):
+        """Resume case: the previous run already covered everything."""
+        claimer, allocator = self._claimer(5, 1, 1)
+        while allocator.claim_low() is not None:
+            pass
+        assert claimer.next_claim() is None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9042,6 +9042,39 @@ class TestPreloadExternalDependencies:
         assert mcp_server._preload_pinned_commits(real_db) == {}
 
 
+class TestPreloadProvisionalIdents:
+    def test_empty_when_no_markers(self, real_db):
+        import mcp_server
+        assert mcp_server._preload_provisional_idents(real_db) == set()
+
+    def test_returns_every_marked_ident(self, real_db):
+        import mcp_server
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-a", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-b", "2026-01-01T00:00:00Z")
+        assert mcp_server._preload_provisional_idents(real_db) == {":code/fn-a", ":code/fn-b"}
+
+    def test_confirmed_idents_drop_out(self, real_db):
+        """_lineage_confirm retracts the whole companion entity rather than
+        flipping :status, so the set form must agree with the per-ident
+        _lineage_is_provisional check the reconciliation relies on."""
+        import mcp_server
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-a", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-b", "2026-01-01T00:00:00Z")
+        mcp_server._lineage_confirm(real_db, ":code/fn-a")
+        assert mcp_server._preload_provisional_idents(real_db) == {":code/fn-b"}
+        assert mcp_server._lineage_is_provisional(real_db, ":code/fn-a") is False
+
+    def test_load_ingestion_preload_state_returns_it_last(self, real_db, tmp_path):
+        import mcp_server
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-a", "2026-01-01T00:00:00Z")
+        result = mcp_server._load_ingestion_preload_state(str(repo))
+        assert len(result) == 13
+        assert result[-1] == {":code/fn-a"}
+
+
 class TestIngestTransactFactIndex:
     def test_ingest_transact_writes_to_index_with_explicit_con(self, real_db):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11500,6 +11500,54 @@ class TestClosedEntityLifecyclePurge:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("variant", ["rename", "delete"])
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "KNOWN pre-existing phase-2b defect, NOT the D/R gap #222 phase 2d "
+            "Stage B closes: _build_close_triples never retracts :introduced-by, "
+            "so a closed-and-purged entity keeps that fact forever, and "
+            "_reverse_apply's known-entity gate -- "
+            "_entity_introduced_by_query(db, ident) is not None -- still answers "
+            "'known' for it. At the 1:1 default, c3 (which re-creates a.py) lands "
+            "in frontier-high's territory, so _build_code_triples takes its "
+            "'already known' branch and emits only :modified-in: the module is "
+            "resurrected as a ghost with no current :ident. Fixing it means "
+            "changing that gate to test liveness, which is out of Task 9's scope."
+        ),
+    )
+    async def test_reused_path_new_entity_is_not_a_ghost_at_default_ratio(
+        self, tmp_path, monkeypatch, variant
+    ):
+        """Companion to the forward-only-pinned variant above, at the 1:1
+        DEFAULT ratio -- the configuration that actually ships.
+
+        The pin alone makes the suite green at exactly the configuration
+        that hides the ghost, with nothing left to notice when the bug is
+        fixed or when it spreads. This test is that alarm: strict=True means
+        it FAILS the day someone repairs _reverse_apply's gate, forcing both
+        the xfail and the forward-only pin to be removed together rather than
+        letting a stale exemption silently mask a later regression.
+        """
+        # Explicitly at the default: an ambient MINIGRAF_INGEST_STREAM_RATIO
+        # would otherwise decide which stream claims c3 and make the xfail
+        # non-deterministic.
+        monkeypatch.delenv("MINIGRAF_INGEST_STREAM_RATIO", raising=False)
+        repo = _reused_path_repo(tmp_path / "repo", variant)
+        db = await self._ingest_and_open(repo, monkeypatch)
+
+        import mcp_server
+        module_ident = mcp_server._code_ident("module", "a.py")
+        g_ident = mcp_server._code_ident("function", "a.py", "g")
+
+        module_now = self._results(db, f'(query [:find ?i :where [{module_ident} :ident ?i]])')
+        assert module_now == [[module_ident]], \
+            f"[{variant}] re-created module at reused path has no current :ident (ghost): {module_now}"
+
+        g_now = self._results(db, f'(query [:find ?i :where [{g_ident} :ident ?i]])')
+        assert g_now == [[g_ident]], f"[{variant}] re-created function g missing current :ident: {g_now}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("variant", ["rename", "delete"])
     async def test_reused_path_no_phantom_resurrection_window(self, tmp_path, monkeypatch, variant):
         """The original function f (closed at commit2) must NOT be visible at any
         point-in-time between its close (commit2) and the final commit."""
@@ -16269,6 +16317,92 @@ class TestStageBCorrectionSweep:
         db = MiniGrafDb.open(str(graph))
         linearization = frontier_registry.build_linearization(str(repo), "master")
         assert mcp_server._lineage_confirmed_through_query(db) == linearization[-1]
+
+    @pytest.mark.asyncio
+    async def test_phase_is_cleared_when_the_run_finishes(self, tmp_path, monkeypatch):
+        """"phase" describes what a RUNNING ingest is doing. Stage B sets it to
+        "sweeping" and, before this fix, never cleared it -- so
+        minigraf_ingest_status reported {"status": "complete", "phase":
+        "sweeping"} for the entire remaining life of the server process."""
+        import mcp_server
+        repo = self._repo(tmp_path)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete"
+        assert mcp_server._ingest_progress.get("phase") is None, (
+            f"a finished run still reports phase="
+            f"{mcp_server._ingest_progress.get('phase')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_failure_does_not_advance_the_sweep_watermark(
+        self, tmp_path, monkeypatch
+    ):
+        """Stage B does TWO things per swept commit: _correction_sweep_apply
+        (A/M lineage) and then _forward_apply(lifecycle_only=True) (the D/R
+        and gitlink facts the reverse stream skipped). If the sweep watermark
+        advanced when the first half finished, a failure in the second half
+        would leave :ingestion/correction-sweep-through naming a commit whose
+        deletions, renames and gitlink changes were never written -- and the
+        next run's _correction_sweep_select_position, which resumes at
+        through + 1, would skip that commit permanently and silently.
+
+        So: make the lifecycle pass raise for one specific swept commit and
+        assert the watermark still names its PREDECESSOR, i.e. a subsequent
+        run re-selects the failed commit and reprocesses it whole. Asserted
+        directly by calling _correction_sweep_select_position on the
+        persisted graph afterwards.
+        """
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+
+        swept: list = []
+        real_forward_apply = mcp_server._forward_apply
+
+        def failing_forward_apply(*args, **kwargs):
+            # _run_ingestion submits this via run_in_executor, which passes
+            # every argument positionally -- lifecycle_only is the 9th.
+            lifecycle_only = args[8] if len(args) > 8 else kwargs.get("lifecycle_only", False)
+            if lifecycle_only:
+                swept.append(args[3][0])  # commit tuple's hash
+                if len(swept) == 2:
+                    raise RuntimeError("lifecycle pass boom")
+            return real_forward_apply(*args, **kwargs)
+
+        monkeypatch.setattr(mcp_server, "_forward_apply", failing_forward_apply)
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        # Guard against a vacuous pass: the sweep must genuinely have reached
+        # a second commit and failed on it.
+        assert len(swept) == 2, f"expected the sweep to fail on its 2nd commit, saw {swept}"
+        succeeded_hash, failed_hash = swept
+        assert mcp_server._ingest_progress["status"] == "stopped"
+
+        db = MiniGrafDb.open(str(graph))
+        through = mcp_server._correction_sweep_through_query(db)
+        assert through != failed_hash, (
+            "the sweep watermark names a commit whose lifecycle pass failed -- "
+            "its deletions/renames/gitlink changes are lost forever"
+        )
+        assert through == succeeded_hash, (
+            f"watermark should still name the last fully-swept commit, got {through}"
+        )
+
+        # The real consequence: a subsequent run re-selects the failed commit.
+        linearization = frontier_registry.build_linearization(str(repo), "master")
+        commit_metadata = mcp_server._git_commits(str(repo), None, "master")
+        selected = mcp_server._correction_sweep_select_position(
+            db, linearization, commit_metadata,
+        )
+        assert selected is not None and selected[0] == failed_hash, (
+            f"next run must resume at the failed commit {failed_hash}, got {selected}"
+        )
 
     def test_fold_guard_does_not_fire_when_frontier_high_is_absent(self, real_db, tmp_path):
         """_correction_sweep_select_position returns None for six reasons,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11433,21 +11433,6 @@ class TestClosedEntityLifecyclePurge:
         timestamp, widening its valid window across the span it was closed for.
     """
 
-    @pytest.fixture(autouse=True)
-    def _forward_only_ratio(self, monkeypatch):
-        """#222 phase 2d: pin ingestion to the forward stream.
-
-        These tests are about the FORWARD walk's close/purge semantics for
-        deleted and renamed paths. "D"/"R" file handling in the reverse-fill
-        and correction-sweep paths is explicitly out of scope for phase 2
-        (docs/superpowers/specs/2026-07-26-concurrency-wiring-design.md,
-        "Out of scope"), so at the default 1:1 ratio the reverse stream would
-        claim the very commit that performs the deletion/rename and skip it.
-        Pinning the ratio forward-only keeps these tests measuring the
-        behaviour they were written to measure.
-        """
-        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
-
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "",
                 "error": None, "prior_ingested": 0}
@@ -11473,7 +11458,31 @@ class TestClosedEntityLifecyclePurge:
     @pytest.mark.parametrize("variant", ["rename", "delete"])
     async def test_reused_path_new_entity_is_not_a_ghost(self, tmp_path, monkeypatch, variant):
         """The module re-created at the reused path a.py must have a CURRENT
-        :ident fact (join target for nearly every query)."""
+        :ident fact (join target for nearly every query).
+
+        #222 phase 2d Task 9 STILL PINS this one test forward-only, while the
+        rest of this class now runs at the 1:1 default. The remaining failure
+        is NOT the D/R/gitlink gap Stage B closes -- it is an independent
+        _reverse_apply (phase 2b) defect in A/M territory:
+
+          _build_close_triples never retracts :introduced-by, so a closed
+          entity keeps that fact forever. _reverse_apply's "is this entity
+          already known?" gate is _entity_introduced_by_query(db, ident),
+          which therefore still answers "known" for an ident that was closed
+          and purged by the forward walk. When such a path is RE-CREATED at a
+          position the reverse stream claims, _build_code_triples takes its
+          "already known" branch and emits only :modified-in -- the module
+          never re-asserts :ident/:description/:path and stays a ghost.
+          _correction_sweep_apply cannot repair it either: it reconciles
+          lineage only and never emits structural facts.
+
+        Fixing it means changing _reverse_apply's gate to test liveness (a
+        current :ident) rather than :introduced-by, which is phase-2b surface
+        and out of this task's scope. Measured directly: after a 1:1 run of
+        _reused_path_repo, :module/a-py has a live :introduced-by pointing at
+        the ORIGINAL c1 commit and no live :ident at all.
+        """
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
         repo = _reused_path_repo(tmp_path / "repo", variant)
         db = await self._ingest_and_open(repo, monkeypatch)
 
@@ -11522,14 +11531,6 @@ class TestClosedEntityLifecyclePurge:
 
 class TestRunIngestionBitemporalClose:
     """Integration tests verifying bi-temporal correctness of entity lifecycle handling."""
-
-    @pytest.fixture(autouse=True)
-    def _forward_only_ratio(self, monkeypatch):
-        """#222 phase 2d: pin ingestion to the forward stream -- see the
-        identically-named fixture on TestClosedEntityLifecyclePurge for the
-        rationale. Every test in this class turns on a deletion or a rename,
-        which only the forward walk handles."""
-        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
 
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
@@ -12490,15 +12491,6 @@ class TestTransactValidTimeArgumentOrder:
 class TestRunIngestionBitemporalDeps:
     """Tests verifying that :depends-on edges are written/closed bi-temporally in the commit loop."""
 
-    @pytest.fixture(autouse=True)
-    def _forward_only_ratio(self, monkeypatch):
-        """#222 phase 2d: pin ingestion to the forward stream -- see the
-        identically-named fixture on TestClosedEntityLifecyclePurge.
-        :depends-on edge lifecycle (and its close on a removed import) is
-        forward-walk-owned; the reverse-fill path does not write or close
-        dependency edges."""
-        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
-
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
 
@@ -13184,15 +13176,6 @@ class TestResolveModuleImportRelative:
 class TestRunIngestionGitlinks:
     """End-to-end tests for submodule add/bump/remove/flip via _run_ingestion."""
 
-    @pytest.fixture(autouse=True)
-    def _forward_only_ratio(self, monkeypatch):
-        """#222 phase 2d: pin ingestion to the forward stream -- see the
-        identically-named fixture on TestClosedEntityLifecyclePurge.
-        _reverse_apply consumes only _extract_commit's file_results and
-        discards its gitlink_changes/gitmodules_map, so submodule
-        add/bump/remove handling is forward-walk-only."""
-        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
-
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
 
@@ -13489,14 +13472,6 @@ class TestSubmoduleDependencyLinking:
     Verified against the REAL minigraf backend (no mock), since the fix reads
     back existing external-dependency rows via a DB query at gitlink-add time.
     """
-
-    @pytest.fixture(autouse=True)
-    def _forward_only_ratio(self, monkeypatch):
-        """#222 phase 2d: pin ingestion to the forward stream -- see the
-        identically-named fixture on TestRunIngestionGitlinks. The
-        :resolves-to linking under test runs in the forward walk's gitlink
-        handling, which the reverse-fill path does not perform."""
-        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", f"{10**6}:1")
 
     def _make_progress(self):
         return {"status": "idle", "processed": 0, "total": 0, "current_commit": "", "error": None}
@@ -16222,3 +16197,474 @@ class TestStageAInterleave:
         mcp_server._db = None
         await mcp_server._run_ingestion(str(repo), "master")
         assert mcp_server._ingest_progress["status"] == "complete"
+
+
+class TestStageBCorrectionSweep:
+    """#222 phase 2d Task 9: Stage B -- the sequential correction sweep that
+    runs once Stage A's two streams have drained and the shared gap is
+    closed, turning the reverse stream's provisional guesses authoritative.
+
+    Real on-disk graph throughout (docs/testing-conventions.md Pattern 2):
+    _run_ingestion releases and reopens the DB between every commit, which an
+    in-memory store cannot survive.
+    """
+
+    def _repo(self, tmp_path, n_commits=6):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        # -b master explicitly: init.defaultBranch is machine-configurable, and
+        # every test below passes "master" to _run_ingestion.
+        _subprocess.run(["git", "init", "-b", "master"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(n_commits):
+            (repo / "auth.py").write_text(
+                f"def login():\n    return {i}\n\ndef helper_{i}():\n    pass\n"
+            )
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"h{i}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_completed_run_leaves_no_provisional_markers(self, tmp_path, monkeypatch):
+        """The headline postcondition of phase 2: after a full ingest,
+        every entity's lineage is authoritative."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        assert mcp_server._preload_provisional_idents(db) == set()
+
+    @pytest.mark.asyncio
+    async def test_no_entity_has_two_introduced_by_values(self, tmp_path, monkeypatch):
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        raw = mcp_server._db_execute(db, "(query [:find ?e ?c :where [?e :introduced-by ?c]])")
+        pairs = [tuple(row) for row in json.loads(raw)["results"]]
+        entities = [e for e, _c in pairs]
+        assert len(entities) == len(set(entities)), f"duplicate :introduced-by: {pairs}"
+
+    @pytest.mark.asyncio
+    async def test_lineage_confirmed_through_reaches_head(self, tmp_path, monkeypatch):
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph))
+        linearization = frontier_registry.build_linearization(str(repo), "master")
+        assert mcp_server._lineage_confirmed_through_query(db) == linearization[-1]
+
+    def test_fold_guard_does_not_fire_when_frontier_high_is_absent(self, real_db, tmp_path):
+        """_correction_sweep_select_position returns None for six reasons,
+        only one of which is 'reached the ceiling'. Folding the watermark on
+        any None would claim lineage is confirmed through HEAD in exactly
+        the cases where the sweep did no work at all."""
+        import mcp_server
+        repo = self._repo(tmp_path, n_commits=3)
+        linearization = frontier_registry.build_linearization(str(repo), "master")
+        commit_metadata = mcp_server._git_commits(str(repo), None, "master")
+        # frontier-high never created: forward claimed everything.
+        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        assert mcp_server._correction_sweep_select_position(
+            real_db, linearization, commit_metadata,
+        ) is None
+        assert mcp_server._should_fold_lineage_watermark(real_db, linearization) is False
+
+    def test_fold_guard_fires_only_when_sweep_reached_the_ceiling(self, real_db, tmp_path):
+        import mcp_server
+        repo = self._repo(tmp_path, n_commits=3)
+        linearization = frontier_registry.build_linearization(str(repo), "master")
+        commit_metadata = mcp_server._git_commits(str(repo), None, "master")
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Reverse claims the top two, forward the bottom one -> gap closed.
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        pos = allocator.claim_low()
+        mcp_server._frontier_persist_claim(
+            real_db, linearization, pos, from_low=True,
+            commit_ts_iso=commit_metadata[pos][1],
+        )
+        assert mcp_server._should_fold_lineage_watermark(real_db, linearization) is False
+        mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+        assert mcp_server._should_fold_lineage_watermark(real_db, linearization) is True
+
+
+class TestStageBRepairsLifecycleFacts:
+    """#222 phase 2d: the reverse stream skips D/R files and gitlink changes
+    entirely, so at the default 1:1 ratio the newest half of history loses
+    its deletions, renames and submodule bumps. Stage B applies them.
+
+    The oracle here is DIFFERENTIAL wherever it fits: the same repo is
+    ingested twice -- once at the 1:1 default (where the newest half of
+    history is reverse-claimed and repaired by Stage B) and once forward-only
+    via MINIGRAF_INGEST_STREAM_RATIO -- and the two graphs must agree. That is
+    far more durable against unrelated changes in fact shape than
+    hand-enumerated expected facts, and it is exactly the claim under test:
+    a mixed run must produce the same lifecycle facts a forward-only run does.
+    """
+
+    # (find-vars, where-clauses). Every subject is bound through its :ident so
+    # the rows are stable strings rather than minigraf's internal subject UUIDs.
+    _SNAPSHOT_QUERIES = {
+        "entity-type": ("?i ?v", "[?e :ident ?i] [?e :entity-type ?v]"),
+        "description": ("?i ?v", "[?e :ident ?i] [?e :description ?v]"),
+        "introduced-by": ("?i ?v", "[?e :ident ?i] [?e :introduced-by ?v]"),
+        "modified-in": ("?i ?v", "[?e :ident ?i] [?e :modified-in ?v]"),
+        "contains": ("?i ?v", "[?e :ident ?i] [?e :contains ?v]"),
+        "depends-on": ("?i ?v", "[?e :ident ?i] [?e :depends-on ?v]"),
+        "renamed-to": ("?i ?v", "[?e :ident ?i] [?e :renamed-to ?v]"),
+        "renamed-from": ("?i ?v", "[?e :ident ?i] [?e :renamed-from ?v]"),
+        "pinned-commit": ("?i ?v", "[?e :ident ?i] [?e :pinned-commit ?v]"),
+        "static": ("?i ?v", "[?e :ident ?i] [?e :static ?v]"),
+        "path": ("?i ?v", "[?e :ident ?i] [?e :path ?v]"),
+        "file": ("?i ?v", "[?e :ident ?i] [?e :file ?v]"),
+    }
+    # Bookkeeping entities that legitimately differ between the two runs:
+    # frontier-high and :ingestion/correction-sweep-through only exist when a
+    # reverse stream ran at all, and the lineage/candidate companion entities
+    # are transient scratch state.
+    _BOOKKEEPING_PREFIXES = (":ingestion/", ":lineage/", ":candidate/")
+
+    # ---- repo construction -------------------------------------------------
+
+    def _init(self, tmp_path, name="repo"):
+        repo = tmp_path / name
+        repo.mkdir()
+        _subprocess.run(["git", "init", "-b", "master"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _commit(self, repo, msg, day, paths=None):
+        """Commit with a pinned, distinct calendar day so point-in-time
+        (:valid-at) assertions can target a moment strictly inside an
+        entity's true valid window.
+
+        paths=None stages everything (`git add -A`). Any repo carrying a
+        gitlink MUST pass an explicit list instead: `git add -A` sees the
+        submodule's absent working tree and stages the gitlink's deletion,
+        which silently turns a bump into a remove.
+        """
+        ts = f"2020-01-{day:02d}T00:00:00Z"
+        env = {**os.environ, "GIT_AUTHOR_DATE": ts, "GIT_COMMITTER_DATE": ts}
+        add_args = ["-A"] if paths is None else list(paths)
+        if add_args:
+            _subprocess.run(["git", "add", *add_args], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(
+            ["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True, env=env,
+        )
+
+    def _add_submodule(self, repo, day, path="modules/lib", name="lib",
+                       url="https://example.com/lib.git"):
+        sub = repo.parent / f"{repo.name}-sub"
+        _subprocess.run(["git", "init", "-q", "-b", "master", str(sub)], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "config", "user.email", "t@t.com"], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "config", "user.name", "T"], check=True, capture_output=True)
+        _subprocess.run(["git", "-C", str(sub), "commit", "--allow-empty", "-m", "e"], check=True, capture_output=True)
+        sub_hash = _subprocess.run(
+            ["git", "-C", str(sub), "rev-parse", "HEAD"], check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        (repo / ".gitmodules").write_text(f'[submodule "{name}"]\n\tpath = {path}\n\turl = {url}\n')
+        _subprocess.run(
+            ["git", "update-index", "--add", "--cacheinfo", f"160000,{sub_hash},{path}"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        self._commit(repo, "add submodule", day, paths=[".gitmodules"])
+        return sub_hash
+
+    def _bump_submodule(self, repo, day, path="modules/lib", extra_paths=()):
+        sub = repo.parent / f"{repo.name}-sub"
+        _subprocess.run(["git", "-C", str(sub), "commit", "--allow-empty", "-m", "bump"], check=True, capture_output=True)
+        new_hash = _subprocess.run(
+            ["git", "-C", str(sub), "rev-parse", "HEAD"], check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        _subprocess.run(
+            ["git", "update-index", "--cacheinfo", f"160000,{new_hash},{path}"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        self._commit(repo, "bump submodule", day, paths=list(extra_paths))
+        return new_hash
+
+    # ---- ingestion / snapshot helpers -------------------------------------
+
+    async def _ingest(self, repo, graph_path, monkeypatch, ratio):
+        import mcp_server
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", ratio)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph_path))
+        mcp_server._db = None
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+            "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+        }
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete", mcp_server._ingest_progress
+        mcp_server._db = None
+
+    def _results(self, graph_path, datalog):
+        import mcp_server
+        from minigraf import MiniGrafDb
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            return json.loads(mcp_server._db_execute(db, datalog)).get("results", [])
+        finally:
+            db = None  # drop the handle so the file lock is released
+
+    def _snapshot(self, graph_path, valid_at=None):
+        import mcp_server
+        from minigraf import MiniGrafDb
+        clause = f' :valid-at "{valid_at}"' if valid_at else ""
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            out = {}
+            for label, (find, where) in self._SNAPSHOT_QUERIES.items():
+                raw = mcp_server._db_execute(db, f"(query [:find {find}{clause} :where {where}])")
+                out[label] = sorted(
+                    tuple(row) for row in json.loads(raw).get("results", [])
+                    if not str(row[0]).startswith(self._BOOKKEEPING_PREFIXES)
+                )
+            return out
+        finally:
+            db = None
+
+    async def _assert_graphs_agree(self, repo, tmp_path, monkeypatch, valid_ats=()):
+        """Ingest `repo` twice -- 1:1 default, then forward-only -- and assert
+        the two graphs carry identical facts, at current time and at every
+        supplied point in valid time."""
+        mixed = tmp_path / "mixed.graph"
+        forward = tmp_path / "forward.graph"
+        await self._ingest(repo, mixed, monkeypatch, "1:1")
+        await self._ingest(repo, forward, monkeypatch, f"{10**6}:1")
+        for valid_at in (None,) + tuple(valid_ats):
+            a = self._snapshot(mixed, valid_at)
+            b = self._snapshot(forward, valid_at)
+            for label in self._SNAPSHOT_QUERIES:
+                assert a[label] == b[label], (
+                    f"1:1 and forward-only graphs disagree on {label} "
+                    f"(valid_at={valid_at}):\n  only in 1:1:  "
+                    f"{sorted(set(a[label]) - set(b[label]))}\n  only in fwd: "
+                    f"{sorted(set(b[label]) - set(a[label]))}"
+                )
+        return mixed
+
+    def _assert_reverse_claimed(self, graph_path, repo, positions):
+        """Guard against a vacuous differential: the commits carrying the
+        lifecycle change must actually have landed in frontier-high's
+        territory, otherwise the two runs agree for the boring reason."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            high = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_HIGH_IDENT)
+        finally:
+            db = None
+        assert high is not None, "the reverse stream claimed nothing -- test is vacuous"
+        linearization = frontier_registry.build_linearization(str(repo), "master")
+        pos = {h: i for i, h in enumerate(linearization)}
+        lo, hi = pos[high[0]], pos[high[1]]
+        for p in positions:
+            assert lo <= p <= hi, (
+                f"position {p} was not reverse-claimed (frontier-high covers "
+                f"{lo}..{hi}) -- this test would pass vacuously"
+            )
+
+    # ---- the tests ---------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_deletion_in_the_reverse_region_is_closed(self, tmp_path, monkeypatch):
+        """A function deleted in a recent commit must not still read as live
+        at HEAD. Without Stage B's lifecycle pass it stays open forever."""
+        import mcp_server
+        repo = self._init(tmp_path)
+        (repo / "a.py").write_text("def alpha():\n    return 1\n")
+        (repo / "b.py").write_text("def beta():\n    return 2\n")
+        self._commit(repo, "c1", 1)
+        (repo / "a.py").write_text("def alpha():\n    return 11\n")
+        self._commit(repo, "c2", 2)
+        (repo / "b.py").write_text("def beta():\n    return 22\n")
+        self._commit(repo, "c3", 3)                       # position 2 -- reverse
+        _subprocess.run(["git", "rm", "b.py"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "c4 delete b.py", 4)           # position 3 -- reverse
+
+        mixed = await self._assert_graphs_agree(
+            repo, tmp_path, monkeypatch, valid_ats=("2020-01-03T12:00:00Z",),
+        )
+        self._assert_reverse_claimed(mixed, repo, [3])
+
+        module_ident = mcp_server._code_ident("module", "b.py")
+        fn_ident = mcp_server._code_ident("function", "b.py", "beta")
+        for ident in (module_ident, fn_ident):
+            assert self._results(mixed, f"(query [:find ?i :where [{ident} :ident ?i]])") == [], \
+                f"{ident} was deleted at HEAD but still reads as live"
+            # ...and it must still be visible strictly inside its true window.
+            assert self._results(
+                mixed,
+                f'(query [:find ?i :valid-at "2020-01-03T12:00:00Z" :where [{ident} :ident ?i]])',
+            ) == [[ident]], f"{ident} must be live before the delete commit"
+
+    @pytest.mark.asyncio
+    async def test_rename_in_the_reverse_region_emits_both_edges(self, tmp_path, monkeypatch):
+        """:renamed-from AND :renamed-to, and the old module closed.
+
+        The new path is ALSO modified one commit later, which the reverse
+        stream claims first -- so it holds a provisional :introduced-by guess
+        at that later commit which the sweep's rename application must
+        supersede rather than duplicate.
+        """
+        import mcp_server
+        repo = self._init(tmp_path)
+        (repo / "old.py").write_text("def f():\n    return 1\n")
+        (repo / "other.py").write_text("def g():\n    return 1\n")
+        self._commit(repo, "c1", 1)
+        (repo / "other.py").write_text("def g():\n    return 2\n")
+        self._commit(repo, "c2", 2)
+        _subprocess.run(["git", "mv", "old.py", "new.py"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "c3 rename", 3)                # position 2 -- reverse
+        (repo / "new.py").write_text("def f():\n    return 3\n")
+        self._commit(repo, "c4 edit new.py", 4)           # position 3 -- reverse
+
+        mixed = await self._assert_graphs_agree(repo, tmp_path, monkeypatch)
+        self._assert_reverse_claimed(mixed, repo, [2, 3])
+
+        old_ident = mcp_server._code_ident("module", "old.py")
+        new_ident = mcp_server._code_ident("module", "new.py")
+        assert self._results(
+            mixed, f"(query [:find ?n :where [{old_ident} :renamed-to ?n]])"
+        ) == [[new_ident]], ":renamed-to was never emitted for the reverse-region rename"
+        assert self._results(
+            mixed, f"(query [:find ?o :where [{new_ident} :renamed-from ?o]])"
+        ) == [[old_ident]], ":renamed-from was never emitted for the reverse-region rename"
+        assert self._results(
+            mixed, f"(query [:find ?i :where [{old_ident} :ident ?i]])"
+        ) == [], "the renamed-away module must be closed"
+        # The new path's lineage must be single-valued: the rename is its
+        # introduction, superseding the reverse stream's later guess.
+        intro = self._results(
+            mixed, f"(query [:find ?c :where [{new_ident} :introduced-by ?c]])"
+        )
+        assert len(intro) == 1, f"new path has ambiguous :introduced-by: {intro}"
+
+    @pytest.mark.asyncio
+    async def test_submodule_bump_in_the_reverse_region_updates_pinned_commit(
+        self, tmp_path, monkeypatch
+    ):
+        """Gitlink changes are discarded for reverse-claimed commits in
+        Stage A; the sweep must apply them."""
+        import mcp_server
+        repo = self._init(tmp_path)
+        (repo / "main.py").write_text("def main():\n    return 1\n")
+        self._commit(repo, "c1", 1)
+        first_sha = self._add_submodule(repo, day=2)      # position 1 -- forward
+        (repo / "main.py").write_text("def main():\n    return 2\n")
+        self._commit(repo, "c3", 3, paths=["main.py"])    # position 2 -- reverse
+        second_sha = self._bump_submodule(repo, day=4)    # position 3 -- reverse
+
+        mixed = await self._assert_graphs_agree(repo, tmp_path, monkeypatch)
+        self._assert_reverse_claimed(mixed, repo, [3])
+
+        sub_ident = mcp_server._code_ident("module", "modules/lib")
+        assert self._results(
+            mixed, f"(query [:find ?p :where [{sub_ident} :pinned-commit ?p]])"
+        ) == [[second_sha]], "the bump's new pinned-commit must be the only live one"
+        assert self._results(
+            mixed,
+            f'(query [:find ?p :valid-at "2020-01-03T12:00:00Z" '
+            f":where [{sub_ident} :pinned-commit ?p]])",
+        ) == [[first_sha]], "the original pin must stay visible inside its own window"
+
+    @pytest.mark.asyncio
+    async def test_entity_born_and_deleted_inside_the_reverse_region(self, tmp_path, monkeypatch):
+        """The case that motivates calling _build_code_triples for its dict
+        side effects on A/M files: the entity is absent from the Stage-A
+        entity_valid_from, so without that bookkeeping its close falls back
+        to the DELETE commit's own timestamp and yields a wrong (often
+        zero-width) valid interval."""
+        import mcp_server
+        repo = self._init(tmp_path)
+        (repo / "a.py").write_text("def alpha():\n    return 1\n")
+        self._commit(repo, "c1", 1)
+        (repo / "a.py").write_text("def alpha():\n    return 11\n")
+        self._commit(repo, "c2", 2)
+        (repo / "b.py").write_text("def beta():\n    return 2\n")
+        self._commit(repo, "c3 born", 3)                  # position 2 -- reverse
+        _subprocess.run(["git", "rm", "b.py"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "c4 died", 4)                  # position 3 -- reverse
+
+        mixed = await self._assert_graphs_agree(
+            repo, tmp_path, monkeypatch, valid_ats=("2020-01-03T12:00:00Z",),
+        )
+        self._assert_reverse_claimed(mixed, repo, [2, 3])
+
+        # Born at c3 (day 3), deleted at c4 (day 4): live strictly between.
+        # A close that fell back to the delete commit's own timestamp would
+        # produce the zero-width window [day4, day4) and fail here.
+        fn_ident = mcp_server._code_ident("function", "b.py", "beta")
+        assert self._results(
+            mixed,
+            f'(query [:find ?d :valid-at "2020-01-03T12:00:00Z" :where [{fn_ident} :description ?d]])',
+        ) == [["beta"]], "entity born and deleted inside the reverse region has a wrong valid window"
+        assert self._results(
+            mixed,
+            f'(query [:find ?d :valid-at "2020-01-02T12:00:00Z" :where [{fn_ident} :description ?d]])',
+        ) == [], "entity must not be visible before its introduction"
+        assert self._results(
+            mixed, f"(query [:find ?d :where [{fn_ident} :description ?d]])"
+        ) == [], "entity must not be visible after its deletion"
+
+    @pytest.mark.asyncio
+    async def test_am_facts_are_not_duplicated_by_the_lifecycle_pass(self, tmp_path, monkeypatch):
+        """lifecycle_only must DISCARD _build_code_triples' output for A/M.
+        Re-transacting the same (entity, attribute, value) under a different
+        valid-from creates a genuinely live duplicate rather than a no-op
+        (#156), so assert exactly one :introduced-by and one :entity-type
+        per entity after a full run over a repo whose reverse region carries
+        a deletion, a rename AND a submodule bump."""
+        import mcp_server
+        repo = self._init(tmp_path)
+        (repo / "a.py").write_text("def alpha():\n    return 1\n")
+        (repo / "b.py").write_text("def beta():\n    return 2\n")
+        self._commit(repo, "c1", 1)
+        (repo / "a.py").write_text("def alpha():\n    return 11\n")
+        self._commit(repo, "c2", 2)
+        self._add_submodule(repo, day=3)                  # position 2 -- forward
+        _subprocess.run(["git", "rm", "b.py"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "c4 delete b.py", 4, paths=[])  # position 3 -- reverse
+        _subprocess.run(["git", "mv", "a.py", "c.py"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "c5 rename a.py", 5, paths=[])  # position 4 -- reverse
+        (repo / "c.py").write_text("def alpha():\n    return 111\n")
+        # bump + edit the renamed file in one commit: the reverse stream
+        # claims this position and discards the gitlink half entirely.
+        self._bump_submodule(repo, day=6, extra_paths=["c.py"])  # position 5 -- reverse
+
+        mixed = await self._assert_graphs_agree(repo, tmp_path, monkeypatch)
+        self._assert_reverse_claimed(mixed, repo, [3, 4, 5])
+
+        for attr in (":introduced-by", ":entity-type"):
+            rows = [tuple(r) for r in self._results(
+                mixed, f"(query [:find ?i ?v :where [?e :ident ?i] [?e {attr} ?v]])"
+            ) if not str(r[0]).startswith(self._BOOKKEEPING_PREFIXES)]
+            subjects = [i for i, _v in rows]
+            assert len(subjects) == len(set(subjects)), \
+                f"duplicate live {attr} facts after the lifecycle pass: " \
+                f"{sorted(r for r in rows if subjects.count(r[0]) > 1)}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,6 +16,7 @@ full rationale and pattern reference.
 """
 import asyncio
 import contextlib
+import datetime
 import json
 import sqlite3
 import sys
@@ -9223,7 +9224,7 @@ class TestRunIngestion:
         leaving the server permanently unable to connect."""
         import mcp_server
 
-        def slow_preload(db, repo_path):
+        def slow_preload(db, repo_path, valid_at=None):
             time.sleep(0.3)
             return {}, {}, {}
 
@@ -11502,6 +11503,13 @@ class TestClosedEntityLifecyclePurge:
     @pytest.mark.parametrize("variant", ["rename", "delete"])
     @pytest.mark.xfail(
         strict=True,
+        # Narrowed to the assertion this test actually makes (#222 phase 2d
+        # whole-branch review, finding (o)). Without raises=, ANY exception
+        # counts as the expected failure -- an unrelated breakage in the
+        # ingest path (a TypeError from a changed signature, a git fixture
+        # that stops building) would keep registering as XFAIL and this
+        # alarm would stay silently disarmed.
+        raises=AssertionError,
         reason=(
             "KNOWN pre-existing phase-2b defect, NOT the D/R gap #222 phase 2d "
             "Stage B closes: _build_close_triples never retracts :introduced-by, "
@@ -15731,6 +15739,12 @@ class TestParseStreamRatio:
 
 
 class TestForwardReconcileProvisional:
+    # The commit the forward walk is currently applying, i.e. the entity's
+    # TRUE introduction. Distinct from _seed_provisional's guess commit in
+    # every test here except the self-introduction one below, which is the
+    # whole point of that case (#222 phase 2d review, B2).
+    _TRUE_COMMIT = ":commit/aaaaaaaaaaaa"
+
     def _seed_provisional(self, real_db):
         """An entity Stream 2 discovered at a late commit and guessed wrong."""
         import mcp_server
@@ -15763,7 +15777,7 @@ class TestForwardReconcileProvisional:
             real_db, "[[:code/fn-x :introduced-by :commit/aaaaaaaaaaaa]]", "2026-01-01T00:00:00Z",
         )
         result = mcp_server._forward_reconcile_provisional(
-            real_db, ":code/fn-x", [], "2026-01-01T00:00:00Z", {},
+            real_db, ":code/fn-x", [], "2026-01-01T00:00:00Z", {}, self._TRUE_COMMIT,
         )
         assert result is None
         assert mcp_server._entity_introduced_by_query(real_db, ":code/fn-x") == ":commit/aaaaaaaaaaaa"
@@ -15773,7 +15787,7 @@ class TestForwardReconcileProvisional:
         guess_ident, structural = self._seed_provisional(real_db)
         mcp_server._forward_reconcile_provisional(
             real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
-            {guess_ident: "2026-06-01T00:00:00Z"},
+            {guess_ident: "2026-06-01T00:00:00Z"}, self._TRUE_COMMIT,
         )
         # No :introduced-by left at all -- the caller writes the authoritative
         # one immediately after, via the normal forward emission path.
@@ -15784,7 +15798,7 @@ class TestForwardReconcileProvisional:
         guess_ident, structural = self._seed_provisional(real_db)
         returned = mcp_server._forward_reconcile_provisional(
             real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
-            {guess_ident: "2026-06-01T00:00:00Z"},
+            {guess_ident: "2026-06-01T00:00:00Z"}, self._TRUE_COMMIT,
         )
         assert returned == guess_ident
         assert mcp_server._lineage_is_provisional(real_db, ":code/fn-login") is False
@@ -15800,7 +15814,7 @@ class TestForwardReconcileProvisional:
         guess_ident, structural = self._seed_provisional(real_db)
         mcp_server._forward_reconcile_provisional(
             real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
-            {guess_ident: "2026-06-01T00:00:00Z"},
+            {guess_ident: "2026-06-01T00:00:00Z"}, self._TRUE_COMMIT,
         )
         raw = mcp_server._db_execute(
             real_db,
@@ -15824,7 +15838,7 @@ class TestForwardReconcileProvisional:
         guess_ident, structural = self._seed_provisional(real_db)
         mcp_server._forward_reconcile_provisional(
             real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
-            {guess_ident: "2026-06-01T00:00:00Z"},
+            {guess_ident: "2026-06-01T00:00:00Z"}, self._TRUE_COMMIT,
         )
         raw = mcp_server._db_execute(
             real_db,
@@ -15841,7 +15855,7 @@ class TestForwardReconcileProvisional:
         guess_ident, structural = self._seed_provisional(real_db)
         mcp_server._forward_reconcile_provisional(
             real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
-            {guess_ident: "2026-06-01T00:00:00Z"},
+            {guess_ident: "2026-06-01T00:00:00Z"}, self._TRUE_COMMIT,
         )
         raw = mcp_server._db_execute(
             real_db,
@@ -15857,6 +15871,7 @@ class TestForwardReconcileProvisional:
         guess_ident, structural = self._seed_provisional(real_db)
         mcp_server._forward_reconcile_provisional(
             real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z", {},
+            self._TRUE_COMMIT,
         )
         raw = mcp_server._db_execute(
             real_db, "(query [:find ?c :where [:code/fn-login :modified-in ?c]])",
@@ -15865,6 +15880,34 @@ class TestForwardReconcileProvisional:
         assert "no timestamp in commit_metadata" in capsys.readouterr().err
         # The rest of the reconciliation still happened.
         assert mcp_server._lineage_is_provisional(real_db, ":code/fn-login") is False
+
+    def test_skips_modified_in_when_the_guess_is_this_very_commit(self, real_db):
+        """#222 phase 2d review, B2: Stream 2 claims high-to-low, so the first
+        commit at which it sights an entity born inside its own region IS that
+        entity's introduction -- a correct guess that still carries a
+        provisional marker. When a later run's forward walk re-walks that
+        position it must not "promote" the guess to a modification: the entity
+        would end up :introduced-by and :modified-in the SAME commit, a shape
+        forward-only ingest never produces and _correction_sweep_apply
+        explicitly refuses to write."""
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        returned = mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-06-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"}, guess_ident,
+        )
+        # Everything else still happens -- only step 5 is withheld.
+        assert returned == guess_ident
+        assert mcp_server._lineage_is_provisional(real_db, ":code/fn-login") is False
+        assert mcp_server._entity_introduced_by_query(real_db, ":code/fn-login") is None
+        raw = mcp_server._db_execute(
+            real_db,
+            '(query [:find ?c :any-valid-time '
+            ':where [:code/fn-login :modified-in ?c]])',
+        )
+        assert json.loads(raw)["results"] == [], (
+            "the entity was handed a :modified-in edge at its own introduction"
+        )
 
 
 class TestForwardApplyReconcilesProvisional:
@@ -16890,7 +16933,16 @@ class TestMultiStreamParityWithForwardOnly:
         (repo / "feature.py").write_text(
             "import util\n\ndef run():\n    return util.CONST + 1\n\ndef extra():\n    pass\n"
         )
-        self._commit(repo, "c6 edit feature", 6)
+        # auth.py is touched here too, on purpose: this is the LAST "M" on
+        # auth.py before `audit` is born in it at p8, and a resuming forward
+        # walk that thinks `audit` already exists replays exactly this commit
+        # and closes it as a removal (#222 phase 2d review, B1). Without an
+        # auth.py edit between the meeting point and p8 that bug has no
+        # commit to fire on.
+        (repo / "auth.py").write_text(
+            "def login():\n    return 5\n\ndef helper():\n    return 3\n"
+        )
+        self._commit(repo, "c6 edit feature and auth", 6)
 
         # p6: a DELETION in the reverse region. The reverse stream skips D
         # files entirely, so only Stage B's lifecycle pass can close these.
@@ -16908,27 +16960,79 @@ class TestMultiStreamParityWithForwardOnly:
         # p8: edit the renamed path. The reverse stream claims this position
         # BEFORE it claims the rename, so it holds a provisional :introduced-by
         # guess here that the sweep's rename application must supersede.
+        #
+        # `audit` is BORN here, at the very top of the reverse region, and is
+        # the fixture's only entity whose reverse-stream first sighting IS its
+        # own introduction (auth.py is not touched again above p8, so the
+        # guess never moves). It carries both halves of the phase 2d review:
+        # a resuming forward walk must not close it while replaying the
+        # earlier commits that legitimately lack it (B1), and when that walk
+        # reaches p8 and reconciles the guess it must not then assert
+        # [audit :modified-in p8] on top of [audit :introduced-by p8] (B2).
         (repo / "helpers" / "util.py").write_text(
             "CONST = 8\n\ndef normalize(s):\n    return s.strip().lower()\n"
         )
         (repo / "auth.py").write_text(
             "def login():\n    return 8\n\ndef helper():\n    return 3\n"
+            "\ndef audit():\n    return 'audit'\n"
         )
         self._commit(repo, "c9 edit renamed util and auth", 9)
         return repo
+
+    def _new_commit(self, repo):
+        """One more commit on top of _repo's nine -- what lands between two
+        sessions, and what makes _frontier_load hand the whole previous
+        reverse region back to the gap (its high interval no longer reaches
+        the last position, so it is unrepresentable and gets discarded)."""
+        (repo / "auth.py").write_text(
+            "def login():\n    return 9\n\ndef helper():\n    return 9\n"
+            "\ndef audit():\n    return 'audit'\n"
+        )
+        self._commit(repo, "c10 edit auth again", 10)
+
+    def _reset_progress(self):
+        import mcp_server
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+            "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+        }
 
     async def _ingest(self, repo, graph_path, monkeypatch, ratio):
         import mcp_server
         monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", ratio)
         monkeypatch.setattr(mcp_server, "_graph_path", str(graph_path))
         mcp_server._db = None
-        mcp_server._ingest_progress = {
-            "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
-            "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
-        }
+        self._reset_progress()
         await mcp_server._run_ingestion(str(repo), "master")
         assert mcp_server._ingest_progress["status"] == "complete", mcp_server._ingest_progress
         mcp_server._db = None  # release the file lock before reopening to query
+
+    async def _ingest_interrupted(self, repo, graph_path, monkeypatch, stop_after):
+        """Ingest at the 1:1 default but request shutdown from inside the
+        stop_after'th _forward_apply, so Stage A stops with the reverse
+        stream's claims persisted and its lineage still provisional."""
+        import mcp_server
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph_path))
+        mcp_server._db = None
+        self._reset_progress()
+
+        real_forward = mcp_server._forward_apply
+        calls = {"n": 0}
+
+        def stopping_forward(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == stop_after:
+                mcp_server._shutdown_requested.set()
+            return real_forward(*args, **kwargs)
+
+        monkeypatch.setattr(mcp_server, "_forward_apply", stopping_forward)
+        try:
+            await mcp_server._run_ingestion(str(repo), "master")
+        finally:
+            monkeypatch.setattr(mcp_server, "_forward_apply", real_forward)
+        assert mcp_server._ingest_progress["status"] == "stopped", mcp_server._ingest_progress
+        mcp_server._db = None
 
     def _raw_query(self, graph_path, datalog):
         import mcp_server
@@ -16987,6 +17091,97 @@ class TestMultiStreamParityWithForwardOnly:
     def _live_idents(self, graph_path):
         return self._query(graph_path, "(query [:find ?i :where [?e :ident ?i]])")
 
+    def _assert_no_self_modification(self, graph_path, label):
+        """No entity may be :modified-in the same commit it is :introduced-by.
+
+        #222 phase 2d review, B2. A forward-only ingest cannot produce that
+        shape (_build_code_triples emits one or the other, never both) and
+        _correction_sweep_apply has an explicit self-introduction guard
+        against it, so it is a standing invariant of the graph rather than a
+        differential -- asserted on BOTH graphs for that reason.
+        """
+        intro = dict(self._query(
+            graph_path, "(query [:find ?i ?c :where [?e :ident ?i] [?e :introduced-by ?c]])"
+        ))
+        modified = self._query(
+            graph_path, "(query [:find ?i ?c :where [?e :ident ?i] [?e :modified-in ?c]])"
+        )
+        offenders = sorted({(i, c) for i, c in modified if intro.get(i) == c})
+        assert offenders == [], (
+            f"[{label}] entities carry :modified-in at their own :introduced-by "
+            f"commit: {offenders}"
+        )
+
+    def _assert_parity(self, multi, forward_only):
+        """The whole oracle: the two graphs must agree on lineage, on which
+        entities are live, and on the rest of the fact shape -- and neither
+        may carry a provisional marker or a self-modification.
+
+        Extracted from test_introduced_by_matches_a_forward_only_ingest
+        unchanged (#222 phase 2d review, findings (t)/B2) so the incremental
+        re-ingest tests below measure the graph against exactly the same
+        oracle rather than a weaker restatement of it.
+        """
+        import mcp_server
+
+        multi_lineage = self._lineage(multi)
+        forward_lineage = self._lineage(forward_only)
+        assert multi_lineage, "no lineage facts at all -- the ingest did nothing"
+        assert multi_lineage == forward_lineage, (
+            "1:1 and forward-only graphs disagree on :introduced-by\n"
+            f"  only in 1:1:  {sorted(set(multi_lineage) - set(forward_lineage))}\n"
+            f"  only in fwd:  {sorted(set(forward_lineage) - set(multi_lineage))}"
+        )
+
+        # Lifecycle guard: :introduced-by is never retracted by a close, so
+        # lineage parity alone would not notice an entity that should have
+        # been closed but has no :introduced-by row of its own to betray it.
+        # It is also the half that catches B1 -- an entity a resuming forward
+        # walk wrongly closed as "removed" drops out of :ident here.
+        multi_live = self._live_idents(multi)
+        forward_live = self._live_idents(forward_only)
+        assert multi_live == forward_live, (
+            "1:1 and forward-only graphs disagree on which entities are live\n"
+            f"  only in 1:1:  {sorted(set(multi_live) - set(forward_live))}\n"
+            f"  only in fwd:  {sorted(set(forward_live) - set(multi_live))}"
+        )
+
+        # Checked BEFORE the fact-shape comparison below, which would
+        # otherwise report a self-modification as an anonymous :modified-in
+        # diff. This says what is actually wrong with the row.
+        self._assert_no_self_modification(multi, "1:1")
+        self._assert_no_self_modification(forward_only, "forward-only")
+
+        # The remaining fact shape must agree too -- a rename that landed as
+        # an unrelated birth would still satisfy the two oracles above if it
+        # happened to pick the same commit, but not :renamed-to/:renamed-from
+        # or :contains.
+        multi_snapshot = self._snapshot(multi)
+        forward_snapshot = self._snapshot(forward_only)
+        for label in self._SNAPSHOT_QUERIES:
+            a, b = multi_snapshot[label], forward_snapshot[label]
+            assert a == b, (
+                f"1:1 and forward-only graphs disagree on {label}\n"
+                f"  only in 1:1:  {sorted(set(a) - set(b))}\n"
+                f"  only in fwd:  {sorted(set(b) - set(a))}"
+            )
+
+        # Marker companions carry no :ident of their own -- they are reached
+        # through :entity, exactly as _preload_provisional_idents reaches them.
+        marker_q = (
+            "(query [:find ?e :where "
+            f"[?m :entity-type {mcp_server._LINEAGE_MARKER_ENTITY_TYPE}] [?m :entity ?e]])"
+        )
+        assert self._raw_query(multi, marker_q) == [], (
+            "the 1:1 run left provisional lineage markers behind -- Stage B's "
+            "reconciliation never confirmed them: "
+            f"{self._raw_query(multi, marker_q)}"
+        )
+        assert self._raw_query(forward_only, marker_q) == [], \
+            "a forward-only run should never create a provisional lineage marker"
+
+        return multi_live
+
     def _assert_reverse_claimed(self, graph_path, repo, positions):
         """Guard against a vacuous differential: if the reverse stream never
         claimed the lifecycle commits, the two runs agree for a boring
@@ -17023,68 +17218,23 @@ class TestMultiStreamParityWithForwardOnly:
         # edit (p8) must all have been reverse-claimed in the 1:1 run.
         self._assert_reverse_claimed(multi, repo, [6, 7, 8])
 
-        multi_lineage = self._lineage(multi)
-        forward_lineage = self._lineage(forward_only)
-        assert multi_lineage, "no lineage facts at all -- the ingest did nothing"
-        assert multi_lineage == forward_lineage, (
-            "1:1 and forward-only graphs disagree on :introduced-by\n"
-            f"  only in 1:1:  {sorted(set(multi_lineage) - set(forward_lineage))}\n"
-            f"  only in fwd:  {sorted(set(forward_lineage) - set(multi_lineage))}"
-        )
-
-        # Lifecycle guard: :introduced-by is never retracted by a close, so
-        # lineage parity alone would not notice an entity that should have
-        # been closed but has no :introduced-by row of its own to betray it.
-        multi_live = self._live_idents(multi)
-        forward_live = self._live_idents(forward_only)
-        assert multi_live == forward_live, (
-            "1:1 and forward-only graphs disagree on which entities are live\n"
-            f"  only in 1:1:  {sorted(set(multi_live) - set(forward_live))}\n"
-            f"  only in fwd:  {sorted(set(forward_live) - set(multi_live))}"
-        )
-
-        # The remaining fact shape must agree too -- a rename that landed as
-        # an unrelated birth would still satisfy the two oracles above if it
-        # happened to pick the same commit, but not :renamed-to/:renamed-from
-        # or :contains.
-        multi_snapshot = self._snapshot(multi)
-        forward_snapshot = self._snapshot(forward_only)
-        for label in self._SNAPSHOT_QUERIES:
-            a, b = multi_snapshot[label], forward_snapshot[label]
-            assert a == b, (
-                f"1:1 and forward-only graphs disagree on {label}\n"
-                f"  only in 1:1:  {sorted(set(a) - set(b))}\n"
-                f"  only in fwd:  {sorted(set(b) - set(a))}"
-            )
-
-        # Stage B's OTHER half -- the A/M lineage RECONCILIATION -- is
-        # deliberately invisible in the fact shape above whenever the reverse
-        # stream's guess was already the right commit, which is the common
-        # case (feature.py's `extra` is born at p5, inside the reverse region,
-        # so the reverse walk guesses p5 correctly and there is nothing to
-        # correct). What reconciliation alone does is retract the
+        # The oracle itself. Stage B's A/M lineage RECONCILIATION half is
+        # deliberately invisible in the fact shape it compares whenever the
+        # reverse stream's guess was already the right commit, which is the
+        # common case (feature.py's `extra` is born at p5, inside the reverse
+        # region, so the reverse walk guesses p5 correctly and there is
+        # nothing to correct). What reconciliation alone does is retract the
         # :type/lineage-marker companion that says "provisional". Measured:
         # disabling _correction_sweep_apply leaves exactly `extra` marked and
-        # changes no other fact, so without this assertion the reconciliation
-        # half of Stage B would be untested here. A forward-only run never
-        # creates a marker at all, so this stays a differential.
-        import mcp_server
-        # Marker companions carry no :ident of their own -- they are reached
-        # through :entity, exactly as _preload_provisional_idents reaches them.
-        marker_q = (
-            "(query [:find ?e :where "
-            f"[?m :entity-type {mcp_server._LINEAGE_MARKER_ENTITY_TYPE}] [?m :entity ?e]])"
-        )
-        assert self._raw_query(multi, marker_q) == [], (
-            "the 1:1 run left provisional lineage markers behind -- Stage B's "
-            "reconciliation never confirmed them: "
-            f"{self._raw_query(multi, marker_q)}"
-        )
-        assert self._raw_query(forward_only, marker_q) == [], \
-            "a forward-only run should never create a provisional lineage marker"
+        # changes no other fact, so without _assert_parity's marker assertion
+        # the reconciliation half of Stage B would be untested here. A
+        # forward-only run never creates a marker at all, so it stays a
+        # differential.
+        multi_live = self._assert_parity(multi, forward_only)
 
         # ...and the agreed-on graph is one that really did see the lifecycle
         # events, so parity is not agreement on an inert history.
+        import mcp_server
         live = {i for (i,) in multi_live}
         assert mcp_server._code_ident("module", "legacy.py") not in live, \
             "the deleted module is still live -- Stage B's lifecycle pass did nothing"
@@ -17093,18 +17243,142 @@ class TestMultiStreamParityWithForwardOnly:
         assert mcp_server._code_ident("module", "helpers/util.py") in live, \
             "the rename destination was never created"
 
+    @pytest.mark.asyncio
+    async def test_incremental_re_ingest_matches_a_forward_only_ingest(
+        self, tmp_path, monkeypatch
+    ):
+        """#222 phase 2d review, B1: the oracle above, run over a SECOND
+        ingest of the same graph after a new commit lands.
+
+        This is the shape every real session has -- the plugin auto-ingests at
+        server start, and _frontier_load discards the previous run's high
+        interval the moment HEAD moves past it, handing the whole previous
+        reverse region back to the gap. The resuming forward walk therefore
+        re-walks commits whose entities the reverse stream (and Stage B) have
+        already written, ABOVE :ingestion/watermark. Before the fix, the
+        current-graph preload handed those entities to the forward walk as
+        "previously known", the earlier commits it replayed did not contain
+        them, and they were closed and purged as removals -- so
+        :module/helpers-util-py and friends simply vanished from the graph.
+        """
+        repo = self._repo(tmp_path)
+        multi = tmp_path / "multi.graph"
+        forward_only = tmp_path / "fwd.graph"
+
+        await self._ingest(repo, multi, monkeypatch, "1:1")
+        # Non-vacuity twice over: entities exclusive to the reverse region
+        # (helpers/util.py's, born at p7) are what the resumed walk can lose.
+        self._assert_reverse_claimed(multi, repo, [6, 7, 8])
+
+        self._new_commit(repo)
+
+        await self._ingest(repo, multi, monkeypatch, "1:1")
+        await self._ingest(repo, forward_only, monkeypatch, f"{10**6}:1")
+
+        multi_live = self._assert_parity(multi, forward_only)
+
+        import mcp_server
+        live = {i for (i,) in multi_live}
+        assert mcp_server._code_ident("module", "helpers/util.py") in live, \
+            "the rename destination born in the previous run's reverse region " \
+            "was closed by the resumed forward walk"
+        assert mcp_server._code_ident("function", "feature.py", "extra") in live, \
+            "the function born inside the previous run's reverse region was " \
+            "closed by the resumed forward walk"
+
+    @pytest.mark.asyncio
+    async def test_re_ingest_after_an_interrupted_run_matches_forward_only(
+        self, tmp_path, monkeypatch
+    ):
+        """The same regression, reached the other way (#222 phase 2d review,
+        B1 and B2).
+
+        A run stopped mid-Stage-A leaves the reverse stream's claims durable
+        and its lineage still PROVISIONAL -- Stage B never ran. The next run
+        then both resumes the forward walk into that region and reconciles
+        those guesses, which is where B2's self-:modified-in appears: the
+        reverse stream's first sighting of an entity born inside its own
+        region IS that entity's introduction (`audit`, at p8), so the guess
+        and the commit the forward walk is applying are the same commit.
+
+        The resumed run is deliberately forward-heavy, not 1:1. Both bugs
+        need the FORWARD stream to reach the positions the previous run's
+        reverse stream wrote; at 1:1 over the re-opened gap the reverse
+        stream re-claims the top of the range and the forward walk never
+        arrives, so a 1:1 resume here would pass vacuously. The
+        clean-completed-run variant above covers the 1:1 resume.
+        """
+        repo = self._repo(tmp_path)
+        multi = tmp_path / "multi.graph"
+        forward_only = tmp_path / "fwd.graph"
+
+        # Stop from inside the fourth forward apply: at 1:1 the claimer has
+        # by then run F0, R8, F1, R7, F2, R6, F3, so positions 6..8 are
+        # durably reverse-claimed with their lineage still provisional.
+        await self._ingest_interrupted(repo, multi, monkeypatch, stop_after=4)
+        self._assert_reverse_claimed(multi, repo, [6, 7, 8])
+
+        self._new_commit(repo)
+
+        await self._ingest(repo, multi, monkeypatch, f"{10**6}:1")
+        await self._ingest(repo, forward_only, monkeypatch, f"{10**6}:1")
+
+        multi_live = self._assert_parity(multi, forward_only)
+
+        import mcp_server
+        live = {i for (i,) in multi_live}
+        assert mcp_server._code_ident("function", "auth.py", "audit") in live, \
+            "the function born in the interrupted run's reverse region was " \
+            "closed by the resumed forward walk"
+
 
 class TestStagingAndShutdown:
     def _repo(self, tmp_path, n_commits=6):
+        """A linear auth.py history where the newest third also carries a
+        function that does NOT exist earlier.
+
+        That last part is load-bearing (#222 phase 2d review, findings B1 and
+        (t)). This fixture originally wrote the identical `def login()` body
+        in every commit, so every commit parsed to the identical entity set
+        and NO entity was ever exclusive to the region the reverse stream
+        claims -- which is precisely why
+        test_shutdown_during_stage_a_stops_and_resumes could resume cleanly
+        while the resumed forward walk was silently closing and purging every
+        reverse-region entity in a real repo.
+
+        Commit dates are pinned and strictly increasing rather than left to
+        wall-clock: ingest valid-time is denominated in committer dates, and
+        a burst of same-second commits is indistinguishable on that axis.
+        """
         repo = tmp_path / "repo"
         repo.mkdir()
         _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
         _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
         _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        # `helper` is introduced in the newest third, i.e. inside
+        # frontier-high's territory at the 1:1 default. `audit` is introduced
+        # in the LAST commit alone, so it is exclusive to the reverse region
+        # even when a run is interrupted after a single reverse claim -- the
+        # narrowest case, and the one test_shutdown_during_stage_a_stops_and_
+        # resumes exercises.
+        helper_from = n_commits - max(1, n_commits // 3)
         for i in range(n_commits):
-            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            body = f"def login():\n    return {i}\n"
+            if i >= helper_from:
+                body += "\ndef helper():\n    return 0\n"
+            if i == n_commits - 1:
+                body += "\ndef audit():\n    return 0\n"
+            (repo / "auth.py").write_text(body)
+            ts = (
+                datetime.datetime(2021, 3, 1, tzinfo=datetime.timezone.utc)
+                + datetime.timedelta(days=i)
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+            env = {**os.environ, "GIT_AUTHOR_DATE": ts, "GIT_COMMITTER_DATE": ts}
             _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
-            _subprocess.run(["git", "commit", "-m", f"h{i}"], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(
+                ["git", "commit", "-m", f"h{i}"], cwd=repo, check=True,
+                capture_output=True, env=env,
+            )
         return repo
 
     @pytest.mark.asyncio
@@ -17206,6 +17480,25 @@ class TestStagingAndShutdown:
         db2 = MiniGrafDb.open(str(graph))
         assert mcp_server._preload_provisional_idents(db2) == set()
         assert mcp_server._lineage_confirmed_through_query(db2) == linearization[-1]
+
+        # #222 phase 2d review, B1: "resumed cleanly" has to mean the graph
+        # still holds what the interrupted run wrote. `audit` exists only in
+        # the last commit and `helper` only in the newest third -- the region
+        # the reverse stream claims -- so the resuming forward walk replays
+        # commits that legitimately lack them, and before the fix closed and
+        # purged them as removals. Asserted through :ident, which a close
+        # retracts (unlike :introduced-by, which it does not).
+        for name in ("helper", "audit"):
+            ident = mcp_server._code_ident("function", "auth.py", name)
+            live = json.loads(mcp_server._db_execute(
+                db2, f'(query [:find ?i :where [{ident} :ident ?i]])'
+            ))["results"]
+            assert live == [[ident]], (
+                f"`{name}`, born in the reverse-claimed region, did not survive "
+                f"the resume: {live}"
+            )
+        db2 = None
+        mcp_server._db = None
 
     @pytest.mark.asyncio
     async def test_neither_sync_wrapper_is_called_from_run_ingestion(self, tmp_path, monkeypatch):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16804,6 +16804,296 @@ class TestStageBRepairsLifecycleFacts:
                 f"{sorted(r for r in rows if subjects.count(r[0]) > 1)}"
 
 
+class TestMultiStreamParityWithForwardOnly:
+    """#222 phase 2d Task 11: the payoff for the whole phase.
+
+    Stage A's converging streams and Stage B's correction sweep are only
+    worth anything if together they land the lineage a plain forward walk
+    would have landed. That is one assertion, and this is it: ingest the
+    same repo twice -- once at the shipping 1:1 default, once forward-only
+    via a forward ratio large enough that the forward stream drains the
+    whole gap before the reverse stream ever claims -- and require the two
+    graphs to agree.
+
+    Where TestStageBRepairsLifecycleFacts drills into one lifecycle event
+    per tiny repo, this one runs a single longer history whose newest third
+    (the region the reverse stream claims at 1:1) carries a deletion, a
+    rename and a post-rename edit at once, so the meeting point, the
+    provisional-lineage reconciliation and the sweep's lifecycle-repair pass
+    are all exercised together.
+
+    NOTE ON THE FIXTURE: it deliberately contains NO path reuse -- nothing
+    is re-created at a path that was earlier deleted or renamed away. That
+    is not to hide anything; it is because path reuse hits a KNOWN,
+    out-of-scope phase-2b defect (_build_close_triples never retracts
+    :introduced-by, so _reverse_apply's known-entity gate resurrects a
+    ghost) which is already pinned by
+    TestClosedEntityLifecyclePurge::test_reused_path_new_entity_is_not_a_ghost
+    and its strict-xfail companion. Mixing that failure into the parity
+    oracle would only make this test say something the pins already say,
+    while destroying its ability to report a genuine parity break.
+    """
+
+    # frontier-high and :ingestion/correction-sweep-through only exist when a
+    # reverse stream ran at all; :lineage/ and :candidate/ are transient
+    # scratch state. All of them legitimately differ between the two runs.
+    _BOOKKEEPING_PREFIXES = (":ingestion/", ":lineage/", ":candidate/")
+
+    def _commit(self, repo, msg, day, paths=None):
+        ts = f"2021-03-{day:02d}T00:00:00Z"
+        env = {**os.environ, "GIT_AUTHOR_DATE": ts, "GIT_COMMITTER_DATE": ts}
+        _subprocess.run(
+            ["git", "add", *(["-A"] if paths is None else list(paths))],
+            cwd=repo, check=True, capture_output=True,
+        )
+        _subprocess.run(
+            ["git", "commit", "-m", msg], cwd=repo, check=True, capture_output=True, env=env,
+        )
+
+    def _repo(self, tmp_path):
+        """Nine commits. Positions are linearization indices (0 = oldest).
+
+        At the 1:1 default the claimer alternates F0, R8, F1, R7, F2, R6,
+        F3, R5, F4 -- so frontier-high covers 5..8 and every lifecycle event
+        below lands in reverse-claimed territory. _assert_reverse_claimed
+        re-derives that from the persisted frontier rather than trusting it.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init", "-b", "master"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+
+        # p0: three files born together.
+        (repo / "auth.py").write_text(
+            "def login():\n    return 0\n\ndef helper():\n    return 0\n"
+        )
+        (repo / "util.py").write_text("CONST = 0\n\ndef normalize(s):\n    return s\n")
+        (repo / "legacy.py").write_text("def old_api():\n    return 'legacy'\n")
+        self._commit(repo, "c1 initial", 1)
+
+        # p1..p5: plain modifications, plus one new file, spanning the
+        # forward region and the low end of the reverse region.
+        (repo / "auth.py").write_text(
+            "def login():\n    return 1\n\ndef helper():\n    return 0\n"
+        )
+        self._commit(repo, "c2 edit auth", 2)
+        (repo / "util.py").write_text("CONST = 2\n\ndef normalize(s):\n    return s.strip()\n")
+        self._commit(repo, "c3 edit util", 3)
+        (repo / "feature.py").write_text("import util\n\ndef run():\n    return util.CONST\n")
+        (repo / "auth.py").write_text(
+            "def login():\n    return 3\n\ndef helper():\n    return 3\n"
+        )
+        self._commit(repo, "c4 add feature, edit auth", 4)
+        (repo / "legacy.py").write_text("def old_api():\n    return 'still here'\n")
+        self._commit(repo, "c5 edit legacy", 5)
+        (repo / "feature.py").write_text(
+            "import util\n\ndef run():\n    return util.CONST + 1\n\ndef extra():\n    pass\n"
+        )
+        self._commit(repo, "c6 edit feature", 6)
+
+        # p6: a DELETION in the reverse region. The reverse stream skips D
+        # files entirely, so only Stage B's lifecycle pass can close these.
+        _subprocess.run(["git", "rm", "legacy.py"], cwd=repo, check=True, capture_output=True)
+        self._commit(repo, "c7 delete legacy.py", 7, paths=[])
+
+        # p7: a RENAME in the reverse region, to a path never used before.
+        # git mv refuses a missing destination directory, so make it first.
+        (repo / "helpers").mkdir()
+        _subprocess.run(
+            ["git", "mv", "util.py", "helpers/util.py"], cwd=repo, check=True, capture_output=True,
+        )
+        self._commit(repo, "c8 rename util.py", 8, paths=[])
+
+        # p8: edit the renamed path. The reverse stream claims this position
+        # BEFORE it claims the rename, so it holds a provisional :introduced-by
+        # guess here that the sweep's rename application must supersede.
+        (repo / "helpers" / "util.py").write_text(
+            "CONST = 8\n\ndef normalize(s):\n    return s.strip().lower()\n"
+        )
+        (repo / "auth.py").write_text(
+            "def login():\n    return 8\n\ndef helper():\n    return 3\n"
+        )
+        self._commit(repo, "c9 edit renamed util and auth", 9)
+        return repo
+
+    async def _ingest(self, repo, graph_path, monkeypatch, ratio):
+        import mcp_server
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", ratio)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph_path))
+        mcp_server._db = None
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+            "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+        }
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete", mcp_server._ingest_progress
+        mcp_server._db = None  # release the file lock before reopening to query
+
+    def _raw_query(self, graph_path, datalog):
+        import mcp_server
+        from minigraf import MiniGrafDb
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            rows = json.loads(mcp_server._db_execute(db, datalog)).get("results", [])
+        finally:
+            db = None
+        return sorted(tuple(r) for r in rows)
+
+    def _query(self, graph_path, datalog):
+        """_raw_query minus the bookkeeping entities the two runs
+        legitimately differ on."""
+        return [
+            r for r in self._raw_query(graph_path, datalog)
+            if not str(r[0]).startswith(self._BOOKKEEPING_PREFIXES)
+        ]
+
+    # The rest of the fact shape, beyond the :introduced-by and live-:ident
+    # oracles asserted first. Bound through :ident on purpose: `?e` alone is
+    # minigraf's internal subject, which is not stable across two
+    # separately-built graphs.
+    _SNAPSHOT_QUERIES = {
+        "modified-in": "[?e :ident ?i] [?e :modified-in ?v]",
+        "entity-type": "[?e :ident ?i] [?e :entity-type ?v]",
+        "description": "[?e :ident ?i] [?e :description ?v]",
+        "path": "[?e :ident ?i] [?e :path ?v]",
+        "file": "[?e :ident ?i] [?e :file ?v]",
+        "contains": "[?e :ident ?i] [?e :contains ?v]",
+        "depends-on": "[?e :ident ?i] [?e :depends-on ?v]",
+        "renamed-to": "[?e :ident ?i] [?e :renamed-to ?v]",
+        "renamed-from": "[?e :ident ?i] [?e :renamed-from ?v]",
+    }
+
+    def _snapshot(self, graph_path):
+        return {
+            label: self._query(graph_path, f"(query [:find ?i ?v :where {where}])")
+            for label, where in self._SNAPSHOT_QUERIES.items()
+        }
+
+    def _lineage(self, graph_path):
+        """Every live entity's :introduced-by, keyed by :ident.
+
+        Bound through :ident on purpose. `?e` alone is minigraf's internal
+        subject, which is not stable across two separately-built graphs, and
+        joining through :ident additionally means an entity the forward walk
+        closed (no live :ident) drops out -- so a deletion the mixed run
+        failed to apply shows up here as an extra row rather than hiding
+        behind the fact that a close does not retract :introduced-by.
+        """
+        return self._query(
+            graph_path, "(query [:find ?i ?c :where [?e :ident ?i] [?e :introduced-by ?c]])"
+        )
+
+    def _live_idents(self, graph_path):
+        return self._query(graph_path, "(query [:find ?i :where [?e :ident ?i]])")
+
+    def _assert_reverse_claimed(self, graph_path, repo, positions):
+        """Guard against a vacuous differential: if the reverse stream never
+        claimed the lifecycle commits, the two runs agree for a boring
+        reason and this test proves nothing."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            high = mcp_server._frontier_read_bounds(db, mcp_server._FRONTIER_HIGH_IDENT)
+        finally:
+            db = None
+        assert high is not None, "the reverse stream claimed nothing -- test is vacuous"
+        linearization = frontier_registry.build_linearization(str(repo), "master")
+        pos = {h: i for i, h in enumerate(linearization)}
+        lo, hi = pos[high[0]], pos[high[1]]
+        for p in positions:
+            assert lo <= p <= hi, (
+                f"position {p} was not reverse-claimed (frontier-high covers "
+                f"{lo}..{hi}) -- this test would pass vacuously"
+            )
+
+    @pytest.mark.asyncio
+    async def test_introduced_by_matches_a_forward_only_ingest(self, tmp_path, monkeypatch):
+        repo = self._repo(tmp_path)
+        multi = tmp_path / "multi.graph"
+        forward_only = tmp_path / "fwd.graph"
+
+        await self._ingest(repo, multi, monkeypatch, "1:1")
+        # Forward-only: give the forward stream the entire range by making the
+        # reverse side never get a turn before the gap is exhausted.
+        await self._ingest(repo, forward_only, monkeypatch, f"{10**6}:1")
+
+        # Non-vacuity: the deletion (p6), the rename (p7) and the post-rename
+        # edit (p8) must all have been reverse-claimed in the 1:1 run.
+        self._assert_reverse_claimed(multi, repo, [6, 7, 8])
+
+        multi_lineage = self._lineage(multi)
+        forward_lineage = self._lineage(forward_only)
+        assert multi_lineage, "no lineage facts at all -- the ingest did nothing"
+        assert multi_lineage == forward_lineage, (
+            "1:1 and forward-only graphs disagree on :introduced-by\n"
+            f"  only in 1:1:  {sorted(set(multi_lineage) - set(forward_lineage))}\n"
+            f"  only in fwd:  {sorted(set(forward_lineage) - set(multi_lineage))}"
+        )
+
+        # Lifecycle guard: :introduced-by is never retracted by a close, so
+        # lineage parity alone would not notice an entity that should have
+        # been closed but has no :introduced-by row of its own to betray it.
+        multi_live = self._live_idents(multi)
+        forward_live = self._live_idents(forward_only)
+        assert multi_live == forward_live, (
+            "1:1 and forward-only graphs disagree on which entities are live\n"
+            f"  only in 1:1:  {sorted(set(multi_live) - set(forward_live))}\n"
+            f"  only in fwd:  {sorted(set(forward_live) - set(multi_live))}"
+        )
+
+        # The remaining fact shape must agree too -- a rename that landed as
+        # an unrelated birth would still satisfy the two oracles above if it
+        # happened to pick the same commit, but not :renamed-to/:renamed-from
+        # or :contains.
+        multi_snapshot = self._snapshot(multi)
+        forward_snapshot = self._snapshot(forward_only)
+        for label in self._SNAPSHOT_QUERIES:
+            a, b = multi_snapshot[label], forward_snapshot[label]
+            assert a == b, (
+                f"1:1 and forward-only graphs disagree on {label}\n"
+                f"  only in 1:1:  {sorted(set(a) - set(b))}\n"
+                f"  only in fwd:  {sorted(set(b) - set(a))}"
+            )
+
+        # Stage B's OTHER half -- the A/M lineage RECONCILIATION -- is
+        # deliberately invisible in the fact shape above whenever the reverse
+        # stream's guess was already the right commit, which is the common
+        # case (feature.py's `extra` is born at p5, inside the reverse region,
+        # so the reverse walk guesses p5 correctly and there is nothing to
+        # correct). What reconciliation alone does is retract the
+        # :type/lineage-marker companion that says "provisional". Measured:
+        # disabling _correction_sweep_apply leaves exactly `extra` marked and
+        # changes no other fact, so without this assertion the reconciliation
+        # half of Stage B would be untested here. A forward-only run never
+        # creates a marker at all, so this stays a differential.
+        import mcp_server
+        # Marker companions carry no :ident of their own -- they are reached
+        # through :entity, exactly as _preload_provisional_idents reaches them.
+        marker_q = (
+            "(query [:find ?e :where "
+            f"[?m :entity-type {mcp_server._LINEAGE_MARKER_ENTITY_TYPE}] [?m :entity ?e]])"
+        )
+        assert self._raw_query(multi, marker_q) == [], (
+            "the 1:1 run left provisional lineage markers behind -- Stage B's "
+            "reconciliation never confirmed them: "
+            f"{self._raw_query(multi, marker_q)}"
+        )
+        assert self._raw_query(forward_only, marker_q) == [], \
+            "a forward-only run should never create a provisional lineage marker"
+
+        # ...and the agreed-on graph is one that really did see the lifecycle
+        # events, so parity is not agreement on an inert history.
+        live = {i for (i,) in multi_live}
+        assert mcp_server._code_ident("module", "legacy.py") not in live, \
+            "the deleted module is still live -- Stage B's lifecycle pass did nothing"
+        assert mcp_server._code_ident("module", "util.py") not in live, \
+            "the renamed-away module is still live"
+        assert mcp_server._code_ident("module", "helpers/util.py") in live, \
+            "the rename destination was never created"
+
+
 class TestStagingAndShutdown:
     def _repo(self, tmp_path, n_commits=6):
         repo = tmp_path / "repo"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15575,3 +15575,140 @@ class TestParseStreamRatio:
         this runs inside a background coroutine with no user in the loop."""
         import mcp_server
         assert mcp_server._parse_stream_ratio("\x00\xff") == (1, 1)
+
+
+class TestForwardReconcileProvisional:
+    def _seed_provisional(self, real_db):
+        """An entity Stream 2 discovered at a late commit and guessed wrong."""
+        import mcp_server
+        guess_ident = ":commit/bbbbbbbbbbbb"
+        structural = [
+            ":code/fn-login :entity-type :type/function",
+            ':code/fn-login :name "login"',
+            ":module/auth :contains :code/fn-login",
+        ]
+        structural_triples = [f"[{t}]" for t in structural]
+        mcp_server._transact(
+            real_db, "[" + " ".join(f"[{t}]" for t in structural if ":contains" not in t) + "]",
+            "2026-06-01T00:00:00Z",
+        )
+        mcp_server._transact(
+            real_db, "[[:module/auth :contains :code/fn-login]]", "2026-06-01T00:00:00Z",
+        )
+        mcp_server._transact(
+            real_db, f"[[:code/fn-login :introduced-by {guess_ident}]]", "2026-06-01T00:00:00Z",
+        )
+        mcp_server._lineage_mark_provisional(real_db, ":code/fn-login", "2026-06-01T00:00:00Z")
+        mcp_server._candidate_diff_persist(
+            real_db, "bbbbbbbbbbbb" + "0" * 28, ":code/fn-login", "hash-b", "2026-06-01T00:00:00Z",
+        )
+        return guess_ident, structural_triples
+
+    def test_returns_none_and_writes_nothing_when_not_provisional(self, real_db):
+        import mcp_server
+        mcp_server._transact(
+            real_db, "[[:code/fn-x :introduced-by :commit/aaaaaaaaaaaa]]", "2026-01-01T00:00:00Z",
+        )
+        result = mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-x", [], "2026-01-01T00:00:00Z", {},
+        )
+        assert result is None
+        assert mcp_server._entity_introduced_by_query(real_db, ":code/fn-x") == ":commit/aaaaaaaaaaaa"
+
+    def test_retracts_the_provisional_guess(self, real_db):
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        # No :introduced-by left at all -- the caller writes the authoritative
+        # one immediately after, via the normal forward emission path.
+        assert mcp_server._entity_introduced_by_query(real_db, ":code/fn-login") is None
+
+    def test_confirms_the_marker_and_clears_the_candidate_diff(self, real_db):
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        returned = mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        assert returned == guess_ident
+        assert mcp_server._lineage_is_provisional(real_db, ":code/fn-login") is False
+        assert mcp_server._candidate_diff_read(
+            real_db, "bbbbbbbbbbbb" + "0" * 28, ":code/fn-login",
+        ) is None
+
+    def test_writes_modified_in_at_the_guess_commits_own_timestamp(self, real_db):
+        """The guess commit is now known to be a genuine modification rather
+        than the introduction. Dating the edge at the TRUE introduction's
+        timestamp would assert a fact valid before it was true."""
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        raw = mcp_server._db_execute(
+            real_db,
+            '(query [:find ?c :valid-at "2026-06-02T00:00:00Z" '
+            ':where [:code/fn-login :modified-in ?c]])',
+        )
+        assert [row[0] for row in json.loads(raw)["results"]] == [guess_ident]
+        # Not yet true the day BEFORE the guess commit.
+        raw_before = mcp_server._db_execute(
+            real_db,
+            '(query [:find ?c :valid-at "2026-05-31T00:00:00Z" '
+            ':where [:code/fn-login :modified-in ?c]])',
+        )
+        assert json.loads(raw_before)["results"] == []
+
+    def test_re_dates_structural_facts_to_the_true_introduction(self, real_db):
+        """Otherwise there is a valid-time window where :introduced-by is live
+        for an entity with no type, name or file, so an :as-of query at the
+        true introduction reports the entity as nonexistent."""
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        raw = mcp_server._db_execute(
+            real_db,
+            '(query [:find ?n :valid-at "2026-02-01T00:00:00Z" '
+            ':where [:code/fn-login :name ?n]])',
+        )
+        assert [row[0] for row in json.loads(raw)["results"]] == ["login"]
+
+    def test_contains_edge_survives_re_dating(self, real_db):
+        """:contains shares (entity, attribute, valid_from) with any sibling
+        edge, so it must be retracted and re-transacted one triple per call
+        -- batching silently keeps only the last (#222 phase 2b1)."""
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z",
+            {guess_ident: "2026-06-01T00:00:00Z"},
+        )
+        raw = mcp_server._db_execute(
+            real_db,
+            '(query [:find ?c :valid-at "2026-02-01T00:00:00Z" '
+            ':where [:module/auth :contains ?c]])',
+        )
+        assert [row[0] for row in json.loads(raw)["results"]] == [":code/fn-login"]
+
+    def test_skips_modified_in_when_guess_timestamp_unknown(self, real_db, capsys):
+        """Falling back to the true introduction's timestamp would back-date
+        the edge to before the modification it describes. Skip and say so."""
+        import mcp_server
+        guess_ident, structural = self._seed_provisional(real_db)
+        mcp_server._forward_reconcile_provisional(
+            real_db, ":code/fn-login", structural, "2026-01-01T00:00:00Z", {},
+        )
+        raw = mcp_server._db_execute(
+            real_db, "(query [:find ?c :where [:code/fn-login :modified-in ?c]])",
+        )
+        assert json.loads(raw)["results"] == []
+        assert "no timestamp in commit_metadata" in capsys.readouterr().err
+        # The rest of the reconciliation still happened.
+        assert mcp_server._lineage_is_provisional(real_db, ":code/fn-login") is False

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16802,3 +16802,139 @@ class TestStageBRepairsLifecycleFacts:
             assert len(subjects) == len(set(subjects)), \
                 f"duplicate live {attr} facts after the lifecycle pass: " \
                 f"{sorted(r for r in rows if subjects.count(r[0]) > 1)}"
+
+
+class TestStagingAndShutdown:
+    def _repo(self, tmp_path, n_commits=6):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(n_commits):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"h{i}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_phase_reaches_sweeping_and_processed_never_exceeds_total(self, tmp_path, monkeypatch):
+        """Stage B's commits are re-visits of positions Stage A already
+        counted -- counting them again would push processed past total.
+
+        NOTE on a deviation from the brief's literal assertion: the brief
+        reads `_ingest_progress["phase"] == "sweeping"` AFTER `_run_ingestion`
+        has already returned. That directly contradicts Task 9's review fix
+        (#222 phase 2d, commit de0a062, finding 3): "phase" describes what a
+        RUNNING ingest is doing and must not outlive the run, because leaving
+        "sweeping" in place after completion made a finished run permanently
+        report {"status": "complete", "phase": "sweeping"} -- exactly the bug
+        that fix corrected, with its own code comment saying so at the clear
+        site. Reverting that would reintroduce a real, previously-flagged
+        defect, so this test instead observes the transition to "sweeping"
+        DURING the run (via a spy on _correction_sweep_apply, the same seam
+        test_sweep_does_not_start_before_stage_a_drains uses) and separately
+        asserts the phase is correctly cleared once the run is over.
+        """
+        import mcp_server
+        repo = self._repo(tmp_path)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+
+        observed_sweeping = False
+        real_apply = mcp_server._correction_sweep_apply
+
+        def spy(db, *args, **kwargs):
+            nonlocal observed_sweeping
+            if mcp_server._ingest_progress["phase"] == "sweeping":
+                observed_sweeping = True
+            return real_apply(db, *args, **kwargs)
+
+        monkeypatch.setattr(mcp_server, "_correction_sweep_apply", spy)
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert observed_sweeping, "phase must reach 'sweeping' at some point during Stage B"
+        assert mcp_server._ingest_progress["phase"] is None, \
+            "phase must not outlive the run (Task 9 review fix, de0a062)"
+        assert mcp_server._ingest_progress["processed"] <= mcp_server._ingest_progress["total"]
+
+    @pytest.mark.asyncio
+    async def test_sweep_does_not_start_before_stage_a_drains(self, tmp_path, monkeypatch):
+        """The sweep's precondition is a CLOSED gap. Stage A pre-claims up to
+        pipeline_depth positions ahead of persisting them, so the in-memory
+        gap can close while commits are still in flight -- the DB-read
+        precondition is what makes this safe, and this test pins it."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+
+        observed = []
+        real_apply = mcp_server._correction_sweep_apply
+
+        def spy(db, *args, **kwargs):
+            observed.append(mcp_server._ingest_progress["phase"])
+            return real_apply(db, *args, **kwargs)
+
+        monkeypatch.setattr(mcp_server, "_correction_sweep_apply", spy)
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert observed, "the sweep must actually have run"
+        assert set(observed) == {"sweeping"}
+
+    @pytest.mark.asyncio
+    async def test_shutdown_during_stage_a_stops_and_resumes(self, tmp_path, monkeypatch):
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path, n_commits=10)
+        graph = tmp_path / "g.graph"
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph))
+
+        real_forward = mcp_server._forward_apply
+        calls = {"n": 0}
+
+        def stopping_forward(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                mcp_server._shutdown_requested.set()
+            return real_forward(*args, **kwargs)
+
+        monkeypatch.setattr(mcp_server, "_forward_apply", stopping_forward)
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "stopped"
+        mcp_server._db = None
+
+        # A run stopped in Stage A must NOT claim confirmed lineage at HEAD.
+        db = MiniGrafDb.open(str(graph))
+        linearization = frontier_registry.build_linearization(str(repo))
+        assert mcp_server._lineage_confirmed_through_query(db) != linearization[-1]
+        db = None
+        mcp_server._db = None
+
+        monkeypatch.setattr(mcp_server, "_forward_apply", real_forward)
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete"
+        mcp_server._db = None
+        db2 = MiniGrafDb.open(str(graph))
+        assert mcp_server._preload_provisional_idents(db2) == set()
+        assert mcp_server._lineage_confirmed_through_query(db2) == linearization[-1]
+
+    @pytest.mark.asyncio
+    async def test_neither_sync_wrapper_is_called_from_run_ingestion(self, tmp_path, monkeypatch):
+        """2c and 2b both document that their sync wrappers must not be
+        called from async code -- each fuses a CPU-bound parse with DB-bound
+        writes into one executor-schedulable unit."""
+        import mcp_server
+        repo = self._repo(tmp_path)
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+
+        for name in (
+            "_correction_sweep_claim_and_process",
+            "_correction_sweep_walk",
+            "_reverse_bulk_fill_walk",
+            "_reverse_fill_claim_and_process",
+        ):
+            def boom(*a, _n=name, **k):
+                raise AssertionError(f"{_n} must not be called from _run_ingestion")
+            monkeypatch.setattr(mcp_server, name, boom)
+
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7938,6 +7938,25 @@ class TestIngestionWrites:
         result = mcp_server._watermark_query(real_db)
         assert result == "abc123"
 
+    def test_commit_date_query_is_silent_for_an_empty_watermark(self, real_db, capsys):
+        """A fresh graph has no watermark; None there is the ordinary path
+        and must not produce noise (#222 phase 2d review, minor 4)."""
+        import mcp_server
+        assert mcp_server._commit_date_query(real_db, None) is None
+        assert capsys.readouterr().err == ""
+
+    def test_commit_date_query_warns_when_a_real_watermark_has_no_date(
+        self, real_db, capsys,
+    ):
+        """Returning None for a NON-empty watermark silently degrades every
+        caller's resume bound back to the unbounded, pre-fix B1 queries, so
+        the degradation is announced (#222 phase 2d review, minor 4)."""
+        import mcp_server
+        assert mcp_server._commit_date_query(real_db, "abc123def456") is None
+        err = capsys.readouterr().err
+        assert "abc123def456" in err
+        assert "unbounded" in err
+
     def test_ingest_transact_noop_for_empty_triples(self, real_db):
         import mcp_server
         with execute_spy() as calls:
@@ -9035,6 +9054,71 @@ class TestPreloadExternalDependencies:
         pinned = mcp_server._preload_pinned_commits(real_db)
 
         assert pinned[":module/vendor-lib"] == ("abc123", "2026-01-01T00:00:00.000Z")
+
+    def test_unresolved_stubs_share_the_resume_bound_with_submodule_paths(
+        self, real_db, tmp_path,
+    ):
+        """#222 phase 2d review, B1 follow-up: _preload_unresolved_dep_idents
+        is a minuend whose subtrahend (submodule_paths) is bounded to the
+        resume position, so it must carry the same bound.
+
+        Seeds two REAL submodules with prefix-related paths — one introduced
+        below the watermark, one above it (as a prior run's Stage B would
+        leave it) — plus one genuine unresolved-import stub. Bounded to the
+        watermark, the above-watermark submodule drops out of BOTH sides and
+        only the stub remains. Unbounded (the pre-fix shape, asserted below
+        so the misclassification is pinned and not merely described), it
+        drops out of the subtrahend only and is misclassified as a stub —
+        at which point the replayed gitlink "add" for vendor/lib mints
+        [:module/vendor-lib-extra :resolves-to :module/vendor-lib], since a
+        submodule's :description is `name or path`.
+        """
+        import mcp_server
+
+        real_db.execute(
+            '(transact {:valid-from "2026-01-01T00:00:00Z"} '
+            '[[:module/vendor-lib :entity-type :type/external-dependency] '
+            '[:module/vendor-lib :ident ":module/vendor-lib"] '
+            '[:module/vendor-lib :path "vendor/lib"] '
+            '[:module/vendor-lib :description "vendor/lib"] '
+            '[:module/vendor-lib :introduced-by :commit/c1] '
+            '[:commit/c1 :date "2026-01-01T00:00:00Z"] '
+            # A genuine unresolved-import stub: no :path, ever.
+            '[:module/pkg-missing :entity-type :type/external-dependency] '
+            '[:module/pkg-missing :ident ":module/pkg-missing"] '
+            '[:module/pkg-missing :description "pkg.missing"]])'
+        )
+        # Above the watermark: what a prior run's Stage B leaves behind.
+        real_db.execute(
+            '(transact {:valid-from "2026-06-01T00:00:00Z"} '
+            '[[:module/vendor-lib-extra :entity-type :type/external-dependency] '
+            '[:module/vendor-lib-extra :ident ":module/vendor-lib-extra"] '
+            '[:module/vendor-lib-extra :path "vendor/lib/extra"] '
+            '[:module/vendor-lib-extra :description "vendor/lib/extra"] '
+            '[:module/vendor-lib-extra :introduced-by :commit/c2] '
+            '[:commit/c2 :date "2026-06-01T00:00:00Z"]])'
+        )
+
+        resume_valid_at = "2026-03-01T00:00:00Z"
+        *_, submodule_paths = mcp_server._preload_known_entities(
+            real_db, str(tmp_path), valid_at=resume_valid_at,
+        )
+        assert submodule_paths == {":module/vendor-lib": "vendor/lib"}, (
+            "precondition: the above-watermark submodule must be out of the subtrahend"
+        )
+
+        bounded = mcp_server._preload_unresolved_dep_idents(
+            real_db, submodule_paths, valid_at=resume_valid_at,
+        )
+        assert bounded == {":module/pkg-missing": "pkg.missing"}
+
+        unbounded = mcp_server._preload_unresolved_dep_idents(real_db, submodule_paths)
+        assert ":module/vendor-lib-extra" in unbounded, (
+            "the pre-fix shape must still misclassify, or this test proves nothing"
+        )
+        assert mcp_server._submodule_path_matches_import(
+            "vendor/lib", unbounded[":module/vendor-lib-extra"]
+        ), "and the gitlink 'add' linking would then fire on it"
 
     def test_preload_pinned_commits_returns_empty_on_query_failure(self, real_db, monkeypatch):
         """Same malformed-query technique as
@@ -14380,8 +14464,9 @@ def _assert_no_modified_in_at_or_before_introduction(db, linearization):
     Forward walk cannot produce either shape -- _build_code_triples emits
     :modified-in only on its already-known branch, never at introduction --
     so both are pure reverse-walk corruption. Positions, never timestamps:
-    committer dates are not monotonic in topological order (this repo's own
-    history has a six-day inversion), which is why build_linearization uses
+    ingest :date values are AUTHOR dates (_git_commits reads `%at`) and are
+    not monotonic in topological order (this repo's own history has a
+    six-day inversion), which is why build_linearization uses
     --topo-order in the first place.
     """
     import mcp_server
@@ -17099,14 +17184,22 @@ class TestMultiStreamParityWithForwardOnly:
         _correction_sweep_apply has an explicit self-introduction guard
         against it, so it is a standing invariant of the graph rather than a
         differential -- asserted on BOTH graphs for that reason.
+
+        Held as a SET of (ident, commit) pairs, not a dict keyed by ident: a
+        close does not retract :introduced-by, and a duplicate introduction
+        leaves an entity with two live :introduced-by rows, so dict() would
+        keep only whichever row came last and this helper could then
+        under-report its own offenders. The duplicate itself is still caught
+        by _assert_parity's _lineage comparison -- this only makes the list
+        printed here accurate.
         """
-        intro = dict(self._query(
+        intro = {(i, c) for i, c in self._query(
             graph_path, "(query [:find ?i ?c :where [?e :ident ?i] [?e :introduced-by ?c]])"
-        ))
+        )}
         modified = self._query(
             graph_path, "(query [:find ?i ?c :where [?e :ident ?i] [?e :modified-in ?c]])"
         )
-        offenders = sorted({(i, c) for i, c in modified if intro.get(i) == c})
+        offenders = sorted({(i, c) for i, c in modified if (i, c) in intro})
         assert offenders == [], (
             f"[{label}] entities carry :modified-in at their own :introduced-by "
             f"commit: {offenders}"
@@ -17347,8 +17440,14 @@ class TestStagingAndShutdown:
         reverse-region entity in a real repo.
 
         Commit dates are pinned and strictly increasing rather than left to
-        wall-clock: ingest valid-time is denominated in committer dates, and
-        a burst of same-second commits is indistinguishable on that axis.
+        wall-clock: ingest valid-time is denominated in AUTHOR dates
+        (_git_commits reads `%at`, not `%ct`), and a burst of same-second
+        commits is indistinguishable on that axis. GIT_AUTHOR_DATE is the
+        one that matters here; GIT_COMMITTER_DATE is set alongside it only
+        so the fixture's two clocks cannot disagree. Author dates are more
+        inversion-prone than committer dates in real histories (rebase,
+        cherry-pick, late merges), which is why this fixture pins them
+        rather than relying on them being ordered.
         """
         repo = tmp_path / "repo"
         repo.mkdir()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15515,3 +15515,30 @@ class TestCorrectionSweepWalk:
         assert json.loads(raw)["results"] == []
         bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
         assert mcp_server._correction_sweep_through_query(real_db) == bounds[1]
+
+
+class TestParseStreamRatio:
+    def test_default_when_unset(self):
+        import mcp_server
+        assert mcp_server._parse_stream_ratio(None) == (1, 1)
+
+    def test_parses_explicit_ratios(self):
+        import mcp_server
+        assert mcp_server._parse_stream_ratio("1:1") == (1, 1)
+        assert mcp_server._parse_stream_ratio("1:3") == (1, 3)
+        assert mcp_server._parse_stream_ratio("3:1") == (3, 1)
+        assert mcp_server._parse_stream_ratio(" 2 : 5 ") == (2, 5)
+
+    def test_malformed_falls_back_to_default_and_logs_once(self, capsys):
+        import mcp_server
+        for bad in ("x", "", "1", "1:2:3", "0:1", "1:0", "-1:2", "a:b", "1.5:2"):
+            assert mcp_server._parse_stream_ratio(bad) == (1, 1), bad
+        err = capsys.readouterr().err
+        # One line per bad value, and each names the offending value.
+        assert err.count("MINIGRAF_INGEST_STREAM_RATIO") == 9
+
+    def test_does_not_raise_on_any_input(self):
+        """A bad env var must never be the reason a repo never ingests --
+        this runs inside a background coroutine with no user in the loop."""
+        import mcp_server
+        assert mcp_server._parse_stream_ratio("\x00\xff") == (1, 1)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15712,3 +15712,129 @@ class TestForwardReconcileProvisional:
         assert "no timestamp in commit_metadata" in capsys.readouterr().err
         # The rest of the reconciliation still happened.
         assert mcp_server._lineage_is_provisional(real_db, ":code/fn-login") is False
+
+
+class TestForwardApplyReconcilesProvisional:
+    def _repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def login():\n    return 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def login():\n    return 2\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h1"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def test_forward_apply_supersedes_a_provisional_guess(self, real_db, tmp_path):
+        """Stream 2 claimed h1 and guessed login() was introduced there. The
+        forward walk then reaches h0, the TRUE introduction. Exactly one
+        :introduced-by must survive, naming h0, with a confirmed marker."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        # Stream 2 claims the newest commit (h1) and guesses.
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{linearization[1][:12]}"
+
+        # Stream 1 now reaches h0, the true introduction.
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={}, entity_descriptions={}, file_entities={},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents=mcp_server._preload_provisional_idents(real_db),
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(
+            real_db, str(repo), state, commit_metadata[0], extracted,
+        )
+
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :introduced-by ?c]])",
+        )
+        values = {row[0] for row in json.loads(raw)["results"]}
+        assert values == {f":commit/{linearization[0][:12]}"}, "exactly one, naming h0"
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        # h1 is now a genuine modification.
+        raw_mod = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :modified-in ?c]])",
+        )
+        assert f":commit/{linearization[1][:12]}" in {row[0] for row in json.loads(raw_mod)["results"]}
+
+    def test_resumed_run_variant_is_not_suppressed_by_entity_valid_from(self, real_db, tmp_path):
+        """The silent failure mode: on a RESUMED run, Stream 2's structural
+        facts are already in the preloaded entity_valid_from, so
+        _build_code_triples would suppress the introduction entirely and the
+        wrong provisional guess would survive forever."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+
+        # Simulate the resumed-run preload: entity_valid_from ALREADY knows
+        # this entity, because Stream 2 wrote its structural facts last run.
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={fn_ident: "2026-06-01T00:00:00Z"},
+            entity_descriptions={fn_ident: "login"}, file_entities={"auth.py": [fn_ident]},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents={fn_ident},
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(
+            real_db, str(repo), state, commit_metadata[0], extracted,
+        )
+
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?c :where [{fn_ident} :introduced-by ?c]])",
+        )
+        assert {row[0] for row in json.loads(raw)["results"]} == {f":commit/{linearization[0][:12]}"}
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+
+    def test_without_provisional_idents_the_resumed_case_regresses(self, real_db, tmp_path):
+        """Pins that provisional_idents is actually consulted: with it empty,
+        the resumed-run case leaves the wrong guess in place. This is the
+        direct regression test for the silent failure mode."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={fn_ident: "2026-06-01T00:00:00Z"},
+            entity_descriptions={fn_ident: "login"}, file_entities={"auth.py": [fn_ident]},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents=set(),   # the bug
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(
+            real_db, str(repo), state, commit_metadata[0], extracted,
+        )
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{linearization[1][:12]}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14151,6 +14151,47 @@ class TestReverseFillClaimAndProcess:
         assert hi_hash == linearization[-1]
 
 
+class TestReverseApplySplit:
+    def test_split_pieces_compose_to_the_same_graph_as_the_wrapper(self, tmp_path):
+        """Two independent graphs from one repo fixture -- the walk mutates
+        the state a second run would start from, so this cannot be two
+        passes over one graph."""
+        import mcp_server, frontier_registry
+        from minigraf import MiniGrafDb
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def login():\n    return 1\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+
+        def snapshot(db):
+            raw = mcp_server._db_execute(db, "(query [:find ?e ?a ?v :where [?e ?a ?v]])")
+            return sorted(tuple(row) for row in json.loads(raw)["results"])
+
+        db_a = MiniGrafDb.open(str(tmp_path / "a.graph"))
+        alloc_a = mcp_server._frontier_load(db_a, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            db_a, str(repo), linearization, commit_metadata, alloc_a,
+        )
+
+        db_b = MiniGrafDb.open(str(tmp_path / "b.graph"))
+        alloc_b = mcp_server._frontier_load(db_b, linearization, "2026-01-04T00:00:00Z")
+        pos = alloc_b.claim_high()
+        file_results, _g, _m, _r = mcp_server._extract_commit(str(repo), linearization[pos], ())
+        applied = mcp_server._reverse_apply(
+            db_b, str(repo), linearization, commit_metadata, pos, file_results,
+        )
+        assert applied == linearization[pos]
+        assert snapshot(db_a) == snapshot(db_b)
+
+
 class _NoProgressAllocator:
     """Stand-in for a FrontierAllocator whose claim_high() stops making
     progress -- the pre-2b1 behaviour on a grown linearization, where


### PR DESCRIPTION
Phase 2d of #222 — the concurrency wiring. **This is the first sub-phase that changes real behaviour.** Phases 1, 2a, 2b and 2c built the frontier allocator, the provisional/authoritative lineage fact model, the reverse-bulk-fill walk and the correction sweep; every one of them was inert, with no caller in `_run_ingestion`. This wires them together.

Spec: `docs/superpowers/specs/2026-07-26-concurrency-wiring-design.md` · Plan: `docs/superpowers/plans/2026-07-26-concurrency-wiring.md`

## Shape

- **Stage A** — one coroutine over a single tagged prefetch pipeline. `submit_next()` alternates `claim_low()`/`claim_high()` by `MINIGRAF_INGEST_STREAM_RATIO` (default `1:1`), submits every `_extract_commit` to the process pool, and dispatches drained entries by tag to `_forward_apply` or `_reverse_apply` on `write_executor`. Deliberately **one loop, not two asyncio tasks**: all DB writes already serialise on the single-worker `write_executor`, so two tasks would contend for the same thread for no throughput while adding `_db` lifecycle hazards and nondeterministic interleaving. Fairness is the submit order, which makes the interleave deterministic and directly assertable.
- **Stage B** — a third, strictly *sequential* pass. Per swept commit: `_correction_sweep_apply` (A/M lineage provisional→authoritative), then `_forward_apply(..., lifecycle_only=True)`.
- **Stage C** — the pre-existing tag / last-run bookkeeping.

## Two scope changes made during review

**1. D/R + gitlink moved into the sweep.** The spec had out-scoped deletions, renames and submodule changes in the reverse region as "2b's existing scope cut, unchanged". That held only while every stream was inert. Stage A made them live, and forcing the default ratio made 19 previously-green tests fail — closed entities staying open, `:renamed-to` never emitted, removed fields still satisfying `[?e :static true]`, closed `:depends-on` edges staying live. The sweep now applies them: it already walks the region ascending, re-parsing each commit, which is the direction lifecycle attribution needs. Applied *fresh*, not by re-running the forward body — nothing wrote those facts for those commits, whereas re-running A/M emission would duplicate under minigraf#156.

**2. Preloads bounded to the resume position.** Before this branch the graph only ever held facts up to `:ingestion/watermark`, so an unbounded current-graph preload was safe. The reverse stream breaks that invariant by writing above the forward walk's resume position. Unfixed, a resumed run saw *future* entities, failed to find them in the current commit's parse, and closed + purged them — a 10-commit repo where `helper()` is added at commit 8 lost that entity entirely on the next incremental run while reporting `status: "complete"`, and left an inverted valid interval permanently in bi-temporal history. Found by the whole-branch review; no per-task review could see it, since each task only ever observed a single fresh run.

## Verification

895 passing, 2 xfailed, 0 failing (baseline at branch point: 839). The 2 xfails are `xfail(strict=True, raises=AssertionError)` pins on a pre-existing phase-2b defect (`_build_close_triples` never retracts `:introduced-by`), deliberately not fixed here.

The load-bearing test is `TestMultiStreamParityWithForwardOnly`: ingest one repo at `1:1` and again forward-only, and assert the graphs agree. Its non-vacuity was verified by breaking each half of Stage B and observing the failure — which caught that the originally-planned assertion would have passed with `_correction_sweep_apply` deleted entirely.

## Follow-ups to file (none blocking)

1. `_build_close_triples` not retracting `:introduced-by` (the "ghost"). **Sequencing matters:** it currently masks the residual severity of the preload bound — fixing it alone converts transient loss into permanent loss plus a duplicate `:introduced-by`.
2. Position-indexed preload to *replace* the valid-time bound. The bound uses author dates (`%at`), which are non-monotonic in topological order; measured on this repo, 6 of 552 watermark positions retain a narrow data-loss direction and 5 a benign one. An ancestry filter must replace the bound, not union with it.
3. Stage B holds the graph file lock for the whole sweep, locking out the between-turns memory hook.
4. `_ingest_progress["processed"]` exceeds `total` on incremental re-ingest (measured 145%).
5. `_forward_apply` double-checkpoints per swept commit.
6. `_forward_apply` is ~490 lines; decomposition deferred since the extraction task.

#222 stays open until phase 5. Phases 3 (tip-liveness), 4 (status/observability) and 5 (hardening) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zsK22DvuUECZmGyAUqjPL
