### PR TITLE
perf: fix reverse-walk write amplification (#233)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-reverse-walk-write-amplification.md
+++ b/docs/superpowers/plans/2026-07-31-reverse-walk-write-amplification.md
@@ -1,0 +1,1445 @@
+# Reverse-Walk Write Amplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the reverse-bulk-fill walk (#222 Stage A) from ~6,970 transactions per commit down to the forward walk's ~12, by making its per-commit write count O(1) in the number of entities touched.
+
+**Architecture:** Three independent levers, measured by a per-call-site profile (see the spec). (1) Structural re-dating moves out of `_reverse_apply`'s provisional-move loop and into `_correction_sweep_apply`'s confirm branch, where it runs once per entity for the whole region instead of once per entity per commit. (2) The `:type/candidate-diff` record path is deleted — it has no production reader. (3) The surviving per-entity writes (the provisional guess move, the lineage markers, the retroactive `:modified-in`, the sweep's confirm) are batched into one call per commit, which is safe because facts differing in entity do not collide in minigraf's EAVT pending index.
+
+**Tech Stack:** Python 3, `minigraf` (bi-temporal Datalog graph), `pytest`, tree-sitter. Single file under change: `mcp_server.py`, plus `tests/test_mcp_server.py`.
+
+## Global Constraints
+
+- **Design spec:** `docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md`. Read it before Task 1. Every task's requirements implicitly include it.
+- **Real-backend-only tests.** See `docs/testing-conventions.md`. Use the `real_db` fixture. No mocking of `minigraf`, `_transact`, `_retract`, or `_db_execute` for the purpose of *avoiding* the backend — wrapping them to *count* real calls (as `execute_spy` at `tests/test_mcp_server.py:64` already does) is fine and is used below.
+- **`:contains` facts are transacted and retracted ONE TRIPLE PER CALL, on both sides.** Minigraf's EAVT pending index omits value bytes, so facts sharing `(entity, attribute, valid_from)` in one call collapse to the last. `[module :contains fn]` has the *module* as its entity, so a module's children all collide with each other. This is minigraf#287 / #222 phase 2b1, and it cost five of six containment edges when it was got wrong. **Never batch `:contains`.**
+- **Facts differing in *entity* do not collide.** Every batch this plan introduces is over distinct entities. `_reverse_apply` already relies on this for `authoritative_modified_triples`.
+- **`:parent` edges are also one transact per parent** — a merge commit has two and they share `(entity, attribute, valid_from)`. Do not batch them either.
+- **Do not push.** Commit locally only. No `git push`, no `gh pr create`.
+- **Run the full suite** (`.venv/bin/python -m pytest tests/test_mcp_server.py -q`) before each commit. The suite must be green at every task boundary.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `mcp_server.py:5259-5331` | `_candidate_diff_ident/_persist/_read/_clear` | **Deleted** (Task 1) |
+| `mcp_server.py:5012-5067` | `_frontier_load` — one-time migration site | Gains `_candidate_diff_purge_legacy` call (Task 1) |
+| `mcp_server.py:6689-6702` | `_precompute_file_triples`'s `body_hashes` | **Deleted** — existed only for candidate-diff (Task 1) |
+| `mcp_server.py:5341-5398` | `_entity_introduced_by_set_provisional` | Becomes a wrapper over a new batch function (Task 3) |
+| `mcp_server.py:5401-5434` | `_re_date_structural_facts` | Unchanged body; docstring updated (Task 2) |
+| `mcp_server.py:5158-5171` | `_lineage_confirm` | Becomes a wrapper over a new batch function (Task 4) |
+| `mcp_server.py:~7700-7995` | `_reverse_apply` | Loses re-dating and candidate-diff; gains batching (Tasks 1–4) |
+| `mcp_server.py:8820-8941` | `_correction_sweep_apply` | Gains re-dating in case 1; loses candidate-diff; batches confirm (Tasks 1, 2, 4) |
+| `tests/test_mcp_server.py` | All tests | Classes deleted, moved, and added (all tasks) |
+
+---
+
+### Task 1: Delete the candidate-diff path
+
+`_candidate_diff_read`'s only callers are `_candidate_diff_persist` and `_candidate_diff_clear` themselves — no production code consults the persisted body hash. 2a specced these so 2c could confirm a candidate without re-parsing; 2c as built re-parses and reads `precomputed["unchanged_idents"]`. The profile attributes 34% of Stage A's wall time (172.7 s of 502 s, almost all in `_candidate_diff_clear`'s retracts) to maintaining them.
+
+**Files:**
+- Modify: `mcp_server.py` — delete `_candidate_diff_ident/_persist/_read/_clear` (5259–5331); add `_candidate_diff_purge_legacy`; call it from `_frontier_load` (5012–5067); remove six call sites; delete `body_hashes` from `_precompute_file_triples` (6689–6702) and `body_hash_by_ident` from `_reverse_apply`
+- Test: `tests/test_mcp_server.py` — delete `TestCandidateDiff` (6306), delete `TestReverseFillCandidateDiffLifecycle` (14526), add `TestCandidateDiffLegacyPurge`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks
+- Produces: `_candidate_diff_purge_legacy(db: Any, index_con: Optional[Any] = None) -> int` — returns the number of records purged. Nothing else in this plan calls it; it exists for its test and for `_frontier_load`.
+
+- [ ] **Step 1: Write the failing test for the legacy purge**
+
+Add to `tests/test_mcp_server.py`, replacing the deleted `TestCandidateDiff` class:
+
+```python
+class TestCandidateDiffLegacyPurge:
+    """#233: the :type/candidate-diff record path is deleted, so nothing
+    clears the records a phase-2d graph already holds -- and they ARE
+    indexed (fact_index filters nothing by prefix; _MEMORY_PREFIXES affects
+    scoring only), so they would stay retrievable scratch noise forever.
+    _frontier_load is already the one-time-migration site."""
+
+    def _seed_legacy_record(self, db, commit_hash, entity_ident, body_hash):
+        """Write a candidate-diff record the way the deleted
+        _candidate_diff_persist used to, so the purge has something real to
+        find on a graph written by phase 2d."""
+        import mcp_server
+        ident = f":candidate/{commit_hash[:12]}-{entity_ident.lstrip(':').replace('/', '-')}"
+        commit_ident = f":commit/{commit_hash[:12]}"
+        mcp_server._transact(
+            db,
+            "[" + " ".join([
+                f"[{ident} :entity-type :type/candidate-diff]",
+                f"[{ident} :commit {commit_ident}]",
+                f"[{ident} :entity {entity_ident}]",
+                f'[{ident} :body-hash "{body_hash}"]',
+            ]) + "]",
+            "2026-01-01T00:00:00Z",
+        )
+        return ident
+
+    def _live_record_count(self, db):
+        import mcp_server
+        raw = mcp_server._db_execute(
+            db, "(query [:find (count ?e) :where [?e :entity-type :type/candidate-diff]])"
+        )
+        results = json.loads(raw)["results"]
+        return results[0][0] if results else 0
+
+    def test_purges_pre_existing_records(self, real_db):
+        import mcp_server
+        self._seed_legacy_record(real_db, "a" * 40, ":function/src-auth-py-login", "h1")
+        self._seed_legacy_record(real_db, "b" * 40, ":function/src-auth-py-login", "h2")
+        assert self._live_record_count(real_db) == 2
+
+        purged = mcp_server._candidate_diff_purge_legacy(real_db)
+
+        assert purged == 2
+        assert self._live_record_count(real_db) == 0
+
+    def test_noop_on_a_graph_with_no_records(self, real_db):
+        import mcp_server
+        assert mcp_server._candidate_diff_purge_legacy(real_db) == 0
+
+    def test_frontier_load_purges_on_an_existing_graph(self, real_db, tmp_path):
+        """The purge has to run from _frontier_load, not just exist -- an
+        already-migrated graph is loaded by every subsequent run and is
+        exactly where these orphans live."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def login(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "c0"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        self._seed_legacy_record(real_db, "a" * 40, ":function/src-auth-py-login", "h1")
+
+        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        assert self._live_record_count(real_db) == 0
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestCandidateDiffLegacyPurge -q`
+Expected: FAIL — `AttributeError: module 'mcp_server' has no attribute '_candidate_diff_purge_legacy'`
+
+- [ ] **Step 3: Delete the four candidate-diff helpers**
+
+In `mcp_server.py`, delete the whole block from `def _candidate_diff_ident(` through the end of `_candidate_diff_clear` (currently lines 5259–5331, ending just before `def _entity_introduced_by_query`). Replace it with the purge function:
+
+```python
+def _candidate_diff_purge_legacy(db: Any, index_con: Optional[Any] = None) -> int:
+    """One-time cleanup for graphs written by #222 phase 2d, which persisted
+    a :type/candidate-diff record per (claimed commit, candidate entity)
+    pair. #233 deleted that path outright -- 2a specced the records so 2c
+    could confirm a candidate by hash comparison instead of re-parsing, but
+    2c as built re-parses on the process pool and reads
+    precomputed["unchanged_idents"], so nothing ever read them.
+
+    Without this, the records a 2d graph already holds are orphaned: the
+    writer AND the clearer are both gone. They are not inert -- fact_index
+    filters nothing by prefix (_MEMORY_PREFIXES affects scoring, not
+    inclusion), so they stay retrievable scratch noise indefinitely.
+
+    Called unconditionally from _frontier_load rather than gated on a
+    watermark: it is one query per load, cheap when there is nothing to
+    purge, and gating it would need a new watermark whose only job is to
+    record that a one-time deletion happened.
+
+    Returns the number of records purged. Records for distinct :candidate/
+    entities do not share (entity, attribute, valid_from), so the whole
+    purge is one collision-free _retract.
+    """
+    raw = _db_execute(
+        db, "(query [:find ?e ?c ?ent ?h :where "
+            "[?e :entity-type :type/candidate-diff] [?e :commit ?c] "
+            "[?e :entity ?ent] [?e :body-hash ?h]])"
+    )
+    rows = json.loads(raw).get("results", [])
+    if not rows:
+        return 0
+    facts = []
+    for ident, commit_ident, entity_ident, body_hash in rows:
+        facts.extend([
+            f"[{ident} :entity-type :type/candidate-diff]",
+            f"[{ident} :commit {commit_ident}]",
+            f"[{ident} :entity {entity_ident}]",
+            f'[{ident} :body-hash "{_edn_escape(body_hash)}"]',
+        ])
+    _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+    return len(rows)
+```
+
+- [ ] **Step 4: Call the purge from `_frontier_load`**
+
+In `_frontier_load`, immediately after the existing `_lineage_confirmed_through_migrate` call (currently line 5027):
+
+```python
+    _lineage_confirmed_through_migrate(db, run_ts_iso, index_con=index_con)
+    _candidate_diff_purge_legacy(db, index_con=index_con)
+```
+
+- [ ] **Step 5: Run the purge tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestCandidateDiffLegacyPurge -q`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Remove the six call sites**
+
+The suite is currently red — the helpers are gone but callers remain. Remove each:
+
+**a. `_forward_reconcile_provisional`** — delete the `_candidate_diff_clear` call and its comment block (currently step 4, around line 5485–5490), and renumber the following comment from `# 5.` to `# 4.`.
+
+**b. `_reverse_apply`, `new_candidates` loop** — becomes:
+
+```python
+    for ident in new_candidates:
+        _entity_introduced_by_set_provisional(
+            db, ident, commit_ident, commit_ts_iso, index_con=index_con,
+            pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+        )
+```
+
+**c. `_reverse_apply`, `provisional_moves` loop** — delete the `if ident in body_hash_by_ident:` / `_candidate_diff_persist(...)` block, and delete the `_candidate_diff_clear` call together with its "The superseded candidate-diff record is stale..." comment block (currently around lines 7965–7972). The `if superseded_pos is None or superseded_pos > pos:` branch keeps only the `_re_date_structural_facts` call — Task 2 removes that too.
+
+**d. `_correction_sweep_apply`** — delete both `_candidate_diff_clear` lines (currently 8896 and 8924). In case 1 the body becomes just `_lineage_confirm(db, ident, index_con=index_con)`; in case 3's single-value branch, drop the trailing clear.
+
+**e. `_reverse_apply`'s `body_hash_by_ident`** — now unused. Delete its declaration (`body_hash_by_ident: Dict[str, str] = {}`) and the `body_hash_by_ident.update(precomputed.get("body_hashes", {}))` line in the file loop.
+
+**f. `_precompute_file_triples`** — delete the `body_hashes` computation block (the comment starting `# #222 phase 2b: per-entity body hash...` through `body_hashes = {}` in the `except`) and the `"body_hashes": body_hashes,` entry from the returned dict. `unchanged_idents` calls `_normalized_body_hash` independently and is unaffected — leave it alone.
+
+- [ ] **Step 7: Delete the two obsolete test classes**
+
+Delete `TestReverseFillCandidateDiffLifecycle` (currently `tests/test_mcp_server.py:14526`) in full — it asserts one live candidate-diff record per guess, a property of a path that no longer exists. `TestCandidateDiff` was already replaced in Step 1.
+
+- [ ] **Step 8: Run the full suite**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py -q`
+Expected: PASS. If anything else references `_candidate_diff_*` or `body_hashes`, grep and remove it:
+`grep -rn "_candidate_diff\|body_hashes" mcp_server.py tests/ evals/`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Delete the candidate-diff record path (#233)
+
+_candidate_diff_read's only callers were _candidate_diff_persist and
+_candidate_diff_clear themselves. 2a specced these records so 2c could
+confirm a candidate by hash comparison instead of re-parsing, but 2c as
+built re-parses on the process pool and reads
+precomputed[\"unchanged_idents\"] -- the persisted body hash was never
+consulted by any production path.
+
+Per-call-site profiling of 12 commits of the reverse walk attributes 34%
+of its wall time (172.7s of 502s, almost all in _candidate_diff_clear's
+retracts) to maintaining them.
+
+_precompute_file_triples's body_hashes existed only to feed this path and
+goes with it; unchanged_idents computes its own hashes and is untouched.
+
+Adds _candidate_diff_purge_legacy, called from _frontier_load alongside
+the existing one-time migrations: a 2d graph's records are orphaned once
+both the writer and the clearer are gone, and they are indexed, so
+without this they stay retrievable scratch noise indefinitely.
+
+Refs #233"
+```
+
+---
+
+### Task 2: Defer structural re-dating to the correction sweep
+
+`_re_date_structural_facts` fires on every provisional move, so a long-lived entity is fully re-dated once per touch. It is 48% of Stage A's wall time (241.3 s of 502 s; 17,250 retracts at ~13 ms each). The correction sweep already visits every commit in the reverse region exactly once, ascending, and — by its gap-closed precondition — with Stream 2's guess final, so the commit at which an entity reaches case 1 *is* its introduction.
+
+**Files:**
+- Modify: `mcp_server.py` — remove the `_re_date_structural_facts` call from `_reverse_apply`; add it to `_correction_sweep_apply` case 1; update three docstrings
+- Test: `tests/test_mcp_server.py` — extend `TestReverseFillValidTimeParity` (14566), add its negative counterpart, add a sweep re-date test
+
+**Interfaces:**
+- Consumes: Task 1's cleaned-up `_correction_sweep_apply` case 1 (`_lineage_confirm(db, ident, index_con=index_con)` alone)
+- Produces: `_correction_sweep_apply` now needs each candidate's structural triples, built per file into a local `candidate_triples_by_ident: Dict[str, List[str]]` exactly as `_reverse_apply` does. Task 4 batches the `_lineage_confirm` in this same branch.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the existing `TestReverseFillValidTimeParity` class body with the following (keep the class name — its `test_structural_facts_are_re_dated_when_the_guess_moves_earlier` method is being moved to a later point in the pipeline, not deleted):
+
+```python
+class TestReverseFillValidTimeParity:
+    def _repo_with_three_commits(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(3):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _attrs_at(self, real_db, entity_ident, ts_iso):
+        import mcp_server
+        raw = mcp_server._db_execute(
+            real_db, f'(query [:find ?a :valid-at "{ts_iso}" :where [{entity_ident} ?a ?v]])'
+        )
+        return {row[0] for row in json.loads(raw)["results"]}
+
+    def test_structural_facts_are_re_dated_by_the_correction_sweep(self, real_db, tmp_path):
+        """2b wrote an entity's structural facts once, at the timestamp of
+        the commit where the walk first SIGHTED it. That leaves a valid-time
+        window where :introduced-by is live for an entity with no type, name
+        or file -- so ":as-of the introduction" answers "this entity did not
+        exist", while ":when was it introduced" answers with that very
+        commit.
+
+        #233 moved the repair from _reverse_apply (which did it on every
+        provisional move: 48% of Stage A's wall time) to the correction
+        sweep's confirm branch, which visits each entity's introduction
+        exactly once. So the invariant now holds after Stage B, not after
+        Stage A -- this test asserts the end state, and its negative
+        counterpart below pins the Stage A window deliberately."""
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_three_commits(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+
+        login = mcp_server._code_ident("function", "auth.py", "login")
+        attrs = self._attrs_at(real_db, login, commit_metadata[0][1])
+        assert ":introduced-by" in attrs
+        assert ":entity-type" in attrs, (
+            "an entity live at its own introduction must carry its structure there too; "
+            f"got only {sorted(attrs)}"
+        )
+        assert ":file" in attrs
+
+    def test_stage_a_alone_leaves_the_window_open(self, real_db, tmp_path):
+        """The other half of the moved invariant. Deferring the re-date is a
+        real behaviour change and the window it opens is deliberate, so pin
+        it in both directions -- otherwise a future change could re-introduce
+        eager re-dating (and its 48% cost) with the suite still green."""
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_three_commits(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        login = mcp_server._code_ident("function", "auth.py", "login")
+        assert mcp_server._entity_introduced_by_query(real_db, login) == \
+            f":commit/{linearization[0][:12]}"
+        assert mcp_server._lineage_is_provisional(real_db, login) is True
+        attrs = self._attrs_at(real_db, login, commit_metadata[0][1])
+        assert ":entity-type" not in attrs, (
+            "Stage A must NOT re-date -- that is the amplification #233 removed"
+        )
+
+    def test_reverse_walk_issues_no_re_dating_writes(self, real_db, tmp_path):
+        """The cost assertion behind the behaviour assertions above:
+        _re_date_structural_facts must not be reached at all during Stage A.
+        At 17,250 retracts over 12 real commits (~13ms each) this was the
+        single largest line in the profile."""
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_three_commits(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        calls = []
+        real_re_date = mcp_server._re_date_structural_facts
+        mcp_server._re_date_structural_facts = lambda *a, **k: (
+            calls.append(a) or real_re_date(*a, **k)
+        )
+        try:
+            mcp_server._reverse_bulk_fill_walk(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        finally:
+            mcp_server._re_date_structural_facts = real_re_date
+
+        assert calls == []
+```
+
+Add a sweep-side test to `TestCorrectionSweepApply`:
+
+```python
+    def test_case_one_re_dates_structural_facts(self, real_db, tmp_path):
+        """#233: the sweep's confirm branch is where re-dating now happens.
+        It already has the triples -- precomputed carries
+        module_candidate_triples and (ident, name, triples) per entries key
+        -- and previously read only the idents out of it."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(3):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        login = mcp_server._code_ident("function", "auth.py", "login")
+
+        file_results, _g, _m, _r = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._correction_sweep_apply(
+            real_db, linearization[0], commit_metadata[0][1], file_results,
+        )
+
+        assert mcp_server._lineage_is_provisional(real_db, login) is False
+        raw = mcp_server._db_execute(
+            real_db,
+            f'(query [:find ?a :valid-at "{commit_metadata[0][1]}" :where [{login} ?a ?v]])',
+        )
+        attrs = {row[0] for row in json.loads(raw)["results"]}
+        assert ":entity-type" in attrs
+        assert ":file" in attrs
+
+    def test_case_one_re_dates_the_contains_edge(self, real_db, tmp_path):
+        """A child's own candidate triples carry its [parent :contains child]
+        edge, so re-dating a child must re-date its containment edge with it.
+        This is the edge minigraf#287 destroys if the re-date ever batches
+        multiple children of one module into a single call."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(3):
+            (repo / "auth.py").write_text(
+                f"def a():\n    return {i}\n\ndef b():\n    return {i}\n\ndef c():\n    return {i}\n"
+            )
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+
+        module = mcp_server._code_ident("module", "auth.py")
+        raw = mcp_server._db_execute(
+            real_db,
+            f'(query [:find ?child :valid-at "{commit_metadata[0][1]}" '
+            f'  :where [{module} :contains ?child]])',
+        )
+        children = {row[0] for row in json.loads(raw)["results"]}
+        assert len(children) == 3, f"all three containment edges must survive; got {sorted(children)}"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestReverseFillValidTimeParity tests/test_mcp_server.py::TestCorrectionSweepApply -q`
+Expected: `test_stage_a_alone_leaves_the_window_open`, `test_reverse_walk_issues_no_re_dating_writes`, `test_case_one_re_dates_structural_facts`, and `test_case_one_re_dates_the_contains_edge` FAIL. `test_structural_facts_are_re_dated_by_the_correction_sweep` may already pass (Stage A still re-dates eagerly) — that is expected and it must still pass at the end.
+
+- [ ] **Step 3: Remove the re-date from `_reverse_apply`**
+
+In the `provisional_moves` loop, the `if superseded_pos is None or superseded_pos > pos:` branch loses its entire body — the `_re_date_structural_facts` call and its comment block. The branch's only remaining purpose was that call, so delete the branch too. The loop's tail becomes:
+
+```python
+    for ident, superseded_ident in provisional_moves:
+        _entity_introduced_by_set_provisional(
+            db, ident, commit_ident, commit_ts_iso, index_con=index_con,
+            pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+        )
+        if superseded_ident is not None and superseded_ident != commit_ident:
+            superseded_pos = pos_by_commit_ident.get(superseded_ident)
+            if superseded_pos is not None and superseded_pos <= pos:
+                # The move was refused (or would be): the "superseded" guess
+                # is not actually later than this commit, so asserting it as
+                # a modification would claim the entity changed at or before
+                # its own introduction.
+                continue
+            superseded_ts = ts_by_commit_ident.get(superseded_ident)
+            if superseded_ts is None:
+                # Falling back to THIS commit's timestamp back-dates the edge
+                # to before the modification it describes -- a fact asserted
+                # valid before it was true. Skip and say so instead.
+                print(
+                    f"[_reverse_apply] skipping retroactive :modified-in "
+                    f"for {ident} at {superseded_ident}: no timestamp in commit_metadata",
+                    file=sys.stderr,
+                )
+                continue
+            _transact(
+                db, f"[[{ident} :modified-in {superseded_ident}]]", superseded_ts, index_con=index_con,
+            )
+```
+
+`candidate_triples_by_ident` in `_reverse_apply` is now unused — delete its declaration and both population sites (the `module_ident` assignment and the `entries_key` loop) in the file loop.
+
+- [ ] **Step 4: Add the re-date to `_correction_sweep_apply`**
+
+Inside the per-file loop, alongside the existing `candidate_idents` and `unchanged_idents` construction, build the triple map:
+
+```python
+        # #233: the sweep re-dates structural facts, which _reverse_apply
+        # used to do eagerly on every provisional move (48% of Stage A's
+        # wall time -- 17,250 retracts over 12 real commits). This pass
+        # already visits every commit in the reverse region exactly once,
+        # ascending, and its gap-closed precondition means Stream 2's guess
+        # is final -- so the commit at which an entity reaches case 1 IS its
+        # introduction, and re-dating there is once per entity for the whole
+        # region. precomputed already carried these triples; only the idents
+        # were being read out of it.
+        candidate_triples_by_ident: Dict[str, List[str]] = {
+            precomputed["module_ident"]: list(precomputed["module_candidate_triples"])
+        }
+        for entries_key in ("function_entries", "class_entries", "global_entries", "field_entries"):
+            for entry_ident, _entry_name, entry_triples in precomputed[entries_key]:
+                candidate_triples_by_ident[entry_ident] = list(entry_triples)
+```
+
+Then in case 1, before the confirm:
+
+```python
+                if introduced_by_values == {commit_ident}:
+                    # Case 1: the provisional guess matches this commit --
+                    # confirm. The :introduced-by fact itself is untouched,
+                    # since its value was already correct.
+                    _re_date_structural_facts(
+                        db,
+                        [t for t in candidate_triples_by_ident.get(ident, [])
+                         if ":introduced-by" not in t],
+                        commit_ts_iso,
+                        index_con=index_con,
+                    )
+                    _lineage_confirm(db, ident, index_con=index_con)
+```
+
+- [ ] **Step 5: Update the three docstrings**
+
+**a. `_re_date_structural_facts`** — its docstring currently names `_reverse_apply` as a caller. Replace that sentence:
+
+```
+    Used whenever a provisional :introduced-by guess is resolved to an
+    earlier commit -- by _correction_sweep_apply when the sweep confirms an
+    entity at its introduction, and by _forward_reconcile_provisional when
+    the forward walk reaches the true introduction. In both cases the facts
+    were written at the timestamp of the commit where the entity was first
+    SIGHTED, which is later than the introduction now is, leaving a valid
+    time window where :introduced-by is live for an entity with no type,
+    name or file -- so ":as-of the introduction" reports it as nonexistent.
+
+    _reverse_apply deliberately does NOT call this (#233): it used to, on
+    every provisional move, which re-dated a long-lived entity once per
+    touch instead of once. Both callers above fire once per entity.
+```
+
+**b. `_reverse_apply`** — add to its docstring, after the existing paragraph about provisional guesses:
+
+```
+    Does NOT re-date structural facts as a guess moves earlier (#233). They
+    stay at the timestamp of the commit where this walk first SIGHTED the
+    entity, which is later than the provisional :introduced-by, so ":as-of
+    the provisional introduction" reports the entity as nonexistent for as
+    long as it stays provisional. The correction sweep closes that window
+    when it confirms. This is the same "temporarily dangling, and
+    convergent" shape as the :parent edges below, and the region is already
+    excluded from 2a's trust predicate -- but note that an INTERRUPTED run
+    now leaves a wider inconsistent window than it did before #233, closed
+    by the next run's sweep.
+```
+
+**c. `_correction_sweep_apply`** — add after the "Never calls `_extract_commit` itself" paragraph:
+
+```
+    Re-dates each confirmed entity's structural facts to the introduction
+    commit (#233), which _reverse_apply used to do eagerly on every
+    provisional move. Sound here and only here: the gap-closed precondition
+    means Stream 2's guess is final, so an entity reaching case 1 is at its
+    introduction, and this pass visits each commit exactly once ascending.
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestReverseFillValidTimeParity tests/test_mcp_server.py::TestCorrectionSweepApply -q`
+Expected: PASS
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py -q`
+Expected: PASS. `TestStageBCorrectionSweep` is the most likely place for a real regression — it drives Stage A and Stage B together and is the integration check that the invariant genuinely still holds end to end.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Re-date structural facts in the sweep, not on every move (#233)
+
+_re_date_structural_facts fired from _reverse_apply on every provisional
+move, so a long-lived entity was fully re-dated once per touch: 17,250
+retracts over 12 commits of this repo, 225.9s of the 502s spent inside
+write calls, 48% of Stage A's wall time.
+
+The correction sweep already visits every commit in the reverse region
+exactly once, ascending, and its gap-closed precondition means Stream 2's
+guess is final -- so the commit at which an entity reaches case 1 IS its
+introduction. Re-dating there is once per entity for the whole region,
+and rides on the induction the 2c spec already makes to justify
+confirming at all. The sweep also already carried the triples in
+precomputed and was reading only the idents out of them.
+
+_forward_reconcile_provisional keeps its own call: that path already
+fires once per entity.
+
+Behaviour change, pinned in both directions: \"an entity live at its own
+introduction carries its structure there too\" now holds after Stage B
+rather than after Stage A. During Stage A the window is deliberately
+open, which is what provisional means -- the region is excluded from 2a's
+trust predicate either way -- but an interrupted run now leaves a wider
+inconsistent window, closed by the next run's sweep.
+
+Refs #233"
+```
+
+---
+
+### Task 3: Batch the provisional guess move and its lineage markers
+
+`_entity_introduced_by_set_provisional` issues one retract plus one transact per moved entity (8,618 retracts / 55.1 s, 10,122 transacts / 8.3 s over 12 commits), and `_lineage_mark_provisional` one transact per newly-marked entity. All are over distinct entities, so all are batchable.
+
+**Files:**
+- Modify: `mcp_server.py` — add `_entity_introduced_by_set_provisional_batch`; reduce `_entity_introduced_by_set_provisional` to a delegating wrapper; add `_lineage_mark_provisional_batch`; call the batch from `_reverse_apply`'s two loops
+- Test: `tests/test_mcp_server.py` — add `TestEntityIntroducedBySetProvisionalBatch`
+
+**Interfaces:**
+- Consumes: Task 1's `_reverse_apply` loops (no candidate-diff calls), Task 2's `provisional_moves` loop shape
+- Produces:
+  - `_lineage_mark_provisional_batch(db, entity_idents: Sequence[str], commit_ts_iso: str, index_con=None) -> None`
+  - `_entity_introduced_by_set_provisional_batch(db, entity_idents: Sequence[str], commit_ident: str, commit_ts_iso: str, index_con=None, pos: Optional[int] = None, pos_by_commit_ident: Optional[Dict[str, int]] = None) -> Set[str]` — returns the idents whose guess actually moved (or was first asserted)
+  - `_entity_introduced_by_set_provisional(...)` keeps its exact current signature and becomes `_entity_introduced_by_set_provisional_batch(db, [entity_ident], ...)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add after the existing `TestEntityIntroducedBySetProvisional` class:
+
+```python
+class TestEntityIntroducedBySetProvisionalBatch:
+    """#233: _reverse_apply's two loops were the only production callers of
+    the per-ident function, at one retract + one transact each -- 8,618
+    retracts over 12 commits of this repo, and retracts cost ~13ms against
+    a transact's ~1ms. The batch is the implementation now; the per-ident
+    function delegates to it so the gates cannot drift apart."""
+
+    def test_first_assert_batches_distinct_entities(self, real_db):
+        import mcp_server
+        idents = [f":function/src-auth-py-f{i}" for i in range(5)]
+
+        moved = mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, idents, ":commit/h2", "2026-01-03T00:00:00Z",
+        )
+
+        assert moved == set(idents)
+        for ident in idents:
+            assert mcp_server._entity_introduced_by_query(real_db, ident) == ":commit/h2"
+            assert mcp_server._lineage_is_provisional(real_db, ident) is True
+
+    def test_batch_issues_a_constant_number_of_write_calls(self, real_db):
+        """The whole point. Five entities must not cost five retracts."""
+        import mcp_server
+        idents = [f":function/src-auth-py-f{i}" for i in range(5)]
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, idents, ":commit/h2", "2026-01-03T00:00:00Z",
+        )
+
+        calls = []
+        real_transact, real_retract = mcp_server._transact, mcp_server._retract
+        mcp_server._transact = lambda *a, **k: (calls.append("t") or real_transact(*a, **k))
+        mcp_server._retract = lambda *a, **k: (calls.append("r") or real_retract(*a, **k))
+        try:
+            mcp_server._entity_introduced_by_set_provisional_batch(
+                real_db, idents, ":commit/h0", "2026-01-01T00:00:00Z",
+            )
+        finally:
+            mcp_server._transact, mcp_server._retract = real_transact, real_retract
+
+        assert calls.count("r") == 1, f"one retract for the whole batch; got {calls}"
+        assert calls.count("t") <= 2, f"at most guess + markers; got {calls}"
+
+    def test_moving_the_batch_earlier_leaves_one_value_each(self, real_db):
+        import mcp_server
+        idents = [f":function/src-auth-py-f{i}" for i in range(3)]
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, idents, ":commit/h2", "2026-01-03T00:00:00Z",
+        )
+
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, idents, ":commit/h0", "2026-01-01T00:00:00Z",
+        )
+
+        for ident in idents:
+            assert mcp_server._entity_introduced_by_query(real_db, ident) == ":commit/h0"
+            raw = mcp_server._db_execute(
+                real_db, f"(query [:find (count ?c) :where [{ident} :introduced-by ?c]])"
+            )
+            assert json.loads(raw)["results"] == [[1]]
+
+    def test_monotonicity_refusal_is_per_ident_not_per_batch(self, real_db):
+        """The gate that must not become batch-wide. One ident whose guess
+        would move LATER must be left alone while the rest of the batch
+        still applies -- batching must not turn a refusal into a dropped
+        batch, nor a refused ident into an included one."""
+        import mcp_server
+        pinned = ":function/src-auth-py-pinned"
+        movable = ":function/src-auth-py-movable"
+        pos_by_commit_ident = {":commit/h0": 0, ":commit/h1": 1, ":commit/h2": 2}
+        # pinned already sits at the EARLIEST commit; h1 would move it later.
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [pinned], ":commit/h0", "2026-01-01T00:00:00Z",
+            pos=0, pos_by_commit_ident=pos_by_commit_ident,
+        )
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [movable], ":commit/h2", "2026-01-03T00:00:00Z",
+            pos=2, pos_by_commit_ident=pos_by_commit_ident,
+        )
+
+        moved = mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [pinned, movable], ":commit/h1", "2026-01-02T00:00:00Z",
+            pos=1, pos_by_commit_ident=pos_by_commit_ident,
+        )
+
+        assert moved == {movable}
+        assert mcp_server._entity_introduced_by_query(real_db, pinned) == ":commit/h0"
+        assert mcp_server._entity_introduced_by_query(real_db, movable) == ":commit/h1"
+
+    def test_authoritative_entities_are_never_touched(self, real_db):
+        import mcp_server
+        authoritative = ":function/src-auth-py-authoritative"
+        provisional = ":function/src-auth-py-provisional"
+        mcp_server._transact(
+            real_db, f"[[{authoritative} :introduced-by :commit/h5]]", "2026-01-06T00:00:00Z",
+        )
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [provisional], ":commit/h2", "2026-01-03T00:00:00Z",
+        )
+
+        moved = mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [authoritative, provisional], ":commit/h0", "2026-01-01T00:00:00Z",
+        )
+
+        assert moved == {provisional}
+        assert mcp_server._entity_introduced_by_query(real_db, authoritative) == ":commit/h5"
+        assert mcp_server._lineage_is_provisional(real_db, authoritative) is False
+
+    def test_same_value_is_idempotent_but_still_marks(self, real_db):
+        import mcp_server
+        ident = ":function/src-auth-py-login"
+
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [ident], ":commit/h1", "2026-01-02T00:00:00Z",
+        )
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [ident], ":commit/h1", "2026-01-02T00:00:01Z",
+        )
+
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find (count ?c) :where [{ident} :introduced-by ?c]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+        assert mcp_server._lineage_is_provisional(real_db, ident) is True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestEntityIntroducedBySetProvisionalBatch -q`
+Expected: FAIL — `AttributeError: module 'mcp_server' has no attribute '_entity_introduced_by_set_provisional_batch'`
+
+- [ ] **Step 3: Add `_lineage_mark_provisional_batch`**
+
+Immediately after `_lineage_mark_provisional`:
+
+```python
+def _lineage_mark_provisional_batch(
+    db: Any, entity_idents: Sequence[str], commit_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Batched _lineage_mark_provisional (#233). Same query-before-write
+    per ident -- an entity already marked is skipped, never duplicated --
+    but the facts for every genuinely-new marker go in ONE _transact.
+
+    Collision-free: each marker is its own :lineage/... companion entity, so
+    no two facts in the batch share (entity, attribute, valid_from).
+    """
+    facts = []
+    for entity_ident in entity_idents:
+        if _lineage_is_provisional(db, entity_ident):
+            continue
+        ident = _lineage_marker_ident(entity_ident)
+        facts.extend([
+            f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
+            f"[{ident} :entity {entity_ident}]",
+            f"[{ident} :status :provisional]",
+        ])
+    if facts:
+        _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
+```
+
+- [ ] **Step 4: Add the batch and reduce the per-ident function to a wrapper**
+
+Replace the body of `_entity_introduced_by_set_provisional` and add the batch above it:
+
+```python
+def _entity_introduced_by_set_provisional_batch(
+    db: Any,
+    entity_idents: Sequence[str],
+    commit_ident: str,
+    commit_ts_iso: str,
+    index_con: Optional[Any] = None,
+    pos: Optional[int] = None,
+    pos_by_commit_ident: Optional[Dict[str, int]] = None,
+) -> Set[str]:
+    """Assert or move a PROVISIONAL :introduced-by to commit_ident for many
+    entities at once (#233), in one _retract and at most two _transact
+    calls instead of two writes per ident. _reverse_apply's two loops were
+    the only production callers of the per-ident form, at ~1,265 idents per
+    commit on a real repository; retracts cost ~13ms against a transact's
+    ~1ms, so the retract batching is the load-bearing half.
+
+    Returns the set of idents whose guess was actually asserted or moved.
+
+    Every gate is per-ident and is applied in the same order the per-ident
+    function used, because batching must not turn one ident's refusal into
+    the whole batch being dropped, nor a refused ident into an included one:
+
+      - authoritative (a value exists and _lineage_is_provisional is False)
+        -- never touched; reverse walk must never clobber a confirmed fact
+      - value already equals commit_ident -- no write, but still marked
+      - the monotonicity refusal (a guess may only move EARLIER), with its
+        own stderr line per refused ident
+
+    Collision-free: within each batch the facts differ in entity, and only
+    facts sharing (entity, attribute, valid_from) collapse in minigraf's
+    EAVT pending index. :contains is the attribute where that bites, and it
+    is not written here.
+    """
+    to_retract: List[str] = []
+    to_transact: List[str] = []
+    to_mark: List[str] = []
+    moved: Set[str] = set()
+
+    for entity_ident in entity_idents:
+        current = _entity_introduced_by_query(db, entity_ident)
+        if current is not None and not _lineage_is_provisional(db, entity_ident):
+            continue  # authoritative -- never touch
+        if current == commit_ident:
+            to_mark.append(entity_ident)
+            continue
+        if current is not None and pos is not None and pos_by_commit_ident is not None:
+            current_pos = pos_by_commit_ident.get(current)
+            if current_pos is not None and pos >= current_pos:
+                print(
+                    f"[_entity_introduced_by_set_provisional] refusing to move "
+                    f"{entity_ident}'s guess from {current} (position {current_pos}) "
+                    f"to {commit_ident} (position {pos}): a guess may only move earlier",
+                    file=sys.stderr,
+                )
+                continue
+        if current is not None:
+            to_retract.append(f"[{entity_ident} :introduced-by {current}]")
+        to_transact.append(f"[{entity_ident} :introduced-by {commit_ident}]")
+        to_mark.append(entity_ident)
+        moved.add(entity_ident)
+
+    if to_retract:
+        _retract(db, "[" + " ".join(to_retract) + "]", index_con=index_con)
+    if to_transact:
+        _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
+    _lineage_mark_provisional_batch(db, to_mark, commit_ts_iso, index_con=index_con)
+    return moved
+
+
+def _entity_introduced_by_set_provisional(
+    db: Any,
+    entity_ident: str,
+    commit_ident: str,
+    commit_ts_iso: str,
+    index_con: Optional[Any] = None,
+    pos: Optional[int] = None,
+    pos_by_commit_ident: Optional[Dict[str, int]] = None,
+) -> None:
+    """One-entity form of _entity_introduced_by_set_provisional_batch --
+    see that function for the gates. A delegating wrapper rather than a
+    parallel implementation (#233) so the batched and unbatched paths
+    cannot drift apart; the batch is the only production caller shape.
+    """
+    _entity_introduced_by_set_provisional_batch(
+        db, [entity_ident], commit_ident, commit_ts_iso,
+        index_con=index_con, pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+    )
+```
+
+Confirm `Sequence` and `Set` are in the `typing` import line at the top of `mcp_server.py`; add them if not.
+
+- [ ] **Step 5: Call the batch from `_reverse_apply`'s two loops**
+
+Replace the `new_candidates` loop and the head of the `provisional_moves` loop:
+
+```python
+    _entity_introduced_by_set_provisional_batch(
+        db, new_candidates, commit_ident, commit_ts_iso, index_con=index_con,
+        pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+    )
+    _entity_introduced_by_set_provisional_batch(
+        db, [ident for ident, _superseded in provisional_moves], commit_ident,
+        commit_ts_iso, index_con=index_con,
+        pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+    )
+
+    for ident, superseded_ident in provisional_moves:
+        if superseded_ident is not None and superseded_ident != commit_ident:
+            # ... body unchanged from what Task 2 Step 3 left in the file:
+            # the superseded_pos refusal, the missing-timestamp skip, and
+            # the per-ident `_transact` of the retroactive :modified-in.
+            # Task 4 replaces this whole loop; leave it alone here.
+```
+
+Only the two `_entity_introduced_by_set_provisional` calls change in this
+step. The `provisional_moves` loop keeps the body Task 2 gave it, minus its
+now-hoisted `_entity_introduced_by_set_provisional` call.
+
+- [ ] **Step 6: Run the batch tests**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestEntityIntroducedBySetProvisionalBatch tests/test_mcp_server.py::TestEntityIntroducedBySetProvisional tests/test_mcp_server.py::TestLineageProvisionalMarker -q`
+Expected: PASS. `TestEntityIntroducedBySetProvisional` and `TestLineageProvisionalMarker` are unchanged and prove the wrapper preserves per-ident behaviour.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py -q`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Batch the provisional guess move and its lineage markers (#233)
+
+_entity_introduced_by_set_provisional issued one retract plus one transact
+per entity, called once per candidate per commit from _reverse_apply's two
+loops -- ~1,265 idents per commit on this repo, 8,618 retracts over 12
+commits. Retracts cost ~13ms against a transact's ~1ms, so the retract is
+the load-bearing half.
+
+Facts differing in entity do not collide in minigraf's EAVT pending index
+-- only facts sharing (entity, attribute, valid_from) collapse, which is
+why :contains has to stay one triple per call and :introduced-by does not.
+_reverse_apply already batched authoritative_modified_triples on exactly
+this reasoning.
+
+The batch is the implementation and the per-ident function delegates to
+it, so the authoritative-skip, already-equal and monotonicity gates cannot
+drift between the two. All three stay per-ident: batching must not turn
+one ident's refusal into a dropped batch, nor a refused ident into an
+included one.
+
+Refs #233"
+```
+
+---
+
+### Task 4: Batch the retroactive `:modified-in` and the sweep's confirm
+
+The retroactive `:modified-in` loop issues one transact per entity (10,161 over 12 commits). Each edge carries the *superseded* commit's timestamp rather than this commit's, so a single batch is impossible — but grouping by `superseded_ts` collapses to a handful per commit, because entities in one file were almost always last sighted at the same commit. Separately, the sweep's `_lineage_confirm` is one retract per confirmed entity.
+
+**Files:**
+- Modify: `mcp_server.py` — group the retroactive `:modified-in` transacts in `_reverse_apply`; add `_lineage_confirm_batch`; use it in `_correction_sweep_apply`
+- Test: `tests/test_mcp_server.py` — add tests to `TestReverseApplySplit` and `TestCorrectionSweepApply`
+
+**Interfaces:**
+- Consumes: Task 2's retroactive `:modified-in` body, Task 3's batching precedent
+- Produces: `_lineage_confirm_batch(db, entity_idents: Sequence[str], index_con=None) -> None`; `_lineage_confirm(db, entity_ident, index_con=None)` keeps its signature and delegates
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TestReverseApplySplit`:
+
+```python
+    def test_retroactive_modified_in_is_grouped_by_superseded_timestamp(self, real_db, tmp_path):
+        """#233: one transact per entity here was 10,161 calls over 12
+        commits of this repo. Each edge carries the SUPERSEDED commit's
+        timestamp, not this commit's, so one batch is impossible -- but
+        entities in one file were almost always last sighted at the same
+        commit, so grouping by timestamp collapses to a handful."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        bodies = "\n\n".join(f"def f{i}():\n    return 0" for i in range(12))
+        for rev in range(2):
+            (repo / "wide.py").write_text(bodies.replace("return 0", f"return {rev}") + "\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{rev}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Claim the tip first so the second claim is a genuine move.
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        transacts = []
+        real_transact = mcp_server._transact
+        mcp_server._transact = lambda db_, facts, *a, **k: (
+            transacts.append(facts) or real_transact(db_, facts, *a, **k)
+        )
+        try:
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        finally:
+            mcp_server._transact = real_transact
+
+        retroactive = [f for f in transacts if ":modified-in" in f]
+        assert len(retroactive) <= 2, (
+            f"grouped by superseded timestamp, not one per entity; got {len(retroactive)}"
+        )
+
+    def test_grouped_retroactive_modified_in_keeps_every_edge(self, real_db, tmp_path):
+        """Grouping must not lose edges -- these facts differ in entity, so
+        they do not collide, but that is the assumption worth pinning."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        bodies = "\n\n".join(f"def f{i}():\n    return 0" for i in range(6))
+        for rev in range(2):
+            (repo / "wide.py").write_text(bodies.replace("return 0", f"return {rev}") + "\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{rev}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        tip_ident = f":commit/{linearization[1][:12]}"
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find ?e :where [?e :modified-in {tip_ident}]])"
+        )
+        modified = {row[0] for row in json.loads(raw)["results"]}
+        for i in range(6):
+            ident = mcp_server._code_ident("function", "wide.py", f"f{i}")
+            assert ident in modified, f"{ident} lost its retroactive edge; got {sorted(modified)}"
+```
+
+Add to `TestCorrectionSweepApply`:
+
+```python
+    def test_confirm_is_batched_across_entities_at_one_commit(self, real_db, tmp_path):
+        """#233: _lineage_confirm was one retract per confirmed entity, and
+        retracts are the expensive op. The markers are distinct :lineage/...
+        companion entities, so one call covers them all."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        bodies = "\n\n".join(f"def f{i}():\n    return 0" for i in range(8))
+        (repo / "wide.py").write_text(bodies + "\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "c0"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        file_results, _g, _m, _r = mcp_server._extract_commit(str(repo), linearization[0], ())
+
+        retracts = []
+        real_retract = mcp_server._retract
+        mcp_server._retract = lambda db_, facts, *a, **k: (
+            retracts.append(facts) or real_retract(db_, facts, *a, **k)
+        )
+        try:
+            mcp_server._correction_sweep_apply(
+                real_db, linearization[0], commit_metadata[0][1], file_results,
+            )
+        finally:
+            mcp_server._retract = real_retract
+
+        marker_retracts = [f for f in retracts if ":type/lineage-marker" in f]
+        assert len(marker_retracts) == 1, (
+            f"one retract for every marker at this commit; got {len(marker_retracts)}"
+        )
+        for i in range(8):
+            ident = mcp_server._code_ident("function", "wide.py", f"f{i}")
+            assert mcp_server._lineage_is_provisional(real_db, ident) is False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestReverseApplySplit tests/test_mcp_server.py::TestCorrectionSweepApply -q`
+Expected: the three new tests FAIL on their call-count assertions (`test_grouped_retroactive_modified_in_keeps_every_edge` may already pass — it is the guard, not the driver).
+
+- [ ] **Step 3: Group the retroactive `:modified-in` transacts**
+
+Replace the `provisional_moves` loop tail in `_reverse_apply`:
+
+```python
+    # #233: one transact per entity here was 10,161 calls over 12 commits of
+    # this repo. Each edge is asserted at the SUPERSEDED commit's own
+    # timestamp, not this commit's, so one batch is impossible -- but
+    # entities touched by one commit were almost always last sighted at the
+    # same commit, so grouping by that timestamp collapses to a handful.
+    # Every per-ident gate below stays per-ident and is evaluated during
+    # grouping. Facts differing in entity do not collide, so each group is
+    # one safe transact.
+    retroactive_by_ts: Dict[str, List[str]] = {}
+    for ident, superseded_ident in provisional_moves:
+        if superseded_ident is None or superseded_ident == commit_ident:
+            continue
+        superseded_pos = pos_by_commit_ident.get(superseded_ident)
+        if superseded_pos is not None and superseded_pos <= pos:
+            # The move was refused (or would be): the "superseded" guess is
+            # not actually later than this commit, so asserting it as a
+            # modification would claim the entity changed at or before its
+            # own introduction.
+            continue
+        superseded_ts = ts_by_commit_ident.get(superseded_ident)
+        if superseded_ts is None:
+            # Falling back to THIS commit's timestamp back-dates the edge to
+            # before the modification it describes -- a fact asserted valid
+            # before it was true. Skip and say so instead.
+            print(
+                f"[_reverse_apply] skipping retroactive :modified-in "
+                f"for {ident} at {superseded_ident}: no timestamp in commit_metadata",
+                file=sys.stderr,
+            )
+            continue
+        retroactive_by_ts.setdefault(superseded_ts, []).append(
+            f"[{ident} :modified-in {superseded_ident}]"
+        )
+    for superseded_ts, triples in retroactive_by_ts.items():
+        _transact(db, "[" + " ".join(triples) + "]", superseded_ts, index_con=index_con)
+```
+
+- [ ] **Step 4: Add `_lineage_confirm_batch` and delegate**
+
+Replace `_lineage_confirm` with:
+
+```python
+def _lineage_confirm_batch(
+    db: Any, entity_idents: Sequence[str], index_con: Optional[Any] = None
+) -> None:
+    """Batched _lineage_confirm (#233). Retracts the :type/lineage-marker
+    companion entity's facts for every still-provisional ident in ONE
+    _retract; idents with no marker are skipped, so callers can pass a whole
+    commit's candidates unconditionally.
+
+    Collision-free: each marker is its own :lineage/... companion entity.
+    """
+    facts = []
+    for entity_ident in entity_idents:
+        if not _lineage_is_provisional(db, entity_ident):
+            continue
+        ident = _lineage_marker_ident(entity_ident)
+        facts.extend([
+            f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
+            f"[{ident} :entity {entity_ident}]",
+            f"[{ident} :status :provisional]",
+        ])
+    if facts:
+        _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+
+
+def _lineage_confirm(db: Any, entity_ident: str, index_con: Optional[Any] = None) -> None:
+    """Retract the :type/lineage-marker companion entity's facts for
+    entity_ident if present; no-op if absent, so callers can call this
+    unconditionally without checking first. One-entity form of
+    _lineage_confirm_batch, delegating so the two cannot drift (#233).
+    """
+    _lineage_confirm_batch(db, [entity_ident], index_con=index_con)
+```
+
+- [ ] **Step 5: Use the batch in `_correction_sweep_apply`**
+
+Case 1 no longer confirms inline. Collect instead, and flush once per file loop iteration — the re-date from Task 2 stays inline, since `:contains` cannot be batched:
+
+```python
+        to_confirm: List[str] = []
+        for ident in candidate_idents:
+            ...
+            if _lineage_is_provisional(db, ident):
+                if introduced_by_values == {commit_ident}:
+                    _re_date_structural_facts(
+                        db,
+                        [t for t in candidate_triples_by_ident.get(ident, [])
+                         if ":introduced-by" not in t],
+                        commit_ts_iso,
+                        index_con=index_con,
+                    )
+                    to_confirm.append(ident)
+                else:
+                    # case 2: unchanged -- the skipped_events increment and
+                    # its capped stderr line, exactly as they are today
+                    ...
+            else:
+                # case 3 (already authoritative): unchanged -- the
+                # single-value :modified-in assert/retract and the
+                # ambiguous-value skip, exactly as they are today
+                ...
+        _lineage_confirm_batch(db, to_confirm, index_con=index_con)
+```
+
+The only edits in case 1 are: `_lineage_confirm(db, ident, index_con=index_con)` becomes `to_confirm.append(ident)`. Cases 2 and 3 are untouched. Declare `to_confirm: List[str] = []` at the top of the per-file loop body and flush it at the bottom of that same iteration, so a file's confirms are one call.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestReverseApplySplit tests/test_mcp_server.py::TestCorrectionSweepApply -q`
+Expected: PASS
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py -q`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Batch the retroactive :modified-in and the sweep's confirm (#233)
+
+The retroactive :modified-in loop issued one transact per entity: 10,161
+calls over 12 commits of this repo. Each edge is asserted at the SUPERSEDED
+commit's own timestamp rather than this commit's, so a single batch is
+impossible -- but entities touched by one commit were almost always last
+sighted at the same commit, so grouping by that timestamp collapses to a
+handful per commit. Every per-ident gate (the superseded_pos <= pos
+refusal, the self-introduction guard, the missing-timestamp skip and its
+stderr line) is evaluated during grouping and stays per-ident.
+
+_lineage_confirm was one retract per confirmed entity in the sweep, and
+retracts cost ~13ms against a transact's ~1ms. The markers are distinct
+:lineage/... companion entities, so one retract covers a whole file's
+confirms. The per-ident function delegates to the batch.
+
+The re-date stays inline per entity: its :contains half cannot be batched
+(minigraf#287 -- [module :contains fn] has the module as entity, so a
+module's children all collide), and after the previous commit it runs once
+per entity for the whole region rather than once per touch.
+
+Refs #233"
+```
+
+---
+
+### Task 5: The budget regression test and the benchmark acceptance run
+
+Phase 2's fixtures were all 6–10 commits and varied *commit* count. #233 is a per-entity scaling defect, so no fixture in the suite could have caught it. This task adds the test that would have, and runs the acceptance gate.
+
+**Files:**
+- Test: `tests/test_mcp_server.py` — add `TestReverseApplyWriteBudget`
+- Modify: `evals/at_scale/benchmark.md` — record the post-fix numbers
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4
+- Produces: nothing consumed downstream
+
+- [ ] **Step 1: Write the budget test**
+
+```python
+class TestReverseApplyWriteBudget:
+    """#233's regression test. The reverse walk was issuing ~6,970 write
+    calls per commit against the forward walk's 12, because every per-entity
+    write was per-entity-per-commit. Phase 2's fixtures were all 6-10
+    commits and varied COMMIT count, so none of them could see it -- this
+    varies ENTITY count at a fixed commit count, which is the axis the
+    defect lived on."""
+
+    def _repo_with_n_functions(self, tmp_path, n, name):
+        repo = tmp_path / name
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for rev in range(2):
+            body = "\n\n".join(f"def f{i}():\n    return {rev}" for i in range(n))
+            (repo / "wide.py").write_text(body + "\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{rev}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _writes_for_the_second_claim(self, tmp_path, repo, graph_name):
+        """Claim the tip (every entity is new), then count write calls for
+        the claim below it (every entity is a provisional MOVE -- the path
+        that scaled with entity count).
+
+        Opens its own graph rather than reusing the real_db fixture's: this
+        test runs two repos in one test body, and both name their file
+        wide.py with functions f0.., so their idents would collide in a
+        shared graph (and the second _frontier_load would read the first
+        repo's now-stale bounds). The real_db fixture has already
+        monkeypatched MiniGrafDb.open to hand back a fresh in-memory db per
+        call, so open_db here is cheap and isolated."""
+        import mcp_server
+        import frontier_registry
+        real_db = mcp_server.open_db(str(tmp_path / graph_name)) or mcp_server.get_db()
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        calls = []
+        real_transact, real_retract = mcp_server._transact, mcp_server._retract
+        mcp_server._transact = lambda *a, **k: (calls.append("t") or real_transact(*a, **k))
+        mcp_server._retract = lambda *a, **k: (calls.append("r") or real_retract(*a, **k))
+        try:
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        finally:
+            mcp_server._transact, mcp_server._retract = real_transact, real_retract
+        return len(calls)
+
+    def test_per_commit_writes_do_not_scale_with_entity_count(self, real_db, tmp_path):
+        small = self._writes_for_the_second_claim(
+            tmp_path, self._repo_with_n_functions(tmp_path, 5, "small"), "small.graph"
+        )
+        large = self._writes_for_the_second_claim(
+            tmp_path, self._repo_with_n_functions(tmp_path, 50, "large"), "large.graph"
+        )
+
+        assert large - small <= 5, (
+            f"a 10x entity count must not multiply per-commit writes: "
+            f"5 functions cost {small} write calls, 50 cost {large}. "
+            f"Before #233 this ratio was ~10x."
+        )
+
+    def test_per_commit_writes_stay_in_the_forward_walk_s_range(self, real_db, tmp_path):
+        """The absolute bar, not just the scaling one. The forward walk
+        sustains ~12 writes per commit: one batched transact, one per
+        :contains, one per :parent, watermark, checkpoint."""
+        writes = self._writes_for_the_second_claim(
+            tmp_path, self._repo_with_n_functions(tmp_path, 50, "wide"), "wide.graph"
+        )
+
+        assert writes <= 20, f"expected the forward walk's ~12 per commit; got {writes}"
+```
+
+- [ ] **Step 2: Run the budget test**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py::TestReverseApplyWriteBudget -q`
+Expected: PASS after Tasks 1–4.
+
+If `test_per_commit_writes_stay_in_the_forward_walk_s_range` fails on a count between 20 and 40, do **not** relax the bound first — re-run the profiler to find the remaining per-entity call site and fix it:
+`.venv/bin/python evals/at_scale/profile_reverse_walk_writes.py 3`
+
+- [ ] **Step 3: Verify the test would have caught the original bug**
+
+A regression test that has never been seen to fail is not yet a regression test. Swap in master's `mcp_server.py` and confirm it fails:
+
+```bash
+git checkout master -- mcp_server.py
+.venv/bin/python -m pytest tests/test_mcp_server.py::TestReverseApplyWriteBudget -q
+```
+Expected: FAIL, on both methods.
+
+Restore and re-confirm:
+```bash
+git checkout HEAD -- mcp_server.py
+.venv/bin/python -m pytest tests/test_mcp_server.py::TestReverseApplyWriteBudget -q
+```
+Expected: PASS
+
+Record the failing numbers from the first run — they belong in the commit message.
+
+- [ ] **Step 4: Run the per-call-site profiler on real history**
+
+Run: `.venv/bin/python evals/at_scale/profile_reverse_walk_writes.py 12`
+
+Compare against the pre-fix baseline recorded in the spec (83,638 writes, 6,970 tx/commit, 532.1 s). Record the new table — it goes in the final commit message.
+
+- [ ] **Step 5: Run the acceptance gate**
+
+Run: `.venv/bin/python evals/at_scale/run_ingestion_benchmark.py --repo-path . --branch master`
+
+This must **complete**. Compare against the recorded 2026-07-19 forward-only baseline: 498 commits, 78.87 s, 378.9 commits/min, 45,801,472 B graph.
+
+The bar is not parity with 78.87 s — Stage A writes provisional lineage the baseline never wrote, and Stage B re-parses. The bar is that total ingestion completes in a time of the same order rather than a different one, with graph size within a small multiple of 45,801,472 B, and that neither number scales with entity *touches*.
+
+- [ ] **Step 6: Run the full suite one final time**
+
+Run: `.venv/bin/python -m pytest tests/test_mcp_server.py -q`
+Expected: PASS
+
+- [ ] **Step 7: Record the results and commit**
+
+Add a row to `evals/at_scale/benchmark.md` recording the post-#233 run alongside the 2026-07-19 baseline and the killed 2d run, with the same columns the existing rows use.
+
+```bash
+git add tests/test_mcp_server.py evals/at_scale/benchmark.md
+git commit -m "Add the #233 write-budget regression test and record the benchmark
+
+Phase 2's fixtures were all 6-10 commits and varied COMMIT count. #233 was
+a per-ENTITY scaling defect, so no test in the suite could see it: the
+reverse walk issued ~6,970 write calls per commit against the forward
+walk's 12, and a 10-commit fixture with three functions in it looks
+perfectly healthy.
+
+TestReverseApplyWriteBudget varies entity count at a fixed commit count --
+5 functions against 50, both committed twice, counting write calls for the
+second claim (where every entity is a provisional move, the path that
+scaled). It asserts both the scaling property and the absolute bar.
+
+Verified to fail against master's mcp_server.py.
+
+Refs #233"
+```
+
+- [ ] **Step 8: Check the docs**
+
+`SKILL.md` documents query syntax and the memory interface; none of this changes either, so it needs no edit — but confirm rather than assume:
+`grep -n "candidate-diff\|provisional\|introduced-by" SKILL.md README.md ROADMAP.md`
+
+If `ROADMAP.md` tracks #222's phases, note that #233 is resolved and phases 3–5 are unblocked. Commit any doc change separately.
+
+---
+
+## Done
+
+The branch is `fix-233-reverse-walk-write-amplification`, already carrying the spec commit. **Do not push** — commit locally only until the user lifts that restriction. Report the profiler table and the benchmark result; the user will decide when it goes out.

--- a/docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md
+++ b/docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md
@@ -189,8 +189,11 @@ The batch:
 4. Emits one `_transact` carrying the lineage-marker facts for every ident not
    already marked (three facts each, on distinct `:lineage/…` companion
    entities).
-5. Returns the set of idents that actually moved, so the caller knows which
-   supersede-side work applies.
+5. Returns the set of idents that actually moved. No caller consumes this
+   return value — the retroactive `:modified-in` loop re-derives which
+   idents moved independently rather than taking it as an input — so this
+   documents the batch's contract (and is asserted directly by tests)
+   rather than feeding any supersede-side work.
 
 All four batches are collision-free: within each, the facts differ in entity.
 The monotonicity refusal is per-ident and must stay per-ident — batching must
@@ -206,9 +209,17 @@ rather than one per entity. The `superseded_pos <= pos` refusal, the
 `superseded_ident != commit_ident` guard, and the missing-timestamp skip with
 its stderr line all stay per-ident, evaluated during grouping.
 
-**`_lineage_confirm` in the sweep is batched per commit.** One `_retract`
-carrying the marker facts for every entity confirming at that commit. The
-per-ident `_lineage_confirm` is retained for its other callers.
+**`_lineage_confirm` in the sweep is batched per file, not per commit.** One
+`_retract` carrying the marker facts for every entity confirming in one
+`file_results` entry (`_correction_sweep_apply`'s per-file loop collects
+`to_confirm` and flushes it at the bottom of each iteration) — so a commit
+touching *k* files pays *k* retracts, not one. The per-file flush is
+intentional, not a shortfall to fix: `candidate_idents` and the confirm
+decision are already computed per file, and merging across files within one
+commit would need to hold state across loop iterations for a savings that,
+per the real-repository measurements above, is dwarfed by the per-entity
+retract count this section already cut. The per-ident `_lineage_confirm` is
+retained for its other callers.
 
 **`:contains` re-dating stays one triple per `_retract`/`_transact` call.** The
 issue comment proposed batching these "when the facts differ in entity"; they

--- a/docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md
+++ b/docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md
@@ -321,6 +321,48 @@ The instrumented harness used to produce the profile above is retained under
 `evals/at_scale/` so the per-call-site attribution can be re-run rather than
 re-derived.
 
+## Post-implementation revision: the cost model above was wrong
+
+**Added 2026-08-02, after the fix landed and a full instrumented run attributed
+all 5,627 s of a complete ingestion.** Full tables:
+`.superpowers/sdd/2026-07-31-reverse-walk-write-amplification/stage-split-measurement.md`.
+
+Finding 1 of the Measurement section — "retract *count* is the actual cost
+driver" — **is not correct**, and the design leaned on it.
+
+Retract cost scales with the number of **facts inside the call**, not with the
+number of calls. Batching collapses call count and leaves wall clock roughly
+where it was. Three pieces of evidence from the completed run:
+
+- `_entity_introduced_by_set_provisional_batch` — the batch this spec's §3
+  introduced specifically to collapse per-ident retracts — is **204 calls
+  costing 2,181 s, averaging 10.7 seconds per call**: 38.8% of the entire run.
+  Python-side overhead cannot explain a 10-second call.
+- Inside `_re_date_structural_facts`, the *batched* non-`:contains` pair costs
+  **3.8x more** in aggregate than the per-triple `:contains` loop, despite being
+  one call instead of N.
+- Across the whole run, `_retract` averages **52.1 ms/call** against the ~13 ms
+  this spec quoted for the unbatched case — i.e. batched calls are individually
+  far more expensive, not amortised.
+
+Consequences for what this spec claimed:
+
+- **§3's batching delivered much less than predicted.** It is not harmful, and
+  the call-count reduction is real, but it is not where the wall clock went.
+- **§1's deferral did work.** `_re_date_structural_facts` was 48% of Stage A's
+  cost before; it is now **3.0% of the whole run**. That lever was real.
+- **§2's deletion did work** — the candidate-diff path is simply gone.
+- **The acceptance gate's 65x gap is dominated by minigraf's per-fact retract
+  cost**, which is outside this codebase. `_retract` is 73.5% of total run time
+  across call sites that are, at the hot ones, already batched.
+
+One codebase-side lever this spec missed entirely: `_correction_sweep_apply`'s
+case-3 `:modified-in` retract (`mcp_server.py`, the `already_has_modified_in`
+branch) is called **72,971 times individually**, costing **1,629 s — 29.0% of
+the run** — and is the one hot retract site never batched. Whether batching it
+recovers anything depends on minigraf's per-fact vs per-call cost split, which
+has not been measured.
+
 ## Explicitly not in scope
 
 - **Caching `_entity_introduced_by_query` in-run** (issue suggestion 3). The
@@ -329,6 +371,8 @@ re-derived.
   sweep also writes. Revisit only if it becomes visible after this fix lands.
 - **Why `_retract` costs 13x a `_transact`.** That is a minigraf-side question
   and may be worth its own issue; this spec routes around it by not issuing
-  34,473 retracts.
+  34,473 retracts. **Revised:** routing around it did not work, because the cost
+  follows facts rather than calls. See the revision section above — this is now
+  the single largest remaining lever, and it is minigraf-side.
 - **Phase 3 (tip-liveness), 4 (status/observability), 5 (hardening).**
   Unblocked by this work, not part of it.

--- a/docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md
+++ b/docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md
@@ -1,0 +1,323 @@
+# Reverse-Walk Write Amplification — Design Spec
+
+**Issue:** #233 (blocking #222 phases 3–5)
+**Date:** 2026-07-31
+
+## Background
+
+#222's phase 2 built a converging multi-stream ingestion: a forward-truth
+stream that owns lineage correctness, and a reverse-bulk-fill stream (Stream
+2) that provisionally back-fills recent history from `HEAD` downward so recent
+commits become queryable early. Phase 2d (PR #230, merged) wired both into
+`_run_ingestion` as Stage A, with a terminal correction sweep as Stage B.
+
+Every test in phase 2 uses a fixture of 6–10 commits. At that size the walk's
+per-commit cost is invisible. Against a real repository it is not: the at-scale
+ingestion benchmark run against master at `bbe7fee` was killed incomplete after
+62 minutes having reached 100 of ~552 commits, where the recorded 2026-07-19
+forward-only baseline completed 498 commits in 78.87 seconds.
+
+### Measurement
+
+The issue established transaction amplification by inspecting the two benchmark
+graphs (12 tx/commit baseline vs 3,152 tx/commit at 2d — 263x). This spec is
+designed against a sharper measurement: `_transact` and `_retract` wrapped with
+per-call-site counters and timers, driving `_reverse_fill_claim_and_process`
+over the 12 commits below `HEAD` of this repository.
+
+**12 commits, 532.1 s, 83,638 writes → 6,970 tx/commit.** (Higher than the
+issue's 3,152 average over the first 100 commits: these tip commits touch both
+`mcp_server.py` and `tests/test_mcp_server.py`, so ~1,265 candidate entities
+per commit rather than the run-wide average.)
+
+| call site | op | count | sec |
+|---|---|---:|---:|
+| `_re_date_structural_facts` | retract | 17,250 | **225.9** |
+| `_candidate_diff_clear` | retract | 8,605 | **172.7** |
+| `_entity_introduced_by_set_provisional` | retract | 8,618 | 55.1 |
+| `_re_date_structural_facts` | transact | 17,250 | 15.4 |
+| `_reverse_apply` (retroactive `:modified-in`) | transact | 10,161 | 10.9 |
+| `_candidate_diff_persist` | transact | 10,105 | 9.6 |
+| `_entity_introduced_by_set_provisional` | transact | 10,122 | 8.3 |
+| `_lineage_mark_provisional` | transact | 1,504 | 1.1 |
+| `_frontier_persist_claim` | both | 23 | 0.1 |
+
+Reads, for completeness: `_entity_introduced_by_query` 30,061 calls / 4.4 s,
+`_lineage_is_provisional` 27,358 / 2.8 s, `_candidate_diff_read` 18,723 / 2.2 s.
+
+Three findings this spec is built on, none of which were available in the
+issue:
+
+1. **Retracts cost ~13 ms each; transacts cost ~1 ms.** 34,473 retracts account
+   for 454 s of the 502 s spent inside write calls. Transaction *count* is the
+   proxy the issue measured; **retract count is the actual cost driver**, and
+   the two rank the fixes differently.
+2. **`_candidate_diff_*` is 34% of wall time writing records nothing reads.**
+   `_candidate_diff_read` has exactly two callers: `_candidate_diff_persist`
+   and `_candidate_diff_clear` themselves. 2a specced these records so that 2c
+   could confirm or reject a candidate "via hash comparison, without
+   re-invoking git-show + tree-sitter parsing" — but 2c as built re-parses on
+   the process pool and reads `precomputed["unchanged_idents"]`. The persisted
+   body hash is never consulted by any production code path.
+3. **The retroactive `:modified-in` loop issues one transact per entity**
+   (10,161 over 12 commits). Facts differing in entity do not collide in
+   minigraf's EAVT pending index — `_reverse_apply` already batches
+   `authoritative_modified_triples` on exactly that reasoning — so these are
+   batchable and currently are not.
+
+Read against the profile, the issue's own diagnosis holds and is the largest
+single lever (48% of wall time), but it is not sufficient on its own: with only
+re-dating deferred, Stage A would still issue ~3,600 tx/commit against the
+forward walk's 12, because every remaining per-entity write is still
+per-entity-per-commit.
+
+### The asymmetry being corrected
+
+The forward walk sustains 12 tx/commit over the same ~1,265 candidate entities
+because it decides "have I seen this ident before" from an in-memory
+`entity_valid_from` dict and emits one batched transact per commit. The reverse
+walk substitutes a DB query for that dict (correctly — it has no accumulated
+forward state, and the gap allocator is resumed from persisted state, not
+memory), but it also inherited a *write* shape of one-or-more calls per entity
+per commit. The query substitution is sound and cheap (7.2 s of 532 s). The
+write shape is the defect.
+
+**Goal: Stage A's per-commit transaction count becomes O(1) in the number of
+entities touched, matching the forward walk's cadence.** Per-entity structural
+work does not disappear; it moves to a path that runs once per entity for the
+whole region instead of once per entity per commit.
+
+## Design
+
+### 1. Re-dating moves from `_reverse_apply` to the correction sweep
+
+`_re_date_structural_facts` is removed from `_reverse_apply`'s
+`provisional_moves` loop entirely. `_correction_sweep_apply` calls it in case 1
+(provisional, guess equals the commit being visited → confirm), immediately
+before `_lineage_confirm`.
+
+The sweep already carries the necessary data and discards it: `precomputed`
+holds `module_candidate_triples` and `(ident, name, triples)` for each of
+`function_entries`/`class_entries`/`global_entries`/`field_entries` — the same
+source `_reverse_apply` builds `candidate_triples_by_ident` from — and the
+sweep currently reads only the idents out of it. The sweep builds the identical
+`candidate_triples_by_ident` map per file and passes
+`[t for t in triples if ":introduced-by" not in t]` to
+`_re_date_structural_facts`, matching both existing callers.
+
+**Why this is sound.** The sweep's gap-closed precondition
+(`frontier-low.:hi-hash` position `+ 1 == frontier-high.:lo-hash` position,
+checked on every `_correction_sweep_claim_and_process` call) means
+`claim_high()` can never return another position for the rest of the run, so
+Stream 2's guess for every entity in frontier-high's range is final. Combined
+with the sweep's ascending walk, the commit at which an entity reaches case 1
+*is* its introduction. Re-dating there is once per entity for the whole region.
+This is the same induction the 2c spec relies on to justify confirming at all —
+deferring re-dating rides on an argument the design already makes, rather than
+introducing a new one.
+
+`_forward_reconcile_provisional` keeps its `_re_date_structural_facts` call
+unchanged: that path already fires once per entity, at the forward walk's
+arrival at the true introduction.
+
+**Known, unchanged exposure.** `_re_date_structural_facts` retracts the triples
+the *caller* computed, not the triples that are actually live. If the sweep's
+parse at the introduction commit produced a structurally different triple from
+the reverse walk's parse at the sighting commit, the retract would miss and the
+transact would add, leaving a duplicate. In practice the re-dated attributes
+(`:entity-type`, `:ident`, `:description`, `:file`/`:path`, `:contains`) are
+functions of the ident and the containing module, which are stable for a fixed
+ident. This exposure is pre-existing and identical in
+`_forward_reconcile_provisional` today; this spec does not widen it and does
+not fix it.
+
+### 2. The candidate-diff path is deleted
+
+Removed: `_candidate_diff_ident`, `_candidate_diff_persist`,
+`_candidate_diff_read`, `_candidate_diff_clear`, the `:type/candidate-diff`
+entity type, and all six call sites (`_reverse_apply` ×3,
+`_forward_reconcile_provisional` ×1, `_correction_sweep_apply` ×2).
+
+These were 2a infrastructure for an optimization 2c did not take. They are
+recoverable from git history if a later phase wants them; carrying them costs
+34% of Stage A's wall time and 22% of its writes to maintain records with no
+reader.
+
+**Migration.** Graphs written by 2d hold live `:candidate/…` records that
+nothing will clear once `_candidate_diff_clear`'s call sites are gone, and
+these records *are* indexed — `fact_index.py` filters nothing by prefix
+(`_MEMORY_PREFIXES` affects scoring only, not inclusion), so they would remain
+retrievable scratch noise indefinitely.
+
+`_frontier_load` — already the one-time-migration site for the
+watermark→interval and lineage-marker migrations, and already called on
+`write_executor` with a live `db` and `index_con` for that reason — gains a
+one-time purge: query every entity with
+`[?e :entity-type :type/candidate-diff]`, retract each record's four facts in
+one batched `_retract` call, and no-op when the query is empty. Records for
+distinct `:candidate/…` entities do not share `(entity, attribute, valid_from)`
+so the batch is collision-free.
+
+The purge is unconditional rather than watermark-gated: it is a single query on
+every load, cheap when there is nothing to purge, and gating it would require a
+new watermark whose only job is to record that a one-time deletion happened.
+
+### 3. Remaining per-entity writes are batched per commit
+
+Ordered by retract count, since retracts dominate wall time.
+
+**`_entity_introduced_by_set_provisional` becomes batch-first.** Its only two
+production callers are the `new_candidates` and `provisional_moves` loops in
+`_reverse_apply`; everything else that calls it is a unit test. So the batch
+becomes the implementation —
+`_entity_introduced_by_set_provisional_batch(db, idents, commit_ident,
+commit_ts_iso, pos, pos_by_commit_ident, index_con)` — and the existing
+per-ident function is kept as a one-element delegating wrapper. That preserves
+`TestLineageProvisionalMarker`'s per-ident tests verbatim and makes it
+structurally impossible for the batched and unbatched gates to drift apart.
+
+The batch:
+
+1. Classifies every ident first, applying the existing gates verbatim and in
+   the same order — authoritative-skip (`current is not None and not
+   _lineage_is_provisional`), the `current == commit_ident` no-op-but-still-mark
+   case, and the monotonicity refusal with its stderr line (`a guess may only
+   move earlier`).
+2. Emits one `_retract` carrying every `[E :introduced-by old_E]` for the
+   idents that genuinely move.
+3. Emits one `_transact` carrying every `[E :introduced-by commit_ident]`.
+4. Emits one `_transact` carrying the lineage-marker facts for every ident not
+   already marked (three facts each, on distinct `:lineage/…` companion
+   entities).
+5. Returns the set of idents that actually moved, so the caller knows which
+   supersede-side work applies.
+
+All four batches are collision-free: within each, the facts differ in entity.
+The monotonicity refusal is per-ident and must stay per-ident — batching must
+not turn one refused move into a whole batch being dropped, or into a refused
+ident being silently included.
+
+**Retroactive `:modified-in` is grouped by superseded timestamp.** Each edge is
+transacted at the *superseded* commit's own timestamp, not this commit's, so a
+single batch is not possible. Grouping by `superseded_ts` and emitting one
+transact per distinct value is: entities in the same file were almost always
+last sighted at the same commit, so this collapses to a handful per commit
+rather than one per entity. The `superseded_pos <= pos` refusal, the
+`superseded_ident != commit_ident` guard, and the missing-timestamp skip with
+its stderr line all stay per-ident, evaluated during grouping.
+
+**`_lineage_confirm` in the sweep is batched per commit.** One `_retract`
+carrying the marker facts for every entity confirming at that commit. The
+per-ident `_lineage_confirm` is retained for its other callers.
+
+**`:contains` re-dating stays one triple per `_retract`/`_transact` call.** The
+issue comment proposed batching these "when the facts differ in entity"; they
+do not differ in entity. `[module :contains fn]` has the *module* as its
+entity, so batching a module's children into one call collapses them to the
+last — precisely the minigraf#287 EAVT collision that cost five of six
+containment edges in 2b1. Section 1 already reduces these from
+O(entity-touches) to O(entities), which is what the forward walk pays for the
+same edges.
+
+### 4. The invariant that moves
+
+This is the only observable behaviour change, and it is a real one.
+
+Today, because re-dating is eager, "an entity live at its own introduction
+carries its structure there too" holds after Stage A alone — this is what
+`TestReverseFillValidTimeParity` asserts against `_reverse_bulk_fill_walk` with
+no sweep. After this change it holds **after Stage B**. During Stage A a
+provisional entity's structural facts are dated at its sighting commit, later
+than its provisional `:introduced-by`, so `:as-of` the provisional introduction
+reports the entity as nonexistent.
+
+That is what provisional means, and the region is already excluded from 2a's
+trust predicate — `lineage-confirmed-through` does not cover frontier-high, and
+nothing may trust what Stream 2 wrote until the sweep completes (2c/2d
+constraint 2). The `:parent` edges `_reverse_apply` writes already carry the
+same "temporarily dangling, and convergent" shape, for the same reason.
+
+What genuinely widens: an **interrupted** run now leaves a larger inconsistent
+window than before, because the eager re-date was doing partial repair as it
+went. The next run's sweep closes it, and the region was untrustworthy either
+way — but this is a property a reader of `_reverse_apply` would otherwise have
+to derive, so it is stated in `_reverse_apply`'s docstring, in
+`_re_date_structural_facts`'s docstring (whose current text names
+`_reverse_apply` as a caller), and in `_correction_sweep_apply`'s.
+
+### 5. Expected result
+
+Per commit, Stage A after this change: one transact for the batched structural
+facts, one per `:contains` for genuinely-new entities only, one per parent
+edge, one batched transact for authoritative `:modified-in`, one retract plus
+two transacts for the batched provisional guess and markers, a handful of
+transacts for grouped retroactive `:modified-in`, plus the frontier claim and
+checkpoint — the forward walk's ~12 tx/commit cadence.
+
+The sweep absorbs ~2 writes per entity **for the whole region**, plus one
+`:contains` pair per entity, which is the same order the forward walk pays for
+the same facts.
+
+## Testing
+
+Real-backend only, per `docs/testing-conventions.md`.
+
+**The regression test #233 needed.** A budget test: commit a file with N
+functions, commit it again with one function's body changed, run the reverse
+walk over both, and assert the total `_transact` + `_retract` call count for
+the second commit does not scale with N. Parameterized on N=5 and N=50; the
+assertion is that the count for N=50 is within a small constant of the count
+for N=5, not an absolute number. This is the shape of test that phase 2's
+6-to-10-commit fixtures could never have caught, because they varied commit
+count and never varied entity count.
+
+**Moved.** `TestReverseFillValidTimeParity::test_structural_facts_are_re_dated_when_the_guess_moves_earlier`
+currently runs `_reverse_bulk_fill_walk` alone and asserts `:entity-type` and
+`:file` are live at the introduction timestamp. It is extended to run the
+correction sweep before asserting — same assertions, later point in the
+pipeline. A companion test asserts the negative during Stage A (structural
+facts are *not* yet re-dated), so the moved invariant is pinned in both
+directions rather than merely relaxed.
+
+**New.** The sweep's case 1 re-dates structural facts. `_frontier_load` purges
+pre-existing candidate-diff records, and no-ops on a graph containing none.
+`_entity_introduced_by_set_provisional_batch` honours the monotonicity refusal
+per-ident: a batch containing one ident whose guess would move *later* leaves
+that ident alone and still applies the rest.
+
+**Deleted.** `TestCandidateDiff` and `TestReverseFillCandidateDiffLifecycle`.
+
+**Unchanged and must stay green.** Every class under `TestReverseFill*`,
+`TestReverseApplySplit`, `TestReverseBulkFillWalk*`, `TestCorrectionSweep*`,
+and `TestStageBCorrectionSweep`. The `:contains` edge tests
+(`TestReverseFillContainsEdges`) are the guard against the batching in section
+3 being over-applied.
+
+## Acceptance gate
+
+`.venv/bin/python evals/at_scale/run_ingestion_benchmark.py --repo-path . --branch master`
+must complete, and is compared against the recorded 2026-07-19 forward-only
+baseline: 498 commits, 78.87 s, 378.9 commits/min, 45,801,472 B graph.
+
+Stage A now does strictly more work per commit than the forward-only baseline
+did (it writes provisional lineage the baseline never wrote, and Stage B
+re-parses), so parity with 78.87 s is not the bar. The bar is that total
+ingestion completes in a time of the same order as the baseline rather than a
+different one, with graph size within a small multiple of 45,801,472 B — and
+specifically that neither number scales with entity *touches*.
+
+The instrumented harness used to produce the profile above is retained under
+`evals/at_scale/` so the per-call-site attribution can be re-run rather than
+re-derived.
+
+## Explicitly not in scope
+
+- **Caching `_entity_introduced_by_query` in-run** (issue suggestion 3). The
+  profile shows 30,061 calls costing 4.4 s of 532 s. It is 0.8% of the problem
+  and would introduce an in-memory cache that must stay coherent with a DB the
+  sweep also writes. Revisit only if it becomes visible after this fix lands.
+- **Why `_retract` costs 13x a `_transact`.** That is a minigraf-side question
+  and may be worth its own issue; this spec routes around it by not issuing
+  34,473 retracts.
+- **Phase 3 (tip-liveness), 4 (status/observability), 5 (hardening).**
+  Unblocked by this work, not part of it.

--- a/docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md
+++ b/docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md
@@ -352,9 +352,60 @@ Consequences for what this spec claimed:
 - **§1's deferral did work.** `_re_date_structural_facts` was 48% of Stage A's
   cost before; it is now **3.0% of the whole run**. That lever was real.
 - **§2's deletion did work** — the candidate-diff path is simply gone.
-- **The acceptance gate's 65x gap is dominated by minigraf's per-fact retract
-  cost**, which is outside this codebase. `_retract` is 73.5% of total run time
-  across call sites that are, at the hot ones, already batched.
+- **The acceptance gate's 65x gap is dominated by `_retract`**, which is 73.5%
+  of total run time across call sites that are, at the hot ones, already
+  batched. *(First attributed to minigraf; that was wrong — see the second
+  revision immediately below.)*
+
+## Second revision: it is our fact index, not minigraf
+
+**Added 2026-08-02, after two controlled microbenchmarks.** The revision above
+concluded the residual cost was "minigraf's per-fact retract cost, outside this
+codebase." That is **also wrong**, and in a more useful direction: the cost is
+in `fact_index.delete_facts`, which we own.
+
+**Minigraf's raw retract is free.** Retracting 1,000 facts from a 10,000-fact
+graph takes 0.06 s at one fact per call and 0.01 s batched — 0.06 ms/fact — with
+no measurable scaling in graph size (2k/10k/40k graphs all indistinguishable).
+
+The cost is the fact-index maintenance inside `mcp_server._retract`:
+
+```
+DELETE FROM facts_fts WHERE entity=? AND attribute=? AND value=? AND valid_to IS NULL
+```
+
+`facts_fts` is an **FTS5 virtual table** (`fact_index.py:23`). FTS5 has no
+B-tree over its columns, so an equality predicate cannot seek — every deleted
+triple costs a full scan of the index. Measured:
+
+| index rows | ms per deleted triple |
+|---:|---:|
+| 5,000 | 0.805 |
+| 20,000 | 2.887 (3.6x) |
+| 80,000 | 11.088 (3.8x) |
+
+Linear in index size. And **batching is irrelevant** — at a fixed 80,000-row
+index, deleting 200 triples costs 11.17 / 11.41 / 11.53 ms per triple whether
+issued as 200 calls, 20 calls, or 1. That is the direct explanation for why §3's
+batching did not move the needle.
+
+The *insert* path is flat at **0.006 ms/triple** regardless of index size —
+~1,800x faster — because `insert_facts` checks the B-tree-indexed `facts_dedup`
+companion table. `fact_index.py:31` states outright that scanning `facts_fts` is
+"an O(n) scan", which is why `facts_dedup` was introduced for inserts (#152).
+**The delete path never received the same treatment.**
+
+This also explains `_candidate_diff_purge_legacy`'s O(N^2) behaviour (500 records
+0.50 s, 8,000 records 126.71 s, chunking no help) found in this branch's final
+review — same root cause, not a separate defect.
+
+**Consequence:** the residual 65x is a fixable, in-codebase problem, not an
+upstream one. `facts_dedup` already carries the
+`(entity, attribute, value, valid_from, valid_to)` key a delete needs to seek
+on; giving it (or an equivalent mapping) the `facts_fts` rowid would let
+`delete_facts` issue `DELETE FROM facts_fts WHERE rowid = ?`, which FTS5 does
+support efficiently. That is a fact-index schema change with a version bump and
+migration — its own issue, not #233's.
 
 One codebase-side lever this spec missed entirely: `_correction_sweep_apply`'s
 case-3 `:modified-in` retract (`mcp_server.py`, the `already_has_modified_in`

--- a/evals/at_scale/bench_index_delete_cost.py
+++ b/evals/at_scale/bench_index_delete_cost.py
@@ -1,0 +1,112 @@
+"""Where does _retract's 73.5% actually go?
+
+The raw minigraf retract is free (0.06 ms/fact, no graph-size scaling --
+see retract_microbench.py). But a full ingestion spends 4,138 s of 5,627 s
+inside mcp_server._retract. That wrapper does three things:
+
+    raw = _db_execute(db, f"(retract {facts})")        # measured: free
+    triples = _resolved_facts_triples(facts, db)       # a _query_ident per
+                                                       # non-keyword entity
+    _index_write("delete", triples, index_con)         # fact_index.delete_facts
+
+fact_index.delete_facts issues, per triple:
+
+    DELETE FROM facts_fts WHERE entity=? AND attribute=? AND value=?
+                          AND valid_to IS NULL
+
+facts_fts is an FTS5 virtual table (fact_index.py:23). FTS5 has no B-tree on
+its columns, so equality predicates cannot seek -- this is a full scan of the
+index per deleted triple. fact_index.py:31 already says as much ("an O(n)
+scan over facts_fts"), which is exactly why facts_dedup was added for the
+INSERT path. The DELETE path never got the same treatment.
+
+Prediction if that is the cause: delete cost per triple grows linearly with
+the number of rows in facts_fts, and is unaffected by how many triples are
+batched into one delete_facts call.
+
+    .venv/bin/python scratchpad/index_delete_bench.py
+"""
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+REPO = "/home/aditya/Work/AMC/Minigraf/temporal_reasoning"
+sys.path.insert(0, REPO)
+
+import fact_index
+
+TS = "2026-01-01T00:00:00Z"
+
+
+def build_index(tmpdir, name, n_rows):
+    path = os.path.join(tmpdir, f"{name}.sqlite3")
+    con = fact_index.open_writer(path)
+    rows = [
+        (f":e/n{i}", ":attr", f"value number {i} with some text", TS, None)
+        for i in range(n_rows)
+    ]
+    for start in range(0, n_rows, 2000):
+        fact_index.insert_facts(con, rows[start:start + 2000])
+    con.commit()
+    return con, path
+
+
+def bench_delete(con, n_delete, per_call):
+    rows = [
+        (f":e/n{i}", ":attr", f"value number {i} with some text", TS, None)
+        for i in range(n_delete)
+    ]
+    t0 = time.perf_counter()
+    for start in range(0, n_delete, per_call):
+        fact_index.delete_facts(con, rows[start:start + per_call])
+    con.commit()
+    return time.perf_counter() - t0
+
+
+def main(tmpdir):
+    print("=== D1: delete 200 rows one call, vary index size ===")
+    print(f"{'index rows':>11} {'seconds':>9} {'ms/triple':>11}")
+    prev = None
+    for n_rows in (5_000, 20_000, 80_000):
+        con, _ = build_index(tmpdir, f"d1_{n_rows}", n_rows)
+        secs = bench_delete(con, 200, 200)
+        per = secs / 200 * 1000
+        growth = f"  ({per / prev:.1f}x)" if prev else ""
+        print(f"{n_rows:>11} {secs:>9.3f} {per:>11.3f}{growth}")
+        prev = per
+        con.close()
+
+    print("\n=== D2: fixed 80,000-row index, delete 200, vary triples/call ===")
+    print(f"{'triples/call':>13} {'calls':>7} {'seconds':>9} {'ms/triple':>11}")
+    for per_call in (1, 10, 200):
+        con, _ = build_index(tmpdir, f"d2_{per_call}", 80_000)
+        secs = bench_delete(con, 200, per_call)
+        n_calls = (200 + per_call - 1) // per_call
+        print(f"{per_call:>13} {n_calls:>7} {secs:>9.3f} {secs / 200 * 1000:>11.3f}")
+        con.close()
+
+    print("\n=== D3: contrast -- insert the same volumes ===")
+    print(f"{'index rows':>11} {'seconds':>9} {'ms/triple':>11}")
+    for n_rows in (5_000, 20_000, 80_000):
+        con, _ = build_index(tmpdir, f"d3_{n_rows}", n_rows)
+        new = [
+            (f":new/n{i}", ":attr", f"fresh value {i} with some text", TS, None)
+            for i in range(200)
+        ]
+        t0 = time.perf_counter()
+        fact_index.insert_facts(con, new)
+        con.commit()
+        secs = time.perf_counter() - t0
+        print(f"{n_rows:>11} {secs:>9.3f} {secs / 200 * 1000:>11.3f}")
+        con.close()
+
+
+if __name__ == "__main__":
+    tmpdir = tempfile.mkdtemp(prefix="idx-del-bench-")
+    try:
+        main(tmpdir)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    print("\ndone")

--- a/evals/at_scale/bench_retract_cost.py
+++ b/evals/at_scale/bench_retract_cost.py
@@ -1,0 +1,124 @@
+"""Microbenchmark: what does minigraf's retract actually cost?
+
+Decides one question: is retract cost per-FACT, per-CALL, or dependent on
+total graph size? That determines whether batching
+_correction_sweep_apply's 72,971 individual :modified-in retracts (1,629 s,
+29% of a full ingestion run) can recover anything.
+
+Experiment A -- fixed graph, vary facts-per-call.
+  Retract the same 1,000 facts as 1000x1, 100x10, 10x100, 1x1000.
+  Total time roughly constant  -> pure per-fact cost, batching is useless.
+  Total time falls with fewer calls -> a per-call component exists, batching wins.
+
+Experiment B -- fixed call shape, vary graph size.
+  Retract 100 facts one-at-a-time from graphs of 2k / 10k / 40k facts.
+  Per-retract cost rising with graph size -> retract scans, and the real
+  problem is graph size, not call shape.
+
+Experiment C -- transact, same shape as A, for contrast.
+
+    .venv/bin/python scratchpad/retract_microbench.py
+"""
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+REPO = "/home/aditya/Work/AMC/Minigraf/temporal_reasoning"
+sys.path.insert(0, REPO)
+
+TS = "2026-01-01T00:00:00Z"
+
+
+def fresh_db(tmpdir, name):
+    """A real on-disk MiniGrafDb, like the benchmark uses."""
+    from minigraf import MiniGrafDb
+    path = os.path.join(tmpdir, f"{name}.graph")
+    for suffix in ("", ".wal", ".lock"):
+        if os.path.exists(path + suffix):
+            os.remove(path + suffix)
+    return MiniGrafDb.open(path), path
+
+
+def facts_for(lo, hi):
+    """Distinct entities so nothing collides in the EAVT index."""
+    return [f'[:e/n{i} :attr "v{i}"]' for i in range(lo, hi)]
+
+
+def populate(db, n, chunk=500):
+    """Seed the graph with n facts, in chunks so the seeding itself is fast."""
+    for start in range(0, n, chunk):
+        batch = facts_for(start, min(start + chunk, n))
+        db.execute(f'(transact {{:valid-from "{TS}"}} [' + " ".join(batch) + "])")
+
+
+def timed_retract(db, groups):
+    """Retract each group as ONE call. Returns (seconds, n_calls, n_facts)."""
+    n_calls = n_facts = 0
+    t0 = time.perf_counter()
+    for g in groups:
+        db.execute("(retract [" + " ".join(g) + "])")
+        n_calls += 1
+        n_facts += len(g)
+    return time.perf_counter() - t0, n_calls, n_facts
+
+
+def chunks(items, size):
+    return [items[i:i + size] for i in range(0, len(items), size)]
+
+
+def experiment_a(tmpdir):
+    print("\n=== A: fixed graph (10,000 facts), retract 1,000, vary facts/call ===")
+    print(f"{'shape':>16} {'calls':>7} {'facts':>7} {'seconds':>9} {'ms/call':>10} {'ms/fact':>9}")
+    for per_call in (1, 10, 100, 1000):
+        db, path = fresh_db(tmpdir, f"a{per_call}")
+        populate(db, 10_000)
+        targets = facts_for(0, 1000)
+        secs, n_calls, n_facts = timed_retract(db, chunks(targets, per_call))
+        print(f"{per_call:>10} f/call {n_calls:>7} {n_facts:>7} {secs:>9.2f} "
+              f"{secs / n_calls * 1000:>10.1f} {secs / n_facts * 1000:>9.2f}")
+        del db
+
+
+def experiment_b(tmpdir):
+    print("\n=== B: retract 100 facts one-at-a-time, vary graph size ===")
+    print(f"{'graph facts':>12} {'seconds':>9} {'ms/retract':>12}")
+    for graph_size in (2_000, 10_000, 40_000):
+        db, path = fresh_db(tmpdir, f"b{graph_size}")
+        populate(db, graph_size)
+        targets = facts_for(0, 100)
+        secs, n_calls, _ = timed_retract(db, chunks(targets, 1))
+        print(f"{graph_size:>12} {secs:>9.2f} {secs / n_calls * 1000:>12.1f}")
+        del db
+
+
+def experiment_c(tmpdir):
+    print("\n=== C: transact, same shape as A, for contrast ===")
+    print(f"{'shape':>16} {'calls':>7} {'facts':>7} {'seconds':>9} {'ms/call':>10} {'ms/fact':>9}")
+    for per_call in (1, 10, 100, 1000):
+        db, path = fresh_db(tmpdir, f"c{per_call}")
+        populate(db, 10_000)
+        new = [f'[:new/n{i} :attr "v{i}"]' for i in range(1000)]
+        n_calls = n_facts = 0
+        t0 = time.perf_counter()
+        for g in chunks(new, per_call):
+            db.execute(f'(transact {{:valid-from "{TS}"}} [' + " ".join(g) + "])")
+            n_calls += 1
+            n_facts += len(g)
+        secs = time.perf_counter() - t0
+        print(f"{per_call:>10} f/call {n_calls:>7} {n_facts:>7} {secs:>9.2f} "
+              f"{secs / n_calls * 1000:>10.1f} {secs / n_facts * 1000:>9.2f}")
+        del db
+
+
+if __name__ == "__main__":
+    tmpdir = tempfile.mkdtemp(prefix="retract-bench-")
+    os.environ["MINIGRAF_GRAPH_PATH"] = os.path.join(tmpdir, "unused.graph")
+    try:
+        experiment_a(tmpdir)
+        experiment_b(tmpdir)
+        experiment_c(tmpdir)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    print("\ndone")

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -78,3 +78,48 @@ that was wrong and has been corrected here.
 | 4 | dependency-impact | PASS | 14.5ms | 5.3ms |
 | 5 | cross-layer | PASS | 568.4ms | 6.2ms |
 | 6 | cross-layer | PASS | 549.6ms | 2.9ms |
+
+## Ingestion Run — 20260802T082540Z
+
+- Repo: `.` @ `master`
+
+| Metric | Value |
+|---|---|
+| Commits ingested | 553 |
+| Final status | complete |
+| Wall-clock | 5133.19s |
+| Throughput | 6.5 commits/min |
+| Peak RSS | 541132 KB |
+| Graph size | 174772224 bytes |
+| Fact-index size | 79183872 bytes |
+| Status-query latency (min/p50/p99/max) | 0.0ms / 0.0ms / 0.0ms / 0.8ms |
+| Graph-query latency (min/p50/p99/max) | 0.1ms / 12.2ms / 697.2ms / 956.8ms |
+
+This is the post-#233 acceptance-gate run (Task 5, issue #233; see
+`docs/superpowers/specs/2026-07-31-reverse-walk-write-amplification-design.md`).
+Compared to the pre-fix phase-2d run against master at `bbe7fee`, which was
+**killed incomplete after 62 minutes having reached ~100 of ~552 commits**
+(measured at 3,152 tx/commit average, 263x the 12 tx/commit forward-only
+baseline): this run **completes**, which the pre-fix run did not. That is
+the real, headline improvement.
+
+Against the 2026-07-19 forward-only baseline (498 commits, 78.87s, 378.9
+commits/min, 45,801,472 B) — not an apples-to-apples comparison, since this
+run does strictly more work (Stage A writes provisional lineage the baseline
+never wrote, and Stage B re-parses) and ingests 553 commits, not 498:
+
+- Wall-clock is 5,133.19s against 78.87s — **65x**. The design spec's stated
+  bar was "completes in a time of the same order as the baseline rather than
+  a different one." **That bar is not met.**
+- Graph size is 174,772,224 B against 45,801,472 B — **3.8x**, which does
+  fit the spec's "within a small multiple" bar.
+
+Neither number is dominated by per-entity-per-commit scaling of the kind
+#233 fixed — Task 5's `TestReverseApplyWriteBudget` isolates that axis
+directly and shows flat, O(1) per-commit write cost as entity count varies
+(see the commit message and the task-5 report for the counts). The
+remaining 65x gap against the baseline is a real, unresolved cost — most
+plausibly Stage B's re-parse and the two-stream interleaving overhead
+inherent to concurrent forward+reverse ingestion, rather than anything this
+task's regression test is positioned to catch. Left as a decision for a
+human, not addressed further in this task.

--- a/evals/at_scale/profile_reverse_walk_writes.py
+++ b/evals/at_scale/profile_reverse_walk_writes.py
@@ -1,0 +1,130 @@
+"""Instrumented micro-harness for #233 -- per-call-site write attribution
+for the reverse-bulk-fill walk (Stage A).
+
+Drives N commits of the reverse walk directly, wrapping _transact/_retract
+with counters and timers keyed by calling function, so the walk's write
+amplification can be READ per call site rather than inferred from the graph
+size after the fact. The full at-scale ingestion benchmark
+(run_ingestion_benchmark.py) reports the aggregate; this reports where it
+goes, on a slice small enough to iterate on.
+
+Self-isolating: creates its own tempdir and points MINIGRAF_GRAPH_PATH and
+MINIGRAF_INDEX_PATH at it, so it never touches memory.graph.
+
+    .venv/bin/python evals/at_scale/profile_reverse_walk_writes.py [N] [REPO] [BRANCH]
+"""
+import collections
+import os
+import sys
+import tempfile
+import time
+import traceback
+
+N = int(sys.argv[1]) if len(sys.argv) > 1 else 10
+REPO = os.path.abspath(sys.argv[2]) if len(sys.argv) > 2 else os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+BRANCH = sys.argv[3] if len(sys.argv) > 3 else "HEAD"
+sys.path.insert(0, REPO)
+
+tmpdir = tempfile.mkdtemp(prefix="reverse-prof-")
+os.environ["MINIGRAF_GRAPH_PATH"] = os.path.join(tmpdir, "bench.graph")
+os.environ["MINIGRAF_INDEX_PATH"] = os.path.join(tmpdir, "bench.graph.fts.sqlite3")
+
+import mcp_server as m
+import frontier_registry
+
+counts = collections.Counter()
+timings = collections.Counter()
+
+
+def _caller():
+    st = traceback.extract_stack()
+    # st[-1] is _caller, st[-2] is the wrapper, st[-3] is the real caller
+    return st[-3].name
+
+
+_real_transact = m._transact
+_real_retract = m._retract
+
+
+def _t(*a, **k):
+    c = _caller()
+    t0 = time.perf_counter()
+    try:
+        return _real_transact(*a, **k)
+    finally:
+        counts[(c, "transact")] += 1
+        timings[(c, "transact")] += time.perf_counter() - t0
+
+
+def _r(*a, **k):
+    c = _caller()
+    t0 = time.perf_counter()
+    try:
+        return _real_retract(*a, **k)
+    finally:
+        counts[(c, "retract")] += 1
+        timings[(c, "retract")] += time.perf_counter() - t0
+
+
+m._transact = _t
+m._retract = _r
+
+_real_db_execute = m._db_execute
+query_counts = collections.Counter()
+query_timings = collections.Counter()
+
+
+def _dbx(db, datalog):
+    if datalog.startswith("(query"):
+        c = traceback.extract_stack()[-2].name
+        t0 = time.perf_counter()
+        try:
+            return _real_db_execute(db, datalog)
+        finally:
+            query_counts[c] += 1
+            query_timings[c] += time.perf_counter() - t0
+    return _real_db_execute(db, datalog)
+
+
+m._db_execute = _dbx
+
+db = m._open_db_at(os.environ["MINIGRAF_GRAPH_PATH"])
+commits = m._git_commits(REPO, None, BRANCH)
+linearization = [c[0] for c in commits]
+print(f"{len(linearization)} commits in history; walking {N} from the tip")
+
+alloc = frontier_registry.FrontierAllocator(len(linearization))
+index_con = None
+
+t0 = time.perf_counter()
+per_commit = []
+for i in range(N):
+    c0 = time.perf_counter()
+    before = sum(counts.values())
+    h = m._reverse_fill_claim_and_process(
+        db, REPO, linearization, commits, alloc, index_con=index_con,
+    )
+    if h is None:
+        break
+    per_commit.append((h[:12], sum(counts.values()) - before, time.perf_counter() - c0))
+elapsed = time.perf_counter() - t0
+
+total = sum(counts.values())
+print(f"\n{len(per_commit)} commits in {elapsed:.1f}s -> {elapsed/max(1,len(per_commit)):.2f}s/commit")
+print(f"total writes: {total} -> {total/max(1,len(per_commit)):.0f} tx/commit\n")
+
+print(f"{'call site':<42} {'op':<9} {'count':>8} {'sec':>8}")
+for (site, op), n in counts.most_common():
+    print(f"{site:<42} {op:<9} {n:>8} {timings[(site, op)]:>8.1f}")
+
+print(f"\n{'query call site':<42} {'count':>8} {'sec':>8}")
+for site, n in query_counts.most_common(15):
+    print(f"{site:<42} {n:>8} {query_timings[site]:>8.1f}")
+
+print("\nper-commit writes:")
+for h, n, secs in per_commit:
+    print(f"  {h}  {n:>7} writes  {secs:>7.2f}s")
+
+print(f"\ngraph: {os.path.getsize(os.environ['MINIGRAF_GRAPH_PATH'])} B  ({tmpdir})")

--- a/evals/at_scale/results/ingestion-20260802T082540Z.json
+++ b/evals/at_scale/results/ingestion-20260802T082540Z.json
@@ -1,0 +1,23 @@
+{
+  "repo_path": ".",
+  "branch": "master",
+  "commits_ingested": 553,
+  "wall_clock_seconds": 5133.189456358028,
+  "throughput_per_minute": 6.463817531399093,
+  "peak_rss_kb": 541132,
+  "graph_size_bytes": 174772224,
+  "index_size_bytes": 79183872,
+  "status_latency": {
+    "min": 4.129018634557724e-06,
+    "p50": 7.518974598497152e-06,
+    "p99": 2.0295032300055027e-05,
+    "max": 0.0008073740173131227
+  },
+  "query_latency": {
+    "min": 5.1179027650505304e-05,
+    "p50": 0.012188596010673791,
+    "p99": 0.6972144250175916,
+    "max": 0.9568492589751258
+  },
+  "final_status": "complete"
+}

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5180,20 +5180,37 @@ def _lineage_mark_provisional_batch(
         _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
 
 
+def _lineage_confirm_batch(
+    db: Any, entity_idents: Sequence[str], index_con: Optional[Any] = None
+) -> None:
+    """Batched _lineage_confirm (#233). Retracts the :type/lineage-marker
+    companion entity's facts for every still-provisional ident in ONE
+    _retract; idents with no marker are skipped, so callers can pass a whole
+    commit's candidates unconditionally.
+
+    Collision-free: each marker is its own :lineage/... companion entity.
+    """
+    facts = []
+    for entity_ident in entity_idents:
+        if not _lineage_is_provisional(db, entity_ident):
+            continue
+        ident = _lineage_marker_ident(entity_ident)
+        facts.extend([
+            f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
+            f"[{ident} :entity {entity_ident}]",
+            f"[{ident} :status :provisional]",
+        ])
+    if facts:
+        _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+
+
 def _lineage_confirm(db: Any, entity_ident: str, index_con: Optional[Any] = None) -> None:
     """Retract the :type/lineage-marker companion entity's facts for
-    entity_ident if present; no-op if absent, so callers (2c) can call this
-    unconditionally without checking first.
+    entity_ident if present; no-op if absent, so callers can call this
+    unconditionally without checking first. One-entity form of
+    _lineage_confirm_batch, delegating so the two cannot drift (#233).
     """
-    if not _lineage_is_provisional(db, entity_ident):
-        return
-    ident = _lineage_marker_ident(entity_ident)
-    facts = [
-        f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
-        f"[{ident} :entity {entity_ident}]",
-        f"[{ident} :status :provisional]",
-    ]
-    _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+    _lineage_confirm_batch(db, [entity_ident], index_con=index_con)
 
 
 def _lineage_is_provisional(db: Any, entity_ident: str) -> bool:
@@ -7968,29 +7985,41 @@ def _reverse_apply(
         pos=pos, pos_by_commit_ident=pos_by_commit_ident,
     )
 
+    # #233: one transact per entity here was 10,161 calls over 12 commits of
+    # this repo. Each edge is asserted at the SUPERSEDED commit's own
+    # timestamp, not this commit's, so one batch is impossible -- but
+    # entities touched by one commit were almost always last sighted at the
+    # same commit, so grouping by that timestamp collapses to a handful.
+    # Every per-ident gate below stays per-ident and is evaluated during
+    # grouping. Facts differing in entity do not collide, so each group is
+    # one safe transact.
+    retroactive_by_ts: Dict[str, List[str]] = {}
     for ident, superseded_ident in provisional_moves:
-        if superseded_ident is not None and superseded_ident != commit_ident:
-            superseded_pos = pos_by_commit_ident.get(superseded_ident)
-            if superseded_pos is not None and superseded_pos <= pos:
-                # The move was refused (or would be): the "superseded" guess
-                # is not actually later than this commit, so asserting it as
-                # a modification would claim the entity changed at or before
-                # its own introduction.
-                continue
-            superseded_ts = ts_by_commit_ident.get(superseded_ident)
-            if superseded_ts is None:
-                # Falling back to THIS commit's timestamp back-dates the edge
-                # to before the modification it describes -- a fact asserted
-                # valid before it was true. Skip and say so instead.
-                print(
-                    f"[_reverse_apply] skipping retroactive :modified-in "
-                    f"for {ident} at {superseded_ident}: no timestamp in commit_metadata",
-                    file=sys.stderr,
-                )
-                continue
-            _transact(
-                db, f"[[{ident} :modified-in {superseded_ident}]]", superseded_ts, index_con=index_con,
+        if superseded_ident is None or superseded_ident == commit_ident:
+            continue
+        superseded_pos = pos_by_commit_ident.get(superseded_ident)
+        if superseded_pos is not None and superseded_pos <= pos:
+            # The move was refused (or would be): the "superseded" guess is
+            # not actually later than this commit, so asserting it as a
+            # modification would claim the entity changed at or before its
+            # own introduction.
+            continue
+        superseded_ts = ts_by_commit_ident.get(superseded_ident)
+        if superseded_ts is None:
+            # Falling back to THIS commit's timestamp back-dates the edge to
+            # before the modification it describes -- a fact asserted valid
+            # before it was true. Skip and say so instead.
+            print(
+                f"[_reverse_apply] skipping retroactive :modified-in "
+                f"for {ident} at {superseded_ident}: no timestamp in commit_metadata",
+                file=sys.stderr,
             )
+            continue
+        retroactive_by_ts.setdefault(superseded_ts, []).append(
+            f"[{ident} :modified-in {superseded_ident}]"
+        )
+    for superseded_ts, triples in retroactive_by_ts.items():
+        _transact(db, "[" + " ".join(triples) + "]", superseded_ts, index_con=index_con)
 
     _frontier_persist_claim(db, linearization, pos, from_low=False, commit_ts_iso=commit_ts_iso, index_con=index_con)
     _db_checkpoint(db)
@@ -8911,6 +8940,11 @@ def _correction_sweep_apply(
             for entry_ident, _entry_name, entry_triples in precomputed[entries_key]:
                 candidate_triples_by_ident[entry_ident] = list(entry_triples)
 
+        # #233: _lineage_confirm was one retract per confirmed entity here,
+        # and retracts cost ~13ms against a transact's ~1ms. Collected per
+        # file and flushed once at the bottom of this same iteration, so a
+        # file's confirms are one call.
+        to_confirm: List[str] = []
         for ident in candidate_idents:
             raw = _db_execute(db, f"(query [:find ?c :where [{ident} :introduced-by ?c]])")
             introduced_by_values = {row[0] for row in json.loads(raw).get("results", [])}
@@ -8927,7 +8961,7 @@ def _correction_sweep_apply(
                         commit_ts_iso,
                         index_con=index_con,
                     )
-                    _lineage_confirm(db, ident, index_con=index_con)
+                    to_confirm.append(ident)
                 else:
                     # Case 2: guess points elsewhere, or an ambiguous
                     # (zero/2+) value count -- fail safe, leave untouched.
@@ -8966,6 +9000,8 @@ def _correction_sweep_apply(
                             f"(ambiguous introduced-by values: {sorted(introduced_by_values)})",
                             file=sys.stderr,
                         )
+
+        _lineage_confirm_batch(db, to_confirm, index_con=index_con)
 
     if update_watermark:
         _correction_sweep_through_update(db, commit_hash, commit_ts_iso, index_con=index_con)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5385,14 +5385,18 @@ def _re_date_structural_facts(
 ) -> None:
     """Retract and re-assert an entity's structural facts at new_ts_iso.
 
-    Used whenever a provisional :introduced-by guess moves to an earlier
-    commit -- by _reverse_apply when the reverse walk finds an even earlier
-    occurrence, and by _forward_reconcile_provisional when the forward walk
-    reaches the true introduction. In both cases the facts were written at
-    the timestamp of the commit where the entity was first SIGHTED, which is
-    later than the introduction now is, leaving a valid-time window where
-    :introduced-by is live for an entity with no type, name or file -- so
-    ":as-of the introduction" reports it as nonexistent.
+    Used whenever a provisional :introduced-by guess is resolved to an
+    earlier commit -- by _correction_sweep_apply when the sweep confirms an
+    entity at its introduction, and by _forward_reconcile_provisional when
+    the forward walk reaches the true introduction. In both cases the facts
+    were written at the timestamp of the commit where the entity was first
+    SIGHTED, which is later than the introduction now is, leaving a valid
+    time window where :introduced-by is live for an entity with no type,
+    name or file -- so ":as-of the introduction" reports it as nonexistent.
+
+    _reverse_apply deliberately does NOT call this (#233): it used to, on
+    every provisional move, which re-dated a long-lived entity once per
+    touch instead of once. Both callers above fire once per entity.
 
     _retract targets live rows regardless of their original valid_from, so
     this is a straight re-assert at the earlier timestamp.
@@ -7663,10 +7667,10 @@ def _reverse_apply(
     index_con: Optional[Any] = None,
 ) -> str:
     """#222 phase 2b: apply one already-claimed, already-extracted commit --
-    structural facts, :modified-in edges, provisional :introduced-by, and
-    candidate-diff records for every entity the commit's "A"/"M" files
-    touch. "D"/"R" files are skipped entirely (deletions and renames are
-    out of scope for this sub-phase -- see the design spec).
+    structural facts, :modified-in edges, and provisional :introduced-by for
+    every entity the commit's "A"/"M" files touch. "D"/"R" files are skipped
+    entirely (deletions and renames are out of scope for this sub-phase --
+    see the design spec).
 
     Split out of _reverse_fill_claim_and_process's single body (#222 phase
     2d): `pos` (from allocator.claim_high()) and `file_results` (from
@@ -7703,6 +7707,17 @@ def _reverse_apply(
     Already-authoritative entities are never touched, but a genuine later
     touch always gets :modified-in (unless #221's unchanged-body check
     says the body is provably unchanged this commit).
+
+    Does NOT re-date structural facts as a guess moves earlier (#233). They
+    stay at the timestamp of the commit where this walk first SIGHTED the
+    entity, which is later than the provisional :introduced-by, so ":as-of
+    the provisional introduction" reports the entity as nonexistent for as
+    long as it stays provisional. The correction sweep closes that window
+    when it confirms. This is the same "temporarily dangling, and
+    convergent" shape as the :parent edges below, and the region is already
+    excluded from 2a's trust predicate -- but note that an INTERRUPTED run
+    now leaves a wider inconsistent window than it did before #233, closed
+    by the next run's sweep.
 
     Known, documented limitation, and who fixes it: the retroactive
     :modified-in for a superseded commit does not re-check #221's
@@ -7761,7 +7776,6 @@ def _reverse_apply(
         f'[{commit_ident} :subject "{_edn_escape(subject[:200])}"]',
         f'[{commit_ident} :date "{commit_ts_iso}"]',
     ]
-    candidate_triples_by_ident: Dict[str, List[str]] = {}
     pos_by_commit_ident = {f":commit/{h[:12]}": i for i, (h, _t, _a, _s) in enumerate(commit_metadata)}
     ts_by_commit_ident = {f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata}
     new_candidates: List[str] = []
@@ -7799,17 +7813,6 @@ def _reverse_apply(
         unchanged_idents = precomputed.get("unchanged_idents", set())
         for ident in candidate_idents:
             unchanged_by_ident[ident] = ident in unchanged_idents
-
-        # Keep each entity's candidate triples so a provisional move can
-        # re-date them (#222 phase 2b1). A child's own list carries its
-        # [parent :contains child] edge, so re-dating a child re-dates its
-        # containment edge with it.
-        candidate_triples_by_ident[precomputed["module_ident"]] = list(
-            precomputed["module_candidate_triples"]
-        )
-        for entries_key in ("function_entries", "class_entries", "global_entries", "field_entries"):
-            for entry_ident, _entry_name, entry_triples in precomputed[entries_key]:
-                candidate_triples_by_ident[entry_ident] = list(entry_triples)
 
         new_candidates.extend(set(known_before.keys()) - known_before_snapshot)
         for ident in set(candidate_idents) & known_before_snapshot:
@@ -7893,19 +7896,6 @@ def _reverse_apply(
         )
         if superseded_ident is not None and superseded_ident != commit_ident:
             superseded_pos = pos_by_commit_ident.get(superseded_ident)
-            if superseded_pos is None or superseded_pos > pos:
-                # The move happened: this commit is genuinely earlier.
-                # Re-date the entity's structural facts to match (#222 phase
-                # 2b1) -- see _re_date_structural_facts's own docstring for
-                # why (they were written at the timestamp of the commit
-                # where the walk first SIGHTED the entity, which is later
-                # than the guess now is).
-                _re_date_structural_facts(
-                    db,
-                    [t for t in candidate_triples_by_ident.get(ident, []) if ":introduced-by" not in t],
-                    commit_ts_iso,
-                    index_con=index_con,
-                )
             if superseded_pos is not None and superseded_pos <= pos:
                 # The move was refused (or would be): the "superseded" guess
                 # is not actually later than this commit, so asserting it as
@@ -8775,6 +8765,12 @@ def _correction_sweep_apply(
     never writes commit_hash's own :type/commit entity (2b already wrote
     it for every commit in this sweep's range). DB-bound, parse-free.
 
+    Re-dates each confirmed entity's structural facts to the introduction
+    commit (#233), which _reverse_apply used to do eagerly on every
+    provisional move. Sound here and only here: the gap-closed precondition
+    means Stream 2's guess is final, so an entity reaching case 1 is at its
+    introduction, and this pass visits each commit exactly once ascending.
+
     skipped_so_far is the driving loop's running total of skipped_events
     from every previous call this run -- it exists solely to make the
     stderr log cap (_CORRECTION_SWEEP_LOG_CAP) work across calls without
@@ -8819,6 +8815,22 @@ def _correction_sweep_apply(
         )
         unchanged_idents = precomputed.get("unchanged_idents", set())
 
+        # #233: the sweep re-dates structural facts, which _reverse_apply
+        # used to do eagerly on every provisional move (48% of Stage A's
+        # wall time -- 17,250 retracts over 12 real commits). This pass
+        # already visits every commit in the reverse region exactly once,
+        # ascending, and its gap-closed precondition means Stream 2's guess
+        # is final -- so the commit at which an entity reaches case 1 IS its
+        # introduction, and re-dating there is once per entity for the whole
+        # region. precomputed already carried these triples; only the idents
+        # were being read out of it.
+        candidate_triples_by_ident: Dict[str, List[str]] = {
+            precomputed["module_ident"]: list(precomputed["module_candidate_triples"])
+        }
+        for entries_key in ("function_entries", "class_entries", "global_entries", "field_entries"):
+            for entry_ident, _entry_name, entry_triples in precomputed[entries_key]:
+                candidate_triples_by_ident[entry_ident] = list(entry_triples)
+
         for ident in candidate_idents:
             raw = _db_execute(db, f"(query [:find ?c :where [{ident} :introduced-by ?c]])")
             introduced_by_values = {row[0] for row in json.loads(raw).get("results", [])}
@@ -8828,6 +8840,13 @@ def _correction_sweep_apply(
                     # Case 1: the provisional guess matches this commit --
                     # confirm. The :introduced-by fact itself is untouched,
                     # since its value was already correct.
+                    _re_date_structural_facts(
+                        db,
+                        [t for t in candidate_triples_by_ident.get(ident, [])
+                         if ":introduced-by" not in t],
+                        commit_ts_iso,
+                        index_con=index_con,
+                    )
                     _lineage_confirm(db, ident, index_con=index_con)
                 else:
                     # Case 2: guess points elsewhere, or an ambiguous

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5439,8 +5439,11 @@ def _forward_reconcile_provisional(
     exactly one code path that mints an authoritative introduction and this
     function cannot drift from it.
 
-    Mirrors the supersede path in _reverse_apply: the same re-dating of
-    structural facts (via _re_date_structural_facts), the same refusal to
+    Re-dates structural facts itself (via _re_date_structural_facts), same
+    as _correction_sweep_apply's case 1 does (#233) -- _reverse_apply's own
+    supersede path deliberately does NOT do this anymore (see its
+    docstring), so this function no longer mirrors it on that point.
+    Still mirrors _reverse_apply's supersede path for the refusal to
     back-date a :modified-in edge whose commit timestamp is unknown, and --
     what commit_ident is for -- the same refusal to hand the entity a
     :modified-in edge at its OWN introduction (_reverse_apply's
@@ -7713,11 +7716,15 @@ def _reverse_apply(
     entity, which is later than the provisional :introduced-by, so ":as-of
     the provisional introduction" reports the entity as nonexistent for as
     long as it stays provisional. The correction sweep closes that window
-    when it confirms. This is the same "temporarily dangling, and
-    convergent" shape as the :parent edges below, and the region is already
-    excluded from 2a's trust predicate -- but note that an INTERRUPTED run
-    now leaves a wider inconsistent window than it did before #233, closed
-    by the next run's sweep.
+    when it CONFIRMS the entity (case 1) -- but leaves it open for an entity
+    the sweep instead leaves provisional (case 2's fail-safe skip on an
+    ambiguous/wrong guess, already logged as skipped): that entity keeps its
+    stale-dated structural facts indefinitely, not just until the sweep
+    runs. This is the same "temporarily dangling, and convergent" shape as
+    the :parent edges below, and the region is already excluded from 2a's
+    trust predicate -- but note that an INTERRUPTED run now leaves a wider
+    inconsistent window than it did before #233, closed by the next run's
+    sweep (for entities that reach case 1, not case 2).
 
     Known, documented limitation, and who fixes it: the retroactive
     :modified-in for a superseded commit does not re-check #221's
@@ -8765,11 +8772,16 @@ def _correction_sweep_apply(
     never writes commit_hash's own :type/commit entity (2b already wrote
     it for every commit in this sweep's range). DB-bound, parse-free.
 
-    Re-dates each confirmed entity's structural facts to the introduction
-    commit (#233), which _reverse_apply used to do eagerly on every
-    provisional move. Sound here and only here: the gap-closed precondition
-    means Stream 2's guess is final, so an entity reaching case 1 is at its
-    introduction, and this pass visits each commit exactly once ascending.
+    Re-dates each confirmed (case 1) entity's structural facts to the
+    introduction commit (#233), which _reverse_apply used to do eagerly on
+    every provisional move. Sound here and only here: the gap-closed
+    precondition means Stream 2's guess is final, so an entity reaching
+    case 1 is at its introduction, and this pass visits each commit exactly
+    once ascending. An entity case 2 leaves provisional (ambiguous or wrong
+    guess, already logged as skipped) is NOT re-dated and keeps its
+    stale-dated structural facts -- the valid-time window _reverse_apply's
+    docstring describes closes only for entities this sweep confirms, not
+    for ones it skips.
 
     skipped_so_far is the driving loop's running total of skipped_events
     from every previous call this run -- it exists solely to make the

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5166,7 +5166,7 @@ def _lineage_mark_provisional_batch(
     Collision-free: each marker is its own :lineage/... companion entity, so
     no two facts in the batch share (entity, attribute, valid_from).
     """
-    facts = []
+    facts: List[str] = []
     for entity_ident in entity_idents:
         if _lineage_is_provisional(db, entity_ident):
             continue
@@ -5368,6 +5368,21 @@ def _entity_introduced_by_set_provisional_batch(
       - value already equals commit_ident -- no write, but still marked
       - the monotonicity refusal (a guess may only move EARLIER), with its
         own stderr line per refused ident
+
+    Idempotent per ident: an ident whose value already equals commit_ident
+    contributes no fact write (but is still included in the marker batch).
+    Query-before-write, retract-then-reassert only for idents whose value
+    genuinely changed -- mirrors _watermark_update's pattern, since
+    re-transacting the same (entity, attribute, value) at a new valid_from
+    creates a duplicate live datom under minigraf's write semantics.
+
+    Positions, never timestamps: ingest :date values are AUTHOR dates
+    (_git_commits reads `%at`) and are not monotonic in topological order
+    (clock skew, rebases, cherry-picks), which is why build_linearization
+    uses --topo-order at all, so comparing :date values would silently
+    mis-order commits. pos and pos_by_commit_ident both default to None, in
+    which case the monotonicity guard is skipped for every ident in the
+    batch; _reverse_apply passes them always.
 
     Collision-free: within each batch the facts differ in entity, and only
     facts sharing (entity, attribute, valid_from) collapse in minigraf's

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5156,6 +5156,30 @@ def _lineage_mark_provisional(
     _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
 
 
+def _lineage_mark_provisional_batch(
+    db: Any, entity_idents: Sequence[str], commit_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Batched _lineage_mark_provisional (#233). Same query-before-write
+    per ident -- an entity already marked is skipped, never duplicated --
+    but the facts for every genuinely-new marker go in ONE _transact.
+
+    Collision-free: each marker is its own :lineage/... companion entity, so
+    no two facts in the batch share (entity, attribute, valid_from).
+    """
+    facts = []
+    for entity_ident in entity_idents:
+        if _lineage_is_provisional(db, entity_ident):
+            continue
+        ident = _lineage_marker_ident(entity_ident)
+        facts.extend([
+            f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
+            f"[{ident} :entity {entity_ident}]",
+            f"[{ident} :status :provisional]",
+        ])
+    if facts:
+        _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
+
+
 def _lineage_confirm(db: Any, entity_ident: str, index_con: Optional[Any] = None) -> None:
     """Retract the :type/lineage-marker companion entity's facts for
     entity_ident if present; no-op if absent, so callers (2c) can call this
@@ -5317,6 +5341,75 @@ def _entity_introduced_by_query(db: Any, entity_ident: str) -> Optional[str]:
     return results[0][0] if results else None
 
 
+def _entity_introduced_by_set_provisional_batch(
+    db: Any,
+    entity_idents: Sequence[str],
+    commit_ident: str,
+    commit_ts_iso: str,
+    index_con: Optional[Any] = None,
+    pos: Optional[int] = None,
+    pos_by_commit_ident: Optional[Dict[str, int]] = None,
+) -> Set[str]:
+    """Assert or move a PROVISIONAL :introduced-by to commit_ident for many
+    entities at once (#233), in one _retract and at most two _transact
+    calls instead of two writes per ident. _reverse_apply's two loops were
+    the only production callers of the per-ident form, at ~1,265 idents per
+    commit on a real repository; retracts cost ~13ms against a transact's
+    ~1ms, so the retract batching is the load-bearing half.
+
+    Returns the set of idents whose guess was actually asserted or moved.
+
+    Every gate is per-ident and is applied in the same order the per-ident
+    function used, because batching must not turn one ident's refusal into
+    the whole batch being dropped, nor a refused ident into an included one:
+
+      - authoritative (a value exists and _lineage_is_provisional is False)
+        -- never touched; reverse walk must never clobber a confirmed fact
+      - value already equals commit_ident -- no write, but still marked
+      - the monotonicity refusal (a guess may only move EARLIER), with its
+        own stderr line per refused ident
+
+    Collision-free: within each batch the facts differ in entity, and only
+    facts sharing (entity, attribute, valid_from) collapse in minigraf's
+    EAVT pending index. :contains is the attribute where that bites, and it
+    is not written here.
+    """
+    to_retract: List[str] = []
+    to_transact: List[str] = []
+    to_mark: List[str] = []
+    moved: Set[str] = set()
+
+    for entity_ident in entity_idents:
+        current = _entity_introduced_by_query(db, entity_ident)
+        if current is not None and not _lineage_is_provisional(db, entity_ident):
+            continue  # authoritative -- never touch
+        if current == commit_ident:
+            to_mark.append(entity_ident)
+            continue
+        if current is not None and pos is not None and pos_by_commit_ident is not None:
+            current_pos = pos_by_commit_ident.get(current)
+            if current_pos is not None and pos >= current_pos:
+                print(
+                    f"[_entity_introduced_by_set_provisional] refusing to move "
+                    f"{entity_ident}'s guess from {current} (position {current_pos}) "
+                    f"to {commit_ident} (position {pos}): a guess may only move earlier",
+                    file=sys.stderr,
+                )
+                continue
+        if current is not None:
+            to_retract.append(f"[{entity_ident} :introduced-by {current}]")
+        to_transact.append(f"[{entity_ident} :introduced-by {commit_ident}]")
+        to_mark.append(entity_ident)
+        moved.add(entity_ident)
+
+    if to_retract:
+        _retract(db, "[" + " ".join(to_retract) + "]", index_con=index_con)
+    if to_transact:
+        _transact(db, "[" + " ".join(to_transact) + "]", commit_ts_iso, index_con=index_con)
+    _lineage_mark_provisional_batch(db, to_mark, commit_ts_iso, index_con=index_con)
+    return moved
+
+
 def _entity_introduced_by_set_provisional(
     db: Any,
     entity_ident: str,
@@ -5326,55 +5419,15 @@ def _entity_introduced_by_set_provisional(
     pos: Optional[int] = None,
     pos_by_commit_ident: Optional[Dict[str, int]] = None,
 ) -> None:
-    """Assert or move entity_ident's PROVISIONAL :introduced-by to
-    commit_ident. Never touches an entity whose :introduced-by is already
-    authoritative (a fact exists and _lineage_is_provisional is False) --
-    reverse walk (#222 phase 2b) must never clobber a fact Stream 1 has
-    already confirmed. Idempotent: no-ops the fact write (but still ensures
-    the marker is present) if the current value already equals
-    commit_ident. Query-before-write, retract-then-reassert only if the
-    value genuinely changed -- mirrors _watermark_update's pattern, since
-    re-transacting the same (entity, attribute, value) at a new valid_from
-    creates a duplicate live datom under minigraf's write semantics.
-
-    Monotonicity (#222 phase 2b1): when pos and pos_by_commit_ident are
-    supplied, a move is REFUSED unless commit_ident is strictly earlier than
-    the current guess. This docstring always claimed the contract ("reverse
-    walk has now reached an earlier commit") but nothing enforced it, so a
-    re-claim of a higher position -- routine on a resumed run -- dragged the
-    guess forward while the caller's retroactive :modified-in landed at the
-    older, lower commit, producing an entity modified before it was
-    introduced. Forward walk cannot produce that shape, nothing in the graph
-    or the audit detects it, and it persists.
-
-    Positions, never timestamps: ingest :date values are AUTHOR dates
-    (_git_commits reads `%at`) and are not monotonic in topological order
-    (clock skew, rebases, cherry-picks), which is why
-    build_linearization uses --topo-order at all, so comparing :date values
-    would silently mis-order commits. Both parameters default to None, in
-    which case the guard is skipped and behaviour is exactly as before --
-    2a's existing callers are unaffected; 2b passes them always.
+    """One-entity form of _entity_introduced_by_set_provisional_batch --
+    see that function for the gates. A delegating wrapper rather than a
+    parallel implementation (#233) so the batched and unbatched paths
+    cannot drift apart; the batch is the only production caller shape.
     """
-    current = _entity_introduced_by_query(db, entity_ident)
-    if current is not None and not _lineage_is_provisional(db, entity_ident):
-        return  # authoritative -- never touch
-    if current == commit_ident:
-        _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
-        return
-    if current is not None and pos is not None and pos_by_commit_ident is not None:
-        current_pos = pos_by_commit_ident.get(current)
-        if current_pos is not None and pos >= current_pos:
-            print(
-                f"[_entity_introduced_by_set_provisional] refusing to move "
-                f"{entity_ident}'s guess from {current} (position {current_pos}) "
-                f"to {commit_ident} (position {pos}): a guess may only move earlier",
-                file=sys.stderr,
-            )
-            return
-    if current is not None:
-        _retract(db, f"[[{entity_ident} :introduced-by {current}]]", index_con=index_con)
-    _transact(db, f"[[{entity_ident} :introduced-by {commit_ident}]]", commit_ts_iso, index_con=index_con)
-    _lineage_mark_provisional(db, entity_ident, commit_ts_iso, index_con=index_con)
+    _entity_introduced_by_set_provisional_batch(
+        db, [entity_ident], commit_ident, commit_ts_iso,
+        index_con=index_con, pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+    )
 
 
 def _re_date_structural_facts(
@@ -7890,17 +7943,17 @@ def _reverse_apply(
             db, "[" + " ".join(authoritative_modified_triples) + "]", commit_ts_iso, index_con=index_con,
         )
 
-    for ident in new_candidates:
-        _entity_introduced_by_set_provisional(
-            db, ident, commit_ident, commit_ts_iso, index_con=index_con,
-            pos=pos, pos_by_commit_ident=pos_by_commit_ident,
-        )
+    _entity_introduced_by_set_provisional_batch(
+        db, new_candidates, commit_ident, commit_ts_iso, index_con=index_con,
+        pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+    )
+    _entity_introduced_by_set_provisional_batch(
+        db, [ident for ident, _superseded in provisional_moves], commit_ident,
+        commit_ts_iso, index_con=index_con,
+        pos=pos, pos_by_commit_ident=pos_by_commit_ident,
+    )
 
     for ident, superseded_ident in provisional_moves:
-        _entity_introduced_by_set_provisional(
-            db, ident, commit_ident, commit_ts_iso, index_con=index_con,
-            pos=pos, pos_by_commit_ident=pos_by_commit_ident,
-        )
         if superseded_ident is not None and superseded_ident != commit_ident:
             superseded_pos = pos_by_commit_ident.get(superseded_ident)
             if superseded_pos is not None and superseded_pos <= pos:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5143,17 +5143,11 @@ def _lineage_mark_provisional(
     -- a marker already present is a no-op, never a duplicate write. Uses
     internal _transact directly, never handle_minigraf_transact: :type/
     lineage-marker is deliberately unregistered in MINIGRAF_SCHEMA, and the
-    public handler's schema gate would reject it outright.
+    public handler's schema gate would reject it outright. One-entity form
+    of _lineage_mark_provisional_batch, delegating so the two cannot drift
+    (#233, matching _lineage_confirm's own delegation rationale).
     """
-    if _lineage_is_provisional(db, entity_ident):
-        return
-    ident = _lineage_marker_ident(entity_ident)
-    facts = [
-        f"[{ident} :entity-type {_LINEAGE_MARKER_ENTITY_TYPE}]",
-        f"[{ident} :entity {entity_ident}]",
-        f"[{ident} :status :provisional]",
-    ]
-    _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
+    _lineage_mark_provisional_batch(db, [entity_ident], commit_ts_iso, index_con=index_con)
 
 
 def _lineage_mark_provisional_batch(
@@ -5316,15 +5310,36 @@ def _candidate_diff_purge_legacy(db: Any, index_con: Optional[Any] = None) -> in
     purge, and gating it would need a new watermark whose only job is to
     record that a one-time deletion happened.
 
-    Returns the number of records purged. Records for distinct :candidate/
-    entities do not share (entity, attribute, valid_from), so the whole
-    purge is one collision-free _retract.
+    Returns the number of records purged (0 if there was nothing to purge,
+    or if the retract itself failed -- see below).
+
+    COST SHAPE: cheap when there is nothing to purge (one query, no
+    retract), but the retract itself is NOT cheap for a graph that actually
+    holds legacy records -- measured on the real backend at ~0.5s for 500
+    records, ~7.2s for 2,000, and ~127s for 8,000 (roughly O(N^2); chunking
+    the retract does not help, since the cost is in minigraf's retract
+    itself, not in call-count). A phase-2d graph can hold on the order of
+    10k+ live records, i.e. minutes of no output. This is still called
+    unconditionally (see above) because it is one-time per graph -- once
+    purged, later loads see zero rows and return immediately -- and gating
+    it behind a new watermark would add persistent state for a problem that
+    self-resolves after the first successful run. A row count is logged to
+    stderr before retracting so a multi-minute stall is legible rather than
+    looking like a hang, and the retract is best-effort: a failure is
+    logged and swallowed rather than propagated, because this is scratch
+    cleanup, not core ingestion, and _frontier_load's caller must not be
+    bricked for every future run by one bad retract here.
+
+    Records for distinct :candidate/ entities do not share (entity,
+    attribute, valid_from), so the whole purge is one collision-free
+    _retract call (cost above is backend-internal to that one call, not a
+    batching artifact).
 
     Note: minigraf resolves ?e in a query result to its internal entity id,
     not the :candidate/... keyword the fact was minted with, and that
     internal id is not accepted as an entity token in a retract pattern
     (no :ident back-reference is populated for these records the way it is
-    for e.g. commits -- see _entity_introduced_by_query's ident_map). The
+    for e.g. commits -- see _rebuild_index_from_graph's ident_map). The
     keyword ident is deterministic from (commit_ident, entity_ident) --
     the same formula the deleted _candidate_diff_ident used -- so it is
     rebuilt here instead of relying on ?e.
@@ -5337,6 +5352,12 @@ def _candidate_diff_purge_legacy(db: Any, index_con: Optional[Any] = None) -> in
     rows = json.loads(raw).get("results", [])
     if not rows:
         return 0
+    print(
+        f"[_candidate_diff_purge_legacy] purging {len(rows)} legacy "
+        ":type/candidate-diff record(s) -- this is O(n^2) in minigraf's "
+        "retract and may take a while (measured ~127s at 8,000 records)",
+        file=sys.stderr,
+    )
     facts = []
     for commit_ident, entity_ident, body_hash in rows:
         ident = f":candidate/{commit_ident[len(':commit/'):]}-{entity_ident.lstrip(':').replace('/', '-')}"
@@ -5346,7 +5367,11 @@ def _candidate_diff_purge_legacy(db: Any, index_con: Optional[Any] = None) -> in
             f"[{ident} :entity {entity_ident}]",
             f'[{ident} :body-hash "{_edn_escape(body_hash)}"]',
         ])
-    _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+    try:
+        _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+    except Exception as e:
+        print(f"[_candidate_diff_purge_legacy] retract failed, {len(rows)} record(s) left in place: {e}", file=sys.stderr)
+        return 0
     return len(rows)
 
 
@@ -8335,7 +8360,7 @@ def _forward_apply(
                     if _lineage_is_provisional(db, ident)
                 ]
             # Built once per file rather than scanned per ident (matches
-            # _reverse_fill_claim_and_process's candidate_triples_by_ident
+            # _correction_sweep_apply's candidate_triples_by_ident
             # precedent) -- a per-ident linear scan here is O(n^2) per file
             # once there is more than one reconcilable entity.
             structural_triples_by_ident = (
@@ -8693,10 +8718,9 @@ def _forward_structural_triples_by_ident(precomputed: Dict[str, Any]) -> Dict[st
     """Every candidate ident's own structural triples, for re-dating, built
     once per file instead of scanned per ident (#222 phase 2d Task 5 fix --
     the previous per-ident linear scan was O(n^2) per file once more than one
-    entity needed reconciling). Matches the existing precedent in
-    _reverse_apply's candidate_triples_by_ident (moved verbatim out of
-    _reverse_fill_claim_and_process by #222 phase 2d Task 6), which builds
-    the same shape of dict from the same five sources.
+    entity needed reconciling). Called by both _forward_apply and
+    _correction_sweep_apply, which need the same shape of dict built from
+    the same five sources for the same reason (#233).
 
     A child's own list carries its [parent :contains child] edge, so
     re-dating a child re-dates its containment edge with it (#222 phase
@@ -8933,12 +8957,7 @@ def _correction_sweep_apply(
         # introduction, and re-dating there is once per entity for the whole
         # region. precomputed already carried these triples; only the idents
         # were being read out of it.
-        candidate_triples_by_ident: Dict[str, List[str]] = {
-            precomputed["module_ident"]: list(precomputed["module_candidate_triples"])
-        }
-        for entries_key in ("function_entries", "class_entries", "global_entries", "field_entries"):
-            for entry_ident, _entry_name, entry_triples in precomputed[entries_key]:
-                candidate_triples_by_ident[entry_ident] = list(entry_triples)
+        candidate_triples_by_ident = _forward_structural_triples_by_ident(precomputed)
 
         # #233: _lineage_confirm was one retract per confirmed entity here,
         # and retracts cost ~13ms against a transact's ~1ms. Collected per
@@ -8956,7 +8975,7 @@ def _correction_sweep_apply(
                     # since its value was already correct.
                     _re_date_structural_facts(
                         db,
-                        [t for t in candidate_triples_by_ident.get(ident, [])
+                        [t for t in candidate_triples_by_ident[ident]
                          if ":introduced-by" not in t],
                         commit_ts_iso,
                         index_con=index_con,

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5025,6 +5025,7 @@ def _frontier_load(
     ):
         _frontier_seed_from_watermark(db, linearization, run_ts_iso, index_con=index_con)
     _lineage_confirmed_through_migrate(db, run_ts_iso, index_con=index_con)
+    _candidate_diff_purge_legacy(db, index_con=index_con)
 
     hash_to_pos = {h: i for i, h in enumerate(linearization)}
     intervals: List[frontier_registry.Interval] = []
@@ -5256,78 +5257,56 @@ def _lineage_confirmed_through_migrate(
     _lineage_confirmed_through_update(db, hi_hash, run_ts_iso, index_con=index_con)
 
 
-def _candidate_diff_ident(commit_hash: str, entity_ident: str) -> str:
-    """Deterministic ident for a candidate-diff record. Not a public schema
-    type -- see the #222 phase 2a design spec's "Schema/audit status of new
-    entity types" section.
-    """
-    return f":candidate/{commit_hash[:12]}-{entity_ident.lstrip(':').replace('/', '-')}"
+def _candidate_diff_purge_legacy(db: Any, index_con: Optional[Any] = None) -> int:
+    """One-time cleanup for graphs written by #222 phase 2d, which persisted
+    a :type/candidate-diff record per (claimed commit, candidate entity)
+    pair. #233 deleted that path outright -- 2a specced the records so 2c
+    could confirm a candidate by hash comparison instead of re-parsing, but
+    2c as built re-parses on the process pool and reads
+    precomputed["unchanged_idents"], so nothing ever read them.
 
+    Without this, the records a 2d graph already holds are orphaned: the
+    writer AND the clearer are both gone. They are not inert -- fact_index
+    filters nothing by prefix (_MEMORY_PREFIXES affects scoring, not
+    inclusion), so they stay retrievable scratch noise indefinitely.
 
-def _candidate_diff_persist(
-    db: Any,
-    commit_hash: str,
-    entity_ident: str,
-    body_hash: str,
-    commit_ts_iso: str,
-    index_con: Optional[Any] = None,
-) -> None:
-    """Mint/update one candidate-diff record for (commit_hash, entity_ident).
-    Query-before-write -- no-ops if the persisted body_hash already
-    matches, retracts+reasserts only the :body-hash if it genuinely
-    changed (the other attributes are all derived from commit_hash/
-    entity_ident, which never change for a given record's ident). Uses
-    internal _transact/_retract directly, never handle_minigraf_transact:
-    :type/candidate-diff is deliberately unregistered in MINIGRAF_SCHEMA.
+    Called unconditionally from _frontier_load rather than gated on a
+    watermark: it is one query per load, cheap when there is nothing to
+    purge, and gating it would need a new watermark whose only job is to
+    record that a one-time deletion happened.
+
+    Returns the number of records purged. Records for distinct :candidate/
+    entities do not share (entity, attribute, valid_from), so the whole
+    purge is one collision-free _retract.
+
+    Note: minigraf resolves ?e in a query result to its internal entity id,
+    not the :candidate/... keyword the fact was minted with, and that
+    internal id is not accepted as an entity token in a retract pattern
+    (no :ident back-reference is populated for these records the way it is
+    for e.g. commits -- see _entity_introduced_by_query's ident_map). The
+    keyword ident is deterministic from (commit_ident, entity_ident) --
+    the same formula the deleted _candidate_diff_ident used -- so it is
+    rebuilt here instead of relying on ?e.
     """
-    ident = _candidate_diff_ident(commit_hash, entity_ident)
-    existing = _candidate_diff_read(db, commit_hash, entity_ident)
-    if existing == body_hash:
-        return
-    if existing is None:
-        commit_ident = f":commit/{commit_hash[:12]}"
-        facts = [
+    raw = _db_execute(
+        db, "(query [:find ?c ?ent ?h :where "
+            "[?e :entity-type :type/candidate-diff] [?e :commit ?c] "
+            "[?e :entity ?ent] [?e :body-hash ?h]])"
+    )
+    rows = json.loads(raw).get("results", [])
+    if not rows:
+        return 0
+    facts = []
+    for commit_ident, entity_ident, body_hash in rows:
+        ident = f":candidate/{commit_ident[len(':commit/'):]}-{entity_ident.lstrip(':').replace('/', '-')}"
+        facts.extend([
             f"[{ident} :entity-type :type/candidate-diff]",
             f"[{ident} :commit {commit_ident}]",
             f"[{ident} :entity {entity_ident}]",
             f'[{ident} :body-hash "{_edn_escape(body_hash)}"]',
-        ]
-        _transact(db, "[" + " ".join(facts) + "]", commit_ts_iso, index_con=index_con)
-    else:
-        _retract(db, f'[[{ident} :body-hash "{_edn_escape(existing)}"]]', index_con=index_con)
-        _transact(
-            db, f'[[{ident} :body-hash "{_edn_escape(body_hash)}"]]', commit_ts_iso, index_con=index_con
-        )
-
-
-def _candidate_diff_read(db: Any, commit_hash: str, entity_ident: str) -> Optional[str]:
-    """Return the persisted body_hash for (commit_hash, entity_ident), or
-    None if no candidate record exists for that pair."""
-    ident = _candidate_diff_ident(commit_hash, entity_ident)
-    raw = _db_execute(db, f"(query [:find ?h :where [{ident} :body-hash ?h]])")
-    results = json.loads(raw).get("results", [])
-    return results[0][0] if results else None
-
-
-def _candidate_diff_clear(
-    db: Any, commit_hash: str, entity_ident: str, index_con: Optional[Any] = None
-) -> None:
-    """Retract the candidate record once consumed (2c calls this after
-    confirming/rejecting), so these scratch facts don't accumulate
-    unbounded across a full ingest. No-op if no record exists.
-    """
-    existing = _candidate_diff_read(db, commit_hash, entity_ident)
-    if existing is None:
-        return
-    ident = _candidate_diff_ident(commit_hash, entity_ident)
-    commit_ident = f":commit/{commit_hash[:12]}"
-    facts = [
-        f"[{ident} :entity-type :type/candidate-diff]",
-        f"[{ident} :commit {commit_ident}]",
-        f"[{ident} :entity {entity_ident}]",
-        f'[{ident} :body-hash "{_edn_escape(existing)}"]',
-    ]
+        ])
     _retract(db, "[" + " ".join(facts) + "]", index_con=index_con)
+    return len(rows)
 
 
 def _entity_introduced_by_query(db: Any, entity_ident: str) -> Optional[str]:
@@ -5485,11 +5464,7 @@ def _forward_reconcile_provisional(
     if guess_ident is None:
         return None
 
-    # 4. The candidate-diff record is stale the moment the guess moves off it,
-    # and this is the cheapest place to drop it -- guess_ident is right here.
-    _candidate_diff_clear(db, guess_ident[len(":commit/"):], entity_ident, index_con=index_con)
-
-    # 5. The guess commit is now known to be a genuine modification rather
+    # 4. The guess commit is now known to be a genuine modification rather
     # than the introduction -- UNLESS it is this very commit, which is the
     # introduction. Stream 2 can guess the right commit and still leave a
     # provisional marker on it (it claims high-to-low, so the first sighting
@@ -6685,23 +6660,6 @@ def _precompute_file_triples(
     except Exception:
         unchanged_idents = set()
 
-    # #222 phase 2b: per-entity body hash for every entity present on the
-    # NEW side, keyed the same way unchanged_idents is above -- lets the
-    # reverse-bulk-fill walk persist a candidate-diff record (body hash)
-    # for an entity without needing the raw tree-sitter node itself.
-    # Module-level entries are deliberately excluded: there is no
-    # tree-sitter node to hash for a whole file, and candidate-diff
-    # persistence is function/class/variable/field-only (matching
-    # unchanged_idents' own category scope).
-    body_hashes: Dict[str, str] = {}
-    try:
-        new_nodes_for_hash = new_entity_nodes or {}
-        for category in ("function", "class", "variable", "field"):
-            for name, node in new_nodes_for_hash.get(category, {}).items():
-                body_hashes[_code_ident(category, file_path, name)] = _normalized_body_hash(node)
-    except Exception:
-        body_hashes = {}
-
     return {
         "module_ident": module_ident,
         "module_candidate_triples": module_candidate_triples,
@@ -6713,7 +6671,6 @@ def _precompute_file_triples(
         "field_static_map": field_static_map,
         "resolved_imports": resolved_imports,
         "unchanged_idents": unchanged_idents,
-        "body_hashes": body_hashes,
     }
 
 
@@ -7810,7 +7767,6 @@ def _reverse_apply(
     new_candidates: List[str] = []
     provisional_moves: List[Tuple[str, str]] = []  # (ident, superseded_commit_ident)
     already_authoritative_touched: List[Tuple[str, Optional[str]]] = []
-    body_hash_by_ident: Dict[str, str] = {}
     unchanged_by_ident: Dict[str, bool] = {}
 
     for status, file_path, extracted, precomputed, _old_path in file_results:
@@ -7864,8 +7820,6 @@ def _reverse_apply(
                 already_authoritative_touched.append(
                     (ident, _entity_introduced_by_query(db, ident))
                 )
-
-        body_hash_by_ident.update(precomputed.get("body_hashes", {}))
 
     # Split :contains out before batching (#222 phase 2b1). Minigraf's EAVT
     # pending index lacks value bytes in the key, so batching multiple
@@ -7931,20 +7885,12 @@ def _reverse_apply(
             db, ident, commit_ident, commit_ts_iso, index_con=index_con,
             pos=pos, pos_by_commit_ident=pos_by_commit_ident,
         )
-        if ident in body_hash_by_ident:
-            _candidate_diff_persist(
-                db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
-            )
 
     for ident, superseded_ident in provisional_moves:
         _entity_introduced_by_set_provisional(
             db, ident, commit_ident, commit_ts_iso, index_con=index_con,
             pos=pos, pos_by_commit_ident=pos_by_commit_ident,
         )
-        if ident in body_hash_by_ident:
-            _candidate_diff_persist(
-                db, commit_hash, ident, body_hash_by_ident[ident], commit_ts_iso, index_con=index_con,
-            )
         if superseded_ident is not None and superseded_ident != commit_ident:
             superseded_pos = pos_by_commit_ident.get(superseded_ident)
             if superseded_pos is None or superseded_pos > pos:
@@ -7959,16 +7905,6 @@ def _reverse_apply(
                     [t for t in candidate_triples_by_ident.get(ident, []) if ":introduced-by" not in t],
                     commit_ts_iso,
                     index_con=index_con,
-                )
-
-                # The superseded candidate-diff record is stale the moment
-                # the guess moves off it, and this is the cheapest place to
-                # drop it -- superseded_ident is right here. Without it these
-                # scratch facts accumulate as O(entity touches) rather than
-                # O(entities), which is exactly what _candidate_diff_clear's
-                # own docstring says must not happen.
-                _candidate_diff_clear(
-                    db, superseded_ident[len(":commit/"):], ident, index_con=index_con,
                 )
             if superseded_pos is not None and superseded_pos <= pos:
                 # The move was refused (or would be): the "superseded" guess
@@ -8893,7 +8829,6 @@ def _correction_sweep_apply(
                     # confirm. The :introduced-by fact itself is untouched,
                     # since its value was already correct.
                     _lineage_confirm(db, ident, index_con=index_con)
-                    _candidate_diff_clear(db, commit_hash, ident, index_con=index_con)
                 else:
                     # Case 2: guess points elsewhere, or an ambiguous
                     # (zero/2+) value count -- fail safe, leave untouched.
@@ -8921,7 +8856,6 @@ def _correction_sweep_apply(
                             _transact(
                                 db, f"[[{ident} :modified-in {commit_ident}]]", commit_ts_iso, index_con=index_con,
                             )
-                    _candidate_diff_clear(db, commit_hash, ident, index_con=index_con)
                 else:
                     # Zero or 2+ distinct values -- same duplicate-fact
                     # risk as case 2 -- skip, left alone rather than

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,12 @@ classifiers = [
 
 dependencies = [
     "minigraf>=1.2.1",
-    "mcp>=1.27.0",
+    # Capped below 2.0: mcp 2.0.0 removed Server.list_tools, which
+    # mcp_server.py registers its handlers through. With the bound open, CI
+    # resolved 2.0.0 and every test that imports mcp_server errored at import
+    # (902 of them). Migrating to the 2.x handler API is its own change --
+    # raise the cap as part of that, not before it.
+    "mcp>=1.27.0,<2.0.0",
 ]
 
 [project.scripts]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6433,6 +6433,131 @@ class TestEntityIntroducedBySetProvisional:
         assert mcp_server._lineage_is_provisional(db, entity_ident) is False
 
 
+class TestEntityIntroducedBySetProvisionalBatch:
+    """#233: _reverse_apply's two loops were the only production callers of
+    the per-ident function, at one retract + one transact each -- 8,618
+    retracts over 12 commits of this repo, and retracts cost ~13ms against
+    a transact's ~1ms. The batch is the implementation now; the per-ident
+    function delegates to it so the gates cannot drift apart."""
+
+    def test_first_assert_batches_distinct_entities(self, real_db):
+        import mcp_server
+        idents = [f":function/src-auth-py-f{i}" for i in range(5)]
+
+        moved = mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, idents, ":commit/h2", "2026-01-03T00:00:00Z",
+        )
+
+        assert moved == set(idents)
+        for ident in idents:
+            assert mcp_server._entity_introduced_by_query(real_db, ident) == ":commit/h2"
+            assert mcp_server._lineage_is_provisional(real_db, ident) is True
+
+    def test_batch_issues_a_constant_number_of_write_calls(self, real_db):
+        """The whole point. Five entities must not cost five retracts."""
+        import mcp_server
+        idents = [f":function/src-auth-py-f{i}" for i in range(5)]
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, idents, ":commit/h2", "2026-01-03T00:00:00Z",
+        )
+
+        calls = []
+        real_transact, real_retract = mcp_server._transact, mcp_server._retract
+        mcp_server._transact = lambda *a, **k: (calls.append("t") or real_transact(*a, **k))
+        mcp_server._retract = lambda *a, **k: (calls.append("r") or real_retract(*a, **k))
+        try:
+            mcp_server._entity_introduced_by_set_provisional_batch(
+                real_db, idents, ":commit/h0", "2026-01-01T00:00:00Z",
+            )
+        finally:
+            mcp_server._transact, mcp_server._retract = real_transact, real_retract
+
+        assert calls.count("r") == 1, f"one retract for the whole batch; got {calls}"
+        assert calls.count("t") <= 2, f"at most guess + markers; got {calls}"
+
+    def test_moving_the_batch_earlier_leaves_one_value_each(self, real_db):
+        import mcp_server
+        idents = [f":function/src-auth-py-f{i}" for i in range(3)]
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, idents, ":commit/h2", "2026-01-03T00:00:00Z",
+        )
+
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, idents, ":commit/h0", "2026-01-01T00:00:00Z",
+        )
+
+        for ident in idents:
+            assert mcp_server._entity_introduced_by_query(real_db, ident) == ":commit/h0"
+            raw = mcp_server._db_execute(
+                real_db, f"(query [:find (count ?c) :where [{ident} :introduced-by ?c]])"
+            )
+            assert json.loads(raw)["results"] == [[1]]
+
+    def test_monotonicity_refusal_is_per_ident_not_per_batch(self, real_db):
+        """The gate that must not become batch-wide. One ident whose guess
+        would move LATER must be left alone while the rest of the batch
+        still applies -- batching must not turn a refusal into a dropped
+        batch, nor a refused ident into an included one."""
+        import mcp_server
+        pinned = ":function/src-auth-py-pinned"
+        movable = ":function/src-auth-py-movable"
+        pos_by_commit_ident = {":commit/h0": 0, ":commit/h1": 1, ":commit/h2": 2}
+        # pinned already sits at the EARLIEST commit; h1 would move it later.
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [pinned], ":commit/h0", "2026-01-01T00:00:00Z",
+            pos=0, pos_by_commit_ident=pos_by_commit_ident,
+        )
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [movable], ":commit/h2", "2026-01-03T00:00:00Z",
+            pos=2, pos_by_commit_ident=pos_by_commit_ident,
+        )
+
+        moved = mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [pinned, movable], ":commit/h1", "2026-01-02T00:00:00Z",
+            pos=1, pos_by_commit_ident=pos_by_commit_ident,
+        )
+
+        assert moved == {movable}
+        assert mcp_server._entity_introduced_by_query(real_db, pinned) == ":commit/h0"
+        assert mcp_server._entity_introduced_by_query(real_db, movable) == ":commit/h1"
+
+    def test_authoritative_entities_are_never_touched(self, real_db):
+        import mcp_server
+        authoritative = ":function/src-auth-py-authoritative"
+        provisional = ":function/src-auth-py-provisional"
+        mcp_server._transact(
+            real_db, f"[[{authoritative} :introduced-by :commit/h5]]", "2026-01-06T00:00:00Z",
+        )
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [provisional], ":commit/h2", "2026-01-03T00:00:00Z",
+        )
+
+        moved = mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [authoritative, provisional], ":commit/h0", "2026-01-01T00:00:00Z",
+        )
+
+        assert moved == {provisional}
+        assert mcp_server._entity_introduced_by_query(real_db, authoritative) == ":commit/h5"
+        assert mcp_server._lineage_is_provisional(real_db, authoritative) is False
+
+    def test_same_value_is_idempotent_but_still_marks(self, real_db):
+        import mcp_server
+        ident = ":function/src-auth-py-login"
+
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [ident], ":commit/h1", "2026-01-02T00:00:00Z",
+        )
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [ident], ":commit/h1", "2026-01-02T00:00:01Z",
+        )
+
+        raw = mcp_server._db_execute(
+            real_db, f"(query [:find (count ?c) :where [{ident} :introduced-by ?c]])"
+        )
+        assert json.loads(raw)["results"] == [[1]]
+        assert mcp_server._lineage_is_provisional(real_db, ident) is True
+
+
 class TestGitCommitsTopoOrder:
     def test_orders_by_topology_not_committer_date(self, git_repo_diamond_clock_skewed):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6303,82 +6303,75 @@ class TestLineageConfirmedThroughMigration:
         assert mcp_server._lineage_confirmed_through_query(db) == "h2"
 
 
-class TestCandidateDiff:
-    def test_read_absent_record_returns_none(self, real_db):
+class TestCandidateDiffLegacyPurge:
+    """#233: the :type/candidate-diff record path is deleted, so nothing
+    clears the records a phase-2d graph already holds -- and they ARE
+    indexed (fact_index filters nothing by prefix; _MEMORY_PREFIXES affects
+    scoring only), so they would stay retrievable scratch noise forever.
+    _frontier_load is already the one-time-migration site."""
+
+    def _seed_legacy_record(self, db, commit_hash, entity_ident, body_hash):
+        """Write a candidate-diff record the way the deleted
+        _candidate_diff_persist used to, so the purge has something real to
+        find on a graph written by phase 2d."""
         import mcp_server
-        assert mcp_server._candidate_diff_read(real_db, "a" * 40, ":function/foo") is None
+        ident = f":candidate/{commit_hash[:12]}-{entity_ident.lstrip(':').replace('/', '-')}"
+        commit_ident = f":commit/{commit_hash[:12]}"
+        mcp_server._transact(
+            db,
+            "[" + " ".join([
+                f"[{ident} :entity-type :type/candidate-diff]",
+                f"[{ident} :commit {commit_ident}]",
+                f"[{ident} :entity {entity_ident}]",
+                f'[{ident} :body-hash "{body_hash}"]',
+            ]) + "]",
+            "2026-01-01T00:00:00Z",
+        )
+        return ident
 
-    def test_persist_then_read_round_trip(self, real_db):
+    def _live_record_count(self, db):
         import mcp_server
-        db = real_db
-        commit_hash = "a" * 40
-        entity_ident = ":function/src-auth-py-login"
+        raw = mcp_server._db_execute(
+            db, "(query [:find (count ?e) :where [?e :entity-type :type/candidate-diff]])"
+        )
+        results = json.loads(raw)["results"]
+        return results[0][0] if results else 0
 
-        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
-
-        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash1"
-        # A different (commit, entity) pair must not resolve to this record.
-        assert mcp_server._candidate_diff_read(db, "b" * 40, entity_ident) is None
-        assert mcp_server._candidate_diff_read(db, commit_hash, ":function/other") is None
-
-    def test_persist_same_hash_twice_does_not_duplicate(self, real_db):
+    def test_purges_pre_existing_records(self, real_db):
         import mcp_server
-        db = real_db
-        commit_hash = "a" * 40
-        entity_ident = ":function/src-auth-py-login"
+        self._seed_legacy_record(real_db, "a" * 40, ":function/src-auth-py-login", "h1")
+        self._seed_legacy_record(real_db, "b" * 40, ":function/src-auth-py-login", "h2")
+        assert self._live_record_count(real_db) == 2
 
-        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
-        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:01Z")
+        purged = mcp_server._candidate_diff_purge_legacy(real_db)
 
-        ident = mcp_server._candidate_diff_ident(commit_hash, entity_ident)
-        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :body-hash ?h]])")
-        assert json.loads(raw)["results"] == [[1]]
+        assert purged == 2
+        assert self._live_record_count(real_db) == 0
 
-    def test_persist_different_hash_updates_without_duplicating(self, real_db):
+    def test_noop_on_a_graph_with_no_records(self, real_db):
         import mcp_server
-        db = real_db
-        commit_hash = "a" * 40
-        entity_ident = ":function/src-auth-py-login"
+        assert mcp_server._candidate_diff_purge_legacy(real_db) == 0
 
-        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
-        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash2", "2026-01-01T00:00:01Z")
-
-        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash2"
-        ident = mcp_server._candidate_diff_ident(commit_hash, entity_ident)
-        raw = mcp_server._db_execute(db, f"(query [:find (count ?h) :where [{ident} :body-hash ?h]])")
-        assert json.loads(raw)["results"] == [[1]]
-
-    def test_clear_removes_the_record(self, real_db):
+    def test_frontier_load_purges_on_an_existing_graph(self, real_db, tmp_path):
+        """The purge has to run from _frontier_load, not just exist -- an
+        already-migrated graph is loaded by every subsequent run and is
+        exactly where these orphans live."""
         import mcp_server
-        db = real_db
-        commit_hash = "a" * 40
-        entity_ident = ":function/src-auth-py-login"
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "auth.py").write_text("def login(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "c0"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        self._seed_legacy_record(real_db, "a" * 40, ":function/src-auth-py-login", "h1")
 
-        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
-        mcp_server._candidate_diff_clear(db, commit_hash, entity_ident)
+        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
 
-        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) is None
-        ident = mcp_server._candidate_diff_ident(commit_hash, entity_ident)
-        raw = mcp_server._db_execute(db, f"(query [:find (count ?e) :where [{ident} :entity ?e]])")
-        assert json.loads(raw)["results"] == [[0]]
-
-    def test_clear_absent_record_is_a_noop(self, real_db):
-        import mcp_server
-        db = real_db
-        # Must not raise.
-        mcp_server._candidate_diff_clear(db, "a" * 40, ":function/never-persisted")
-
-    def test_candidate_diff_survives_audit(self, real_db):
-        import mcp_server
-        db = real_db
-        commit_hash = "a" * 40
-        entity_ident = ":function/src-auth-py-login"
-
-        mcp_server._candidate_diff_persist(db, commit_hash, entity_ident, "hash1", "2026-01-01T00:00:00Z")
-        result = mcp_server.handle_minigraf_audit()
-
-        assert result["retracted"] == 0
-        assert mcp_server._candidate_diff_read(db, commit_hash, entity_ident) == "hash1"
+        assert self._live_record_count(real_db) == 0
 
 
 class TestEntityIntroducedBySetProvisional:
@@ -8667,50 +8660,6 @@ class TestPrecomputeFileTriplesBodyDiff:
         )
         field_ident = mcp_server._code_ident("field", "models.py", "Foo.bar")
         assert field_ident in result["unchanged_idents"]
-
-    def test_body_hashes_populated_for_every_new_side_function(self):
-        import mcp_server
-        parser = self._python_parser()
-        new_nodes = self._all_nodes(parser, b"def login(user):\n    return user.ok\n")
-        extracted = {"functions": ["login"], "classes": [], "imports": []}
-        result = mcp_server._precompute_file_triples(
-            "auth.py", extracted, ":commit/c1", {}, new_entity_nodes=new_nodes,
-        )
-        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
-        assert result["body_hashes"][fn_ident] == mcp_server._normalized_body_hash(new_nodes["function"]["login"])
-
-    def test_body_hashes_match_across_textually_identical_bodies(self):
-        import mcp_server
-        parser = self._python_parser()
-        nodes_a = self._all_nodes(parser, b"def login(user):\n    return user.ok\n")
-        nodes_b = self._all_nodes(parser, b"def login(user):\n\n    return   user.ok\n")
-        extracted = {"functions": ["login"], "classes": [], "imports": []}
-        result_a = mcp_server._precompute_file_triples(
-            "auth.py", extracted, ":commit/c1", {}, new_entity_nodes=nodes_a,
-        )
-        result_b = mcp_server._precompute_file_triples(
-            "auth.py", extracted, ":commit/c2", {}, new_entity_nodes=nodes_b,
-        )
-        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
-        assert result_a["body_hashes"][fn_ident] == result_b["body_hashes"][fn_ident]
-
-    def test_body_hashes_absent_without_new_entity_nodes(self):
-        import mcp_server
-        extracted = {"functions": ["login"], "classes": [], "imports": []}
-        result = mcp_server._precompute_file_triples("auth.py", extracted, ":commit/c1", {})
-        assert result["body_hashes"] == {}
-
-    def test_module_ident_never_appears_in_body_hashes(self):
-        import mcp_server
-        parser = self._python_parser()
-        new_nodes = self._all_nodes(parser, b"def login(user):\n    return user.ok\n")
-        extracted = {"functions": ["login"], "classes": [], "imports": []}
-        result = mcp_server._precompute_file_triples(
-            "auth.py", extracted, ":commit/c1", {}, new_entity_nodes=new_nodes,
-        )
-        module_ident = mcp_server._code_ident("module", "auth.py")
-        assert module_ident not in result["body_hashes"]
-
 
 class TestFieldClassContainment:
     """Fields owned by a real (extracted) class get BOTH module- and
@@ -14251,7 +14200,6 @@ class TestReverseFillClaimAndProcess:
         commit_ident = f":commit/{claimed_hash[:12]}"
         assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == commit_ident
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
-        assert mcp_server._candidate_diff_read(real_db, claimed_hash, fn_ident) is not None
 
     def test_walking_backward_moves_introduced_by_to_the_oldest_commit(self, real_db, tmp_path):
         import mcp_server
@@ -14271,7 +14219,6 @@ class TestReverseFillClaimAndProcess:
             real_db, f"(query [:find (count ?c) :where [{fn_ident} :introduced-by ?c]])"
         )
         assert json.loads(raw)["results"] == [[1]]
-        assert mcp_server._candidate_diff_read(real_db, oldest_hash, fn_ident) is not None
 
         # The converged :modified-in set must match what forward walk would
         # have produced: every later touch except the true introduction
@@ -14521,46 +14468,6 @@ class TestEntityIntroducedBySetProvisionalMonotonicity:
             pos=0, pos_by_commit_ident=pos_by,
         )
         assert mcp_server._entity_introduced_by_query(real_db, ident) == ":commit/c0"
-
-
-class TestReverseFillCandidateDiffLifecycle:
-    def test_superseded_candidate_diff_records_are_cleared_at_move_time(self, real_db, tmp_path):
-        """2b persisted a candidate-diff record for every (claimed commit,
-        entity) pair, on first sighting and on every move -- so storage grew
-        as O(entity touches), not O(entities), for scratch facts whose own
-        helper docstring says they must not "accumulate unbounded across a
-        full ingest". Only the final, lowest guess is a correct record; the
-        superseded one is stale the moment the guess moves, and 2b has
-        superseded_ident right there in hand."""
-        import mcp_server
-        import frontier_registry
-        repo = tmp_path / "repo"
-        repo.mkdir()
-        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
-        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
-        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
-        for i in range(6):
-            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
-            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
-            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
-        linearization = frontier_registry.build_linearization(str(repo))
-        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
-        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
-
-        mcp_server._reverse_bulk_fill_walk(
-            real_db, str(repo), linearization, commit_metadata, allocator,
-        )
-
-        login = mcp_server._code_ident("function", "auth.py", "login")
-        raw = mcp_server._db_execute(
-            real_db,
-            f"(query [:find ?rec :where [?rec :entity-type :type/candidate-diff] "
-            f"[?rec :entity {login}]])",
-        )
-        live_records = json.loads(raw)["results"]
-        assert len(live_records) == 1, (
-            f"one record per live guess, not one per touch; got {len(live_records)}"
-        )
 
 
 class TestReverseFillValidTimeParity:
@@ -15253,7 +15160,6 @@ class TestCorrectionSweepApply:
         assert skipped == 0
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
         assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{h0_hash[:12]}"
-        assert mcp_server._candidate_diff_read(real_db, h0_hash, fn_ident) is None
 
     def test_does_not_duplicate_commit_metadata(self, real_db, tmp_path):
         import mcp_server
@@ -15449,23 +15355,6 @@ class TestCorrectionSweepApply:
         )
         modified_in_values = {row[0] for row in json.loads(raw)["results"]}
         assert h2_ident not in modified_in_values
-
-    def test_opportunistic_stale_candidate_diff_cleanup(self, real_db, tmp_path):
-        import mcp_server
-        repo = self._repo_with_evolving_function(tmp_path)
-        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
-        h0_hash = commit_metadata[0][0]
-        h1_hash, h1_ts = commit_metadata[1][0], commit_metadata[1][1]
-        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
-        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/{h0_hash[:12]}]]", "2025-01-01T00:00:00Z")
-        # An orphaned candidate-diff record from a since-superseded guess.
-        mcp_server._candidate_diff_persist(real_db, h1_hash, fn_ident, "stale-hash", "2025-01-01T00:00:00Z")
-        assert mcp_server._candidate_diff_read(real_db, h1_hash, fn_ident) is not None
-
-        file_results = self._extract(repo, h1_hash)
-        mcp_server._correction_sweep_apply(real_db, h1_hash, h1_ts, file_results)
-
-        assert mcp_server._candidate_diff_read(real_db, h1_hash, fn_ident) is None
 
     def test_skipped_events_counts_events_not_entities(self, real_db, tmp_path):
         import mcp_server
@@ -15851,9 +15740,6 @@ class TestForwardReconcileProvisional:
             real_db, f"[[:code/fn-login :introduced-by {guess_ident}]]", "2026-06-01T00:00:00Z",
         )
         mcp_server._lineage_mark_provisional(real_db, ":code/fn-login", "2026-06-01T00:00:00Z")
-        mcp_server._candidate_diff_persist(
-            real_db, "bbbbbbbbbbbb" + "0" * 28, ":code/fn-login", "hash-b", "2026-06-01T00:00:00Z",
-        )
         return guess_ident, structural_triples
 
     def test_returns_none_and_writes_nothing_when_not_provisional(self, real_db):
@@ -15878,7 +15764,7 @@ class TestForwardReconcileProvisional:
         # one immediately after, via the normal forward emission path.
         assert mcp_server._entity_introduced_by_query(real_db, ":code/fn-login") is None
 
-    def test_confirms_the_marker_and_clears_the_candidate_diff(self, real_db):
+    def test_confirms_the_marker(self, real_db):
         import mcp_server
         guess_ident, structural = self._seed_provisional(real_db)
         returned = mcp_server._forward_reconcile_provisional(
@@ -15887,9 +15773,6 @@ class TestForwardReconcileProvisional:
         )
         assert returned == guess_ident
         assert mcp_server._lineage_is_provisional(real_db, ":code/fn-login") is False
-        assert mcp_server._candidate_diff_read(
-            real_db, "bbbbbbbbbbbb" + "0" * 28, ":code/fn-login",
-        ) is None
 
     def test_writes_modified_in_at_the_guess_commits_own_timestamp(self, real_db):
         """The guess commit is now known to be a genuine modification rather

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6180,6 +6180,35 @@ class TestLineageProvisionalMarker:
         raw = mcp_server._db_execute(db, f"(query [:find (count ?e) :where [{ident} :entity ?e]])")
         assert json.loads(raw)["results"] == [[1]]
 
+    def test_batch_marks_many_new_entities_in_one_transact(self, real_db):
+        """#233 review: test_batch_issues_a_constant_number_of_write_calls
+        (TestEntityIntroducedBySetProvisionalBatch) only ever counts a
+        SECOND call, by which point every ident is already marked and
+        _lineage_mark_provisional_batch short-circuits on the
+        _lineage_is_provisional gate before writing anything -- so it never
+        proves the marker batching itself. This test calls
+        _lineage_mark_provisional_batch directly on entities that have
+        never been marked, so the marker-transact path is genuinely
+        exercised, and asserts the write count is 1, not len(idents)."""
+        import mcp_server
+        idents = [f":function/src-auth-py-m{i}" for i in range(5)]
+        for ident in idents:
+            assert mcp_server._lineage_is_provisional(real_db, ident) is False
+
+        calls = []
+        real_transact = mcp_server._transact
+        mcp_server._transact = lambda *a, **k: (calls.append("t") or real_transact(*a, **k))
+        try:
+            mcp_server._lineage_mark_provisional_batch(
+                real_db, idents, "2026-01-03T00:00:00Z",
+            )
+        finally:
+            mcp_server._transact = real_transact
+
+        assert calls.count("t") == 1, f"one transact for all 5 new markers; got {calls}"
+        for ident in idents:
+            assert mcp_server._lineage_is_provisional(real_db, ident) is True
+
     def test_provisional_marker_survives_audit(self, real_db):
         import mcp_server
         db = real_db

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15239,6 +15239,86 @@ class TestReverseBulkFillWalk:
         assert count == 0
 
 
+class TestReverseApplyWriteBudget:
+    """#233's regression test. The reverse walk was issuing ~6,970 write
+    calls per commit against the forward walk's 12, because every per-entity
+    write was per-entity-per-commit. Phase 2's fixtures were all 6-10
+    commits and varied COMMIT count, so none of them could see it -- this
+    varies ENTITY count at a fixed commit count, which is the axis the
+    defect lived on."""
+
+    def _repo_with_n_functions(self, tmp_path, n, name):
+        repo = tmp_path / name
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for rev in range(2):
+            body = "\n\n".join(f"def f{i}():\n    return {rev}" for i in range(n))
+            (repo / "wide.py").write_text(body + "\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{rev}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _writes_for_the_second_claim(self, tmp_path, repo, graph_name):
+        """Claim the tip (every entity is new), then count write calls for
+        the claim below it (every entity is a provisional MOVE -- the path
+        that scaled with entity count).
+
+        Opens its own graph rather than reusing the real_db fixture's: this
+        test runs two repos in one test body, and both name their file
+        wide.py with functions f0.., so their idents would collide in a
+        shared graph (and the second _frontier_load would read the first
+        repo's now-stale bounds). The real_db fixture has already
+        monkeypatched MiniGrafDb.open to hand back a fresh in-memory db per
+        call, so open_db here is cheap and isolated."""
+        import mcp_server
+        import frontier_registry
+        real_db = mcp_server.open_db(str(tmp_path / graph_name)) or mcp_server.get_db()
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        calls = []
+        real_transact, real_retract = mcp_server._transact, mcp_server._retract
+        mcp_server._transact = lambda *a, **k: (calls.append("t") or real_transact(*a, **k))
+        mcp_server._retract = lambda *a, **k: (calls.append("r") or real_retract(*a, **k))
+        try:
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        finally:
+            mcp_server._transact, mcp_server._retract = real_transact, real_retract
+        return len(calls)
+
+    def test_per_commit_writes_do_not_scale_with_entity_count(self, real_db, tmp_path):
+        small = self._writes_for_the_second_claim(
+            tmp_path, self._repo_with_n_functions(tmp_path, 5, "small"), "small.graph"
+        )
+        large = self._writes_for_the_second_claim(
+            tmp_path, self._repo_with_n_functions(tmp_path, 50, "large"), "large.graph"
+        )
+
+        assert large - small <= 5, (
+            f"a 10x entity count must not multiply per-commit writes: "
+            f"5 functions cost {small} write calls, 50 cost {large}. "
+            f"Before #233 this ratio was ~10x."
+        )
+
+    def test_per_commit_writes_stay_in_the_forward_walk_s_range(self, real_db, tmp_path):
+        """The absolute bar, not just the scaling one. The forward walk
+        sustains ~12 writes per commit: one batched transact, one per
+        :contains, one per :parent, watermark, checkpoint."""
+        writes = self._writes_for_the_second_claim(
+            tmp_path, self._repo_with_n_functions(tmp_path, 50, "wide"), "wide.graph"
+        )
+
+        assert writes <= 20, f"expected the forward walk's ~12 per commit; got {writes}"
+
+
 class TestCorrectionSweepThroughWatermark:
     def test_unset_reads_as_none(self, real_db):
         import mcp_server

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6381,6 +6381,47 @@ class TestCandidateDiffLegacyPurge:
         import mcp_server
         assert mcp_server._candidate_diff_purge_legacy(real_db) == 0
 
+    def test_logs_row_count_before_retracting(self, real_db, capsys):
+        """Important 1: a multi-minute stall must be legible, not look like a
+        hang -- the row count is logged to stderr before the (potentially
+        very slow) retract runs."""
+        import mcp_server
+        self._seed_legacy_record(real_db, "a" * 40, ":function/src-auth-py-login", "h1")
+        self._seed_legacy_record(real_db, "b" * 40, ":function/src-auth-py-login", "h2")
+
+        purged = mcp_server._candidate_diff_purge_legacy(real_db)
+
+        assert purged == 2
+        err = capsys.readouterr().err
+        assert "[_candidate_diff_purge_legacy]" in err
+        assert "2" in err
+
+    def test_retract_failure_is_logged_and_swallowed(self, real_db, capsys):
+        """Important 1: this is best-effort scratch cleanup on the hot path
+        _frontier_load awaits -- a raising _retract must be logged and
+        swallowed, returning 0, not propagated. An unhandled raise here
+        would fail _frontier_load itself, bricking every subsequent run of
+        the server identically."""
+        import mcp_server
+        self._seed_legacy_record(real_db, "a" * 40, ":function/src-auth-py-login", "h1")
+
+        def raising_retract(*a, **k):
+            raise RuntimeError("simulated real backend failure on retract")
+
+        real_retract = mcp_server._retract
+        mcp_server._retract = raising_retract
+        try:
+            purged = mcp_server._candidate_diff_purge_legacy(real_db)
+        finally:
+            mcp_server._retract = real_retract
+
+        assert purged == 0
+        err = capsys.readouterr().err
+        assert "[_candidate_diff_purge_legacy]" in err
+        assert "simulated real backend failure on retract" in err
+        # The record is still there -- the retract never actually applied.
+        assert self._live_record_count(real_db) == 1
+
     def test_frontier_load_purges_on_an_existing_graph(self, real_db, tmp_path):
         """The purge has to run from _frontier_load, not just exist -- an
         already-migrated graph is loaded by every subsequent run and is
@@ -16015,9 +16056,21 @@ class TestCorrectionSweepApply:
 
     def test_case_one_re_dates_the_contains_edge(self, real_db, tmp_path):
         """A child's own candidate triples carry its [parent :contains child]
-        edge, so re-dating a child must re-date its containment edge with it.
-        This is the edge minigraf#287 destroys if the re-date ever batches
-        multiple children of one module into a single call."""
+        edge, so re-dating a child must re-date its containment edge with it:
+        a re-dated child's containment edge must still be live (valid-at) at
+        the child's introduction timestamp, for all three siblings. This is
+        the edge minigraf#287 would destroy if the re-date ever batched
+        multiple children of one module's :contains facts into a single
+        _transact/_retract call.
+
+        _re_date_structural_facts does split its triples one call per triple
+        (#233), but at this call site that split is defensive rather than
+        load-bearing: a child's own candidate-triples list carries exactly
+        its own containment edge, and module_candidate_triples carries none,
+        so _re_date_structural_facts is only ever handed 0 or 1 :contains
+        triple per call here regardless of the split. The constraint the
+        split guards against is real elsewhere (minigraf#287 / #222 phase
+        2b1), just not exercised by this test."""
         import mcp_server
         import frontier_registry
         repo = tmp_path / "repo"
@@ -16327,8 +16380,6 @@ class TestCorrectionSweepWalk:
         for i in range(5):
             fn_ident = mcp_server._code_ident("function", f"f{i}.py", f"f{i}")
             assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
-        raw = mcp_server._db_execute(real_db, "(query [:find ?e :where [?e :entity-type :type/candidate-diff]])")
-        assert json.loads(raw)["results"] == []
         bounds = mcp_server._frontier_read_bounds(real_db, mcp_server._FRONTIER_HIGH_IDENT)
         assert mcp_server._correction_sweep_through_query(real_db) == bounds[1]
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14496,6 +14496,83 @@ class TestReverseApplySplit:
         assert applied == linearization[pos]
         assert snapshot(db_a) == snapshot(db_b)
 
+    def test_retroactive_modified_in_is_grouped_by_superseded_timestamp(self, real_db, tmp_path):
+        """#233: one transact per entity here was 10,161 calls over 12
+        commits of this repo. Each edge carries the SUPERSEDED commit's
+        timestamp, not this commit's, so one batch is impossible -- but
+        entities in one file were almost always last sighted at the same
+        commit, so grouping by timestamp collapses to a handful."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        bodies = "\n\n".join(f"def f{i}():\n    return 0" for i in range(12))
+        for rev in range(2):
+            (repo / "wide.py").write_text(bodies.replace("return 0", f"return {rev}") + "\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{rev}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        # Claim the tip first so the second claim is a genuine move.
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        transacts = []
+        real_transact = mcp_server._transact
+        mcp_server._transact = lambda db_, facts, *a, **k: (
+            transacts.append(facts) or real_transact(db_, facts, *a, **k)
+        )
+        try:
+            mcp_server._reverse_fill_claim_and_process(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        finally:
+            mcp_server._transact = real_transact
+
+        retroactive = [f for f in transacts if ":modified-in" in f]
+        assert len(retroactive) <= 2, (
+            f"grouped by superseded timestamp, not one per entity; got {len(retroactive)}"
+        )
+
+    def test_grouped_retroactive_modified_in_keeps_every_edge(self, real_db, tmp_path):
+        """Grouping must not lose edges -- these facts differ in entity, so
+        they do not collide, but that is the assumption worth pinning."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        bodies = "\n\n".join(f"def f{i}():\n    return 0" for i in range(6))
+        for rev in range(2):
+            (repo / "wide.py").write_text(bodies.replace("return 0", f"return {rev}") + "\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{rev}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        tip_ident = f":commit/{linearization[1][:12]}"
+        for i in range(6):
+            ident = mcp_server._code_ident("function", "wide.py", f"f{i}")
+            raw = mcp_server._db_execute(
+                real_db, f"(query [:find ?c :where [{ident} :modified-in ?c]])"
+            )
+            modified_in = {row[0] for row in json.loads(raw)["results"]}
+            assert tip_ident in modified_in, (
+                f"{ident} lost its retroactive edge; got {sorted(modified_in)}"
+            )
+
 
 class _NoProgressAllocator:
     """Stand-in for a FrontierAllocator whose claim_high() stops making
@@ -15757,6 +15834,49 @@ class TestCorrectionSweepApply:
         )
         children = {row[0] for row in json.loads(raw)["results"]}
         assert len(children) == 3, f"all three containment edges must survive; got {sorted(children)}"
+
+    def test_confirm_is_batched_across_entities_at_one_commit(self, real_db, tmp_path):
+        """#233: _lineage_confirm was one retract per confirmed entity, and
+        retracts are the expensive op. The markers are distinct :lineage/...
+        companion entities, so one call covers them all."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        bodies = "\n\n".join(f"def f{i}():\n    return 0" for i in range(8))
+        (repo / "wide.py").write_text(bodies + "\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "c0"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        file_results, _g, _m, _r = mcp_server._extract_commit(str(repo), linearization[0], ())
+
+        retracts = []
+        real_retract = mcp_server._retract
+        mcp_server._retract = lambda db_, facts, *a, **k: (
+            retracts.append(facts) or real_retract(db_, facts, *a, **k)
+        )
+        try:
+            mcp_server._correction_sweep_apply(
+                real_db, linearization[0], commit_metadata[0][1], file_results,
+            )
+        finally:
+            mcp_server._retract = real_retract
+
+        marker_retracts = [f for f in retracts if ":type/lineage-marker" in f]
+        assert len(marker_retracts) == 1, (
+            f"one retract for every marker at this commit; got {len(marker_retracts)}"
+        )
+        for i in range(8):
+            ident = mcp_server._code_ident("function", "wide.py", f"f{i}")
+            assert mcp_server._lineage_is_provisional(real_db, ident) is False
 
 
 class TestCorrectionSweepClaimAndProcess:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14471,24 +14471,77 @@ class TestEntityIntroducedBySetProvisionalMonotonicity:
 
 
 class TestReverseFillValidTimeParity:
-    def test_structural_facts_are_re_dated_when_the_guess_moves_earlier(self, real_db, tmp_path):
-        """2b wrote an entity's structural facts once, at the timestamp of
-        the commit where the walk first SIGHTED it, and never re-dated them
-        as the guess moved earlier. That leaves a valid-time window where
-        :introduced-by is live for an entity with no type, name or file --
-        so ":as-of the introduction" answers "this entity did not exist",
-        while ":when was it introduced" answers with that very commit."""
-        import mcp_server
-        import frontier_registry
+    def _repo_with_three_commits(self, tmp_path):
         repo = tmp_path / "repo"
         repo.mkdir()
         _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
         _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
         _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
         for i in range(3):
+            if i > 0:
+                # ensure distinct commit-timestamp seconds; see
+                # git_repo_with_deletion -- test_stage_a_alone_leaves_the_window_open
+                # below distinguishes "structural facts valid from the newest
+                # sighting" from "valid from the introduction", which collapses
+                # to a false pass if all three commits land in the same second.
+                time.sleep(1.1)
             (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
             _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
             _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        return repo
+
+    def _attrs_at(self, real_db, entity_ident, ts_iso):
+        import mcp_server
+        raw = mcp_server._db_execute(
+            real_db, f'(query [:find ?a :valid-at "{ts_iso}" :where [{entity_ident} ?a ?v]])'
+        )
+        return {row[0] for row in json.loads(raw)["results"]}
+
+    def test_structural_facts_are_re_dated_by_the_correction_sweep(self, real_db, tmp_path):
+        """2b wrote an entity's structural facts once, at the timestamp of
+        the commit where the walk first SIGHTED it. That leaves a valid-time
+        window where :introduced-by is live for an entity with no type, name
+        or file -- so ":as-of the introduction" answers "this entity did not
+        exist", while ":when was it introduced" answers with that very
+        commit.
+
+        #233 moved the repair from _reverse_apply (which did it on every
+        provisional move: 48% of Stage A's wall time) to the correction
+        sweep's confirm branch, which visits each entity's introduction
+        exactly once. So the invariant now holds after Stage B, not after
+        Stage A -- this test asserts the end state, and its negative
+        counterpart below pins the Stage A window deliberately."""
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_three_commits(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+
+        login = mcp_server._code_ident("function", "auth.py", "login")
+        attrs = self._attrs_at(real_db, login, commit_metadata[0][1])
+        assert ":introduced-by" in attrs
+        assert ":entity-type" in attrs, (
+            "an entity live at its own introduction must carry its structure there too; "
+            f"got only {sorted(attrs)}"
+        )
+        assert ":file" in attrs
+
+    def test_stage_a_alone_leaves_the_window_open(self, real_db, tmp_path):
+        """The other half of the moved invariant. Deferring the re-date is a
+        real behaviour change and the window it opens is deliberate, so pin
+        it in both directions -- otherwise a future change could re-introduce
+        eager re-dating (and its 48% cost) with the suite still green."""
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_three_commits(tmp_path)
         linearization = frontier_registry.build_linearization(str(repo))
         commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
         allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
@@ -14498,17 +14551,39 @@ class TestReverseFillValidTimeParity:
         )
 
         login = mcp_server._code_ident("function", "auth.py", "login")
-        intro_ts = commit_metadata[0][1]
-        raw = mcp_server._db_execute(
-            real_db, f'(query [:find ?a :valid-at "{intro_ts}" :where [{login} ?a ?v]])'
+        assert mcp_server._entity_introduced_by_query(real_db, login) == \
+            f":commit/{linearization[0][:12]}"
+        assert mcp_server._lineage_is_provisional(real_db, login) is True
+        attrs = self._attrs_at(real_db, login, commit_metadata[0][1])
+        assert ":entity-type" not in attrs, (
+            "Stage A must NOT re-date -- that is the amplification #233 removed"
         )
-        attrs_at_introduction = {row[0] for row in json.loads(raw)["results"]}
-        assert ":introduced-by" in attrs_at_introduction  # 2b already gets this right
-        assert ":entity-type" in attrs_at_introduction, (
-            "an entity live at its own introduction must carry its structure there too; "
-            f"got only {sorted(attrs_at_introduction)}"
+
+    def test_reverse_walk_issues_no_re_dating_writes(self, real_db, tmp_path):
+        """The cost assertion behind the behaviour assertions above:
+        _re_date_structural_facts must not be reached at all during Stage A.
+        At 17,250 retracts over 12 real commits (~13ms each) this was the
+        single largest line in the profile."""
+        import mcp_server
+        import frontier_registry
+        repo = self._repo_with_three_commits(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        calls = []
+        real_re_date = mcp_server._re_date_structural_facts
+        mcp_server._re_date_structural_facts = lambda *a, **k: (
+            calls.append(a) or real_re_date(*a, **k)
         )
-        assert ":file" in attrs_at_introduction
+        try:
+            mcp_server._reverse_bulk_fill_walk(
+                real_db, str(repo), linearization, commit_metadata, allocator,
+            )
+        finally:
+            mcp_server._re_date_structural_facts = real_re_date
+
+        assert calls == []
 
 
 class TestReverseFillParentEdges:
@@ -15403,6 +15478,7 @@ class TestCorrectionSweepApply:
         mcp_server._transact(real_db, "[[:module/synthetic :introduced-by :commit/preexisting]]", "2025-01-01T00:00:00Z")
         precomputed = {
             "module_ident": ":module/synthetic",
+            "module_candidate_triples": [],
             "function_entries": [(ident, ident, []) for ident in idents],
             "class_entries": [],
             "global_entries": [],
@@ -15447,6 +15523,82 @@ class TestCorrectionSweepApply:
         err = capsys.readouterr().err
         assert err.strip() != ""
         assert "3" in err
+
+    def test_case_one_re_dates_structural_facts(self, real_db, tmp_path):
+        """#233: the sweep's confirm branch is where re-dating now happens.
+        It already has the triples -- precomputed carries
+        module_candidate_triples and (ident, name, triples) per entries key
+        -- and previously read only the idents out of it."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(3):
+            (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        login = mcp_server._code_ident("function", "auth.py", "login")
+
+        file_results, _g, _m, _r = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._correction_sweep_apply(
+            real_db, linearization[0], commit_metadata[0][1], file_results,
+        )
+
+        assert mcp_server._lineage_is_provisional(real_db, login) is False
+        raw = mcp_server._db_execute(
+            real_db,
+            f'(query [:find ?a :valid-at "{commit_metadata[0][1]}" :where [{login} ?a ?v]])',
+        )
+        attrs = {row[0] for row in json.loads(raw)["results"]}
+        assert ":entity-type" in attrs
+        assert ":file" in attrs
+
+    def test_case_one_re_dates_the_contains_edge(self, real_db, tmp_path):
+        """A child's own candidate triples carry its [parent :contains child]
+        edge, so re-dating a child must re-date its containment edge with it.
+        This is the edge minigraf#287 destroys if the re-date ever batches
+        multiple children of one module into a single call."""
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(3):
+            (repo / "auth.py").write_text(
+                f"def a():\n    return {i}\n\ndef b():\n    return {i}\n\ndef c():\n    return {i}\n"
+            )
+            _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+        mcp_server._reverse_bulk_fill_walk(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+
+        mcp_server._correction_sweep_walk(
+            real_db, str(repo), linearization, commit_metadata,
+        )
+
+        module = mcp_server._code_ident("module", "auth.py")
+        raw = mcp_server._db_execute(
+            real_db,
+            f'(query [:find ?child :valid-at "{commit_metadata[0][1]}" '
+            f'  :where [{module} :contains ?child]])',
+        )
+        children = {row[0] for row in json.loads(raw)["results"]}
+        assert len(children) == 3, f"all three containment edges must survive; got {sorted(children)}"
 
 
 class TestCorrectionSweepClaimAndProcess:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14511,6 +14511,8 @@ class TestReverseApplySplit:
         _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
         bodies = "\n\n".join(f"def f{i}():\n    return 0" for i in range(12))
         for rev in range(2):
+            if rev > 0:
+                time.sleep(1.1)  # ensure distinct commit-timestamp seconds; see git_repo_with_deletion
             (repo / "wide.py").write_text(bodies.replace("return 0", f"return {rev}") + "\n")
             _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
             _subprocess.run(["git", "commit", "-m", f"c{rev}"], cwd=repo, check=True, capture_output=True)
@@ -14551,6 +14553,8 @@ class TestReverseApplySplit:
         _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
         bodies = "\n\n".join(f"def f{i}():\n    return 0" for i in range(6))
         for rev in range(2):
+            if rev > 0:
+                time.sleep(1.1)  # ensure distinct commit-timestamp seconds; see git_repo_with_deletion
             (repo / "wide.py").write_text(bodies.replace("return 0", f"return {rev}") + "\n")
             _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
             _subprocess.run(["git", "commit", "-m", f"c{rev}"], cwd=repo, check=True, capture_output=True)
@@ -14572,6 +14576,140 @@ class TestReverseApplySplit:
             assert tip_ident in modified_in, (
                 f"{ident} lost its retroactive edge; got {sorted(modified_in)}"
             )
+
+    def test_retroactive_gate_and_valid_time_survive_a_shared_superseded_timestamp(
+        self, real_db, tmp_path
+    ):
+        """#233 review: all three per-ident gates are pure functions of
+        superseded_ident (plus the fixed pos/commit_ident), and the group
+        key superseded_ts is ALSO a pure function of superseded_ident -- so
+        a group-wide implementation can only diverge from the per-ident one
+        when two DISTINCT superseded commits share a timestamp SECOND. This
+        pins two things at once against that exact fixture shape:
+
+        (a) the superseded_pos <= pos refusal stays per-ident across a group
+            boundary -- one ident's superseded guess (fake_before, position
+            0) is refused, the other's (fake_after, position 2) is allowed,
+            despite both sharing shared_ts, with the real commit processed
+            at position 1 in between;
+        (b) the allowed edge's valid-time is pinned to its OWN
+            superseded_ts, not this commit's commit_ts_iso, checked via
+            :valid-at against the real backend rather than by inspecting
+            transact call arguments.
+
+        commit_metadata/linearization are hand-extended with two fabricated
+        commit idents around one real commit -- the same "no real git
+        history, hand-built pos_by_commit_ident" shape
+        test_monotonicity_refusal_is_per_ident_not_per_batch already uses
+        for the sibling per-ident gate in
+        _entity_introduced_by_set_provisional_batch, because the refusal
+        branch guards a state (a "later" guess that turns out not to be
+        later) normal monotonic reverse-walk traversal can never produce on
+        its own.
+        """
+        import mcp_server
+        import frontier_registry
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "a.py").write_text("def fa():\n    return 0\n")
+        (repo / "b.py").write_text("def fb():\n    return 0\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "root"], cwd=repo, check=True, capture_output=True)
+
+        real_linearization = frontier_registry.build_linearization(str(repo))
+        real_commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        root_hash, _real_root_ts, root_author, root_subject = real_commit_metadata[0]
+        assert real_linearization == [root_hash]
+
+        # All hand-picked, ordered SEED_TS < commit_ts_iso < shared_ts, and
+        # every one safely in minigraf's PAST relative to wall-clock "now"
+        # (unlike the real git-derived timestamp, which is effectively
+        # "now" and therefore too late to precede anything) -- because
+        # _reverse_apply's own "is this entity already known" check
+        # (_entity_introduced_by_query) is a PLAIN, now-relative query: a
+        # future-dated seed would be invisible to it and the whole
+        # provisional_moves path would never fire. See the #233 review
+        # discussion (this was the first, silently-empty version of this
+        # test) -- confirmed empirically against the real backend that a
+        # plain query hides a future-valid_from fact but :valid-at does not.
+        seed_ts = "2019-01-01T00:00:00Z"
+        commit_ts_iso = "2020-01-01T00:00:00Z"  # this call's fabricated "current commit" time
+        shared_ts = "2021-01-01T00:00:00Z"      # both fakes share this -- the collision under test
+
+        fake_before_hash = "a" * 40  # position 0 -- superseded_pos (0) <= pos (1): refused
+        fake_after_hash = "b" * 40   # position 2 -- superseded_pos (2) >  pos (1): allowed
+
+        linearization = [fake_before_hash, root_hash, fake_after_hash]
+        commit_metadata = [
+            (fake_before_hash, shared_ts, "fake", "fake before"),
+            (root_hash, commit_ts_iso, root_author, root_subject),
+            (fake_after_hash, shared_ts, "fake", "fake after"),
+        ]
+        pos = 1
+
+        fa_ident = mcp_server._code_ident("function", "a.py", "fa")
+        fb_ident = mcp_server._code_ident("function", "b.py", "fb")
+        fake_before_ident = f":commit/{fake_before_hash[:12]}"
+        fake_after_ident = f":commit/{fake_after_hash[:12]}"
+
+        # Seed both as already-provisional, guessed-introduced at the two
+        # fabricated commits -- real writes through the real batch helper,
+        # not a mock, mirroring test_monotonicity_refusal_is_per_ident_not_per_batch.
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [fa_ident], fake_before_ident, seed_ts,
+        )
+        mcp_server._entity_introduced_by_set_provisional_batch(
+            real_db, [fb_ident], fake_after_ident, seed_ts,
+        )
+
+        file_results, _g, _m, _r = mcp_server._extract_commit(str(repo), root_hash, ())
+        mcp_server._reverse_apply(
+            real_db, str(repo), linearization, commit_metadata, pos, file_results,
+        )
+
+        # (a) fa's guess (fake_before, position 0) is refused: no
+        # :modified-in fact at all, checked :valid-at shared_ts -- where a
+        # wrongly-admitted one (grouped under shared_ts by a buggy
+        # group-wide gate) would show.
+        raw = mcp_server._db_execute(
+            real_db,
+            f'(query [:find ?c :valid-at "{shared_ts}" :where [{fa_ident} :modified-in ?c]])',
+        )
+        assert json.loads(raw)["results"] == [], (
+            f"fa's refused superseded guess must not get a retroactive edge; "
+            f"got {json.loads(raw)['results']}"
+        )
+
+        # fb's guess (fake_after, position 2) is allowed: exactly the one
+        # retroactive edge, to fake_after_ident -- checked the same way, so
+        # a buggy group-wide gate that drops the WHOLE group (because fa,
+        # iterated first, was refused) is caught here too.
+        raw = mcp_server._db_execute(
+            real_db,
+            f'(query [:find ?c :valid-at "{shared_ts}" :where [{fb_ident} :modified-in ?c]])',
+        )
+        modified_in = {row[0] for row in json.loads(raw)["results"]}
+        assert modified_in == {fake_after_ident}, (
+            f"fb's allowed superseded guess must get its retroactive edge; got {modified_in}"
+        )
+
+        # (b) valid-time: fb's edge reads as [] :valid-at commit_ts_iso (this
+        # call's own commit) and live :valid-at shared_ts (fake_after's own
+        # commit) -- pinned to the SUPERSEDED commit's timestamp, not this
+        # commit's, exactly mirroring the real 4-commit/2-file reproduction
+        # from the #233 review ("a-py-f0 :modified-in reads [] as-of c0's ts
+        # and live as-of c1's").
+        raw = mcp_server._db_execute(
+            real_db,
+            f'(query [:find ?c :valid-at "{commit_ts_iso}" :where [{fb_ident} :modified-in ?c]])',
+        )
+        assert json.loads(raw)["results"] == [], (
+            "fb's retroactive edge must not be valid at commit_ts_iso "
+            f"({commit_ts_iso}); got {json.loads(raw)['results']}"
+        )
 
 
 class _NoProgressAllocator:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15537,6 +15537,8 @@ class TestCorrectionSweepApply:
         _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
         _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
         for i in range(3):
+            if i > 0:
+                time.sleep(1.1)  # ensure distinct commit-timestamp seconds; see git_repo_with_deletion
             (repo / "auth.py").write_text(f"def login():\n    return {i}\n")
             _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
             _subprocess.run(["git", "commit", "-m", f"c{i}"], cwd=repo, check=True, capture_output=True)
@@ -15575,6 +15577,8 @@ class TestCorrectionSweepApply:
         _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
         _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
         for i in range(3):
+            if i > 0:
+                time.sleep(1.1)  # ensure distinct commit-timestamp seconds; see git_repo_with_deletion
             (repo / "auth.py").write_text(
                 f"def a():\n    return {i}\n\ndef b():\n    return {i}\n\ndef c():\n    return {i}\n"
             )


### PR DESCRIPTION
Addresses the write amplification in #233. **This PR must NOT auto-close that issue** — the acceptance gate is not met and the residual cost is now tracked in #236. (An earlier revision of this body phrased that as a negated closing keyword, which GitHub parsed as a closing directive and used to close the issue on merge. It has been reopened.)

## What was wrong

The reverse-bulk-fill walk (#222 Stage A) issued ~6,970 transactions per source commit against the forward walk's 12, so at-scale ingestion never finished — the benchmark was killed incomplete at 62 minutes having reached ~100 of ~552 commits.

Every phase-2 test used a 6–10 commit fixture. The defect scaled with **entity count**, not commit count, so nothing in ~880 tests could see it.

## What changed

Three levers, designed against a per-call-site profile rather than the issue's graph-size inference:

1. **Structural re-dating moved from `_reverse_apply` to `_correction_sweep_apply`'s confirm branch.** It fired on every provisional move, re-dating a long-lived entity once per touch. The sweep visits every commit in the reverse region exactly once, and its gap-closed precondition means Stream 2's guess is final — so the commit where an entity reaches case 1 *is* its introduction. This was the real lever: 48% of Stage A's cost before, **3.0% of the whole run** now.
2. **The `:type/candidate-diff` record path deleted.** `_candidate_diff_read`'s only callers were `_candidate_diff_persist` and `_candidate_diff_clear` themselves. 2a specced these so 2c could confirm without re-parsing, but 2c as built re-parses and reads `precomputed["unchanged_idents"]`. Includes a one-time `_frontier_load` purge for the orphans existing 2d graphs already hold.
3. **Per-entity writes batched per commit.** Honest result: this bought essentially nothing — see below.

## Results

| | baseline (forward-only) | phase 2d | this branch |
|---|---:|---:|---:|
| commits | 498 | ~100 of 552 | **553** |
| wall clock | 78.87 s | killed at 62 min | 5,133 s |
| graph | 45.8 MB | 263.6 MB (incomplete) | 174.8 MB |
| status | complete | **killed incomplete** | **complete** |

Stage A per-commit writes: **6,970 → ~134 average** (~11 for typical commits; the average is carried by two commits that first-sight a 910-function file, where each `:contains` edge is an irreducible separate transact — the forward walk pays the same).

The regression test pins the actual defect axis — entity count at fixed commit count. Against master's `mcp_server.py`: 5 functions → 53 write calls, 50 functions → **458**. On this branch: **6 and 6**.

## The acceptance gate is NOT met

5,133 s against 78.87 s is **65x**. The spec's bar was "completes in a time of the same order as the baseline rather than a different one." It does not. Graph size at 3.8x does meet the "small multiple" bar.

The design spec carries two committed revisions correcting its own cost model, because I got it wrong twice:

- The spec claimed **retract count** was the cost driver. A fully instrumented run (553 commits, every second attributed) disproved it: cost scales with the **facts inside the call**, not call count. Lever 3's batching collapsed call count and left wall clock where it was — `_entity_introduced_by_set_provisional_batch` is 204 calls costing 2,181 s, averaging **10.7 seconds per call**.
- The first correction blamed minigraf. Also wrong. Controlled microbenchmarks (added here as `evals/at_scale/bench_retract_cost.py` and `bench_index_delete_cost.py`) show minigraf's raw retract is free at 0.06 ms/fact with no graph-size scaling, and the cost is `fact_index.delete_facts` issuing an equality `DELETE` against an FTS5 virtual table — a full index scan per deleted triple, linear in index size, unaffected by batching.

That is **#236**, and it is the real sequel to this work.

## Related issues found in passing

- **#235** — pre-existing phase-2d bug: entities get two live `:introduced-by` values that never converge. Root-caused to `_forward_apply`'s preload-snapshot prefilter, reproduced identically on master. Not touched here.
- **#236** — `fact_index.delete_facts` O(index size) per triple, 73.5% of ingestion wall clock. Includes a "what NOT to do" section recording that batching the sweep's 72,971-call `:modified-in` retract recovers nothing.

## Verification

- Full suite green: 1,033 passed, 2 xfailed (pre-existing) across `tests/`.
- Per-task review on every commit, plus a whole-branch review; all findings fixed and re-reviewed.
- The budget test was verified to **fail** against master's `mcp_server.py` before being accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8qWT72sj5ja3wvkcgkK6b

