### PR TITLE
Stop and repair two-value :introduced-by lineage (#235)

### DIFF
--- a/docs/superpowers/plans/2026-08-04-introduced-by-two-value-ambiguity.md
+++ b/docs/superpowers/plans/2026-08-04-introduced-by-two-value-ambiguity.md
@@ -1,0 +1,849 @@
+# Two-value `:introduced-by` ambiguity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the forward walk minting a second `:introduced-by` alongside the reverse stream's provisional guess, collapse the multiplicity on graphs already corrupted, and make any residual ambiguity visible in logs.
+
+**Architecture:** Three independent changes to `mcp_server.py`. (1) `_forward_apply`'s non-`lifecycle_only` branch drops its `state.provisional_idents` prefilter so `_lineage_is_provisional` is the sole authority — the prefilter is a run-start snapshot and is empty of same-run guesses. (2) `_correction_sweep_apply` gains an optional `pos_by_commit_ident` map and, when given it, collapses ≥2 `:introduced-by` values down to the minimum-position one before its existing case 1/2/3 branching runs. (3) A new `_entity_introduced_by_values_query` returns all values; `_entity_introduced_by_query` delegates to it and warns on >1 without raising.
+
+**Tech Stack:** Python 3, `pytest`, real `minigraf` backend (no mocks), git fixtures built with `subprocess`.
+
+Spec: `docs/superpowers/specs/2026-08-04-introduced-by-two-value-ambiguity-design.md`
+Issue: #235. Branch: `fix-235-two-value-introduced-by` (already created, spec already committed as `77e8630`).
+
+## Global Constraints
+
+- **Real backend only.** Every test uses the `real_db` fixture or a real file-backed `MiniGrafDb.open()`. Never a `MagicMock` of `MiniGrafDb`. Never assert on mock call arguments — always re-query the DB and assert on persisted state. See `docs/testing-conventions.md`.
+- **`_entity_introduced_by_query` must never raise on >1 value.** Both walks call it mid-run, before Stage B; raising would hard-fail ingestion on exactly the corrupted graphs the repair exists to heal.
+- **`pos_by_commit_ident` must be the LAST parameter of `_correction_sweep_apply`.** The Stage B driver at `mcp_server.py:9574` calls it through `run_in_executor` with seven *positional* arguments (`db, sweep_hash, sweep_ts, sweep_files, index_con, skipped, False`). Inserting a parameter before `update_watermark` silently shifts them.
+- **Repair collapses multiplicity only; it never confirms.** After collapsing, cases 1/2/3 run unchanged on the surviving single value.
+- **Do not write closing keywords** (`fixes`, `closes`, `resolves`) for #235 in any commit message or PR body — including negated forms. Reference it as `(#235)` only. #235 is closed manually after the benchmark entry lands.
+- Run the full suite with `python -m pytest tests/test_mcp_server.py -q` from the repo root.
+
+---
+
+### Task 1: All-values query helper, loud on ambiguity
+
+**Files:**
+- Modify: `mcp_server.py:5378-5383` (`_entity_introduced_by_query`)
+- Test: `tests/test_mcp_server.py` (new class `TestEntityIntroducedByValuesQuery`, place it immediately after `TestEntityIntroducedBySetProvisional`, which ends at line 6505)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `_entity_introduced_by_values_query(db: Any, entity_ident: str) -> List[str]` — every live `:introduced-by` value for `entity_ident`, in the backend's unspecified order, `[]` if none. Task 3 uses it in `_correction_sweep_apply`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_mcp_server.py`:
+
+```python
+class TestEntityIntroducedByValuesQuery:
+    """#235: an entity can hold two live :introduced-by facts. The
+    single-value query silently returned the first of them, so the
+    ambiguity was invisible; the all-values query is what the correction
+    sweep's repair path needs to collapse it."""
+
+    def test_values_query_returns_empty_for_unknown_entity(self, real_db):
+        import mcp_server
+        assert mcp_server._entity_introduced_by_values_query(real_db, ":function/nope") == []
+
+    def test_values_query_returns_single_value(self, real_db):
+        import mcp_server
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h0]]", "2026-01-01T00:00:00Z",
+        )
+        assert mcp_server._entity_introduced_by_values_query(real_db, entity_ident) == [":commit/h0"]
+
+    def test_values_query_returns_both_values_of_a_corrupted_entity(self, real_db):
+        import mcp_server
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h0]]", "2026-01-01T00:00:00Z",
+        )
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h5]]", "2026-01-05T00:00:00Z",
+        )
+        assert sorted(
+            mcp_server._entity_introduced_by_values_query(real_db, entity_ident)
+        ) == [":commit/h0", ":commit/h5"]
+
+    def test_single_value_query_warns_on_ambiguity_and_still_returns_a_value(
+        self, real_db, capsys,
+    ):
+        """Must NOT raise: both walks call this mid-run, before Stage B,
+        so raising would hard-fail ingestion on the very graphs the
+        sweep's repair exists to heal."""
+        import mcp_server
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h0]]", "2026-01-01T00:00:00Z",
+        )
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h5]]", "2026-01-05T00:00:00Z",
+        )
+        capsys.readouterr()  # discard anything the seeding wrote
+
+        result = mcp_server._entity_introduced_by_query(real_db, entity_ident)
+
+        assert result in (":commit/h0", ":commit/h5")
+        err = capsys.readouterr().err
+        assert entity_ident in err
+        assert ":commit/h0" in err and ":commit/h5" in err
+
+    def test_single_value_query_is_silent_for_one_value(self, real_db, capsys):
+        import mcp_server
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h0]]", "2026-01-01T00:00:00Z",
+        )
+        capsys.readouterr()
+
+        assert mcp_server._entity_introduced_by_query(real_db, entity_ident) == ":commit/h0"
+        assert "introduced-by" not in capsys.readouterr().err
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestEntityIntroducedByValuesQuery -v`
+Expected: FAIL — `AttributeError: module 'mcp_server' has no attribute '_entity_introduced_by_values_query'` for the first three, and the warning test fails with an empty `err`.
+
+- [ ] **Step 3: Implement**
+
+Replace `mcp_server.py:5378-5383` in full:
+
+```python
+def _entity_introduced_by_values_query(db: Any, entity_ident: str) -> List[str]:
+    """Every live :introduced-by value for entity_ident, in the backend's
+    unspecified order; [] if it has none.
+
+    A list rather than a single value because an entity CAN hold more than
+    one (#235): the forward walk used to mint a second alongside the reverse
+    stream's provisional guess. _correction_sweep_apply's repair path needs
+    to see all of them to collapse them.
+    """
+    raw = _db_execute(db, f"(query [:find ?c :where [{entity_ident} :introduced-by ?c]])")
+    return [row[0] for row in json.loads(raw).get("results", [])]
+
+
+def _entity_introduced_by_query(db: Any, entity_ident: str) -> Optional[str]:
+    """Return entity_ident's current :introduced-by value (a commit ident
+    string), or None if it has none yet.
+
+    An entity holding two values is corrupt (#235). Which of them is
+    returned here is UNSPECIFIED -- the backend imposes no ordering -- so
+    this warns and returns an arbitrary one rather than pretending the
+    graph is well-formed. It deliberately does NOT raise: both walks call
+    this during a run, long before Stage B's repair pass, so raising would
+    hard-fail ingestion on exactly the graphs that repair exists to heal.
+    Position-based selection of the survivor lives in
+    _correction_sweep_apply, which has the linearization positions this
+    function does not.
+    """
+    values = _entity_introduced_by_values_query(db, entity_ident)
+    if len(values) > 1:
+        print(
+            f"[_entity_introduced_by] {entity_ident} has {len(values)} live "
+            f":introduced-by values {sorted(values)} -- returning an arbitrary "
+            "one (#235); the correction sweep repairs this",
+            file=sys.stderr,
+        )
+    return values[0] if values else None
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestEntityIntroducedByValuesQuery -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Run the neighbouring suites for regressions**
+
+Run: `python -m pytest tests/test_mcp_server.py -q -k "IntroducedBy or Lineage or CorrectionSweep or ReverseApply or ReverseFill"`
+Expected: all pass. No behaviour changed — only an added stderr line on already-corrupt input.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Add an all-values :introduced-by query and warn on ambiguity (#235)
+
+_entity_introduced_by_query silently returned results[0][0], so an entity
+holding two live values looked well-formed to every caller. It now
+delegates to _entity_introduced_by_values_query and logs when it has to
+pick arbitrarily. It must not raise: both walks call it mid-run, before
+Stage B, so raising would hard-fail ingestion on the corrupted graphs the
+sweep's repair pass exists to heal.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Stop minting the second `:introduced-by`
+
+**Files:**
+- Modify: `mcp_server.py:8306-8361` (comment block + the non-`lifecycle_only` prefilter) and `mcp_server.py:8390` (eviction loop)
+- Modify: `tests/test_mcp_server.py:16619` (the preload-ordering bug in the existing test)
+- Test: `tests/test_mcp_server.py` — new test in `TestForwardApplyReconcilesProvisional` (class starts at line 16580), and a new class `TestNoDuplicateIntroducedByAfterFullIngest` placed immediately before `TestMultiStreamParityWithForwardOnly` (line 17517)
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent — Tasks 1 and 2 may be done in either order).
+- Produces: no new symbols. `_ForwardWalkState.provisional_idents` survives, still populated by `_preload_provisional_idents`, still drained by the eviction loop, but is no longer consulted as a gate.
+
+- [ ] **Step 1: Fix the existing test's preload ordering, and add the fresh-ingest test**
+
+In `tests/test_mcp_server.py`, `test_forward_apply_supersedes_a_provisional_guess` currently builds its state with `provisional_idents=mcp_server._preload_provisional_idents(real_db)` at line 16619 — *after* the reverse stream ran. That is why the bug is invisible to it. Change that one line to:
+
+```python
+            # #235: production preloads at RUN START, before Stream 2 has
+            # written anything, so on a fresh ingest this set is EMPTY. Calling
+            # _preload_provisional_idents here -- after the reverse stream ran --
+            # handed the forward walk a snapshot that already contained the
+            # guess, which no real fresh run ever has, and hid the second-mint
+            # bug entirely.
+            provisional_idents=set(),
+```
+
+Then add this test to the same class, after `test_forward_apply_does_not_duplicate_for_a_stale_provisional_snapshot_entry`:
+
+```python
+    def test_reconciles_a_guess_made_during_this_same_run(self, real_db, tmp_path):
+        """#235: the prefilter was a run-start snapshot, empty on a fresh
+        ingest. Stream 2's guesses are written during that same run, so the
+        prefilter dropped every one of them before the DB-authoritative
+        _lineage_is_provisional check could see it -- and
+        _build_code_triples then minted a SECOND :introduced-by alongside
+        the guess. The DB must be the sole authority."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        # Snapshot taken FIRST, exactly as _run_ingestion does -- empty.
+        snapshot = mcp_server._preload_provisional_idents(real_db)
+        assert snapshot == set(), "a fresh graph has no provisional idents yet"
+
+        # Only now does Stream 2 claim h1 and guess.
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={}, entity_descriptions={}, file_entities={},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents=snapshot,
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(real_db, str(repo), state, commit_metadata[0], extracted)
+
+        values = mcp_server._entity_introduced_by_values_query(real_db, fn_ident)
+        assert values == [f":commit/{linearization[0][:12]}"], (
+            f"exactly one :introduced-by, naming h0; got {sorted(values)}"
+        )
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+
+    def test_evicts_a_stale_snapshot_entry_that_is_no_longer_provisional(
+        self, real_db, tmp_path,
+    ):
+        """The eviction invariant survives dropping the prefilter: every
+        candidate examined leaves state.provisional_idents, whether or not
+        the DB agreed it was provisional. A stale entry left behind is
+        retried, and fails the same way, on every later commit touching the
+        entity (see the comment at mcp_server.py:8345)."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        # Authoritative in the DB (a plain transact, no lineage marker) but
+        # still listed by a stale snapshot -- what a resumed run sees after a
+        # previous run's sweep confirmed the entity.
+        mcp_server._transact(
+            real_db, f"[[{fn_ident} :introduced-by :commit/already]]", "2026-01-01T00:00:00Z",
+        )
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={}, entity_descriptions={}, file_entities={},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents={fn_ident},
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(real_db, str(repo), state, commit_metadata[0], extracted)
+
+        assert fn_ident not in state.provisional_idents, "stale entry must be evicted"
+```
+
+- [ ] **Step 2: Write the whole-run integration oracle**
+
+This is the test that reproduces the issue's reported numbers. Add a new class immediately before `TestMultiStreamParityWithForwardOnly` (line 17517):
+
+```python
+class TestNoDuplicateIntroducedByAfterFullIngest:
+    """#235's reproduction, as a standing oracle.
+
+    A full converging ingest -- both streams plus Stage B -- must leave no
+    entity holding two live :introduced-by facts. On master this yields six
+    such entities on a 14-commit history, and the pair never converges: every
+    later reader sees only one value, retracts that one, and asserts a fresh
+    one, so the corruption regenerates rather than healing.
+
+    The fixture matters. `born_N` functions accumulate one per commit, so
+    each is introduced at a different position and the reverse stream's
+    guesses land above the forward walk's true introductions; the five
+    long-lived functions are edited every commit so they stay candidates all
+    the way down. That combination is what produces same-run provisional
+    guesses for entities the forward walk later reaches.
+    """
+
+    N_COMMITS = 14
+
+    def _reset_progress(self):
+        import mcp_server
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+            "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+        }
+
+    def _repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init", "-b", "master"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(self.N_COMMITS):
+            body = "".join(
+                f"def stay_{k}():\n    return {i}\n\n" for k in range(5)
+            ) + "".join(
+                f"def born_{b}():\n    return {b}\n\n" for b in range(i + 1)
+            )
+            (repo / "mod.py").write_text(body)
+            ts = f"2021-03-{i + 1:02d}T00:00:00Z"
+            env = {**os.environ, "GIT_AUTHOR_DATE": ts, "GIT_COMMITTER_DATE": ts}
+            _subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(
+                ["git", "commit", "-m", f"c{i}"], cwd=repo, check=True,
+                capture_output=True, env=env,
+            )
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_full_ingest_leaves_no_entity_with_two_introduced_by(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph_path = tmp_path / "memory.graph"
+
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph_path))
+        mcp_server._db = None
+        self._reset_progress()
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete", mcp_server._ingest_progress
+        mcp_server._db = None  # release the file lock before reopening
+
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            raw = mcp_server._db_execute(
+                db, "(query [:find ?e (count ?c) :where [?e :introduced-by ?c]])",
+            )
+        finally:
+            db = None
+        ambiguous = sorted(
+            (row[0], row[1]) for row in json.loads(raw)["results"] if row[1] > 1
+        )
+        assert ambiguous == [], f"entities with multiple :introduced-by: {ambiguous}"
+
+        err = capsys.readouterr().err
+        assert "left provisional" not in err, err
+        assert "left unreconciled" not in err, err
+```
+
+- [ ] **Step 3: Run all three to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestNoDuplicateIntroducedByAfterFullIngest tests/test_mcp_server.py::TestForwardApplyReconcilesProvisional -v`
+Expected: FAIL.
+- `test_full_ingest_leaves_no_entity_with_two_introduced_by` — `ambiguous` is a non-empty list (the issue reports 6 entities at 14 commits).
+- `test_reconciles_a_guess_made_during_this_same_run` — two values instead of one.
+- `test_forward_apply_supersedes_a_provisional_guess` — now fails too, because Step 1 removed the ordering that was hiding the bug. That failure is the point: confirm it, don't "fix" the test back.
+- `test_evicts_a_stale_snapshot_entry_that_is_no_longer_provisional` — should PASS already (today's eviction loop drains `candidate_in_set`, which contains that ident). It is a guard against the Step 4 change, not a reproduction.
+
+- [ ] **Step 4: Implement — drop the prefilter**
+
+Replace `mcp_server.py:8306-8326` (the comment paragraph starting `# state.provisional_idents is a PRELOAD SNAPSHOT`) with:
+
+```python
+            # #235: state.provisional_idents is NOT consulted as a gate here.
+            # It is a PRELOAD SNAPSHOT (see _preload_provisional_idents) taken
+            # at run start, so on a fresh ingest it is EMPTY -- and Stream 2
+            # writes its guesses during that same run. Using it as a prefilter
+            # dropped every same-run guess before the DB-authoritative check
+            # below could see it, _forward_reconcile_provisional never fired,
+            # and _build_code_triples minted a SECOND :introduced-by alongside
+            # the guess. A prefilter's false negatives are unrecoverable
+            # precisely because the authority never runs.
+            #
+            # The snapshot is also stale-POSITIVE: by the time this commit is
+            # reached an ident it lists may already have been confirmed
+            # authoritative in the DB (reconciled earlier in this same forward
+            # pass, or by a previous run's correction sweep). That is why
+            # _lineage_is_provisional stays the authority rather than being
+            # dropped in favour of a set -- popping entity_valid_from for an
+            # already-authoritative ident hands it to _build_code_triples as
+            # "new" and mints the same second fact, while
+            # _forward_reconcile_provisional no-ops on it.
+            #
+            # The set survives only so a RESUMED run's genuinely-stale entries
+            # drain: every candidate examined is evicted below regardless of
+            # whether it survives the DB check, because an entry left in place
+            # would be retried, and fail the same way, on every later commit
+            # that touches the entity.
+```
+
+Then replace the `else:` branch at `mcp_server.py:8353-8361` with:
+
+```python
+            else:
+                candidate_in_set = _forward_candidate_idents(precomputed)
+                reconcilable = [
+                    ident for ident in candidate_in_set
+                    if _lineage_is_provisional(db, ident)
+                ]
+```
+
+Leave the `lifecycle_only` branch, the `structural_triples_by_ident` build, the `for ident in reconcilable:` loop and the `for ident in candidate_in_set:` eviction loop exactly as they are. `candidate_in_set` is now the full candidate list, which is what makes eviction drain correctly.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestNoDuplicateIntroducedByAfterFullIngest tests/test_mcp_server.py::TestForwardApplyReconcilesProvisional -v`
+Expected: all pass, `ambiguous == []`.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `python -m pytest tests/test_mcp_server.py -q`
+Expected: all pass. Watch `TestMultiStreamParityWithForwardOnly`, `TestReverseFillValidTimeParity` and `TestStageBCorrectionSweep` in particular — they are the guards that the converging walk still lands what a forward-only walk would.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Let the DB decide which idents are reconcilable (#235)
+
+_forward_apply's non-lifecycle_only branch prefiltered reconciliation
+candidates through state.provisional_idents, a snapshot taken at run
+start and therefore empty on a fresh ingest. Stream 2's guesses are
+written during that same run, so the prefilter dropped every one before
+_lineage_is_provisional could see it, and _build_code_triples minted a
+second :introduced-by alongside the guess.
+
+The set stays only to drain a resumed run's stale entries; the eviction
+loop now covers the full candidate list.
+
+The existing supersedes-a-guess test preloaded the snapshot AFTER the
+reverse stream ran, which no real fresh run does -- that ordering is what
+kept the bug invisible to it.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Repair already-corrupted graphs in the correction sweep
+
+**Files:**
+- Modify: `mcp_server.py:8874-8881` (signature), the docstring, and the per-ident loop at `mcp_server.py:8963-8975`
+- Modify: `mcp_server.py:9078-9081` (`_correction_sweep_claim_and_process`'s call) and `mcp_server.py:9046-9055` (its signature)
+- Modify: `mcp_server.py:9573-9577` (Stage B driver's `run_in_executor` call)
+- Test: `tests/test_mcp_server.py`, new tests in `TestCorrectionSweepApply` (class starts at line 15669)
+
+**Interfaces:**
+- Consumes: `_entity_introduced_by_values_query(db, entity_ident) -> List[str]` from Task 1.
+- Produces: `_correction_sweep_apply(db, commit_hash, commit_ts_iso, file_results, index_con=None, skipped_so_far=0, update_watermark=True, pos_by_commit_ident=None) -> int` — `pos_by_commit_ident` is `Optional[Dict[str, int]]` mapping `:commit/<12-char-hash>` to linearization position, exactly the map `_reverse_apply` builds at `mcp_server.py:7896`. `_correction_sweep_claim_and_process` gains the same keyword and forwards it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TestCorrectionSweepApply` in `tests/test_mcp_server.py`. `self._repo_with_evolving_function` (line 15675) and `self._extract` (line 15699) already exist in that class.
+
+```python
+    def _pos_map(self, repo):
+        import mcp_server, frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        return {f":commit/{h[:12]}": i for i, h in enumerate(linearization)}, linearization
+
+    def test_repair_keeps_the_lowest_position_introduced_by(self, real_db, tmp_path):
+        """#235: an entity carrying two live :introduced-by values is
+        collapsed to the one at the LOWEST linearization position. The
+        reverse stream's guess is a sighting at or above the true
+        introduction -- the same direction its own monotonicity rule
+        encodes -- so the earlier value is the introduction."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        pos_map, linearization = self._pos_map(repo)
+        h0, h2 = f":commit/{linearization[0][:12]}", f":commit/{linearization[2][:12]}"
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h2}]]", "2026-01-03T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h0}]]", "2026-01-01T00:00:00Z")
+        assert len(mcp_server._entity_introduced_by_values_query(real_db, fn_ident)) == 2
+
+        # The sweep meets the entity at h1 -- NEITHER of its two values.
+        # That is the real shape: the second mint happens in the forward
+        # region, which Stage B never sweeps, so a rule keyed on "is this
+        # commit one of the values" would never fire.
+        h1_hash, h1_ts = linearization[1], "2026-01-02T00:00:00Z"
+        mcp_server._correction_sweep_apply(
+            real_db, h1_hash, h1_ts, self._extract(repo, h1_hash),
+            pos_by_commit_ident=pos_map,
+        )
+
+        assert mcp_server._entity_introduced_by_values_query(real_db, fn_ident) == [h0]
+
+    def test_repair_is_inert_without_a_position_map(self, real_db, tmp_path):
+        """Gated: every existing caller and test keeps today's fail-safe
+        behaviour until it opts in."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        _pos_map, linearization = self._pos_map(repo)
+        h0, h2 = f":commit/{linearization[0][:12]}", f":commit/{linearization[2][:12]}"
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h2}]]", "2026-01-03T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h0}]]", "2026-01-01T00:00:00Z")
+
+        h1_hash = linearization[1]
+        mcp_server._correction_sweep_apply(
+            real_db, h1_hash, "2026-01-02T00:00:00Z", self._extract(repo, h1_hash),
+        )
+
+        assert sorted(mcp_server._entity_introduced_by_values_query(real_db, fn_ident)) == sorted([h0, h2])
+
+    def test_repair_sorts_an_unknown_commit_ident_last(self, real_db, tmp_path):
+        """A value absent from the map must never be chosen over a known
+        one, and must never raise."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        pos_map, linearization = self._pos_map(repo)
+        h0 = f":commit/{linearization[0][:12]}"
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/deadbeef0000]]", "2026-01-03T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h0}]]", "2026-01-01T00:00:00Z")
+
+        h1_hash = linearization[1]
+        mcp_server._correction_sweep_apply(
+            real_db, h1_hash, "2026-01-02T00:00:00Z", self._extract(repo, h1_hash),
+            pos_by_commit_ident=pos_map,
+        )
+
+        assert mcp_server._entity_introduced_by_values_query(real_db, fn_ident) == [h0]
+
+    def test_repair_then_case_one_confirms_in_the_same_call(self, real_db, tmp_path):
+        """Repair collapses multiplicity only. If the survivor equals the
+        commit being swept and the entity is still provisional, case 1 runs
+        on the repaired value and confirms it -- without repair it would
+        have hit case 2's fail-safe skip."""
+        import mcp_server, frontier_registry
+        repo = self._repo_with_evolving_function(tmp_path)
+        pos_map, linearization = self._pos_map(repo)
+        h0, h2 = f":commit/{linearization[0][:12]}", f":commit/{linearization[2][:12]}"
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        # Provisional at h0 (marker created), then a stray second value at h2.
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, h0, "2026-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h2}]]", "2026-01-03T00:00:00Z")
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+        h0_hash = linearization[0]
+        skipped = mcp_server._correction_sweep_apply(
+            real_db, h0_hash, "2026-01-01T00:00:00Z", self._extract(repo, h0_hash),
+            pos_by_commit_ident=pos_map,
+        )
+
+        assert mcp_server._entity_introduced_by_values_query(real_db, fn_ident) == [h0]
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        assert skipped == 0, "repaired then confirmed -- nothing left provisional"
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepApply -v -k "repair"`
+Expected: FAIL — `TypeError: _correction_sweep_apply() got an unexpected keyword argument 'pos_by_commit_ident'` for three of them; `test_repair_is_inert_without_a_position_map` passes already (it asserts today's behaviour).
+
+- [ ] **Step 3: Implement the signature and the collapse**
+
+Append the parameter to `_correction_sweep_apply` at `mcp_server.py:8874-8881` — **last, after `update_watermark`**, because the Stage B driver passes seven positional arguments:
+
+```python
+def _correction_sweep_apply(
+    db: Any,
+    commit_hash: str,
+    commit_ts_iso: str,
+    file_results: List[tuple],
+    index_con: Optional[Any] = None,
+    skipped_so_far: int = 0,
+    update_watermark: bool = True,
+    pos_by_commit_ident: Optional[Dict[str, int]] = None,
+) -> int:
+```
+
+Add this paragraph to the docstring, immediately before the `update_watermark=False` paragraph:
+
+```
+    pos_by_commit_ident (#235) enables the repair of graphs that already
+    carry two live :introduced-by facts for one entity -- corruption an
+    earlier version of _forward_apply created and which nothing converges,
+    since every later reader sees one value, retracts it, and asserts a
+    fresh one. When supplied, an ident holding 2+ values is collapsed to
+    the one at the LOWEST linearization position before the case 1/2/3
+    branching below runs; the survivor is then handled exactly as a
+    single-valued entity would be. Repair collapses multiplicity only, it
+    never confirms.
+
+    Earliest-by-position is the right survivor because the reverse stream's
+    guess is a sighting at or above the true introduction --
+    _entity_introduced_by_set_provisional_batch's monotonicity rule already
+    encodes that direction -- while the spurious second mint landed at the
+    true introduction itself.
+
+    Positions are required rather than derivable from arrival order: the
+    second mint happens in the FORWARD region, which this sweep never
+    visits, so it meets these entities at commits that are neither of their
+    two values. A value absent from the map sorts last, so an unrecognised
+    commit ident can never win and can never raise. Left None (the default)
+    the repair is inert and every caller keeps the pre-#235 fail-safe.
+    Best-effort: an entity this sweep never visits is not repaired.
+```
+
+Then, in the per-ident loop, replace `mcp_server.py:8963-8965` — the two lines that read the values, currently:
+
+```python
+        for ident in candidate_idents:
+            raw = _db_execute(db, f"(query [:find ?c :where [{ident} :introduced-by ?c]])")
+            introduced_by_values = {row[0] for row in json.loads(raw).get("results", [])}
+```
+
+with:
+
+```python
+        for ident in candidate_idents:
+            introduced_by_values = set(_entity_introduced_by_values_query(db, ident))
+
+            # #235 repair: collapse a corrupted multi-valued entity BEFORE the
+            # case branching below, so cases 1/2/3 always see a well-formed
+            # entity and need no multi-value handling of their own.
+            if pos_by_commit_ident is not None and len(introduced_by_values) > 1:
+                survivor = min(
+                    sorted(introduced_by_values),
+                    key=lambda c: pos_by_commit_ident.get(c, len(pos_by_commit_ident)),
+                )
+                doomed = sorted(introduced_by_values - {survivor})
+                _retract(
+                    db,
+                    "[" + " ".join(f"[{ident} :introduced-by {c}]" for c in doomed) + "]",
+                    index_con=index_con,
+                )
+                print(
+                    f"[_correction_sweep] repaired {ident}: kept {survivor}, "
+                    f"retracted {doomed} (#235)",
+                    file=sys.stderr,
+                )
+                introduced_by_values = {survivor}
+```
+
+`sorted(...)` inside `min` makes the choice deterministic when two values tie on position (only reachable if both are absent from the map).
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `python -m pytest tests/test_mcp_server.py::TestCorrectionSweepApply -v`
+Expected: all pass, including the pre-existing tests in that class — the collapse is inert for them because none passes `pos_by_commit_ident`.
+
+- [ ] **Step 5: Wire the two callers**
+
+In `_correction_sweep_claim_and_process` (`mcp_server.py:9046-9055`), add the keyword last in its signature:
+
+```python
+    skipped_so_far: int = 0,
+    pos_by_commit_ident: Optional[Dict[str, int]] = None,
+) -> Optional[Tuple[str, int]]:
+```
+
+and forward it in its call at `mcp_server.py:9078-9081`:
+
+```python
+    skipped_events = _correction_sweep_apply(
+        db, commit_hash, commit_ts_iso, file_results,
+        index_con=index_con, skipped_so_far=skipped_so_far,
+        pos_by_commit_ident=pos_by_commit_ident,
+    )
+```
+
+In `_run_ingestion`'s Stage B loop, build the map once *before* the `while` loop that contains the `_correction_sweep_select_position` call at `mcp_server.py:9558`, alongside the other per-run maps:
+
+```python
+                        # #235: the sweep's repair path needs linearization
+                        # positions to pick which of a corrupted entity's
+                        # :introduced-by values survives. Same construction
+                        # _reverse_apply uses (mcp_server.py:7896).
+                        sweep_pos_by_commit_ident = {
+                            f":commit/{h[:12]}": i
+                            for i, (h, _t, _a, _s) in enumerate(commit_metadata)
+                        }
+```
+
+and extend the positional `run_in_executor` call at `mcp_server.py:9573-9577` with the eighth argument:
+
+```python
+                                skipped += await loop.run_in_executor(
+                                    write_executor, _correction_sweep_apply,
+                                    db, sweep_hash, sweep_ts, sweep_files, index_con, skipped,
+                                    False, sweep_pos_by_commit_ident,
+                                )
+```
+
+- [ ] **Step 6: Write the end-to-end repair test**
+
+Add to `TestNoDuplicateIntroducedByAfterFullIngest` (created in Task 2):
+
+```python
+    @pytest.mark.asyncio
+    async def test_a_pre_corrupted_graph_is_repaired_by_the_next_ingest(
+        self, tmp_path, monkeypatch,
+    ):
+        """Fix-forward alone leaves graphs already in the field broken.
+        Corrupt an entity by hand after a clean ingest, then re-ingest: the
+        Stage B sweep must collapse it to the lower-position value."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph_path = tmp_path / "memory.graph"
+
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph_path))
+        mcp_server._db = None
+        self._reset_progress()
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        fn_ident = mcp_server._code_ident("function", "mod.py", "stay_0")
+        late = f":commit/{linearization[-1][:12]}"
+
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            before = mcp_server._entity_introduced_by_values_query(db, fn_ident)
+            assert len(before) == 1, before
+            mcp_server._transact(db, f"[[{fn_ident} :introduced-by {late}]]", "2026-01-09T00:00:00Z")
+            assert len(mcp_server._entity_introduced_by_values_query(db, fn_ident)) == 2
+        finally:
+            db = None
+        mcp_server._db = None
+
+        # Re-ingest the same graph. Stage B sweeps and repairs.
+        self._reset_progress()
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            after = mcp_server._entity_introduced_by_values_query(db, fn_ident)
+        finally:
+            db = None
+        assert after == before, f"repair must keep the original value; got {after}"
+```
+
+If a completed graph's second `_run_ingestion` sweeps nothing (the sweep watermark already covers the history, so `_correction_sweep_select_position` returns None), this test cannot pass as written. In that case, do **not** weaken the assertion: instead corrupt the graph after an *interrupted* Stage A — copy the `_ingest_interrupted` helper from `TestMultiStreamParityWithForwardOnly` (`tests/test_mcp_server.py:17679`), which stops the run with the reverse stream's claims persisted and Stage B still pending, then let the resuming run sweep. Record whichever path you took in the commit message.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `python -m pytest tests/test_mcp_server.py -q`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mcp_server.py tests/test_mcp_server.py
+git commit -m "Repair two-value :introduced-by entities in the correction sweep (#235)
+
+Dropping the prefilter stops new corruption but leaves graphs already in
+the field broken, with no recovery short of re-ingesting from scratch.
+_correction_sweep_apply now takes an optional pos_by_commit_ident and,
+when given it, collapses an entity's 2+ :introduced-by values to the one
+at the lowest linearization position before its case 1/2/3 branching
+runs. Repair collapses multiplicity only; it never confirms.
+
+Positions are needed rather than the ascending sweep's arrival order: the
+spurious mint lands in the forward region, which Stage B never sweeps, so
+the sweep meets these entities at commits that are neither of their
+values. The parameter is last in the signature because the Stage B driver
+passes seven positional arguments through run_in_executor.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Measure the at-scale cost and record it
+
+The fix moves a graph point query onto every candidate ident of every "A"/"M" file in the forward walk — the read class #239 measures at 33.6% of ingestion wall clock. Nothing in the unit suite shows that. **Correctness is not gated on the number**; the measurement exists so #239 starts from a measured baseline and so a regression is attributed here rather than discovered later.
+
+**Files:**
+- Modify: the benchmark log under `evals/at_scale/results/` (recent commits `ca1718a` "Append the 20260803T095104Z run to the benchmark log" and `c076cc1` "Interpret the … entry in the log itself" show the append-and-interpret convention — read both with `git show`)
+
+**Interfaces:**
+- Consumes: the merged behaviour of Tasks 1–3.
+- Produces: a benchmark log entry and a PR line quoting total ingestion seconds against #236's 1,600.55 s.
+
+- [ ] **Step 1: Read the benchmark's own instructions**
+
+Run: `cat evals/at_scale/benchmark.md`
+Do not guess invocation or environment — that file is authoritative.
+
+- [ ] **Step 2: Run the benchmark**
+
+Run: `python evals/at_scale/run_ingestion_benchmark.py`
+Expected: ~85 minutes. Run it in the background and check back rather than blocking.
+
+- [ ] **Step 3: Append the entry and interpret it in the log**
+
+Follow the format of the existing entries. State the total ingestion seconds, the delta against 1,600.55 s (#236's post-fix figure) and the 78.87 s forward-only baseline, and attribute any regression to the added `_lineage_is_provisional` call per forward candidate. If the query-correctness tier reports counts, note whether any entity still holds two `:introduced-by`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add evals/at_scale/
+git commit -m "Record the post-#235 at-scale ingestion result
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin fix-235-two-value-introduced-by
+gh pr create --title "Stop and repair two-value :introduced-by lineage (#235)" --body "..."
+```
+
+The body must reference #235 **without** a closing keyword — negated forms (`does not close #235`) close it too. Include the benchmark delta. `master` requires an approving review on top of green CI; ask before using `--admin` to bypass.
+
+---
+
+## Notes for the implementer
+
+- `docs/testing-conventions.md` is short and worth reading before writing any test.
+- `SKILL.md` documents user-facing query syntax and tool surface. This change adds no tool, no attribute and no query form, so no `SKILL.md` update is expected — confirm that rather than assuming it.
+- `mcp` is pinned `<2.0.0` in `pyproject.toml` on purpose. Do not raise it.
+- If a test needs a graph that survives across `MiniGrafDb.open()` calls, use a real file-backed DB, not the `real_db` fixture — `open_in_memory()` hands back a fresh store on every open.

--- a/docs/superpowers/specs/2026-08-04-introduced-by-two-value-ambiguity-design.md
+++ b/docs/superpowers/specs/2026-08-04-introduced-by-two-value-ambiguity-design.md
@@ -1,0 +1,231 @@
+# Two-value `:introduced-by` ambiguity — design
+
+Issue: #235. A #222 phase 2d defect, independent of #233 and reproduced
+identically on `master` at `bbe7fee`. Sequenced ahead of #231/#238/#239 because
+it is a live data-corruption bug: the corruption is permanent once created and
+nothing in the system repairs it.
+
+## Problem
+
+An entity can end up with **two live `:introduced-by` facts**. The pair never
+converges — it regenerates on every subsequent write — and
+`_correction_sweep_apply` only fails safe on it, never repairs it.
+
+### Why a second fact is minted
+
+`_forward_apply`'s non-`lifecycle_only` branch (`mcp_server.py:8354`) prefilters
+reconciliation candidates through `state.provisional_idents`:
+
+```python
+candidate_in_set = [
+    ident for ident in _forward_candidate_idents(precomputed)
+    if ident in state.provisional_idents          # run-start snapshot
+]
+reconcilable = [
+    ident for ident in candidate_in_set
+    if _lineage_is_provisional(db, ident)
+]
+```
+
+`state.provisional_idents` comes from `_preload_provisional_idents`
+(`mcp_server.py:7317`), taken once at run start. On a fresh ingest it is empty.
+Stream 2 writes its provisional guesses *during that same run*, so they are
+never in it.
+
+The prefilter therefore drops every same-run guess before the DB-authoritative
+`_lineage_is_provisional` check can see it. `reconcilable` comes out empty,
+`_forward_reconcile_provisional` never fires, and `_build_code_triples` — whose
+own gate is `state.entity_valid_from` membership, which the reverse stream also
+does not populate — mints a second `:introduced-by` alongside the guess.
+
+The comment block at `8306`–`8326` already describes this failure mode, and even
+notes for the `lifecycle_only` branch that the snapshot "is empty on a fresh
+ingest, and the guess was made during this same run". Its reasoning about
+*stale-positive* entries (an ident confirmed authoritative mid-run that the set
+still lists) is correct and stays correct. Its conclusion — keep the set as a
+cheap prefilter — is the defect: the set is also stale-*negative*, and a
+prefilter's false negatives are unrecoverable because the authority never runs.
+
+### Why it never converges
+
+`_entity_introduced_by_query` returns `results[0][0]` — the first of possibly
+several values, in unspecified order, silently. Once an entity has two, every
+later reader sees only one, retracts that one, and asserts a fresh one, so the
+pair regenerates rather than collapsing:
+
+```
+[reverse@pos11] :function/mod-py-born-2 existing=[':commit/1cbcc20d42b5'] new=:commit/5a47b50d8cba
+```
+
+— the retract landed on the *other* value. Meanwhile `_correction_sweep_apply`
+fails safe on any count ≠ 1 (case 2, and case 3's `else`), so nothing repairs it.
+
+### Measured impact
+
+Synthetic repo, 14 commits, driven through the real `_run_ingestion` (both
+streams plus the Stage B sweep) against a real on-disk graph:
+
+| | entities with 2 live `:introduced-by` | sweep "left provisional" lines |
+|---|---|---|
+| `master` @ `bbe7fee` | 6 | 11 |
+| `master`, n=20 commits | 9 | 11 (log cap) |
+
+Also visible in a full at-scale ingestion of this repository:
+
+```
+[_correction_sweep] :function/install-py-plugin-version left provisional at b44db0c8667c...
+  (introduced-by values: [':commit/b44db0c8667c', ':commit/c2fd1eb6a515'])
+```
+
+Monkeypatching the preload so `provisional_idents` always reports membership —
+leaving `_lineage_is_provisional(db, ...)` as the sole authority — gives 0
+two-value entities, 0 second-mint events, 0 sweep skips.
+
+## Design
+
+Three parts: prevent new corruption, repair existing corruption, make residual
+ambiguity visible.
+
+### 1. Prevent — drop the prefilter
+
+In `_forward_apply`'s non-`lifecycle_only` branch, `_lineage_is_provisional`
+becomes the sole authority, mirroring what the `lifecycle_only`/`"R"` branch at
+`8337` already does:
+
+```python
+candidate_in_set = _forward_candidate_idents(precomputed)
+reconcilable = [i for i in candidate_in_set if _lineage_is_provisional(db, i)]
+```
+
+The eviction loop at `8390` stays and keeps its invariant — everything examined
+leaves the set — but now drains over the full candidate list rather than the old
+snapshot-filtered one, so a resumed run's stale entries still clear.
+
+The `8306`–`8326` comment is rewritten: the stale-positive reasoning is retained
+(it is why the DB check must remain, rather than trusting a set that would
+otherwise be sufficient), and the "cheap prefilter" conclusion is replaced with
+this issue's finding.
+
+**Rejected: maintaining the set live.**
+`_entity_introduced_by_set_provisional_batch` already returns the exact set of
+idents whose guess it asserted or moved, and both call sites in `_reverse_apply`
+(`8003`, `8007`) discard it; streams interleave through one `_RoundRobinClaimer`
+with single-threaded writes, so feeding that return into
+`state.provisional_idents` would make the set live at zero read cost. Rejected
+because it re-creates a cache-versus-DB coherence dependency, which is the exact
+bug class being fixed here: any future provisional-write path that forgets to
+update the set reintroduces the same silent false negative. Making per-ident
+lineage reads cheap is #239's job, for every call site at once.
+
+### 2. Repair — collapse multiplicity in the sweep
+
+`_correction_sweep_apply` gains `pos_by_commit_ident: Optional[Dict[str, int]] =
+None`. When it is supplied and an ident holds ≥2 `:introduced-by` values, keep
+the **minimum-position** value, retract the rest in one `_retract`, and emit one
+stderr line.
+
+Earliest-by-position is the right survivor. The reverse stream's guess is a
+*sighting* at some commit at or above the true introduction, and
+`_entity_introduced_by_set_provisional_batch`'s existing monotonicity rule
+already encodes this — a guess may only ever move earlier. The forward walk's
+second mint lands at the true introduction, which is therefore the earlier of
+the two.
+
+**Placement: at the top of the per-ident loop**, immediately after
+`introduced_by_values` is read and *before* the `_lineage_is_provisional`
+branch. Cases 1, 2 and 3 then run unchanged against a single value. Repair
+collapses multiplicity only; it never confirms. If the survivor is not
+`commit_ident`, the entity stays provisional and is confirmed normally when the
+sweep reaches that commit.
+
+**Why positions are required.** A position-free rule — "if `commit_ident` is
+among the values, keep it; the ascending sweep reaches the earliest first" —
+needs no new parameter but never fires. The second mint happens in the *forward*
+region, which Stage B does not sweep; the sweep meets these entities at
+unrelated later commits, which is what the at-scale log lines show (the sweep
+commit is neither value). `_reverse_apply` already builds this map at
+`mcp_server.py:7896` from `commit_metadata`; the sweep does not receive it.
+
+**Gating.** Repair is active only when `pos_by_commit_ident` is supplied, so
+every existing caller and test keeps today's fail-safe behaviour until wired.
+Callers holding `commit_metadata` — the 2d Stage B driver and
+`_correction_sweep_claim_and_process` — pass it. A value absent from the map
+sorts last rather than raising, so an unrecognised commit ident can never be
+chosen over a known one and can never crash the sweep.
+
+**Limitation, stated deliberately.** An entity whose values are all outside the
+map, or which the sweep never visits, is not repaired. Repair is best-effort
+healing for graphs already in the field, not a guarantee.
+
+### 3. Observe — make ambiguity loud
+
+Add `_entity_introduced_by_values_query(db, entity_ident) -> List[str]`.
+`_entity_introduced_by_query` delegates to it, emits one stderr line when
+`len > 1`, and returns `results[0][0]` as today, with the arbitrary ordering
+documented rather than implied. The sweep's two inline `:introduced-by` queries
+collapse onto the new helper.
+
+It must **not** raise. Both walks call it during the run, before Stage B, so
+raising on >1 would hard-fail ingestion on exactly the corrupted graphs the
+repair exists to heal. It also cannot pick the earliest itself — it has no
+`pos_by_commit_ident` — so position-based selection stays in the sweep.
+
+## Testing
+
+Real-backend only, per `docs/testing-conventions.md`.
+
+`TestForwardApplyReconcilesProvisional.test_forward_apply_supersedes_a_provisional_guess`
+(`tests/test_mcp_server.py:16594`) already covers this scenario and passes on
+`master`. It hides the bug by calling `_preload_provisional_idents` *after* the
+reverse stream has run (`:16619`), so its snapshot contains the guess.
+Production preloads at run start, before Stream 2 writes anything. Correcting
+that ordering is part of the fix.
+
+RED before any implementation edit:
+
+1. **Integration oracle** (new, Pattern 2, file-backed): the issue's synthetic
+   repo — `mod.py` accumulating `born_0..born_N` plus long-lived functions
+   edited every commit — through the real `_run_ingestion`. Asserts zero
+   entities hold ≥2 live `:introduced-by`, and zero `left provisional` /
+   `left unreconciled` lines. Reproduces at 6 entities on `master`.
+2. **Prefilter drop**: `_ForwardWalkState` built with `provisional_idents=set()`
+   — the honest fresh-ingest value — before the reverse stream runs. Exactly one
+   `:introduced-by` survives, naming h0.
+3. **Eviction still drains**: an ident in the snapshot but not provisional in
+   the DB is still discarded. Guards the loop's changed iteration source; a
+   regression here restores the retry-on-every-commit behaviour the `8345`
+   comment describes.
+4. **Repair**, in `TestCorrectionSweepApply`: two seeded values plus
+   `pos_by_commit_ident` → minimum-position survives, the other is retracted,
+   one log line. Plus three boundaries — `pos_by_commit_ident=None` leaves
+   today's fail-safe skip untouched; a value absent from the map sorts last
+   without raising; and collapse-then-case-1, where a survivor equal to
+   `commit_ident` is confirmed within the same call.
+5. **Loud query**: 2 values → one stderr line via `capsys`, returns a value,
+   does not raise; 1 value → silent.
+6. **Existing guards stay green**: `TestMultiStreamParityWithForwardOnly`,
+   `TestReverseFillValidTimeParity`, `TestStageBCorrectionSweep`.
+
+## Performance
+
+The fix moves a graph point query onto every candidate ident of every "A"/"M"
+file in the forward walk — the same per-ident read class #239 measures at 33.6%
+of ingestion wall clock. The issue's claim that this is "a cost the `"R"` path
+already pays" understates it: the `"R"` path runs only on renames.
+
+`evals/at_scale/run_ingestion_benchmark.py` (~85 min) is run after the fix and
+its entry appended to the benchmark log, with the delta against #236's
+1,600.55 s recorded in the PR. **Correctness is not gated on the number** — the
+measurement exists so #239 starts from a measured baseline rather than a guess,
+and so a large regression is attributed here rather than discovered later.
+
+Reclaiming the cost belongs to #239, whose central design problem is
+maintaining a cache of a value written during the run by the very walks that
+read it. Folding that into this PR would put a correctness fix behind an unsolved
+design question.
+
+## Scope
+
+Not in scope: #231 (`_build_close_triples` never retracts `:introduced-by`),
+#238 (valid-time preload bound), #239 (read-cost reduction). This fix must land
+before phases 3–5 build further on Stage A/Stage B lineage.

--- a/docs/superpowers/specs/2026-08-04-introduced-by-two-value-ambiguity-design.md
+++ b/docs/superpowers/specs/2026-08-04-introduced-by-two-value-ambiguity-design.md
@@ -153,9 +153,22 @@ Callers holding `commit_metadata` — the 2d Stage B driver and
 sorts last rather than raising, so an unrecognised commit ident can never be
 chosen over a known one and can never crash the sweep.
 
-**Limitation, stated deliberately.** An entity whose values are all outside the
-map, or which the sweep never visits, is not repaired. Repair is best-effort
-healing for graphs already in the field, not a guarantee.
+**Limitation, stated deliberately.** Repair reaches only entities the sweep
+actually visits, and on an already-completed graph it visits none. A finished
+run leaves `:ingestion/correction-sweep-through` at frontier-high's `:hi-hash`,
+so the next run's `_correction_sweep_select_position` hits its `pos >
+ceiling_pos` guard (`mcp_server.py:8894`), returns None on its first call, and
+`_correction_sweep_apply` runs zero times — measured on the 14-commit fixture:
+watermark at position 13 of 13, one `select`, zero `apply`. Re-running ingestion
+therefore repairs nothing, and that is the modal state of a graph in the field.
+
+Recovery requires one of: new commits above the old ceiling (and then only for
+entities that are candidates in those commits), an interrupted run that resumes
+with the watermark still short of the ceiling, or an explicit repair pass /
+watermark reset. An entity whose values are all outside the map is likewise not
+repaired. This section buys convergence for graphs that keep being ingested; it
+is not a recovery path for a static corrupted graph, and closing #235 should not
+be read as providing one.
 
 ### 3. Observe — make ambiguity loud
 

--- a/evals/at_scale/bench_lineage_query_cost.py
+++ b/evals/at_scale/bench_lineage_query_cost.py
@@ -1,0 +1,259 @@
+"""Does #235's per-candidate lineage check explain the 30x ingestion slowdown?
+
+Commit 9d91593 (#235) fixed a data-corruption bug in _forward_apply by
+dropping the state.provisional_idents prefilter: before the fix,
+_lineage_is_provisional(db, ident) ran only for idents already in the
+run-start snapshot (small, mostly HITS -- a marker entity exists); after the
+fix it runs for EVERY candidate ident of every "A"/"M" file, and the
+overwhelming majority are MISSES (no :type/lineage-marker companion entity
+was ever created for that ident).
+
+The at-scale ingestion benchmark on the fixed code was killed after 3h54m,
+~1/3 complete; the same benchmark on the pre-fix commit took 1,600.55s for
+568 commits -- roughly 30x. The box was unloaded, and every file was
+byte-static for minutes while the process sat at 99.6% CPU: read-bound, not
+write-bound.
+
+HYPOTHESIS (mirrors #236's fact_index.delete_facts equality-scan finding):
+a lookup for a NON-EXISTENT entity degrades to a scan rather than an index
+seek, so per-call MISS cost grows with total graph size -- making the whole
+run's cumulative cost shape quadratic.
+
+_lineage_is_provisional (mcp_server.py, ~line 5210) issues one point query:
+    (query [:find ?e :where [<marker-ident> :entity ?e]])
+_preload_provisional_idents (mcp_server.py, ~line 7347) issues ONE query for
+the complete provisional set:
+    (query [:find ?e :where [?m :entity-type :type/lineage-marker] [?m :entity ?e]])
+
+This script measures, against a real on-disk graph (no mocks):
+  E1: HIT vs MISS cost for _lineage_is_provisional, across 3 graph sizes
+      spanning 50x (100k / 1M / 5M filler facts).
+  E2: _preload_provisional_idents cost as a function of (a) graph size and
+      (b) marker population size (reverse stream creates ~1,265 provisional
+      idents/commit, so this can grow to tens of thousands mid-run before
+      _forward_reconcile_provisional drains it).
+  E3: crossover at ~1,265 candidates/commit (the reverse stream's working
+      figure) -- N point queries vs one preload call, at each graph size.
+
+METHODOLOGY NOTE: fixture writes are checkpointed (db.checkpoint()) before
+any timed query. Skipping this is a trap -- an uncheckpointed graph answers
+both the point query and the join query incorrectly once enough facts have
+been written since the last checkpoint (verified deterministic, and fully
+fixed by inserting one checkpoint() call; the visibility limit appeared to
+sit near 65,536 recently-written facts in one repro, but did not hold as a
+clean threshold at larger sizes, consistent with an internal auto-checkpoint
+eventually catching up on its own rather than a fixed-capacity bug). Real
+_transact/_retract callers always checkpoint after a write
+(_checkpoint_after_write), so checkpointing fixtures here matches production
+behavior rather than working around a production bug -- this is a benchmark
+fixture gotcha, not a #235-relevant finding, and every reported cell below
+is checked against its expected result to catch a repeat of it.
+
+    .venv/bin/python evals/at_scale/bench_lineage_query_cost.py
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+REPO = "/home/aditya/Work/AMC/Minigraf/temporal_reasoning"
+sys.path.insert(0, REPO)
+
+from minigraf import MiniGrafDb
+import mcp_server
+
+TS = "2026-01-01T00:00:00Z"
+
+# The reverse stream's working figure for provisional idents/commit (task's
+# assumption, stated explicitly per the brief).
+CANDIDATES_PER_COMMIT = 1265
+
+
+def fresh_db(tmpdir, name):
+    """A real on-disk MiniGrafDb, like the other at-scale bench scripts."""
+    path = os.path.join(tmpdir, f"{name}.graph")
+    for suffix in ("", ".wal", ".lock"):
+        if os.path.exists(path + suffix):
+            os.remove(path + suffix)
+    return MiniGrafDb.open(path), path
+
+
+def populate_filler(db, n, chunk=1000):
+    """Bulk unrelated facts, distinct entities, to set total graph size --
+    same shape as bench_retract_cost.py's populate(). These entities also
+    double as realistic MISS targets below: they exist in the graph (as a
+    real forward-walk candidate ident would) but were never given a lineage
+    marker, exactly like the vast majority of #235's new per-candidate
+    checks.
+    """
+    for start in range(0, n, chunk):
+        batch = [f'[:e/n{i} :attr "v{i}"]' for i in range(start, min(start + chunk, n))]
+        db.execute(f'(transact {{:valid-from "{TS}"}} [' + " ".join(batch) + "])")
+    db.checkpoint()  # see module docstring's METHODOLOGY NOTE
+
+
+def add_lineage_markers(db, entity_idents, chunk=1000):
+    """Write the exact 3-fact marker pattern _lineage_confirm_batch writes,
+    via mcp_server._lineage_marker_ident so the ident shape matches
+    production byte-for-byte.
+    """
+    facts = []
+    for ident in entity_idents:
+        mident = mcp_server._lineage_marker_ident(ident)
+        facts.append(f"[{mident} :entity-type :type/lineage-marker]")
+        facts.append(f"[{mident} :entity {ident}]")
+        facts.append(f"[{mident} :status :provisional]")
+    for start in range(0, len(facts), chunk):
+        batch = facts[start:start + chunk]
+        db.execute(f'(transact {{:valid-from "{TS}"}} [' + " ".join(batch) + "])")
+    db.checkpoint()  # see module docstring's METHODOLOGY NOTE
+
+
+def timed_is_provisional(db, idents, reps, expected):
+    """One warmup call (untimed) -- asserted against `expected` so a
+    fixture-visibility bug (see module docstring) fails loudly instead of
+    silently reporting a MISS-cost number as if it were a HIT, or vice
+    versa -- then `reps` timed calls cycling through idents. Returns
+    ms/call."""
+    warmup = mcp_server._lineage_is_provisional(db, idents[0])
+    assert warmup == expected, (
+        f"_lineage_is_provisional({idents[0]!r}) = {warmup}, expected {expected} -- "
+        "fixture not visible to queries yet (see module docstring's METHODOLOGY NOTE)"
+    )
+    t0 = time.perf_counter()
+    for i in range(reps):
+        mcp_server._lineage_is_provisional(db, idents[i % len(idents)])
+    return (time.perf_counter() - t0) / reps * 1000
+
+
+def timed_preload(db, reps, expected_len=None):
+    """One warmup call (untimed), then `reps` timed calls. Returns
+    (ms/call, result_len). When expected_len is given, asserts the warmup
+    call's result count matches it -- same fixture-visibility guard as
+    timed_is_provisional."""
+    result = mcp_server._preload_provisional_idents(db)  # warmup
+    if expected_len is not None:
+        assert len(result) == expected_len, (
+            f"_preload_provisional_idents returned {len(result)} idents, expected "
+            f"{expected_len} -- fixture not visible to queries yet (see module "
+            "docstring's METHODOLOGY NOTE)"
+        )
+    t0 = time.perf_counter()
+    for _ in range(reps):
+        result = mcp_server._preload_provisional_idents(db)
+    return (time.perf_counter() - t0) / reps * 1000, len(result)
+
+
+def experiment_1_and_2a(tmpdir):
+    """E1: HIT vs MISS cost for _lineage_is_provisional, and E2a: preload
+    cost, both across graph size (100k / 1M / 5M filler facts, 50x range).
+    Fixed marker population = CANDIDATES_PER_COMMIT (1,265), on a namespace
+    (:e/hit{i}) disjoint from the filler entities so HIT/MISS draw from
+    consistent, unambiguous pools. REPS=300 for the point query (sub-ms/call,
+    needs volume for a stable mean); REPS=20 for preload (single-digit-ms+
+    per call, stable well before 20).
+    """
+    is_prov_reps = 300
+    preload_reps = 20
+    sizes = (100_000, 1_000_000, 5_000_000)
+    results = {}  # size -> (hit_ms, miss_ms, preload_ms, preload_len)
+
+    print("=== E1: _lineage_is_provisional, HIT vs MISS, vary graph size ===")
+    print(f"({is_prov_reps} reps/cell, 1 warmup call before each timed loop; "
+          f"{CANDIDATES_PER_COMMIT} markers planted per size)")
+    print(f"{'filler facts':>13} {'hit ms/call':>12} {'miss ms/call':>13} {'miss/hit':>9}")
+    for n in sizes:
+        db, _ = fresh_db(tmpdir, f"e1_{n}")
+        populate_filler(db, n)
+        hit_idents = [f":e/hit{i}" for i in range(CANDIDATES_PER_COMMIT)]
+        add_lineage_markers(db, hit_idents)
+        # MISS: real existing entities (the filler pool) with no marker --
+        # the realistic shape of #235's new per-candidate checks.
+        miss_idents = [f":e/n{i}" for i in range(0, n, max(1, n // is_prov_reps))]
+
+        hit_ms = timed_is_provisional(db, hit_idents, is_prov_reps, expected=True)
+        miss_ms = timed_is_provisional(db, miss_idents, is_prov_reps, expected=False)
+        preload_ms, preload_len = timed_preload(db, preload_reps, expected_len=CANDIDATES_PER_COMMIT)
+
+        results[n] = (hit_ms, miss_ms, preload_ms, preload_len)
+        print(f"{n:>13} {hit_ms:>12.4f} {miss_ms:>13.4f} {miss_ms / hit_ms:>8.2f}x")
+        del db
+
+    print("\n=== E2a: _preload_provisional_idents, same graphs as E1 ===")
+    print(f"({preload_reps} reps/cell, 1 warmup call before each timed loop)")
+    print(f"{'filler facts':>13} {'markers':>8} {'preload ms/call':>16} {'result len':>10}")
+    for n in sizes:
+        hit_ms, miss_ms, preload_ms, preload_len = results[n]
+        print(f"{n:>13} {CANDIDATES_PER_COMMIT:>8} {preload_ms:>16.3f} {preload_len:>10}")
+
+    return results
+
+
+def experiment_2b(tmpdir):
+    """E2b: _preload_provisional_idents cost as a function of marker
+    population size, graph size held fixed at 1,000,000 filler facts.
+    Marker counts approximate 0 / 1 / 5 / 10 commits' worth of UNRECONCILED
+    provisionals sitting in the graph. result_len is asserted equal to the
+    marker count at every row (see module docstring's METHODOLOGY NOTE).
+    """
+    preload_reps = 20
+    print("\n=== E2b: _preload_provisional_idents, vary marker population "
+          "(graph fixed at 1,000,000 filler facts) ===")
+    print(f"({preload_reps} reps/cell, 1 warmup call before each timed loop)")
+    print(f"{'markers':>8} {'preload ms/call':>16} {'result len':>10}")
+    db, _ = fresh_db(tmpdir, "e2b")
+    populate_filler(db, 1_000_000)
+    marker_counts = (0, CANDIDATES_PER_COMMIT, 5 * CANDIDATES_PER_COMMIT, 10 * CANDIDATES_PER_COMMIT)
+    prev = 0
+    rows = []
+    for target in marker_counts:
+        if target > prev:
+            add_lineage_markers(db, [f":e/hit{i}" for i in range(prev, target)])
+        prev = target
+        preload_ms, preload_len = timed_preload(db, preload_reps, expected_len=target)
+        rows.append((target, preload_ms, preload_len))
+        print(f"{target:>8} {preload_ms:>16.3f} {preload_len:>10}")
+    del db
+    return rows
+
+
+def experiment_3(e1_results):
+    """E3: crossover at CANDIDATES_PER_COMMIT (~1,265) candidates/commit --
+    N point queries via _lineage_is_provisional vs ONE
+    _preload_provisional_idents call, at each E1 graph size.
+
+    Assumption (stated per the brief): candidates are modeled as ALL MISS.
+    That is the "overwhelming majority" case the #235 diff docstring
+    describes, and it is also the more expensive of the two point-query
+    costs in every E1 row measured above, so it is the conservative
+    (worst-case-for-preload) choice for this comparison.
+    """
+    print("\n=== E3: crossover at "
+          f"{CANDIDATES_PER_COMMIT} candidates/commit (assumed all-MISS) ===")
+    print(f"{'filler facts':>13} {'N x miss_ms':>13} {'1x preload_ms':>14} {'winner':>10} {'margin':>8}")
+    prev_winner = None
+    flipped = False
+    for n, (hit_ms, miss_ms, preload_ms, preload_len) in e1_results.items():
+        pointwise_total = CANDIDATES_PER_COMMIT * miss_ms
+        winner = "preload" if preload_ms < pointwise_total else "pointwise"
+        margin = max(pointwise_total, preload_ms) / min(pointwise_total, preload_ms)
+        print(f"{n:>13} {pointwise_total:>13.2f} {preload_ms:>14.2f} {winner:>10} {margin:>7.2f}x")
+        if prev_winner is not None and winner != prev_winner:
+            flipped = True
+        prev_winner = winner
+    print(f"\ncrossover verdict: winner {'FLIPS' if flipped else 'does NOT flip'} "
+          "across the graph sizes measured.")
+
+
+if __name__ == "__main__":
+    tmpdir = tempfile.mkdtemp(prefix="lineage-query-bench-")
+    os.environ["MINIGRAF_GRAPH_PATH"] = os.path.join(tmpdir, "unused.graph")
+    try:
+        e1_results = experiment_1_and_2a(tmpdir)
+        experiment_2b(tmpdir)
+        experiment_3(e1_results)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    print("\ndone")

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -187,3 +187,64 @@ for a human, and it closes it.
 The remaining 20.3x is therefore still above the design spec's "same order as
 the baseline" bar, but it is no longer an unexplained gap: it has a named,
 measured, filed successor (#239).
+
+## No Ingestion Run — fix-235-two-value-introduced-by
+
+**No acceptance-gate run was completed on this branch, and this entry is not
+one.** Two attempts at the full-history acceptance benchmark on
+`fix-235-two-value-introduced-by` were killed before completion — one at
+3h54m (~1/3 complete), one at 36m. Neither produced a result worth recording
+in the metrics-table format above, and no table is given here. The gate
+should be re-run once #242 (below) is fixed.
+
+- **The cause is the benchmark harness itself, filed as #242, not #235's
+  code.** `_poll_during_ingestion` issues a blocking graph query on the
+  event loop every 0.5 s, and `_STATUS_QUERY` counts every `:type/commit`
+  entity — so the poll's own cost grows across the run. Late in a run it
+  consumes most of the event loop and ingestion approaches a standstill.
+  The second killed attempt shows the collapse directly: graph growth fell
+  1.35 -> 0.405 -> 0.101 MB/min across three consecutive 15-minute windows,
+  with the main process pinned at 99% CPU while all 8 parse workers sat
+  idle at 0.5-1.1%. This implicates the two entries above this one, too: the
+  78.87s and 1600.55s figures carry the same polling overhead, so
+  entry-to-entry *comparisons* remain apples-to-apples (same harness bug,
+  present throughout), but the *absolute* numbers in this file overstate
+  real ingestion cost. **Hypothesis, not measured:** a feedback loop between
+  rising poll-query cost and lock contention against the ingestion writer
+  may explain why the two killed attempts on this branch diverged so
+  sharply in wall clock (3h54m vs 36m) rather than failing at a consistent
+  point.
+- **What replaces it here: a two-revision A/B**, not a single-revision gate
+  run, using `evals/at_scale/profile_forward_reconcile_attribution.py`
+  (committed `f830285`), which drives the same `_run_ingestion` across
+  Stage A and Stage B directly and does not poll. BEFORE = `20b9b38` (the
+  prefilter still in place), AFTER = `7b08db6`. Both legs ingest the same
+  root-anchored refs. On the 450-commit slice, the largest both revisions
+  ran to completion: **720.57s BEFORE vs 741.85s AFTER, a ratio of 1.03**
+  (1.01 at 150 commits, 1.03 at 300 commits). On the full 586-commit
+  history, both capped at 1500s, AFTER is *ahead*: Stage A done at 619.9s
+  vs BEFORE's 675.8s, and more Stage B work completed in the remaining
+  budget. The single largest attributed delta is `_correction_sweep_apply`,
+  +34.5s (131.8 -> 166.3s) over the same 225 calls, driven by `_retract`
+  rising 53,567 -> 79,175 calls (+48%) — the sweep doing repair work the bug
+  used to suppress — partly offset by `_reverse_apply` running 12.9s
+  faster, netting +21.3s overall.
+- **The hypothesis that motivated concern about #235 in the first place is
+  disproved.** `_lineage_is_provisional` was expected to dominate the cost,
+  since #235 makes it run per candidate ident instead of behind an
+  in-memory prefilter. Measured directly
+  (`evals/at_scale/bench_lineage_query_cost.py`, commit `7b08db6`): HIT
+  costs 0.0514 / 0.0600 / 0.0597 ms and MISS costs 0.0459 / 0.0542 / 0.0528
+  ms at 100k / 1M / 5M facts — a miss is *cheaper* than a hit, and neither
+  scales with graph size. In the A/B above it accounts for 29.0s of a
+  741.85s run. The follow-up hypothesis, `_forward_reconcile_provisional`,
+  fires 281 times for 0.73s total — confirming the behavioural claim (0
+  calls on BEFORE: the prefilter suppressed it entirely) while refuting the
+  cost claim.
+- **A separate finding, unrelated to #235, filed as #241:** `_db_checkpoint`
+  is the largest single call site on *both* revisions in the A/B —
+  371.0s vs 367.1s over the same 902 calls on the 450-commit slice, roughly
+  0.69s per checkpoint, once per commit against a graph that grows the
+  whole run. Likely missed by earlier per-call attributions because the
+  per-thread cProfile hook used for them was killing the `write_executor`
+  threads it was attached to.

--- a/evals/at_scale/profile_forward_reconcile_attribution.py
+++ b/evals/at_scale/profile_forward_reconcile_attribution.py
@@ -1,0 +1,347 @@
+# evals/at_scale/profile_forward_reconcile_attribution.py
+"""Two-revision ingestion attribution harness (#235).
+
+Runs the SAME bounded commit slice through the real `_run_ingestion` and
+reports where the wall clock goes, so two revisions of mcp_server.py can be
+compared side by side. Written for #235's 30x at-scale regression, but the
+harness itself is revision-agnostic: it imports mcp_server from an explicit
+--code-root, so a git worktree at any revision can be profiled without
+checking anything out in the main working tree.
+
+Covers Stage A (the two-stream converging walk) AND Stage B (the correction
+sweep) -- unlike profile_reverse_walk_writes.py, which drives
+_reverse_fill_claim_and_process directly and therefore sees Stage A only.
+The phase boundary is sampled from _ingest_progress["phase"] by a polling
+task, so Stage A and Stage B wall clock are reported separately.
+
+Two measurement layers, because they answer different questions:
+
+  1. Wrapper counters/timers on the interesting call sites (_transact,
+     _retract, _db_execute, _lineage_is_provisional,
+     _forward_reconcile_provisional, _re_date_structural_facts, ...).
+     Cheap (sys._getframe, not traceback.extract_stack), so --no-profile
+     runs give a near-clean wall clock while still attributing writes.
+  2. cProfile, enabled on EVERY thread (via threading.setprofile) and
+     merged, because _run_ingestion does all of its DB work on a dedicated
+     write_executor thread -- a main-thread-only cProfile sees nothing.
+     Extraction runs in a spawn ProcessPoolExecutor and is NOT visible to
+     cProfile; its cost shows up in wall clock only.
+
+Self-isolating: creates its own tempdir and points MINIGRAF_GRAPH_PATH and
+MINIGRAF_INDEX_PATH at it, so it never touches memory.graph.
+
+    .venv/bin/python evals/at_scale/profile_forward_reconcile_attribution.py \
+        --code-root /path/to/worktree --repo /path/to/repo --ref <sha> \
+        --label before --outdir /tmp/attr [--no-profile]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import collections
+import cProfile
+import io
+import json
+import os
+import pstats
+import sys
+import tempfile
+import threading
+import time
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--code-root", required=True,
+                   help="Directory to import mcp_server.py from (a git worktree).")
+    p.add_argument("--repo", required=True, help="Repository whose history is ingested.")
+    p.add_argument("--ref", required=True,
+                   help="Explicit ref/SHA bounding the slice; both revisions must be given "
+                        "the same one so they see identical input.")
+    p.add_argument("--label", required=True, help="Short name for this run (before/after).")
+    p.add_argument("--outdir", required=True, help="Where to write JSON + pstats output.")
+    p.add_argument("--no-profile", action="store_true",
+                   help="Skip cProfile (wrapper counters only) for a near-clean wall clock.")
+    p.add_argument("--workers", default="4",
+                   help="MINIGRAF_INGEST_WORKERS; pinned so both revisions match.")
+    p.add_argument("--max-seconds", type=float, default=0.0,
+                   help="Stop Stage A cleanly (via _shutdown_requested) after this many "
+                        "seconds. 0 = run to completion. A capped run SKIPS Stage B -- "
+                        "compare capped runs on the progress timeline, not on wall clock.")
+    return p.parse_args()
+
+
+ARGS = _parse_args()
+
+# Import the revision under test, and nothing from anywhere else. This must
+# happen before `import mcp_server`.
+sys.path.insert(0, os.path.abspath(ARGS.code_root))
+
+TMPDIR = tempfile.mkdtemp(prefix=f"attr-{ARGS.label}-")
+GRAPH_PATH = os.path.join(TMPDIR, "bench.graph")
+os.environ["MINIGRAF_GRAPH_PATH"] = GRAPH_PATH
+os.environ["MINIGRAF_INDEX_PATH"] = GRAPH_PATH + ".fts.sqlite3"
+os.environ["MINIGRAF_INGEST_WORKERS"] = ARGS.workers
+
+import mcp_server as m  # noqa: E402
+
+assert os.path.abspath(os.path.dirname(m.__file__)) == os.path.abspath(ARGS.code_root), (
+    f"mcp_server resolved to {m.__file__}, not {ARGS.code_root}"
+)
+
+# --------------------------------------------------------------------------
+# Layer 1: wrapper counters/timers.
+# --------------------------------------------------------------------------
+
+_lock = threading.Lock()
+counts: collections.Counter = collections.Counter()
+timings: collections.Counter = collections.Counter()
+by_caller: collections.Counter = collections.Counter()
+caller_timings: collections.Counter = collections.Counter()
+
+
+def _wrap(name: str, attribute_caller: bool = False):
+    """Replace m.<name> with a counting/timing wrapper. Module-global call
+    sites inside mcp_server resolve the name at call time, so this is seen by
+    every internal caller."""
+    real = getattr(m, name)
+
+    def wrapper(*a, **k):
+        t0 = time.perf_counter()
+        try:
+            return real(*a, **k)
+        finally:
+            dt = time.perf_counter() - t0
+            caller = sys._getframe(1).f_code.co_name if attribute_caller else None
+            with _lock:
+                counts[name] += 1
+                timings[name] += dt
+                if caller is not None:
+                    by_caller[(name, caller)] += 1
+                    caller_timings[(name, caller)] += dt
+
+    wrapper.__name__ = f"wrapped_{name}"
+    setattr(m, name, wrapper)
+    return real
+
+
+WRAPPED = [
+    "_transact",
+    "_retract",
+    "_db_execute",
+    "_lineage_is_provisional",
+    "_forward_reconcile_provisional",
+    "_re_date_structural_facts",
+    "_lineage_confirm",
+    "_lineage_confirm_batch",
+    "_entity_introduced_by_query",
+    "_forward_apply",
+    "_reverse_apply",
+    "_correction_sweep_apply",
+    "_db_checkpoint",
+]
+ATTRIBUTE_CALLER = {"_transact", "_retract"}
+for _n in WRAPPED:
+    if hasattr(m, _n):
+        _wrap(_n, attribute_caller=_n in ATTRIBUTE_CALLER)
+
+# --------------------------------------------------------------------------
+# Layer 2: cProfile on every thread.
+# --------------------------------------------------------------------------
+
+_profilers: list = []
+_prof_lock = threading.Lock()
+
+
+_thread_profiled: set = set()
+
+
+def _install_thread_profiler(*_a):
+    """Give this thread its own cProfile.
+
+    MUST NOT raise. threading.setprofile's hook runs inside Thread._bootstrap
+    BEFORE the thread's target; an exception here kills the thread at
+    bootstrap. On Python 3.14 a second install attempt on a thread that
+    already has a profiler raises "ValueError: Another profiling tool is
+    already active" -- which silently killed every write_executor /
+    ProcessPoolExecutor management thread, hanging ingestion until the outer
+    timeout rather than producing a profile. Guard on thread identity and
+    swallow anything else.
+    """
+    tid = threading.get_ident()
+    with _prof_lock:
+        if tid in _thread_profiled:
+            return
+        _thread_profiled.add(tid)
+        p = cProfile.Profile()
+        _profilers.append(p)
+    try:
+        p.enable()  # replaces this hook with the profiler itself for this thread
+    except Exception as e:  # pragma: no cover - defensive; see docstring
+        print(f"[profile] could not enable on thread {tid}: {e}", file=sys.stderr)
+
+
+def _start_profiling() -> None:
+    threading.setprofile(_install_thread_profiler)
+    main = cProfile.Profile()
+    _profilers.append(main)
+    main.enable()
+
+
+def _stop_profiling() -> pstats.Stats | None:
+    threading.setprofile(None)
+    merged = None
+    for p in _profilers:
+        try:
+            p.disable()
+            p.create_stats()
+        except Exception:
+            continue
+        try:
+            if merged is None:
+                merged = pstats.Stats(p)
+            else:
+                merged.add(p)
+        except Exception:
+            continue
+    return merged
+
+
+# --------------------------------------------------------------------------
+# Drive the ingestion.
+# --------------------------------------------------------------------------
+
+phase_marks: list = []
+progress_timeline: list = []
+
+
+async def _watch_phase(task: "asyncio.Task[None]", t_start: float) -> None:
+    last = None
+    last_sample = 0.0
+    capped = False
+    while not task.done():
+        now = time.perf_counter()
+        phase = m._ingest_progress.get("phase")
+        if phase != last:
+            phase_marks.append((phase, now))
+            last = phase
+        if now - last_sample >= 1.0:
+            last_sample = now
+            progress_timeline.append({
+                "t": round(now - t_start, 2),
+                "phase": phase,
+                "processed": m._ingest_progress.get("processed"),
+                "graph_bytes": os.path.getsize(GRAPH_PATH) if os.path.exists(GRAPH_PATH) else 0,
+                "reconciles": counts.get("_forward_reconcile_provisional", 0),
+                "retracts": counts.get("_retract", 0),
+                "queries": counts.get("_db_execute", 0),
+            })
+        if ARGS.max_seconds and not capped and now - t_start >= ARGS.max_seconds:
+            capped = True
+            print(f"[{ARGS.label}] max-seconds reached; requesting clean stop",
+                  flush=True)
+            m._shutdown_requested.set()
+        await asyncio.sleep(0.05)
+
+
+async def _main() -> dict:
+    m._db = None
+    m._graph_path = None
+    m.open_db(GRAPH_PATH)
+    m._ingest_progress = {
+        "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+        "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+        "phase": None,
+    }
+    start = time.perf_counter()
+    task = asyncio.create_task(m._run_ingestion(ARGS.repo, ARGS.ref))
+    await _watch_phase(task, start)
+    await task
+    wall = time.perf_counter() - start
+    return {
+        "wall_clock_seconds": wall,
+        "capped": bool(ARGS.max_seconds),
+        "commits_processed": m._ingest_progress.get("processed"),
+        "final_status": m._ingest_progress.get("status"),
+        "error": m._ingest_progress.get("error"),
+    }
+
+
+def main() -> int:
+    os.makedirs(ARGS.outdir, exist_ok=True)
+    n_commits = len(m._git_commits(ARGS.repo, None, ARGS.ref))
+    print(f"[{ARGS.label}] code-root={ARGS.code_root}")
+    print(f"[{ARGS.label}] slice={ARGS.ref} -> {n_commits} commits, graph={GRAPH_PATH}")
+    print(f"[{ARGS.label}] cProfile={'off' if ARGS.no_profile else 'on'}")
+
+    if not ARGS.no_profile:
+        _start_profiling()
+    result = asyncio.run(_main())
+    stats = None if ARGS.no_profile else _stop_profiling()
+
+    result.update({
+        "label": ARGS.label,
+        "code_root": os.path.abspath(ARGS.code_root),
+        "repo": os.path.abspath(ARGS.repo),
+        "ref": ARGS.ref,
+        "slice_commits": n_commits,
+        "profiled": not ARGS.no_profile,
+        "graph_size_bytes": os.path.getsize(GRAPH_PATH) if os.path.exists(GRAPH_PATH) else 0,
+        "index_size_bytes": (
+            os.path.getsize(GRAPH_PATH + ".fts.sqlite3")
+            if os.path.exists(GRAPH_PATH + ".fts.sqlite3") else 0
+        ),
+        "phase_marks": [
+            {"phase": p, "at_seconds": t - (phase_marks[0][1] if phase_marks else t)}
+            for p, t in phase_marks
+        ],
+        "progress_timeline": progress_timeline,
+        "call_counts": {k: counts[k] for k in sorted(counts)},
+        "call_seconds": {k: round(timings[k], 3) for k in sorted(timings)},
+        "by_caller": {
+            f"{fn}<-{caller}": {"count": n, "seconds": round(caller_timings[(fn, caller)], 3)}
+            for (fn, caller), n in by_caller.most_common()
+        },
+    })
+
+    print(f"\n[{ARGS.label}] wall clock: {result['wall_clock_seconds']:.1f}s  "
+          f"status={result['final_status']}  commits={result['commits_processed']}")
+    print(f"[{ARGS.label}] phase marks: "
+          + ", ".join(f"{p}@{d['at_seconds']:.1f}s"
+                      for p, d in zip([x['phase'] for x in result['phase_marks']],
+                                      result['phase_marks'])))
+    print(f"\n{'call site':<38} {'count':>9} {'sec':>9}")
+    for k in sorted(counts, key=lambda x: -timings[x]):
+        print(f"{k:<38} {counts[k]:>9} {timings[k]:>9.1f}")
+
+    print(f"\n{'write call site (by caller)':<58} {'count':>9} {'sec':>9}")
+    for (fn, caller), n in by_caller.most_common(25):
+        print(f"{fn + ' <- ' + caller:<58} {n:>9} {caller_timings[(fn, caller)]:>9.1f}")
+
+    json_path = os.path.join(ARGS.outdir, f"attr-{ARGS.label}.json")
+    with open(json_path, "w") as fh:
+        json.dump(result, fh, indent=2)
+    print(f"\nWrote {json_path}")
+
+    if stats is not None:
+        buf = io.StringIO()
+        stats.stream = buf
+        stats.sort_stats("cumulative").print_stats(45)
+        buf.write("\n\n===== SORTED BY TOTTIME =====\n\n")
+        stats.sort_stats("tottime").print_stats(35)
+        text = buf.getvalue()
+        prof_path = os.path.join(ARGS.outdir, f"attr-{ARGS.label}.prof.txt")
+        with open(prof_path, "w") as fh:
+            fh.write(text)
+        stats.dump_stats(os.path.join(ARGS.outdir, f"attr-{ARGS.label}.pstats"))
+        print(text[:20000])
+        print(f"Wrote {prof_path}")
+
+    print(f"\ngraph: {result['graph_size_bytes']} B  index: {result['index_size_bytes']} B "
+          f"({TMPDIR})")
+    return 0 if result["final_status"] != "error" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -8910,6 +8910,7 @@ def _correction_sweep_apply(
     index_con: Optional[Any] = None,
     skipped_so_far: int = 0,
     update_watermark: bool = True,
+    pos_by_commit_ident: Optional[Dict[str, int]] = None,
 ) -> int:
     """Reconciles every candidate entity file_results describes for
     commit_hash, then records progress via _correction_sweep_through_update
@@ -8947,6 +8948,30 @@ def _correction_sweep_apply(
 
     Never calls _frontier_persist_claim -- frontier-low is not touched by
     this sweep.
+
+    pos_by_commit_ident (#235) enables the repair of graphs that already
+    carry two live :introduced-by facts for one entity -- corruption an
+    earlier version of _forward_apply created and which nothing converges,
+    since every later reader sees one value, retracts it, and asserts a
+    fresh one. When supplied, an ident holding 2+ values is collapsed to
+    the one at the LOWEST linearization position before the case 1/2/3
+    branching below runs; the survivor is then handled exactly as a
+    single-valued entity would be. Repair collapses multiplicity only, it
+    never confirms.
+
+    Earliest-by-position is the right survivor because the reverse stream's
+    guess is a sighting at or above the true introduction --
+    _entity_introduced_by_set_provisional_batch's monotonicity rule already
+    encodes that direction -- while the spurious second mint landed at the
+    true introduction itself.
+
+    Positions are required rather than derivable from arrival order: the
+    second mint happens in the FORWARD region, which this sweep never
+    visits, so it meets these entities at commits that are neither of their
+    two values. A value absent from the map sorts last, so an unrecognised
+    commit ident can never win and can never raise. Left None (the default)
+    the repair is inert and every caller keeps the pre-#235 fail-safe.
+    Best-effort: an entity this sweep never visits is not repaired.
 
     update_watermark=False suppresses BOTH the trailing
     _correction_sweep_through_update and the _db_checkpoint that follows it,
@@ -8996,8 +9021,28 @@ def _correction_sweep_apply(
         # file's confirms are one call.
         to_confirm: List[str] = []
         for ident in candidate_idents:
-            raw = _db_execute(db, f"(query [:find ?c :where [{ident} :introduced-by ?c]])")
-            introduced_by_values = {row[0] for row in json.loads(raw).get("results", [])}
+            introduced_by_values = set(_entity_introduced_by_values_query(db, ident))
+
+            # #235 repair: collapse a corrupted multi-valued entity BEFORE the
+            # case branching below, so cases 1/2/3 always see a well-formed
+            # entity and need no multi-value handling of their own.
+            if pos_by_commit_ident is not None and len(introduced_by_values) > 1:
+                survivor = min(
+                    sorted(introduced_by_values),
+                    key=lambda c: pos_by_commit_ident.get(c, len(pos_by_commit_ident)),
+                )
+                doomed = sorted(introduced_by_values - {survivor})
+                _retract(
+                    db,
+                    "[" + " ".join(f"[{ident} :introduced-by {c}]" for c in doomed) + "]",
+                    index_con=index_con,
+                )
+                print(
+                    f"[_correction_sweep] repaired {ident}: kept {survivor}, "
+                    f"retracted {doomed} (#235)",
+                    file=sys.stderr,
+                )
+                introduced_by_values = {survivor}
 
             if _lineage_is_provisional(db, ident):
                 if introduced_by_values == {commit_ident}:
@@ -9083,6 +9128,7 @@ def _correction_sweep_claim_and_process(
     index_con: Optional[Any] = None,
     hash_to_pos: Optional[Dict[str, int]] = None,
     skipped_so_far: int = 0,
+    pos_by_commit_ident: Optional[Dict[str, int]] = None,
 ) -> Optional[Tuple[str, int]]:
     """Synchronous convenience wrapper composing
     _correction_sweep_select_position, _extract_commit, and
@@ -9109,6 +9155,7 @@ def _correction_sweep_claim_and_process(
     skipped_events = _correction_sweep_apply(
         db, commit_hash, commit_ts_iso, file_results,
         index_con=index_con, skipped_so_far=skipped_so_far,
+        pos_by_commit_ident=pos_by_commit_ident,
     )
     return commit_hash, skipped_events
 
@@ -9580,6 +9627,14 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                 if completed_all:
                     _ingest_progress["phase"] = "sweeping"
                     hash_to_pos = {h: i for i, h in enumerate(linearization)}
+                    # #235: the sweep's repair path needs linearization
+                    # positions to pick which of a corrupted entity's
+                    # :introduced-by values survives. Same construction
+                    # _reverse_apply uses.
+                    sweep_pos_by_commit_ident = {
+                        f":commit/{h[:12]}": i
+                        for i, (h, _t, _a, _s) in enumerate(commit_metadata)
+                    }
                     skipped = 0
                     db = await _ensure_db_async()
                     try:
@@ -9604,7 +9659,7 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                 skipped += await loop.run_in_executor(
                                     write_executor, _correction_sweep_apply,
                                     db, sweep_hash, sweep_ts, sweep_files, index_con, skipped,
-                                    False,
+                                    False, sweep_pos_by_commit_ident,
                                 )
                                 # Apply the lifecycle facts the reverse stream
                                 # skipped entirely (D/R closes, renames,

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -8969,9 +8969,22 @@ def _correction_sweep_apply(
     second mint happens in the FORWARD region, which this sweep never
     visits, so it meets these entities at commits that are neither of their
     two values. A value absent from the map sorts last, so an unrecognised
-    commit ident can never win and can never raise. Left None (the default)
-    the repair is inert and every caller keeps the pre-#235 fail-safe.
-    Best-effort: an entity this sweep never visits is not repaired.
+    commit ident can never win and can never raise. Left None or empty (the
+    default) the repair is inert and every caller keeps the pre-#235
+    fail-safe -- empty is gated out too, since with no positions to compare
+    the "absent sorts last" rule degenerates to picking the
+    lexicographically smallest ident.
+
+    Reach, stated plainly: repair only touches entities this sweep visits,
+    and on an already-COMPLETED graph it visits none. A finished run leaves
+    :ingestion/correction-sweep-through at frontier-high's :hi-hash, so the
+    next run's _correction_sweep_select_position hits its pos > ceiling_pos
+    guard, returns None on its first call, and this function is never
+    invoked -- re-running ingestion on a corrupted graph repairs nothing.
+    Recovery requires new commits above the old ceiling (and then only for
+    entities that are candidates in those commits), a resumed run whose
+    watermark is still short of the ceiling, or an explicit repair pass /
+    watermark reset.
 
     update_watermark=False suppresses BOTH the trailing
     _correction_sweep_through_update and the _db_checkpoint that follows it,
@@ -9026,7 +9039,12 @@ def _correction_sweep_apply(
             # #235 repair: collapse a corrupted multi-valued entity BEFORE the
             # case branching below, so cases 1/2/3 always see a well-formed
             # entity and need no multi-value handling of their own.
-            if pos_by_commit_ident is not None and len(introduced_by_values) > 1:
+            # Truthiness, not `is not None`: an EMPTY map scores every value
+            # with the same len(map)==0 default, collapsing to "smallest
+            # ident wins" -- which contradicts "a value absent from the map
+            # sorts last" above. Unreachable in production (a run with no
+            # commits has nothing to sweep), gated so code and docstring agree.
+            if pos_by_commit_ident and len(introduced_by_values) > 1:
                 survivor = min(
                     sorted(introduced_by_values),
                     key=lambda c: pos_by_commit_ident.get(c, len(pos_by_commit_ident)),

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5388,6 +5388,37 @@ def _entity_introduced_by_values_query(db: Any, entity_ident: str) -> List[str]:
     return [row[0] for row in json.loads(raw).get("results", [])]
 
 
+# Max two-value :introduced-by warnings _entity_introduced_by_query writes to
+# stderr per ingestion run (#235). Same budget and same intent as
+# _CORRECTION_SWEEP_LOG_CAP -- a corrupted at-scale graph must not drown the
+# log -- but it cannot use that cap's caller-threaded-total mechanism: this is
+# a leaf query called from four sites in two walks (_reverse_apply alone calls
+# it up to 3x per ident per commit), none of which carry, or should carry, a
+# running log total just to reach it.
+#
+# The budget therefore lives in a module global, with the per-run reset that
+# _CORRECTION_SWEEP_LOG_CAP gets for free from its caller's zero-initialized
+# local supplied explicitly instead: _run_ingestion calls
+# _reset_introduced_by_ambiguity_log_budget() at the top of every run. That
+# preserves the property the sweep's design note actually cares about -- this
+# server is long-lived and runs many ingests, and a never-reset counter would
+# burn its budget on the first one and log nothing ever after.
+_INTRODUCED_BY_AMBIGUITY_LOG_CAP = 10
+_introduced_by_ambiguity_logged = 0
+
+
+def _reset_introduced_by_ambiguity_log_budget() -> None:
+    """Restore _entity_introduced_by_query's full stderr budget.
+
+    Called once per ingestion run (see _run_ingestion). Not thread-safe in
+    any strict sense, and deliberately so: the counter guards log volume
+    only, never a decision, so a lost increment under concurrency costs at
+    most one extra or one missing warning line.
+    """
+    global _introduced_by_ambiguity_logged
+    _introduced_by_ambiguity_logged = 0
+
+
 def _entity_introduced_by_query(db: Any, entity_ident: str) -> Optional[str]:
     """Return entity_ident's current :introduced-by value (a commit ident
     string), or None if it has none yet.
@@ -5401,15 +5432,31 @@ def _entity_introduced_by_query(db: Any, entity_ident: str) -> Optional[str]:
     Position-based selection of the survivor lives in
     _correction_sweep_apply, which has the linearization positions this
     function does not.
+
+    The warning is rate-capped per run (_INTRODUCED_BY_AMBIGUITY_LOG_CAP);
+    the RETURN VALUE never is. A corrupt at-scale graph can hold thousands
+    of ambiguous entities and _reverse_apply calls this up to 3x per ident
+    per commit, so an uncapped line here buries the rest of the ingest log
+    long before the repair pass can run.
     """
+    global _introduced_by_ambiguity_logged
     values = _entity_introduced_by_values_query(db, entity_ident)
     if len(values) > 1:
-        print(
-            f"[_entity_introduced_by] {entity_ident} has {len(values)} live "
-            f":introduced-by values {sorted(values)} -- returning an arbitrary "
-            "one (#235); the correction sweep repairs this",
-            file=sys.stderr,
-        )
+        _introduced_by_ambiguity_logged += 1
+        if _introduced_by_ambiguity_logged <= _INTRODUCED_BY_AMBIGUITY_LOG_CAP:
+            print(
+                f"[_entity_introduced_by] {entity_ident} has {len(values)} live "
+                f":introduced-by values {sorted(values)} -- returning an arbitrary "
+                "one (#235); the correction sweep repairs this",
+                file=sys.stderr,
+            )
+            if _introduced_by_ambiguity_logged == _INTRODUCED_BY_AMBIGUITY_LOG_CAP:
+                print(
+                    f"[_entity_introduced_by] log cap "
+                    f"({_INTRODUCED_BY_AMBIGUITY_LOG_CAP}) reached -- further "
+                    "ambiguity warnings suppressed for this run",
+                    file=sys.stderr,
+                )
     return values[0] if values else None
 
 
@@ -7417,12 +7464,18 @@ def _load_ingestion_preload_state(repo_path: str) -> tuple:
     unresolved_dep_idents = _preload_unresolved_dep_idents(
         db, submodule_paths, valid_at=resume_valid_at,
     )
-    provisional_idents = _preload_provisional_idents(db)
+    # No provisional-ident preload (#235): the forward walk's reconciliation
+    # gate is _lineage_is_provisional(db, ident), queried per ident at the
+    # moment it matters. A run-start snapshot cannot serve that purpose -- it
+    # is empty on a fresh ingest, where Stream 2 writes its guesses during
+    # this same run -- so preloading one only invites a future maintainer to
+    # re-derive a gate from it. _preload_provisional_idents still exists for
+    # whole-graph assertions ("no markers left after a full ingest"); it is
+    # deliberately not part of the walk's state.
     return (
         watermark, prior_ingested, entity_valid_from, entity_descriptions,
         file_entities, file_deps, dep_valid_from, pinned_commit_state,
         field_class_ident, field_static_ident, submodule_paths, unresolved_dep_idents,
-        provisional_idents,
     )
 
 
@@ -8225,9 +8278,8 @@ def _forward_apply(
       _correction_sweep_apply owns those entities' lineage and has already
       run for this commit. It is still performed for an "R" file's new path,
       where the reverse stream may hold a provisional guess at a LATER
-      commit that this rename supersedes; there the DB is consulted
-      directly, because state.provisional_idents is a run-start preload
-      snapshot and is empty on a fresh ingest.
+      commit that this rename supersedes; there the DB
+      (_lineage_is_provisional) is consulted directly, per ident.
     * _watermark_update, _frontier_persist_claim and
       _lineage_confirmed_through_update are skipped. Stage B tracks its own
       progress through :ingestion/correction-sweep-through, and the forward
@@ -8333,31 +8385,26 @@ def _forward_apply(
             # valid_from Stream 2 recorded is a wrong guess, and must
             # never be used as an orig_ts for a close.
             #
-            # #235: state.provisional_idents is NOT consulted as a gate here.
-            # It is a PRELOAD SNAPSHOT (see _preload_provisional_idents) taken
-            # at run start, so on a fresh ingest it is EMPTY -- and Stream 2
-            # writes its guesses during that same run. Using it as a prefilter
-            # dropped every same-run guess before the DB-authoritative check
-            # below could see it, _forward_reconcile_provisional never fired,
-            # and _build_code_triples minted a SECOND :introduced-by alongside
-            # the guess. A prefilter's false negatives are unrecoverable
-            # precisely because the authority never runs.
+            # #235: _lineage_is_provisional(db, ident) is the SOLE authority
+            # for reconcilability, asked per ident, right here. There is no
+            # preloaded set, and none may be reintroduced as a prefilter --
+            # that is the bug this fix removed, in both directions:
             #
-            # The snapshot is also stale-POSITIVE: by the time this commit is
-            # reached an ident it lists may already have been confirmed
-            # authoritative in the DB (reconciled earlier in this same forward
-            # pass, or by a previous run's correction sweep). That is why
-            # _lineage_is_provisional stays the authority rather than being
-            # dropped in favour of a set -- popping entity_valid_from for an
-            # already-authoritative ident hands it to _build_code_triples as
-            # "new" and mints the same second fact, while
-            # _forward_reconcile_provisional no-ops on it.
-            #
-            # The set survives only so a RESUMED run's genuinely-stale entries
-            # drain: every candidate examined is evicted below regardless of
-            # whether it survives the DB check, because an entry left in place
-            # would be retried, and fail the same way, on every later commit
-            # that touches the entity.
+            #   * stale-NEGATIVE. A run-start snapshot is EMPTY on a fresh
+            #     ingest, and Stream 2 writes its guesses during that same
+            #     run. Prefiltering through it dropped every same-run guess
+            #     before the DB check could see it,
+            #     _forward_reconcile_provisional never fired, and
+            #     _build_code_triples minted a SECOND :introduced-by
+            #     alongside the guess. A prefilter's false negatives are
+            #     unrecoverable precisely because the authority never runs.
+            #   * stale-POSITIVE. By the time this commit is reached, an
+            #     ident such a snapshot listed may already be authoritative
+            #     in the DB (reconciled earlier in this same forward pass, or
+            #     by a previous run's correction sweep). Popping
+            #     entity_valid_from for it hands it to _build_code_triples as
+            #     "new" and mints the same second fact, while
+            #     _forward_reconcile_provisional no-ops and never retracts it.
             #
             # lifecycle_only (Stage B): _correction_sweep_apply owns "A"/"M"
             # lineage and has already run for this very commit, so
@@ -8365,31 +8412,14 @@ def _forward_apply(
             # back. An "R" file's NEW path is the one case that still needs
             # it -- nothing wrote those entities in Stage A, so the reverse
             # stream's provisional guess (if any) sits at a LATER commit that
-            # this rename supersedes. state.provisional_idents cannot be the
-            # prefilter there: it is a run-start snapshot, empty on a fresh
-            # ingest, and the guess was made during this same run.
-            if lifecycle_only:
-                reconcilable = (
-                    [
-                        ident for ident in _forward_candidate_idents(precomputed)
-                        if _lineage_is_provisional(db, ident)
-                    ]
-                    if status == "R" else []
-                )
-                # The eviction invariant above still holds here, it just has a
-                # different source: the preload snapshot is not the prefilter in
-                # this mode, so what must leave the set is exactly what was
-                # reconciled. Leaving these behind (the eviction loop's `[]` in
-                # an earlier revision) meant an R-file ident reconciled during
-                # Stage B stayed in state.provisional_idents and would be
-                # retried by every later commit touching the entity.
-                candidate_in_set = list(reconcilable)
-            else:
-                candidate_in_set = _forward_candidate_idents(precomputed)
-                reconcilable = [
-                    ident for ident in candidate_in_set
-                    if _lineage_is_provisional(db, ident)
-                ]
+            # this rename supersedes.
+            candidates = (
+                _forward_candidate_idents(precomputed)
+                if (not lifecycle_only or status == "R") else []
+            )
+            reconcilable = [
+                ident for ident in candidates if _lineage_is_provisional(db, ident)
+            ]
             # Built once per file rather than scanned per ident (matches
             # _correction_sweep_apply's candidate_triples_by_ident
             # precedent) -- a per-ident linear scan here is O(n^2) per file
@@ -8418,8 +8448,6 @@ def _forward_apply(
                     commit_ts_iso, state.ts_by_commit_ident, commit_ident,
                     index_con=index_con,
                 )
-            for ident in candidate_in_set:
-                state.provisional_idents.discard(ident)
             triples = _build_code_triples(
                 file_path, extracted, commit_ts_iso, state.entity_valid_from,
                 state.entity_descriptions, state.file_entities, commit_ident, precomputed,
@@ -9162,6 +9190,15 @@ def _correction_sweep_claim_and_process(
     _correction_sweep_select_position found nothing safe to do.
     skipped_so_far is forwarded to _correction_sweep_apply unchanged (see
     its docstring for why it exists).
+
+    pos_by_commit_ident (#235) is likewise forwarded unchanged: it enables
+    _correction_sweep_apply's two-value :introduced-by repair, which is
+    inert without it. Optional here only because the repair is optional --
+    but every driving loop should supply it, built exactly as _reverse_apply
+    and _correction_sweep_walk build it,
+    {f":commit/{h[:12]}": i for i, (h, ...) in enumerate(commit_metadata)},
+    which is positionally aligned with linearization by that argument's own
+    contract.
     """
     selected = _correction_sweep_select_position(db, linearization, commit_metadata, hash_to_pos)
     if selected is None:
@@ -9186,10 +9223,17 @@ def _correction_sweep_walk(
     ignore_patterns: Sequence[str] = (),
     index_con: Optional[Any] = None,
 ) -> Tuple[int, int]:
-    """Build hash_to_pos once and repeatedly call
-    _correction_sweep_claim_and_process (passing it down, along with the
+    """Build hash_to_pos and pos_by_commit_ident once and repeatedly call
+    _correction_sweep_claim_and_process (passing them down, along with the
     running skipped-events total as skipped_so_far) until that returns
     None, then call _correction_sweep_log_summary with the final total.
+
+    pos_by_commit_ident (#235) is what arms _correction_sweep_apply's
+    two-value :introduced-by repair; without it this walk would visit a
+    corrupt entity and merely log it as ambiguous. Built with the same
+    expression _reverse_apply uses, off commit_metadata, which
+    _correction_sweep_claim_and_process's own callees require to be
+    positionally aligned with linearization.
 
     Returns (commits_processed, skipped_events) -- summed across every
     call, both 0 when the gap-closed precondition isn't met yet (the
@@ -9204,6 +9248,7 @@ def _correction_sweep_walk(
     _correction_sweep_log_summary when its own loop ends.
     """
     hash_to_pos = {h: i for i, h in enumerate(linearization)}
+    pos_by_commit_ident = {f":commit/{h[:12]}": i for i, (h, _t, _a, _s) in enumerate(commit_metadata)}
     commits_processed = 0
     skipped_events = 0
     while True:
@@ -9211,6 +9256,7 @@ def _correction_sweep_walk(
             db, repo_path, linearization, commit_metadata,
             ignore_patterns=ignore_patterns, index_con=index_con,
             hash_to_pos=hash_to_pos, skipped_so_far=skipped_events,
+            pos_by_commit_ident=pos_by_commit_ident,
         )
         if result is None:
             break
@@ -9346,7 +9392,11 @@ class _ForwardWalkState:
     field_static_ident: Dict[str, bool]
     submodule_paths: Dict[str, str]
     unresolved_dep_idents: Dict[str, str]
-    provisional_idents: Set[str] = field(default_factory=set)
+    # No provisional-ident set here on purpose (#235) -- see _forward_apply's
+    # reconciliation block. Lineage provisionality is a DB question
+    # (_lineage_is_provisional), asked per ident at the moment it matters;
+    # a run-start snapshot of it is wrong on a fresh ingest in both
+    # directions and must not be reintroduced as a prefilter.
     ts_by_commit_ident: Dict[str, str] = field(default_factory=dict)
 
 
@@ -9378,6 +9428,10 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
     # stomped on here; main()'s finally block re-sets the flag on exit regardless,
     # so a shutdown request arriving between runs is never silently lost.
     _shutdown_requested.clear()
+    # Per-run stderr budget for the two-value :introduced-by warning (#235).
+    # Reset HERE, not at module import, because this server is long-lived:
+    # see _reset_introduced_by_ambiguity_log_budget.
+    _reset_introduced_by_ambiguity_log_budget()
     try:
         # Read watermark and pre-load known entities/deps before releasing DB.
         # Off-loaded to a worker thread (see _load_ingestion_preload_state)
@@ -9389,7 +9443,6 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                 watermark, prior_ingested, entity_valid_from, entity_descriptions,
                 file_entities, file_deps, dep_valid_from, pinned_commit_state,
                 field_class_ident, field_static_ident, submodule_paths, unresolved_dep_idents,
-                provisional_idents,  # consumed by _forward_apply (Task 5)
             ) = await loop.run_in_executor(preload_executor, _load_ingestion_preload_state, repo_path)
         # minigraf exposes no explicit close(): the file lock is only released once
         # every reference to the handle is gone — the worker thread's own `db`
@@ -9416,7 +9469,6 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
             field_static_ident=field_static_ident,
             submodule_paths=submodule_paths,
             unresolved_dep_idents=unresolved_dep_idents,
-            provisional_idents=provisional_idents,
             # Full-history, so a resumed run's retroactive :modified-in for a
             # guess commit at or below the watermark still finds a timestamp
             # (a post-watermark-only map would silently skip it).

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -8333,27 +8333,31 @@ def _forward_apply(
             # valid_from Stream 2 recorded is a wrong guess, and must
             # never be used as an orig_ts for a close.
             #
-            # state.provisional_idents is a PRELOAD SNAPSHOT (see
-            # _preload_provisional_idents), not the authority -- by the
-            # time this commit is reached, the entity may already have
-            # been confirmed authoritative in the DB (reconciled earlier
-            # in this same forward pass, or by a previous run's
-            # correction sweep) without the in-memory set knowing.
-            # Trusting the set alone would still pop entity_valid_from and
-            # hand the ident to _build_code_triples as "new" even though
-            # _forward_reconcile_provisional no-ops on an already-
-            # authoritative entity (see its own provisional check) --
-            # minting a SECOND :introduced-by alongside the authoritative
-            # one already there. That is exactly the two-value ambiguity
-            # _correction_sweep_apply fails safe on and never resolves,
-            # reintroduced through this door. So the set is kept only as
-            # a cheap prefilter; the DB (_lineage_is_provisional) is the
-            # authority actually consulted before an ident is treated as
-            # reconcilable. Every candidate that was in the set is
-            # evicted below regardless of whether it survives that
-            # check -- a stale entry left in place would be retried, and
-            # fail the same way, on every later commit that touches the
-            # entity.
+            # #235: state.provisional_idents is NOT consulted as a gate here.
+            # It is a PRELOAD SNAPSHOT (see _preload_provisional_idents) taken
+            # at run start, so on a fresh ingest it is EMPTY -- and Stream 2
+            # writes its guesses during that same run. Using it as a prefilter
+            # dropped every same-run guess before the DB-authoritative check
+            # below could see it, _forward_reconcile_provisional never fired,
+            # and _build_code_triples minted a SECOND :introduced-by alongside
+            # the guess. A prefilter's false negatives are unrecoverable
+            # precisely because the authority never runs.
+            #
+            # The snapshot is also stale-POSITIVE: by the time this commit is
+            # reached an ident it lists may already have been confirmed
+            # authoritative in the DB (reconciled earlier in this same forward
+            # pass, or by a previous run's correction sweep). That is why
+            # _lineage_is_provisional stays the authority rather than being
+            # dropped in favour of a set -- popping entity_valid_from for an
+            # already-authoritative ident hands it to _build_code_triples as
+            # "new" and mints the same second fact, while
+            # _forward_reconcile_provisional no-ops on it.
+            #
+            # The set survives only so a RESUMED run's genuinely-stale entries
+            # drain: every candidate examined is evicted below regardless of
+            # whether it survives the DB check, because an entry left in place
+            # would be retried, and fail the same way, on every later commit
+            # that touches the entity.
             #
             # lifecycle_only (Stage B): _correction_sweep_apply owns "A"/"M"
             # lineage and has already run for this very commit, so
@@ -8381,10 +8385,7 @@ def _forward_apply(
                 # retried by every later commit touching the entity.
                 candidate_in_set = list(reconcilable)
             else:
-                candidate_in_set = [
-                    ident for ident in _forward_candidate_idents(precomputed)
-                    if ident in state.provisional_idents
-                ]
+                candidate_in_set = _forward_candidate_idents(precomputed)
                 reconcilable = [
                     ident for ident in candidate_in_set
                     if _lineage_is_provisional(db, ident)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -5375,12 +5375,42 @@ def _candidate_diff_purge_legacy(db: Any, index_con: Optional[Any] = None) -> in
     return len(rows)
 
 
+def _entity_introduced_by_values_query(db: Any, entity_ident: str) -> List[str]:
+    """Every live :introduced-by value for entity_ident, in the backend's
+    unspecified order; [] if it has none.
+
+    A list rather than a single value because an entity CAN hold more than
+    one (#235): the forward walk used to mint a second alongside the reverse
+    stream's provisional guess. _correction_sweep_apply's repair path needs
+    to see all of them to collapse them.
+    """
+    raw = _db_execute(db, f"(query [:find ?c :where [{entity_ident} :introduced-by ?c]])")
+    return [row[0] for row in json.loads(raw).get("results", [])]
+
+
 def _entity_introduced_by_query(db: Any, entity_ident: str) -> Optional[str]:
     """Return entity_ident's current :introduced-by value (a commit ident
-    string), or None if it has none yet."""
-    raw = _db_execute(db, f"(query [:find ?c :where [{entity_ident} :introduced-by ?c]])")
-    results = json.loads(raw).get("results", [])
-    return results[0][0] if results else None
+    string), or None if it has none yet.
+
+    An entity holding two values is corrupt (#235). Which of them is
+    returned here is UNSPECIFIED -- the backend imposes no ordering -- so
+    this warns and returns an arbitrary one rather than pretending the
+    graph is well-formed. It deliberately does NOT raise: both walks call
+    this during a run, long before Stage B's repair pass, so raising would
+    hard-fail ingestion on exactly the graphs that repair exists to heal.
+    Position-based selection of the survivor lives in
+    _correction_sweep_apply, which has the linearization positions this
+    function does not.
+    """
+    values = _entity_introduced_by_values_query(db, entity_ident)
+    if len(values) > 1:
+        print(
+            f"[_entity_introduced_by] {entity_ident} has {len(values)} live "
+            f":introduced-by values {sorted(values)} -- returning an arbitrary "
+            "one (#235); the correction sweep repairs this",
+            file=sys.stderr,
+        )
+    return values[0] if values else None
 
 
 def _entity_introduced_by_set_provisional_batch(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16682,7 +16682,13 @@ class TestForwardApplyReconcilesProvisional:
             file_deps={}, dep_valid_from={}, pinned_commit_state={},
             field_class_ident={}, field_static_ident={}, submodule_paths={},
             unresolved_dep_idents={},
-            provisional_idents=mcp_server._preload_provisional_idents(real_db),
+            # #235: production preloads at RUN START, before Stream 2 has
+            # written anything, so on a fresh ingest this set is EMPTY. Calling
+            # _preload_provisional_idents here -- after the reverse stream ran --
+            # handed the forward walk a snapshot that already contained the
+            # guess, which no real fresh run ever has, and hid the second-mint
+            # bug entirely.
+            provisional_idents=set(),
             ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
         )
         extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
@@ -16787,6 +16793,83 @@ class TestForwardApplyReconcilesProvisional:
         # the same way) on every later commit that touches this entity.
         assert fn_ident not in state.provisional_idents
 
+    def test_reconciles_a_guess_made_during_this_same_run(self, real_db, tmp_path):
+        """#235: the prefilter was a run-start snapshot, empty on a fresh
+        ingest. Stream 2's guesses are written during that same run, so the
+        prefilter dropped every one of them before the DB-authoritative
+        _lineage_is_provisional check could see it -- and
+        _build_code_triples then minted a SECOND :introduced-by alongside
+        the guess. The DB must be the sole authority."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        # Snapshot taken FIRST, exactly as _run_ingestion does -- empty.
+        snapshot = mcp_server._preload_provisional_idents(real_db)
+        assert snapshot == set(), "a fresh graph has no provisional idents yet"
+
+        # Only now does Stream 2 claim h1 and guess.
+        mcp_server._reverse_fill_claim_and_process(
+            real_db, str(repo), linearization, commit_metadata, allocator,
+        )
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={}, entity_descriptions={}, file_entities={},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents=snapshot,
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(real_db, str(repo), state, commit_metadata[0], extracted)
+
+        values = mcp_server._entity_introduced_by_values_query(real_db, fn_ident)
+        assert values == [f":commit/{linearization[0][:12]}"], (
+            f"exactly one :introduced-by, naming h0; got {sorted(values)}"
+        )
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+
+    def test_evicts_a_stale_snapshot_entry_that_is_no_longer_provisional(
+        self, real_db, tmp_path,
+    ):
+        """The eviction invariant survives dropping the prefilter: every
+        candidate examined leaves state.provisional_idents, whether or not
+        the DB agreed it was provisional. A stale entry left behind is
+        retried, and fails the same way, on every later commit touching the
+        entity (see the comment at mcp_server.py:8345)."""
+        import mcp_server, frontier_registry
+        repo = self._repo(tmp_path)
+        linearization = frontier_registry.build_linearization(str(repo))
+        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
+        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        # Authoritative in the DB (a plain transact, no lineage marker) but
+        # still listed by a stale snapshot -- what a resumed run sees after a
+        # previous run's sweep confirmed the entity.
+        mcp_server._transact(
+            real_db, f"[[{fn_ident} :introduced-by :commit/already]]", "2026-01-01T00:00:00Z",
+        )
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+
+        state = mcp_server._ForwardWalkState(
+            entity_valid_from={}, entity_descriptions={}, file_entities={},
+            file_deps={}, dep_valid_from={}, pinned_commit_state={},
+            field_class_ident={}, field_static_ident={}, submodule_paths={},
+            unresolved_dep_idents={},
+            provisional_idents={fn_ident},
+            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
+        )
+        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
+        mcp_server._forward_apply(real_db, str(repo), state, commit_metadata[0], extracted)
+
+        assert fn_ident not in state.provisional_idents, "stale entry must be evicted"
+
     def test_resumed_run_variant_is_not_suppressed_by_entity_valid_from(self, real_db, tmp_path):
         """The silent failure mode: on a RESUMED run, Stream 2's structural
         facts are already in the preloaded entity_valid_from, so
@@ -16824,10 +16907,16 @@ class TestForwardApplyReconcilesProvisional:
         assert {row[0] for row in json.loads(raw)["results"]} == {f":commit/{linearization[0][:12]}"}
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
 
-    def test_without_provisional_idents_the_resumed_case_regresses(self, real_db, tmp_path):
-        """Pins that provisional_idents is actually consulted: with it empty,
-        the resumed-run case leaves the wrong guess in place. This is the
-        direct regression test for the silent failure mode."""
+    def test_without_provisional_idents_the_resumed_case_still_reconciles(self, real_db, tmp_path):
+        """#235: this pinned the OLD design, where an empty
+        state.provisional_idents left the resumed-run case unreconciled
+        because the set was consulted as a prefilter gate. That gate is
+        gone -- _lineage_is_provisional(db, ...) is the sole authority now,
+        so an empty (or entirely wrong) snapshot must no longer change the
+        outcome. Same setup as
+        test_resumed_run_variant_is_not_suppressed_by_entity_valid_from,
+        with provisional_idents=set() instead of {fn_ident}, and the same
+        result: exactly one :introduced-by, naming h0."""
         import mcp_server, frontier_registry
         repo = self._repo(tmp_path)
         linearization = frontier_registry.build_linearization(str(repo))
@@ -16843,15 +16932,15 @@ class TestForwardApplyReconcilesProvisional:
             file_deps={}, dep_valid_from={}, pinned_commit_state={},
             field_class_ident={}, field_static_ident={}, submodule_paths={},
             unresolved_dep_idents={},
-            provisional_idents=set(),   # the bug
+            provisional_idents=set(),   # no longer a gate -- must not matter
             ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
         )
         extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
         mcp_server._forward_apply(
             real_db, str(repo), state, commit_metadata[0], extracted,
         )
-        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
-        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{linearization[1][:12]}"
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{linearization[0][:12]}"
 
 
 class TestRoundRobinClaimer:
@@ -17578,6 +17667,88 @@ class TestStageBRepairsLifecycleFacts:
             assert len(subjects) == len(set(subjects)), \
                 f"duplicate live {attr} facts after the lifecycle pass: " \
                 f"{sorted(r for r in rows if subjects.count(r[0]) > 1)}"
+
+
+class TestNoDuplicateIntroducedByAfterFullIngest:
+    """#235's reproduction, as a standing oracle.
+
+    A full converging ingest -- both streams plus Stage B -- must leave no
+    entity holding two live :introduced-by facts. On master this yields six
+    such entities on a 14-commit history, and the pair never converges: every
+    later reader sees only one value, retracts that one, and asserts a fresh
+    one, so the corruption regenerates rather than healing.
+
+    The fixture matters. `born_N` functions accumulate one per commit, so
+    each is introduced at a different position and the reverse stream's
+    guesses land above the forward walk's true introductions; the five
+    long-lived functions are edited every commit so they stay candidates all
+    the way down. That combination is what produces same-run provisional
+    guesses for entities the forward walk later reaches.
+    """
+
+    N_COMMITS = 14
+
+    def _reset_progress(self):
+        import mcp_server
+        mcp_server._ingest_progress = {
+            "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+            "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+        }
+
+    def _repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init", "-b", "master"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        for i in range(self.N_COMMITS):
+            body = "".join(
+                f"def stay_{k}():\n    return {i}\n\n" for k in range(5)
+            ) + "".join(
+                f"def born_{b}():\n    return {b}\n\n" for b in range(i + 1)
+            )
+            (repo / "mod.py").write_text(body)
+            ts = f"2021-03-{i + 1:02d}T00:00:00Z"
+            env = {**os.environ, "GIT_AUTHOR_DATE": ts, "GIT_COMMITTER_DATE": ts}
+            _subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+            _subprocess.run(
+                ["git", "commit", "-m", f"c{i}"], cwd=repo, check=True,
+                capture_output=True, env=env,
+            )
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_full_ingest_leaves_no_entity_with_two_introduced_by(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph_path = tmp_path / "memory.graph"
+
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph_path))
+        mcp_server._db = None
+        self._reset_progress()
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete", mcp_server._ingest_progress
+        mcp_server._db = None  # release the file lock before reopening
+
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            raw = mcp_server._db_execute(
+                db, "(query [:find ?e (count ?c) :where [?e :introduced-by ?c]])",
+            )
+        finally:
+            db = None
+        ambiguous = sorted(
+            (row[0], row[1]) for row in json.loads(raw)["results"] if row[1] > 1
+        )
+        assert ambiguous == [], f"entities with multiple :introduced-by: {ambiguous}"
+
+        err = capsys.readouterr().err
+        assert "left provisional" not in err, err
+        assert "left unreconciled" not in err, err
 
 
 class TestMultiStreamParityWithForwardOnly:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6503,6 +6503,72 @@ class TestEntityIntroducedBySetProvisional:
         assert mcp_server._lineage_is_provisional(db, entity_ident) is False
 
 
+class TestEntityIntroducedByValuesQuery:
+    """#235: an entity can hold two live :introduced-by facts. The
+    single-value query silently returned the first of them, so the
+    ambiguity was invisible; the all-values query is what the correction
+    sweep's repair path needs to collapse it."""
+
+    def test_values_query_returns_empty_for_unknown_entity(self, real_db):
+        import mcp_server
+        assert mcp_server._entity_introduced_by_values_query(real_db, ":function/nope") == []
+
+    def test_values_query_returns_single_value(self, real_db):
+        import mcp_server
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h0]]", "2026-01-01T00:00:00Z",
+        )
+        assert mcp_server._entity_introduced_by_values_query(real_db, entity_ident) == [":commit/h0"]
+
+    def test_values_query_returns_both_values_of_a_corrupted_entity(self, real_db):
+        import mcp_server
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h0]]", "2026-01-01T00:00:00Z",
+        )
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h5]]", "2026-01-05T00:00:00Z",
+        )
+        assert sorted(
+            mcp_server._entity_introduced_by_values_query(real_db, entity_ident)
+        ) == [":commit/h0", ":commit/h5"]
+
+    def test_single_value_query_warns_on_ambiguity_and_still_returns_a_value(
+        self, real_db, capsys,
+    ):
+        """Must NOT raise: both walks call this mid-run, before Stage B,
+        so raising would hard-fail ingestion on the very graphs the
+        sweep's repair exists to heal."""
+        import mcp_server
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h0]]", "2026-01-01T00:00:00Z",
+        )
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h5]]", "2026-01-05T00:00:00Z",
+        )
+        capsys.readouterr()  # discard anything the seeding wrote
+
+        result = mcp_server._entity_introduced_by_query(real_db, entity_ident)
+
+        assert result in (":commit/h0", ":commit/h5")
+        err = capsys.readouterr().err
+        assert entity_ident in err
+        assert ":commit/h0" in err and ":commit/h5" in err
+
+    def test_single_value_query_is_silent_for_one_value(self, real_db, capsys):
+        import mcp_server
+        entity_ident = ":function/src-auth-py-login"
+        mcp_server._transact(
+            real_db, f"[[{entity_ident} :introduced-by :commit/h0]]", "2026-01-01T00:00:00Z",
+        )
+        capsys.readouterr()
+
+        assert mcp_server._entity_introduced_by_query(real_db, entity_ident) == ":commit/h0"
+        assert "introduced-by" not in capsys.readouterr().err
+
+
 class TestEntityIntroducedBySetProvisionalBatch:
     """#233: _reverse_apply's two loops were the only production callers of
     the per-ident function, at one retract + one transact each -- 8,618

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16215,6 +16215,113 @@ class TestCorrectionSweepApply:
             ident = mcp_server._code_ident("function", "wide.py", f"f{i}")
             assert mcp_server._lineage_is_provisional(real_db, ident) is False
 
+    def _pos_map(self, repo):
+        import mcp_server, frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        return {f":commit/{h[:12]}": i for i, h in enumerate(linearization)}, linearization
+
+    def test_repair_keeps_the_lowest_position_introduced_by(self, real_db, tmp_path):
+        """#235: an entity carrying two live :introduced-by values is
+        collapsed to the one at the LOWEST linearization position. The
+        reverse stream's guess is a sighting at or above the true
+        introduction -- the same direction its own monotonicity rule
+        encodes -- so the earlier value is the introduction."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        pos_map, linearization = self._pos_map(repo)
+        h0, h2 = f":commit/{linearization[0][:12]}", f":commit/{linearization[2][:12]}"
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h2}]]", "2026-01-03T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h0}]]", "2026-01-01T00:00:00Z")
+        assert len(mcp_server._entity_introduced_by_values_query(real_db, fn_ident)) == 2
+
+        # The sweep meets the entity at h1 -- NEITHER of its two values.
+        # That is the real shape: the second mint happens in the forward
+        # region, which Stage B never sweeps, so a rule keyed on "is this
+        # commit one of the values" would never fire.
+        h1_hash, h1_ts = linearization[1], "2026-01-02T00:00:00Z"
+        mcp_server._correction_sweep_apply(
+            real_db, h1_hash, h1_ts, self._extract(repo, h1_hash),
+            pos_by_commit_ident=pos_map,
+        )
+
+        assert mcp_server._entity_introduced_by_values_query(real_db, fn_ident) == [h0]
+
+    def test_repair_is_inert_without_a_position_map(self, real_db, tmp_path):
+        """Gated: every existing caller and test keeps today's fail-safe
+        behaviour until it opts in."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        _pos_map, linearization = self._pos_map(repo)
+        h0, h2 = f":commit/{linearization[0][:12]}", f":commit/{linearization[2][:12]}"
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h2}]]", "2026-01-03T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h0}]]", "2026-01-01T00:00:00Z")
+
+        h1_hash = linearization[1]
+        mcp_server._correction_sweep_apply(
+            real_db, h1_hash, "2026-01-02T00:00:00Z", self._extract(repo, h1_hash),
+        )
+
+        assert sorted(mcp_server._entity_introduced_by_values_query(real_db, fn_ident)) == sorted([h0, h2])
+
+    def test_repair_sorts_an_unknown_commit_ident_last(self, real_db, tmp_path):
+        """A value absent from the map must never be chosen over a known
+        one, and must never raise."""
+        import mcp_server
+        repo = self._repo_with_evolving_function(tmp_path)
+        pos_map, linearization = self._pos_map(repo)
+        h0 = f":commit/{linearization[0][:12]}"
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by :commit/deadbeef0000]]", "2026-01-03T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h0}]]", "2026-01-01T00:00:00Z")
+
+        h1_hash = linearization[1]
+        mcp_server._correction_sweep_apply(
+            real_db, h1_hash, "2026-01-02T00:00:00Z", self._extract(repo, h1_hash),
+            pos_by_commit_ident=pos_map,
+        )
+
+        assert mcp_server._entity_introduced_by_values_query(real_db, fn_ident) == [h0]
+
+    def test_repair_then_case_one_confirms_in_the_same_call(self, real_db, tmp_path):
+        """Repair collapses multiplicity only. If the survivor equals the
+        commit being swept and the entity is still provisional, case 1 runs
+        on the repaired value and confirms it -- without repair it would
+        have hit case 2's fail-safe skip."""
+        import mcp_server, frontier_registry
+        repo = self._repo_with_evolving_function(tmp_path)
+        pos_map, linearization = self._pos_map(repo)
+        h0, h2 = f":commit/{linearization[0][:12]}", f":commit/{linearization[2][:12]}"
+
+        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
+        # The module is a candidate at h0 too. Seed it authoritative at h0 so
+        # the returned skipped count speaks only about fn_ident: an unseeded
+        # module has zero :introduced-by values and takes case 3's ambiguous
+        # skip, which would mask whether repair-then-confirm skipped anything.
+        mcp_server._transact(
+            real_db,
+            f"[[{mcp_server._code_ident('module', 'auth.py')} :introduced-by {h0}]]",
+            "2026-01-01T00:00:00Z",
+        )
+        # Provisional at h0 (marker created), then a stray second value at h2.
+        mcp_server._entity_introduced_by_set_provisional(real_db, fn_ident, h0, "2026-01-01T00:00:00Z")
+        mcp_server._transact(real_db, f"[[{fn_ident} :introduced-by {h2}]]", "2026-01-03T00:00:00Z")
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
+
+        h0_hash = linearization[0]
+        skipped = mcp_server._correction_sweep_apply(
+            real_db, h0_hash, "2026-01-01T00:00:00Z", self._extract(repo, h0_hash),
+            pos_by_commit_ident=pos_map,
+        )
+
+        assert mcp_server._entity_introduced_by_values_query(real_db, fn_ident) == [h0]
+        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
+        assert skipped == 0, "repaired then confirmed -- nothing left provisional"
+
 
 class TestCorrectionSweepClaimAndProcess:
     def _init_repo(self, repo):
@@ -17741,14 +17848,121 @@ class TestNoDuplicateIntroducedByAfterFullIngest:
             )
         finally:
             db = None
+        rows = json.loads(raw)["results"]
+        # Non-vacuity floor: `ambiguous == []` also holds over an EMPTY result
+        # set, so an ingest that emitted no :introduced-by facts at all would
+        # pass this oracle silently. The fixture guarantees at least the five
+        # stay_* functions plus one born_* per commit, each introduced once.
+        assert len(rows) >= 5 + self.N_COMMITS, (
+            f"only {len(rows)} entities carry :introduced-by; expected at least "
+            f"{5 + self.N_COMMITS} (5 stay_* + {self.N_COMMITS} born_*) -- the "
+            "ambiguity assertion below would pass vacuously"
+        )
         ambiguous = sorted(
-            (row[0], row[1]) for row in json.loads(raw)["results"] if row[1] > 1
+            (row[0], row[1]) for row in rows if row[1] > 1
         )
         assert ambiguous == [], f"entities with multiple :introduced-by: {ambiguous}"
 
         err = capsys.readouterr().err
         assert "left provisional" not in err, err
         assert "left unreconciled" not in err, err
+
+    async def _ingest_interrupted(self, repo, graph_path, monkeypatch, stop_after):
+        """Ingest at the 1:1 default but request shutdown from inside the
+        stop_after'th _forward_apply, so Stage A stops with the reverse
+        stream's claims persisted and Stage B never reached. Same helper
+        TestMultiStreamParityWithForwardOnly uses; _run_ingestion clears
+        _shutdown_requested itself, so the resuming run needs no cleanup."""
+        import mcp_server
+        monkeypatch.setenv("MINIGRAF_INGEST_STREAM_RATIO", "1:1")
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph_path))
+        mcp_server._db = None
+        self._reset_progress()
+
+        real_forward = mcp_server._forward_apply
+        calls = {"n": 0}
+
+        def stopping_forward(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == stop_after:
+                mcp_server._shutdown_requested.set()
+            return real_forward(*args, **kwargs)
+
+        monkeypatch.setattr(mcp_server, "_forward_apply", stopping_forward)
+        try:
+            await mcp_server._run_ingestion(str(repo), "master")
+        finally:
+            monkeypatch.setattr(mcp_server, "_forward_apply", real_forward)
+        assert mcp_server._ingest_progress["status"] == "stopped", mcp_server._ingest_progress
+        mcp_server._db = None
+
+    @pytest.mark.asyncio
+    async def test_a_pre_corrupted_graph_is_repaired_by_the_next_ingest(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        """Fix-forward alone leaves graphs already in the field broken.
+        Corrupt an entity by hand, then let a run reach Stage B: the sweep
+        must collapse it to the lower-position value.
+
+        The corruption is injected after an INTERRUPTED Stage A rather than
+        after a completed ingest, and that is forced, not a preference. A
+        completed run drives the sweep watermark
+        (:ingestion/correction-sweep-through) all the way to frontier-high's
+        :hi-hash -- measured: position 13 of 13 on this 14-commit fixture --
+        so on a second _run_ingestion over the same history
+        _correction_sweep_select_position hits its `pos > ceiling_pos` guard,
+        returns None on its first call, and _correction_sweep_apply is never
+        invoked at all. Stopping inside Stage A instead leaves the watermark
+        unset with the reverse region already claimed, so the resuming run
+        actually sweeps.
+
+        stay_0 is the target because it is authoritative and single-valued at
+        the interruption point, its true introduction is position 0, and it
+        is a candidate in every commit the sweep visits."""
+        import mcp_server
+        from minigraf import MiniGrafDb
+        repo = self._repo(tmp_path)
+        graph_path = tmp_path / "memory.graph"
+
+        await self._ingest_interrupted(repo, graph_path, monkeypatch, stop_after=4)
+
+        import frontier_registry
+        linearization = frontier_registry.build_linearization(str(repo))
+        fn_ident = mcp_server._code_ident("function", "mod.py", "stay_0")
+        late = f":commit/{linearization[-1][:12]}"
+
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            before = mcp_server._entity_introduced_by_values_query(db, fn_ident)
+            assert before == [f":commit/{linearization[0][:12]}"], before
+            assert mcp_server._correction_sweep_through_query(db) is None, (
+                "Stage B must not have run yet, or the resuming run has nothing to sweep"
+            )
+            mcp_server._transact(db, f"[[{fn_ident} :introduced-by {late}]]", "2026-01-09T00:00:00Z")
+            assert len(mcp_server._entity_introduced_by_values_query(db, fn_ident)) == 2
+        finally:
+            db = None
+        mcp_server._db = None
+        capsys.readouterr()  # drop the interrupted run's output
+
+        # Resume. Stage A completes, then Stage B sweeps and repairs.
+        self._reset_progress()
+        monkeypatch.setattr(mcp_server, "_graph_path", str(graph_path))
+        await mcp_server._run_ingestion(str(repo), "master")
+        assert mcp_server._ingest_progress["status"] == "complete", mcp_server._ingest_progress
+        mcp_server._db = None
+        err = capsys.readouterr().err
+
+        db = MiniGrafDb.open(str(graph_path))
+        try:
+            after = mcp_server._entity_introduced_by_values_query(db, fn_ident)
+        finally:
+            db = None
+        assert after == before, f"repair must keep the original value; got {after}"
+        # ...and it must be the SWEEP that repaired it, not some other reader
+        # incidentally collapsing the pair. This is the assertion that makes
+        # the test about Stage B.
+        assert f"[_correction_sweep] repaired {fn_ident}: kept {before[0]}" in err, err
 
 
 class TestMultiStreamParityWithForwardOnly:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -39,13 +39,20 @@ def reset_mcp_server_db():
     gives each test an isolated graph path, and fact_index.index_path_for()
     derives the sidecar index path from it, so each test's index file lives
     in its own fresh temp directory with no cross-test state to leak.
+
+    _entity_introduced_by_query's stderr budget (#235) IS module-level and
+    does need resetting: production resets it once per ingestion run, and
+    without the equivalent here a test that exhausts it would silently
+    suppress the warnings a later test asserts on.
     """
     import mcp_server
     mcp_server._db = None
     mcp_server._grammar_cache.clear()
+    mcp_server._reset_introduced_by_ambiguity_log_budget()
     yield
     mcp_server._db = None
     mcp_server._grammar_cache.clear()
+    mcp_server._reset_introduced_by_ambiguity_log_budget()
 
 
 @pytest.fixture
@@ -6568,6 +6575,76 @@ class TestEntityIntroducedByValuesQuery:
         assert mcp_server._entity_introduced_by_query(real_db, entity_ident) == ":commit/h0"
         assert "introduced-by" not in capsys.readouterr().err
 
+    def _corrupt(self, db, n):
+        import mcp_server
+        idents = [f":function/ambiguous-{i}" for i in range(n)]
+        for ident in idents:
+            mcp_server._transact(db, f"[[{ident} :introduced-by :commit/h0]]", "2026-01-01T00:00:00Z")
+            mcp_server._transact(db, f"[[{ident} :introduced-by :commit/h5]]", "2026-01-05T00:00:00Z")
+        return idents
+
+    def test_ambiguity_warning_is_rate_capped_but_the_value_is_not(self, real_db, capsys):
+        """#235: _reverse_apply calls this up to 3x per ident per commit, so
+        on a corrupted at-scale graph an uncapped warning buries the rest of
+        the ingest log long before the repair pass can run. Only stderr is
+        capped -- every call must still return a value."""
+        import mcp_server
+        n = mcp_server._INTRODUCED_BY_AMBIGUITY_LOG_CAP + 5
+        idents = self._corrupt(real_db, n)
+        capsys.readouterr()
+
+        results = [mcp_server._entity_introduced_by_query(real_db, i) for i in idents]
+
+        assert all(r in (":commit/h0", ":commit/h5") for r in results), (
+            "the cap must never change what is returned"
+        )
+        err = capsys.readouterr().err
+        warned = [line for line in err.splitlines() if "ambiguous-" in line]
+        assert len(warned) == mcp_server._INTRODUCED_BY_AMBIGUITY_LOG_CAP
+        assert "further ambiguity warnings suppressed" in err
+
+    def test_budget_is_restored_per_run_not_burned_forever(self, real_db, capsys):
+        """The sweep's cap resets per run because its budget is a
+        caller-threaded local. This one is a module global (no caller here
+        carries a running total), so the reset is explicit -- _run_ingestion
+        calls it at the top of every run. Without that, a long-lived server
+        would log nothing after its first corrupted ingest."""
+        import mcp_server
+        idents = self._corrupt(real_db, mcp_server._INTRODUCED_BY_AMBIGUITY_LOG_CAP + 3)
+        for ident in idents:
+            mcp_server._entity_introduced_by_query(real_db, ident)
+        capsys.readouterr()
+
+        # Exhausted: a further call says nothing.
+        mcp_server._entity_introduced_by_query(real_db, idents[0])
+        assert "ambiguous-" not in capsys.readouterr().err
+
+        mcp_server._reset_introduced_by_ambiguity_log_budget()
+        mcp_server._entity_introduced_by_query(real_db, idents[0])
+        assert "ambiguous-0" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_run_ingestion_resets_the_budget(self, tmp_path, monkeypatch):
+        """The reset must be wired into the run, not merely available."""
+        import mcp_server
+        monkeypatch.setattr(mcp_server, "_graph_path", str(tmp_path / "g.graph"))
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+        (repo / "a.py").write_text("def f(): pass\n")
+        _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        _subprocess.run(["git", "commit", "-m", "h0"], cwd=repo, check=True, capture_output=True)
+
+        mcp_server._introduced_by_ambiguity_logged = 10**6
+        await mcp_server._run_ingestion(str(repo), "master")
+        mcp_server._db = None
+
+        assert mcp_server._introduced_by_ambiguity_logged < 10**6, (
+            "_run_ingestion must reset the per-run stderr budget"
+        )
+
 
 class TestEntityIntroducedBySetProvisionalBatch:
     """#233: _reverse_apply's two loops were the only production callers of
@@ -9364,15 +9441,25 @@ class TestPreloadProvisionalIdents:
         assert mcp_server._preload_provisional_idents(real_db) == {":code/fn-b"}
         assert mcp_server._lineage_is_provisional(real_db, ":code/fn-a") is False
 
-    def test_load_ingestion_preload_state_returns_it_last(self, real_db, tmp_path):
+    def test_load_ingestion_preload_state_does_not_preload_it(self, real_db, tmp_path):
+        """#235: the ingestion preload deliberately does NOT carry a
+        provisional-ident snapshot. _forward_apply asks
+        _lineage_is_provisional per ident instead, so a snapshot here would
+        be write-only state inviting a future prefilter -- exactly the shape
+        that minted a second :introduced-by. The function itself survives for
+        whole-graph assertions, which is what the tests above cover."""
         import mcp_server
         repo = tmp_path / "repo"
         repo.mkdir()
         _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
         mcp_server._lineage_mark_provisional(real_db, ":code/fn-a", "2026-01-01T00:00:00Z")
+        assert mcp_server._preload_provisional_idents(real_db) == {":code/fn-a"}
+
         result = mcp_server._load_ingestion_preload_state(str(repo))
-        assert len(result) == 13
-        assert result[-1] == {":code/fn-a"}
+        assert len(result) == 12
+        assert {":code/fn-a"} not in result
+        assert not any(isinstance(element, set) and ":code/fn-a" in element
+                       for element in result)
 
 
 class TestIngestTransactFactIndex:
@@ -16508,6 +16595,48 @@ class TestCorrectionSweepWalk:
         assert skipped_events == 0
         assert mcp_server._correction_sweep_through_query(real_db) == linearization[-1]
 
+    def _repo_with_one_evolving_file(self, tmp_path, n):
+        """n commits all touching a.py, so its entities are candidates at
+        every swept commit -- _repo_with_n_commits gives each commit its own
+        file, which the sweep only ever sees once."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._init_repo(repo)
+        for i in range(n):
+            self._commit(repo, "a.py", f"def login():\n    return {i}\n", f"h{i}")
+        return repo
+
+    def test_walk_arms_the_two_value_repair(self, real_db, tmp_path):
+        """#235: _correction_sweep_apply's repair is inert unless a caller
+        supplies pos_by_commit_ident, and _correction_sweep_walk is the
+        driving loop that has commit_metadata in scope. If it does not build
+        and pass the map, an entity holding two live :introduced-by values
+        is merely logged as ambiguous and survives the whole sweep."""
+        import mcp_server
+        repo = self._repo_with_one_evolving_file(tmp_path, 3)
+        linearization, commit_metadata = self._linearization_and_metadata(repo)
+        self._close_gap_at(repo, real_db, linearization, commit_metadata, split_pos=1)
+
+        fn_ident = mcp_server._code_ident("function", "a.py", "login")
+        h0 = f":commit/{linearization[0][:12]}"
+        h2 = f":commit/{linearization[2][:12]}"
+        # Force exactly the corruption the old _forward_apply produced: a
+        # second live value alongside whatever the reverse stream recorded.
+        for value in (h0, h2):
+            if value not in mcp_server._entity_introduced_by_values_query(real_db, fn_ident):
+                mcp_server._transact(
+                    real_db, f"[[{fn_ident} :introduced-by {value}]]", "2026-01-01T00:00:00Z",
+                )
+        before = mcp_server._entity_introduced_by_values_query(real_db, fn_ident)
+        assert len(before) >= 2, f"fixture must start corrupt; got {before}"
+
+        mcp_server._correction_sweep_walk(real_db, str(repo), linearization, commit_metadata)
+
+        after = mcp_server._entity_introduced_by_values_query(real_db, fn_ident)
+        assert after == [h0], (
+            f"the walk must collapse to the lowest-position value; got {sorted(after)}"
+        )
+
     def test_returns_zero_zero_when_gap_still_open(self, real_db, tmp_path):
         import mcp_server
         repo = self._repo_with_n_commits(tmp_path, 3)
@@ -16799,13 +16928,11 @@ class TestForwardApplyReconcilesProvisional:
             file_deps={}, dep_valid_from={}, pinned_commit_state={},
             field_class_ident={}, field_static_ident={}, submodule_paths={},
             unresolved_dep_idents={},
-            # #235: production preloads at RUN START, before Stream 2 has
-            # written anything, so on a fresh ingest this set is EMPTY. Calling
-            # _preload_provisional_idents here -- after the reverse stream ran --
-            # handed the forward walk a snapshot that already contained the
-            # guess, which no real fresh run ever has, and hid the second-mint
-            # bug entirely.
-            provisional_idents=set(),
+            # #235: no provisional-ident snapshot is threaded at all -- the
+            # walk asks _lineage_is_provisional per ident. An earlier revision
+            # of this test seeded one from _preload_provisional_idents AFTER
+            # the reverse stream ran, which no real fresh run ever has, and
+            # that hid the second-mint bug entirely.
             ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
         )
         extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
@@ -16837,21 +16964,23 @@ class TestForwardApplyReconcilesProvisional:
         assert module_values == {f":commit/{linearization[0][:12]}"}, "exactly one, naming h0"
         assert mcp_server._lineage_is_provisional(real_db, module_ident) is False
 
-    def test_forward_apply_does_not_duplicate_for_a_stale_provisional_snapshot_entry(
+    def test_forward_apply_does_not_duplicate_for_an_already_confirmed_entity(
         self, real_db, tmp_path,
     ):
-        """FIX 1 regression (#222 phase 2d Task 5 review): state.provisional_idents
-        is a preload SNAPSHOT, not the authority. If something else (e.g. the
-        correction sweep) already confirmed an entity authoritative in the DB
-        after the snapshot was taken, the snapshot can still list it as
-        provisional. The forward walk must consult the DB
-        (_lineage_is_provisional) before treating the ident as reconcilable --
-        popping it out of entity_valid_from unconditionally would make
-        _build_code_triples mint a SECOND :introduced-by on top of the
-        existing authoritative one, while _forward_reconcile_provisional
-        (itself DB-backed) no-ops on an already-confirmed entity and never
-        retracts the duplicate. Without the fix this yields two
-        :introduced-by values; with it, exactly one survives."""
+        """FIX 1 regression (#222 phase 2d Task 5 review, kept live by #235):
+        an entity the reverse stream introduced provisionally and something
+        else (e.g. the correction sweep) has since confirmed authoritative
+        must NOT be treated as reconcilable. Popping it out of
+        entity_valid_from unconditionally would make _build_code_triples mint
+        a SECOND :introduced-by on top of the existing authoritative one,
+        while _forward_reconcile_provisional (itself DB-backed) no-ops on an
+        already-confirmed entity and never retracts the duplicate. Without
+        the per-ident _lineage_is_provisional check this yields two
+        :introduced-by values; with it, exactly one survives.
+
+        This is the stale-POSITIVE half of the argument in _forward_apply's
+        reconciliation comment: it is why the DB check cannot simply be
+        dropped in favour of any set, snapshot or otherwise."""
         import mcp_server, frontier_registry
         repo = self._repo(tmp_path)
         linearization = frontier_registry.build_linearization(str(repo))
@@ -16865,14 +16994,9 @@ class TestForwardApplyReconcilesProvisional:
         fn_ident = mcp_server._code_ident("function", "auth.py", "login")
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is True
 
-        # Take the preload snapshot while the entity is still genuinely
-        # provisional...
-        provisional_snapshot = mcp_server._preload_provisional_idents(real_db)
-        assert fn_ident in provisional_snapshot
-
-        # ...then simulate something else confirming it authoritative in the
-        # DB afterward (the snapshot is now stale for this ident, though the
-        # existing :introduced-by fact itself is untouched).
+        # Simulate something else confirming it authoritative in the DB
+        # before the forward walk arrives (the existing :introduced-by fact
+        # itself is untouched by that confirmation).
         mcp_server._lineage_confirm(real_db, fn_ident)
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
         existing_raw = mcp_server._db_execute(
@@ -16890,7 +17014,6 @@ class TestForwardApplyReconcilesProvisional:
             file_deps={}, dep_valid_from={}, pinned_commit_state={},
             field_class_ident={}, field_static_ident={}, submodule_paths={},
             unresolved_dep_idents={},
-            provisional_idents=provisional_snapshot,  # stale: still lists fn_ident
             ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
         )
         extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
@@ -16903,12 +17026,9 @@ class TestForwardApplyReconcilesProvisional:
         )
         values = {row[0] for row in json.loads(raw)["results"]}
         assert values == {f":commit/{linearization[1][:12]}"}, (
-            "exactly one :introduced-by must survive -- a stale snapshot "
-            "entry must not cause a second one to be minted"
+            "exactly one :introduced-by must survive -- an already-confirmed "
+            "entity must not have a second one minted on top of it"
         )
-        # The stale entry must be evicted, or it would be retried (and fail
-        # the same way) on every later commit that touches this entity.
-        assert fn_ident not in state.provisional_idents
 
     def test_reconciles_a_guess_made_during_this_same_run(self, real_db, tmp_path):
         """#235: the prefilter was a run-start snapshot, empty on a fresh
@@ -16923,9 +17043,11 @@ class TestForwardApplyReconcilesProvisional:
         commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
         allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
 
-        # Snapshot taken FIRST, exactly as _run_ingestion does -- empty.
-        snapshot = mcp_server._preload_provisional_idents(real_db)
-        assert snapshot == set(), "a fresh graph has no provisional idents yet"
+        # The graph the forward walk starts against, exactly as _run_ingestion
+        # sees it: nothing is provisional yet.
+        assert mcp_server._preload_provisional_idents(real_db) == set(), (
+            "a fresh graph has no provisional idents yet"
+        )
 
         # Only now does Stream 2 claim h1 and guess.
         mcp_server._reverse_fill_claim_and_process(
@@ -16939,7 +17061,6 @@ class TestForwardApplyReconcilesProvisional:
             file_deps={}, dep_valid_from={}, pinned_commit_state={},
             field_class_ident={}, field_static_ident={}, submodule_paths={},
             unresolved_dep_idents={},
-            provisional_idents=snapshot,
             ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
         )
         extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
@@ -16951,47 +17072,19 @@ class TestForwardApplyReconcilesProvisional:
         )
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
 
-    def test_evicts_a_stale_snapshot_entry_that_is_no_longer_provisional(
-        self, real_db, tmp_path,
-    ):
-        """The eviction invariant survives dropping the prefilter: every
-        candidate examined leaves state.provisional_idents, whether or not
-        the DB agreed it was provisional. A stale entry left behind is
-        retried, and fails the same way, on every later commit touching the
-        entity (see the comment at mcp_server.py:8345)."""
-        import mcp_server, frontier_registry
-        repo = self._repo(tmp_path)
-        linearization = frontier_registry.build_linearization(str(repo))
-        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
-        mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
-
-        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
-        # Authoritative in the DB (a plain transact, no lineage marker) but
-        # still listed by a stale snapshot -- what a resumed run sees after a
-        # previous run's sweep confirmed the entity.
-        mcp_server._transact(
-            real_db, f"[[{fn_ident} :introduced-by :commit/already]]", "2026-01-01T00:00:00Z",
-        )
-        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
-
-        state = mcp_server._ForwardWalkState(
-            entity_valid_from={}, entity_descriptions={}, file_entities={},
-            file_deps={}, dep_valid_from={}, pinned_commit_state={},
-            field_class_ident={}, field_static_ident={}, submodule_paths={},
-            unresolved_dep_idents={},
-            provisional_idents={fn_ident},
-            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
-        )
-        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
-        mcp_server._forward_apply(real_db, str(repo), state, commit_metadata[0], extracted)
-
-        assert fn_ident not in state.provisional_idents, "stale entry must be evicted"
-
     def test_resumed_run_variant_is_not_suppressed_by_entity_valid_from(self, real_db, tmp_path):
         """The silent failure mode: on a RESUMED run, Stream 2's structural
         facts are already in the preloaded entity_valid_from, so
         _build_code_triples would suppress the introduction entirely and the
-        wrong provisional guess would survive forever."""
+        wrong provisional guess would survive forever.
+
+        #235: this used to have a sibling
+        (test_without_provisional_idents_the_resumed_case_still_reconciles)
+        that ran the identical setup with an EMPTY provisional-ident
+        snapshot, to prove the snapshot was not the gate. With the snapshot
+        deleted outright the two are the same test, so only this one
+        remains -- the outcome asserted below is now reachable by no other
+        input than the DB's own answer."""
         import mcp_server, frontier_registry
         repo = self._repo(tmp_path)
         linearization = frontier_registry.build_linearization(str(repo))
@@ -17010,7 +17103,6 @@ class TestForwardApplyReconcilesProvisional:
             file_deps={}, dep_valid_from={}, pinned_commit_state={},
             field_class_ident={}, field_static_ident={}, submodule_paths={},
             unresolved_dep_idents={},
-            provisional_idents={fn_ident},
             ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
         )
         extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
@@ -17023,41 +17115,6 @@ class TestForwardApplyReconcilesProvisional:
         )
         assert {row[0] for row in json.loads(raw)["results"]} == {f":commit/{linearization[0][:12]}"}
         assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
-
-    def test_without_provisional_idents_the_resumed_case_still_reconciles(self, real_db, tmp_path):
-        """#235: this pinned the OLD design, where an empty
-        state.provisional_idents left the resumed-run case unreconciled
-        because the set was consulted as a prefilter gate. That gate is
-        gone -- _lineage_is_provisional(db, ...) is the sole authority now,
-        so an empty (or entirely wrong) snapshot must no longer change the
-        outcome. Same setup as
-        test_resumed_run_variant_is_not_suppressed_by_entity_valid_from,
-        with provisional_idents=set() instead of {fn_ident}, and the same
-        result: exactly one :introduced-by, naming h0."""
-        import mcp_server, frontier_registry
-        repo = self._repo(tmp_path)
-        linearization = frontier_registry.build_linearization(str(repo))
-        commit_metadata = mcp_server._git_commits(str(repo), watermark_hash=None)
-        allocator = mcp_server._frontier_load(real_db, linearization, "2026-01-04T00:00:00Z")
-        mcp_server._reverse_fill_claim_and_process(
-            real_db, str(repo), linearization, commit_metadata, allocator,
-        )
-        fn_ident = mcp_server._code_ident("function", "auth.py", "login")
-        state = mcp_server._ForwardWalkState(
-            entity_valid_from={fn_ident: "2026-06-01T00:00:00Z"},
-            entity_descriptions={fn_ident: "login"}, file_entities={"auth.py": [fn_ident]},
-            file_deps={}, dep_valid_from={}, pinned_commit_state={},
-            field_class_ident={}, field_static_ident={}, submodule_paths={},
-            unresolved_dep_idents={},
-            provisional_idents=set(),   # no longer a gate -- must not matter
-            ts_by_commit_ident={f":commit/{h[:12]}": ts for h, ts, _a, _s in commit_metadata},
-        )
-        extracted = mcp_server._extract_commit(str(repo), linearization[0], ())
-        mcp_server._forward_apply(
-            real_db, str(repo), state, commit_metadata[0], extracted,
-        )
-        assert mcp_server._lineage_is_provisional(real_db, fn_ident) is False
-        assert mcp_server._entity_introduced_by_query(real_db, fn_ident) == f":commit/{linearization[0][:12]}"
 
 
 class TestRoundRobinClaimer:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16250,7 +16250,10 @@ class TestCorrectionSweepApply:
 
     def test_repair_is_inert_without_a_position_map(self, real_db, tmp_path):
         """Gated: every existing caller and test keeps today's fail-safe
-        behaviour until it opts in."""
+        behaviour until it opts in. An EMPTY map is gated out too -- with no
+        positions to compare, every value scores the same len(map)==0
+        default and the collapse would degenerate to "lexicographically
+        smallest ident wins", contradicting "absent sorts last"."""
         import mcp_server
         repo = self._repo_with_evolving_function(tmp_path)
         _pos_map, linearization = self._pos_map(repo)
@@ -16263,6 +16266,13 @@ class TestCorrectionSweepApply:
         h1_hash = linearization[1]
         mcp_server._correction_sweep_apply(
             real_db, h1_hash, "2026-01-02T00:00:00Z", self._extract(repo, h1_hash),
+        )
+
+        assert sorted(mcp_server._entity_introduced_by_values_query(real_db, fn_ident)) == sorted([h0, h2])
+
+        mcp_server._correction_sweep_apply(
+            real_db, h1_hash, "2026-01-02T00:00:00Z", self._extract(repo, h1_hash),
+            pos_by_commit_ident={},
         )
 
         assert sorted(mcp_server._entity_introduced_by_values_query(real_db, fn_ident)) == sorted([h0, h2])


### PR DESCRIPTION
Issue: #235

An entity could hold **two live `:introduced-by` facts**. The pair never converged — every later reader saw one value, retracted that one, and asserted a fresh one, so it regenerated rather than collapsing — and `_correction_sweep_apply` only ever failed safe on it. Once created, the corruption was permanent.

## Root cause

`_forward_apply`'s non-`lifecycle_only` branch prefiltered reconciliation candidates through `state.provisional_idents`, a snapshot taken at **run start**. On a fresh ingest that set is empty, and Stream 2 writes its provisional guesses *during that same run* — so the prefilter dropped every same-run guess before the DB-authoritative `_lineage_is_provisional` check could see it. `_forward_reconcile_provisional` never fired, and `_build_code_triples` minted a second `:introduced-by` alongside the guess.

A prefilter's false negatives are unrecoverable precisely because the authority never runs.

## Changes

**1. Prevent.** `_lineage_is_provisional` is now the sole authority, mirroring what the `lifecycle_only`/`"R"` branch already did. The `provisional_idents` snapshot is removed entirely rather than left as dead state — keeping it would have preserved the exact hazard that created this bug.

**2. Repair.** `_correction_sweep_apply` takes an optional `pos_by_commit_ident` and collapses an entity's 2+ values to the one at the lowest linearization position, before its existing case 1/2/3 branching. Repair collapses multiplicity only; it never confirms. Positions are required rather than derivable from the ascending sweep's arrival order, because the spurious mint lands in the *forward* region, which Stage B never sweeps.

**3. Observe.** `_entity_introduced_by_values_query` returns all values; `_entity_introduced_by_query` delegates, warns on >1, and deliberately does **not** raise — both walks call it mid-run, before Stage B, so raising would hard-fail ingestion on exactly the graphs the repair exists to heal. The warning is rate-capped with a per-run reset.

## Evidence

- The whole-run oracle reproduces the issue's reported figure exactly: **6 entities with two `:introduced-by`** on a 14-commit fixture, 0 after.
- Both task reviewers verified by **reverting the change in place** and confirming the new tests fail against unfixed code — including the two pre-existing tests that had to be rewritten, one of which had pinned the defect as intended behaviour (`provisional_idents=set(), # the bug`).
- Full suite: 738 passed. 120 failures are environmental — 119 missing tree-sitter grammars, 1 pre-existing on `master` at 8c8523d (verified there directly).

## Performance

The acceptance-gate ingestion benchmark **could not be completed for this branch**, and the cause is the harness, not this change — see #242. Two attempts were killed (3h54m and 36m) as the benchmark's in-flight poller progressively starved the ingestion it was measuring.

A two-revision A/B without that instrument (`evals/at_scale/profile_forward_reconcile_attribution.py`, added here) gives the attribution:

| slice | before | after | ratio |
|---|---:|---:|---:|
| 150 commits | | | 1.01 |
| 300 commits | | | 1.03 |
| 450 commits | 720.57s | 741.85s | **1.03** |

On full 586-commit history under a time cap the new code is *ahead* — Stage A done at 619.9s vs 675.8s. The residual +3% is `_correction_sweep_apply` doing repair work the bug used to suppress (`_retract` 53,567 → 79,175 calls), partly offset by `_reverse_apply` running 12.9s faster.

The concern that `_lineage_is_provisional` per candidate would be superlinear is refuted three ways: a miss is *cheaper* than a hit and flat across a 50x graph-size range (`evals/at_scale/bench_lineage_query_cost.py`); the A/B ratio stays flat at 1.01/1.03/1.03 where a superlinear term would rise; and it is 29.0s of a 741.85s run.

The acceptance gate should be re-run once #242 is dealt with.

## Known limitation, stated deliberately

**Repair reaches only graphs that keep ingesting.** On an already-completed graph the sweep runs zero times — a finished run parks `:ingestion/correction-sweep-through` at frontier-high's `:hi-hash`, so `_correction_sweep_select_position` returns None on its first call. Re-ingesting such a graph repairs nothing.

Recovery for a static corrupted graph needs new commits above the old ceiling, an interrupted/resumed run, or a watermark reset. The spec and the docstring both say this. Worth a follow-up issue for an explicit reset path.

## Also surfaced

- **#241** — `_db_checkpoint` is the largest single call site in ingestion on *both* revisions (~0.69s per call, once per commit against a growing graph), and appears to have been missed by earlier attributions because the per-thread cProfile hook used for them was killing the `write_executor` threads it runs on.
- **#242** — the benchmark poller described above.

Neither is caused by this branch; both are long-standing.

## Docs

No `SKILL.md` change: this restores an invariant `SKILL.md` already asserts (`:introduced-by` = "commit that first defined this X") and adds no tool, query syntax, or user-visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8qWT72sj5ja3wvkcgkK6b
