### PR TITLE
Measure #245's :depends-on preload exposure, and fix the benchmark poller (#242)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ result = query("[:find ?d :where [?e :decision/description ?d]]")
 - `install.py` - Setup script (runs weekly updates)
 - `docs/testing-conventions.md` - Real-backend-only test conventions for `tests/test_mcp_server.py`
 - `hooks/claude-code.json` - Claude Code MCP + auto-memory hook config
-- `evals/at_scale/` - at-scale ingestion + query-correctness benchmark tier (real repo history, observational, see its own `benchmark.md`)
+- `evals/at_scale/` - at-scale ingestion + query-correctness benchmark tier (real repo history, observational, see its own `benchmark.md`). It also holds one-off read-only probes (e.g. `probe_dep_preload_exposure.py`, #245) and their recorded measurements under `results/`, which are analysis artifacts rather than part of the recurring benchmark run.
 
 ## Graph Storage
 

--- a/docs/superpowers/plans/2026-08-07-dep-preload-exposure-probe.md
+++ b/docs/superpowers/plans/2026-08-07-dep-preload-exposure-probe.md
@@ -1,0 +1,1303 @@
+# `:depends-on` Preload Exposure Probe + Benchmark Poller Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Quantify #245's `:depends-on` preload exposure against real history, and fix the #242 benchmark poller that currently makes a full-history ingestion unfinishable.
+
+**Architecture:** Two independent changes on one branch. #242 moves the benchmark's in-flight poll off the event loop and gives it an adaptive interval, bounding its share of `_db_native_lock`. #245 gets a new read-only probe that ingests this repo into a scratch graph, then drives the *real* `_preload_known_entities` + `_preload_known_deps` at each structurally-affected watermark position and diffs their output against a position-exact offline oracle.
+
+**Tech Stack:** Python 3.10+, pytest + pytest-asyncio, `mcp_server.py`'s in-process handlers, `frontier_registry.build_linearization`, minigraf `:any-valid-time` queries.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-dep-preload-exposure-probe-design.md`
+
+## Global Constraints
+
+- **This branch fixes nothing in `:depends-on` / `:pinned-commit` handling.** No change to `_preload_known_deps`, `_preload_pinned_commits`, or the fact model. #245's three options stay unbuilt until the measurement says which, if any, is warranted.
+- **Issue-keyword discipline.** Commit messages and the PR body use `Refs #245`, `Refs #238`, `Refs #222`. Only `Closes #242` is a closing keyword. GitHub scans both commit messages and the PR body, and on this project a *negated* "does not close #N" has still auto-closed an issue — so never write a closing keyword next to #238 or #245 in any form.
+- **Branch:** `probe-245-dep-preload-exposure`, already created, spec already committed at `0ede760`.
+- **`mcp` stays capped `<2.0.0`.** Do not touch the dependency pin.
+- **Ablation is mandatory for the #242 regression tests.** A test that passes against the pre-fix code is not testing anything; see Task 1 Step 2.
+- **Timestamps are second-granularity.** `_git_commits` formats `"%Y-%m-%dT%H:%M:%SZ"` (`mcp_server.py:4133`), so distinct commits can share a timestamp. Every task that inverts a timestamp to a position must handle a list of positions, never a single one.
+- **Existing test to update:** `tests/test_at_scale_ingestion_benchmark.py:42-46` asserts an exact metric key set. Task 2 adds keys and must update it.
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `evals/at_scale/run_ingestion_benchmark.py` | Modify | #242: off-loop adaptive poller, new poll metrics |
+| `evals/at_scale/report.py` | Modify | Render the poll-duty row in the benchmark report |
+| `evals/at_scale/benchmark.md` | Modify | Dated note that prior entries carry poller overhead |
+| `evals/at_scale/probe_dep_preload_exposure.py` | Create | #245 probe: pure analysis functions + driver |
+| `tests/test_at_scale_ingestion_benchmark.py` | Modify | #242 ablation-proven poller tests; key-set update |
+| `tests/test_at_scale_dep_preload_probe.py` | Create | Probe oracle + affected-position unit tests |
+
+---
+
+### Task 1: Move the benchmark poll off the event loop and bound its duty cycle
+
+**Files:**
+- Modify: `evals/at_scale/run_ingestion_benchmark.py:12-51`
+- Test: `tests/test_at_scale_ingestion_benchmark.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `_poll_during_ingestion(ingest_task, poll_interval, duty_factor=10.0) -> tuple[list[float], list[float], list[float]]` returning `(status_latencies, query_latencies, poll_offsets)`. Note this is a **3-tuple**; it was a 2-tuple. Task 2 consumes all three.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_at_scale_ingestion_benchmark.py`:
+
+```python
+import asyncio
+import time as _time
+
+from evals.at_scale.run_ingestion_benchmark import _poll_during_ingestion
+
+
+class TestPollerDoesNotStarveTheEventLoop:
+    """#242: the poll must not block the event loop, and its share of
+    _db_native_lock must stay bounded as the polled query grows."""
+
+    @pytest.mark.asyncio
+    async def test_event_loop_stays_responsive_while_poll_query_blocks(self, monkeypatch):
+        import mcp_server
+
+        monkeypatch.setattr(mcp_server, "handle_minigraf_ingest_status", lambda: None)
+        monkeypatch.setattr(mcp_server, "handle_minigraf_query", lambda _q: _time.sleep(0.05))
+
+        ticks: list[float] = []
+
+        async def heartbeat(stop: asyncio.Event) -> None:
+            while not stop.is_set():
+                ticks.append(_time.perf_counter())
+                await asyncio.sleep(0.01)
+
+        stop = asyncio.Event()
+        ingest_task = asyncio.create_task(asyncio.sleep(0.6))
+        hb = asyncio.create_task(heartbeat(stop))
+        await _poll_during_ingestion(ingest_task, poll_interval=0.0, duty_factor=0.0)
+        await ingest_task
+        stop.set()
+        await hb
+
+        # A free 0.6s loop ticking every 10ms yields ~60 ticks. With the poll
+        # blocking the loop for 50ms per iteration it yields ~12 (one per poll).
+        # 30 sits well clear of both.
+        assert len(ticks) >= 30, f"event loop was starved: only {len(ticks)} ticks"
+
+    @pytest.mark.asyncio
+    async def test_interval_backs_off_when_the_polled_query_is_slow(self, monkeypatch):
+        import mcp_server
+
+        monkeypatch.setattr(mcp_server, "handle_minigraf_ingest_status", lambda: None)
+        monkeypatch.setattr(mcp_server, "handle_minigraf_query", lambda _q: _time.sleep(0.05))
+
+        ingest_task = asyncio.create_task(asyncio.sleep(1.1))
+        _status, query_latencies, _offsets = await _poll_during_ingestion(
+            ingest_task, poll_interval=0.0, duty_factor=10.0
+        )
+        await ingest_task
+
+        # duty_factor=10 against a 50ms query forces a ~500ms sleep, so a 1.1s
+        # run admits about 2-3 polls. Without the backoff it would poll
+        # continuously and record ~20.
+        assert len(query_latencies) <= 5, f"interval did not back off: {len(query_latencies)} polls"
+
+    @pytest.mark.asyncio
+    async def test_returns_poll_offsets_aligned_with_samples(self, monkeypatch):
+        import mcp_server
+
+        monkeypatch.setattr(mcp_server, "handle_minigraf_ingest_status", lambda: None)
+        monkeypatch.setattr(mcp_server, "handle_minigraf_query", lambda _q: None)
+
+        ingest_task = asyncio.create_task(asyncio.sleep(0.2))
+        status_latencies, query_latencies, poll_offsets = await _poll_during_ingestion(
+            ingest_task, poll_interval=0.02, duty_factor=10.0
+        )
+        await ingest_task
+
+        assert len(poll_offsets) == len(status_latencies) == len(query_latencies)
+        assert poll_offsets == sorted(poll_offsets)
+```
+
+- [ ] **Step 2: Run the tests against the CURRENT implementation and confirm they fail**
+
+Run: `pytest tests/test_at_scale_ingestion_benchmark.py::TestPollerDoesNotStarveTheEventLoop -v`
+
+Expected: all three FAIL. The first two fail on the assertion (starved loop / no backoff); the third fails on `TypeError` from unpacking a 2-tuple into three names, and on the unexpected `duty_factor` keyword.
+
+**This is the ablation and it is mandatory.** If the first two tests *pass* against the current code, they are not exercising #242's mechanism — stop, report that plainly, and rework them before writing any implementation. Do not proceed on a green ablation.
+
+- [ ] **Step 3: Add the import**
+
+In `evals/at_scale/run_ingestion_benchmark.py`, add to the stdlib import block (after `import asyncio`, keeping alphabetical order):
+
+```python
+import concurrent.futures
+```
+
+- [ ] **Step 4: Replace `_poll_during_ingestion`**
+
+Replace lines 31-51 entirely:
+
+```python
+async def _poll_during_ingestion(
+    ingest_task: "asyncio.Task[None]",
+    poll_interval: float,
+    duty_factor: float = 10.0,
+) -> tuple[list[float], list[float], list[float]]:
+    """Poll ingest_status and a graph query while ingest_task runs.
+
+    Returns (status_latencies, query_latencies, poll_offsets); latencies in
+    seconds, offsets in seconds since polling began.
+
+    #242: both halves of this are load-bearing.
+
+    The handlers run on a dedicated single-worker executor rather than inline,
+    because handle_minigraf_query is synchronous -- calling it on the event
+    loop stalls the _run_ingestion coroutine, the process-pool result
+    collection, and every write_executor completion. Two full-history runs
+    were killed at 3h54m and 36m on code measured at +3% before this was
+    understood.
+
+    Off-loop alone is NOT sufficient. handle_minigraf_query acquires
+    _db_native_lock (mcp_server._db_execute), and _STATUS_QUERY counts every
+    :type/commit entity, so its cost grows for the whole run -- a ~1s scan
+    every 0.5s would still serialize against every ingestion write from
+    another thread. The adaptive interval is what bounds the instrument's
+    share of that lock: at duty_factor=10 the poller holds it for at most
+    ~9% of the run however large the scan grows.
+
+    _STATUS_QUERY is deliberately unchanged, so the recorded latency series
+    stays comparable to the entries already in benchmark.md.
+
+    A dedicated executor, rather than the loop default, keeps the poll off any
+    thread the ingestion may want.
+
+    Known limitation: a cancelled run still waits on an in-flight poll thread
+    at executor shutdown. The previous implementation blocked the event loop
+    outright, so this is strictly better, but it is not zero.
+    """
+    import mcp_server
+
+    loop = asyncio.get_running_loop()
+    status_latencies: list[float] = []
+    query_latencies: list[float] = []
+    poll_offsets: list[float] = []
+    started = time.perf_counter()
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="bench-poll"
+    ) as poll_executor:
+        while not ingest_task.done():
+            poll_offsets.append(time.perf_counter() - started)
+
+            t0 = time.perf_counter()
+            await loop.run_in_executor(
+                poll_executor, mcp_server.handle_minigraf_ingest_status
+            )
+            status_duration = time.perf_counter() - t0
+            status_latencies.append(status_duration)
+
+            t0 = time.perf_counter()
+            await loop.run_in_executor(
+                poll_executor, mcp_server.handle_minigraf_query, _STATUS_QUERY
+            )
+            query_duration = time.perf_counter() - t0
+            query_latencies.append(query_duration)
+
+            await asyncio.sleep(
+                max(poll_interval, duty_factor * (status_duration + query_duration))
+            )
+
+    return status_latencies, query_latencies, poll_offsets
+```
+
+- [ ] **Step 5: Update the single existing call site**
+
+`evals/at_scale/run_ingestion_benchmark.py:83` currently unpacks two values. Change it to three:
+
+```python
+        status_latencies, query_latencies, poll_offsets = await _poll_during_ingestion(
+            ingest_task, poll_interval
+        )
+```
+
+- [ ] **Step 6: Run the new tests and confirm they pass**
+
+Run: `pytest tests/test_at_scale_ingestion_benchmark.py::TestPollerDoesNotStarveTheEventLoop -v`
+Expected: 3 passed.
+
+- [ ] **Step 7: Run the whole benchmark test module for regressions**
+
+Run: `pytest tests/test_at_scale_ingestion_benchmark.py -v`
+Expected: `TestPollerDoesNotStarveTheEventLoop` passes; `test_returns_expected_metric_keys` still passes (Task 1 adds no metric keys); everything else passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add evals/at_scale/run_ingestion_benchmark.py tests/test_at_scale_ingestion_benchmark.py
+git commit -m "$(cat <<'EOF'
+Run the benchmark poll off the event loop with a bounded duty cycle
+
+The poll ran handle_minigraf_query synchronously on the event loop, stalling
+the _run_ingestion coroutine, process-pool result collection, and every
+write_executor completion. _STATUS_QUERY's cost grows all run, so the
+instrument's share of the loop rose monotonically until ingestion approached
+a standstill.
+
+Off-loop alone is not sufficient: handle_minigraf_query takes
+_db_native_lock, so a growing scan would still serialize against every
+ingestion write from another thread. The adaptive interval bounds that share
+at ~9% for the default duty_factor=10.
+
+_STATUS_QUERY is unchanged so the latency series stays comparable to the
+entries already in benchmark.md.
+
+Tests are ablation-proven: both regression tests were run against the
+pre-fix implementation and fail there.
+
+Closes #242
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01T8qWT72sj5ja3wvkcgkK6b
+EOF
+)"
+```
+
+---
+
+### Task 2: Surface poll duty cycle in the benchmark result and report
+
+**Files:**
+- Modify: `evals/at_scale/run_ingestion_benchmark.py` (result dict, `main`'s argparse)
+- Modify: `evals/at_scale/report.py:31-56`
+- Modify: `evals/at_scale/benchmark.md`
+- Test: `tests/test_at_scale_ingestion_benchmark.py:42-46`
+
+**Interfaces:**
+- Consumes: `_poll_during_ingestion(...) -> (status_latencies, query_latencies, poll_offsets)` from Task 1.
+- Produces: result-dict keys `poll_count: int`, `poll_duty_fraction: float`, `poll_offsets: list[float]`.
+
+`poll_duty_fraction` is the acceptance criterion for #242 — it is the direct evidence that the instrument is no longer creating the load it measures.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the body of `test_returns_expected_metric_keys` (`tests/test_at_scale_ingestion_benchmark.py:39-46`) with:
+
+```python
+    @pytest.mark.asyncio
+    async def test_returns_expected_metric_keys(self, git_repo, tmp_path):
+        graph_path = tmp_path / "bench.graph"
+        metrics = await run_ingestion_benchmark(str(git_repo), "HEAD", graph_path, poll_interval=0.05)
+        assert set(metrics.keys()) == {
+            "repo_path", "branch", "commits_ingested", "wall_clock_seconds",
+            "throughput_per_minute", "peak_rss_kb", "graph_size_bytes",
+            "index_size_bytes", "status_latency", "query_latency", "final_status",
+            "poll_count", "poll_duty_fraction", "poll_offsets",
+        }
+```
+
+And add to `TestRunIngestionBenchmark`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_poll_duty_fraction_is_a_bounded_fraction(self, git_repo, tmp_path):
+        graph_path = tmp_path / "bench.graph"
+        metrics = await run_ingestion_benchmark(str(git_repo), "HEAD", graph_path, poll_interval=0.05)
+        assert metrics["poll_count"] == len(metrics["poll_offsets"])
+        assert 0.0 <= metrics["poll_duty_fraction"] <= 1.0
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_at_scale_ingestion_benchmark.py::TestRunIngestionBenchmark -v`
+Expected: `test_returns_expected_metric_keys` and `test_poll_duty_fraction_is_a_bounded_fraction` FAIL with a `KeyError`/set-inequality on the three new keys.
+
+- [ ] **Step 3: Add the metrics to the result dict**
+
+In `run_ingestion_benchmark`, immediately after `wall_clock = time.perf_counter() - start` (line 93), add:
+
+```python
+    poll_seconds = sum(status_latencies) + sum(query_latencies)
+    poll_duty_fraction = (poll_seconds / wall_clock) if wall_clock > 0 else 0.0
+```
+
+Then add three entries to the `result` dict, after `"query_latency": ...`:
+
+```python
+        "poll_count": len(poll_offsets),
+        "poll_duty_fraction": poll_duty_fraction,
+        "poll_offsets": poll_offsets,
+```
+
+- [ ] **Step 4: Plumb `--poll-duty-factor` through `main` and `run_ingestion_benchmark`**
+
+Add a parameter to `run_ingestion_benchmark`'s signature, after `poll_interval`:
+
+```python
+    duty_factor: float = 10.0,
+```
+
+Pass it at the call site from Task 1 Step 5:
+
+```python
+        status_latencies, query_latencies, poll_offsets = await _poll_during_ingestion(
+            ingest_task, poll_interval, duty_factor
+        )
+```
+
+In `main`, add the argument after `--poll-interval`:
+
+```python
+    parser.add_argument(
+        "--poll-duty-factor", type=float, default=10.0,
+        help="Sleep max(poll_interval, N * last_poll_duration) between polls, "
+             "bounding the instrument's share of _db_native_lock (#242).",
+    )
+```
+
+`main` currently passes positionally (`args.poll_interval, args.compare_ignore`). Switch to keywords so the new parameter cannot be mis-bound to `compare_ignore`:
+
+```python
+            run_ingestion_benchmark(
+                args.repo_path,
+                args.branch,
+                graph_path,
+                poll_interval=args.poll_interval,
+                duty_factor=args.poll_duty_factor,
+                compare_ignore=args.compare_ignore,
+            )
+```
+
+- [ ] **Step 5: Render the duty cycle in the report**
+
+In `evals/at_scale/report.py`, inside `append_ingestion_report`'s `lines` list, add after the graph-query-latency row (line 55):
+
+```python
+        f"| Poll duty cycle (#242) | {metrics['poll_duty_fraction']*100:.2f}% "
+        f"over {metrics['poll_count']} polls |",
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pytest tests/test_at_scale_ingestion_benchmark.py tests/test_at_scale_report.py -v`
+Expected: all pass.
+
+If `tests/test_at_scale_report.py` builds a metrics dict literal, it needs `poll_duty_fraction` and `poll_count` added to that fixture — fix it there, do not make the report row conditional. The row is the acceptance criterion and must always render.
+
+- [ ] **Step 7: Add the `benchmark.md` note**
+
+Insert immediately after the existing header block at the top of `evals/at_scale/benchmark.md`, before the first run section:
+
+```markdown
+> **2026-08-07 — poller overhead in entries before this date (#242).** Every
+> ingestion entry recorded before 2026-08-07 was measured by a harness whose
+> in-flight poller ran a blocking, cost-growing graph query on the event loop
+> every 0.5s, starving the ingestion it measured. Entry-to-entry comparisons
+> remain valid — both sides carry the same instrument — but the absolute
+> wall-clock figures, including the 78.87s forward-only baseline and the
+> 1,600.55s post-#236 figure, overstate real ingestion cost by an unquantified
+> margin. Entries from 2026-08-07 onward carry a "Poll duty cycle" row; treat
+> its absence as "unmeasured, assume inflated".
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add evals/at_scale/run_ingestion_benchmark.py evals/at_scale/report.py \
+        evals/at_scale/benchmark.md tests/test_at_scale_ingestion_benchmark.py \
+        tests/test_at_scale_report.py
+git commit -m "$(cat <<'EOF'
+Record the benchmark poller's duty cycle, and flag pre-fix entries
+
+poll_duty_fraction is the acceptance criterion for the poller fix: it is
+direct evidence the instrument is no longer creating the load it measures.
+poll_offsets are recorded because the adaptive interval makes the latency
+sample irregular, so percentiles are no longer over a uniform series.
+
+benchmark.md gains a dated note that every entry before today carries poller
+overhead -- entry-to-entry comparisons stay valid, absolute figures overstate
+real cost.
+
+Refs #242
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01T8qWT72sj5ja3wvkcgkK6b
+EOF
+)"
+```
+
+---
+
+### Task 3: Probe analysis primitives — affected positions and the position oracle
+
+**Files:**
+- Create: `evals/at_scale/probe_dep_preload_exposure.py`
+- Test: `tests/test_at_scale_dep_preload_probe.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces, all pure and importable by Task 4:
+  - `build_ts_positions(commit_metadata: list[tuple]) -> dict[str, list[int]]`
+  - `affected_positions(commit_metadata: list[tuple]) -> list[int]`
+  - `resume_envelopes(commit_metadata: list[tuple]) -> list[str]` — `T_hi(W)` for every `W`
+  - `invert_ms_to_positions(ms: int, ts_positions: dict[str, list[int]]) -> list[int]`
+  - `edge_live_at(vf_positions: list[int], vt_positions: list[int] | None, w: int) -> bool`
+  - `VALID_TIME_FOREVER_MS: int`
+
+`commit_metadata` is `_git_commits`' return shape: `(hash, ts_iso, author_email, subject)`, ISO at **second** granularity.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_at_scale_dep_preload_probe.py`:
+
+```python
+# tests/test_at_scale_dep_preload_probe.py
+"""Unit tests for the #245 exposure probe's analysis primitives.
+
+The probe's headline number cannot be asserted -- it is what the probe exists
+to discover. What CAN be asserted are the two components that could silently
+produce a WRONG number: the timestamp-to-position inversion and the
+affected-position derivation. That is the exact error class that cost two fix
+rounds on #238, where a date-bound counterfactual made an inadequate test look
+adequate.
+"""
+
+from evals.at_scale.probe_dep_preload_exposure import (
+    VALID_TIME_FOREVER_MS,
+    affected_positions,
+    build_ts_positions,
+    edge_live_at,
+    invert_ms_to_positions,
+    resume_envelopes,
+)
+
+# Position 2 is inverted: it sits above position 1 but carries an earlier date.
+# Positions 3 and 4 share a timestamp, so inversion of that instant is
+# ambiguous and must yield both.
+META = [
+    ("h0", "2026-01-01T00:00:00Z", "a@b.com", "s0"),
+    ("h1", "2026-01-05T00:00:00Z", "a@b.com", "s1"),
+    ("h2", "2026-01-02T00:00:00Z", "a@b.com", "s2"),
+    ("h3", "2026-01-06T00:00:00Z", "a@b.com", "s3"),
+    ("h4", "2026-01-06T00:00:00Z", "a@b.com", "s4"),
+]
+
+
+class TestBuildTsPositions:
+    def test_maps_each_timestamp_to_its_positions(self):
+        assert build_ts_positions(META)["2026-01-01T00:00:00Z"] == [0]
+
+    def test_collision_yields_every_colliding_position(self):
+        assert build_ts_positions(META)["2026-01-06T00:00:00Z"] == [3, 4]
+
+
+class TestResumeEnvelopes:
+    def test_envelope_is_the_running_maximum(self):
+        assert resume_envelopes(META) == [
+            "2026-01-01T00:00:00Z",
+            "2026-01-05T00:00:00Z",
+            "2026-01-05T00:00:00Z",
+            "2026-01-06T00:00:00Z",
+            "2026-01-06T00:00:00Z",
+        ]
+
+
+class TestAffectedPositions:
+    def test_selects_exactly_the_structurally_exposed_positions(self):
+        # W=0: T_hi == ts, and no later position carries a date <= 01-01. Clean.
+        # W=1: position 2 is above it with an earlier date -> wrong inclusion.
+        # W=2: T_hi (01-05) > ts (01-02)             -> wrong exclusion.
+        # W=3: position 4 is above it and ties its date -> wrong inclusion,
+        #      because the bound is half-open containment [vf, vt) ∋ ts(W)
+        #      and vf <= ts(W) admits an exact tie.
+        # W=4: last position; T_hi == ts and nothing above. Clean.
+        assert affected_positions(META) == [1, 2, 3]
+
+    def test_a_strictly_monotonic_history_exposes_nothing(self):
+        monotonic = [
+            ("h0", "2026-01-01T00:00:00Z", "a@b.com", "s0"),
+            ("h1", "2026-01-02T00:00:00Z", "a@b.com", "s1"),
+            ("h2", "2026-01-03T00:00:00Z", "a@b.com", "s2"),
+        ]
+        assert affected_positions(monotonic) == []
+
+    def test_empty_history_is_handled(self):
+        assert affected_positions([]) == []
+
+
+class TestInvertMsToPositions:
+    def test_inverts_a_unique_timestamp(self):
+        ts_positions = build_ts_positions(META)
+        # 2026-01-02T00:00:00Z
+        assert invert_ms_to_positions(1767312000000, ts_positions) == [2]
+
+    def test_inverts_a_collided_timestamp_to_both_positions(self):
+        ts_positions = build_ts_positions(META)
+        # 2026-01-06T00:00:00Z
+        assert invert_ms_to_positions(1767657600000, ts_positions) == [3, 4]
+
+    def test_unknown_timestamp_yields_no_positions(self):
+        assert invert_ms_to_positions(1, build_ts_positions(META)) == []
+
+
+class TestEdgeLiveAt:
+    def test_open_edge_is_live_at_and_after_its_introduction(self):
+        assert edge_live_at([1], None, 1) is True
+        assert edge_live_at([1], None, 4) is True
+
+    def test_open_edge_is_not_live_below_its_introduction(self):
+        assert edge_live_at([1], None, 0) is False
+
+    def test_closed_edge_is_not_live_at_or_after_its_close(self):
+        assert edge_live_at([1], [3], 3) is False
+        assert edge_live_at([1], [3], 2) is True
+
+    def test_ambiguous_introduction_uses_the_earliest_colliding_position(self):
+        # A collided vf could be either position; the earliest is the only
+        # choice that cannot understate exposure.
+        assert edge_live_at([3, 4], None, 3) is True
+
+    def test_ambiguous_close_uses_the_latest_colliding_position(self):
+        # Symmetrically, the latest close cannot understate exposure.
+        assert edge_live_at([1], [3, 4], 3) is True
+        assert edge_live_at([1], [3, 4], 4) is False
+
+    def test_unmappable_introduction_is_not_live_anywhere(self):
+        assert edge_live_at([], None, 0) is False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_at_scale_dep_preload_probe.py -v`
+Expected: collection error — `ModuleNotFoundError: No module named 'evals.at_scale.probe_dep_preload_exposure'`.
+
+- [ ] **Step 3: Create the module with the analysis primitives**
+
+Create `evals/at_scale/probe_dep_preload_exposure.py`:
+
+```python
+# evals/at_scale/probe_dep_preload_exposure.py
+"""#245 exposure probe: how much does the :depends-on preload's ts(W) bound
+actually misclassify against real history?
+
+#238 replaced the forward-walk entity preload's author-date bound with a
+position-indexed one. That fix reached three of four preload sites.
+_preload_known_deps and _preload_pinned_commits stayed at ts(W) -- the
+watermark commit's own author date -- because those facts carry no commit
+reference to join a :hash to, and so admit no position clause.
+
+This probe MEASURES that residual. It fixes nothing, and the oracle below is
+NOT a candidate fix -- see position_exact_live_edges' docstring.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, List, Optional, Sequence, Tuple
+
+# minigraf's i64::MAX "still open" :db/valid-to sentinel. Mirrors
+# mcp_server._VALID_TIME_FOREVER_MS (mcp_server.py:7450) exactly; duplicated
+# rather than imported so the analysis primitives stay importable without
+# opening a graph. If the two ever diverge, every open edge is misread as
+# closed at a nonsense position, so keep them identical.
+VALID_TIME_FOREVER_MS = (1 << 63) - 1
+
+CommitMeta = Tuple[str, str, str, str]  # (hash, ts_iso, author_email, subject)
+
+
+def build_ts_positions(commit_metadata: Sequence[CommitMeta]) -> Dict[str, List[int]]:
+    """Map each author-date timestamp to every linearization position holding it.
+
+    A LIST, not a single position, and deliberately so: _git_commits formats
+    "%Y-%m-%dT%H:%M:%SZ" (second granularity), so distinct commits routinely
+    share an instant. Collapsing that to one position would silently pick a
+    winner and produce a confidently wrong exposure number.
+    """
+    ts_positions: Dict[str, List[int]] = {}
+    for pos, (_hash, ts_iso, _author, _subject) in enumerate(commit_metadata):
+        ts_positions.setdefault(ts_iso, []).append(pos)
+    return ts_positions
+
+
+def resume_envelopes(commit_metadata: Sequence[CommitMeta]) -> List[str]:
+    """T_hi(W) = max(ts[0..W]) for every W, the bound _preload_known_entities
+    takes after #238.
+
+    Timestamps are fixed-width UTC, so lexicographic max is chronological max
+    -- the same property mcp_server._resume_envelope relies on.
+    """
+    envelopes: List[str] = []
+    running_max = ""
+    for _hash, ts_iso, _author, _subject in commit_metadata:
+        running_max = max(running_max, ts_iso)
+        envelopes.append(running_max)
+    return envelopes
+
+
+def affected_positions(commit_metadata: Sequence[CommitMeta]) -> List[int]:
+    """Positions where the ts(W) bound is structurally capable of misclassifying.
+
+    This is a position-level precondition computed from commit_metadata alone,
+    independent of any fact. It is what keeps the sweep off every position in
+    the history.
+
+    W is exposed iff either direction is possible there:
+
+      wrong exclusion -- T_hi(W) > ts(W): some commit at position <= W carries
+      a LATER date. A fact introduced there is live at W but falls outside the
+      ts(W) bound, so the resuming walk cannot see it.
+
+      wrong inclusion -- min(ts[W+1..]) <= ts(W): some commit ABOVE W carries a
+      date at or below W's own. A fact introduced there is not yet live at W
+      but falls inside the bound, so the resuming walk sees a future edge.
+
+    The wrong-inclusion test uses <=, not <, because the bound is half-open
+    containment [vf, vt) ∋ ts(W) (mcp_server._valid_time_window_clauses), whose
+    vf test is `<=` -- a fact starting exactly at the instant is live.
+    """
+    timestamps = [ts for _h, ts, _a, _s in commit_metadata]
+    n = len(timestamps)
+    if n == 0:
+        return []
+
+    envelopes = resume_envelopes(commit_metadata)
+
+    # suffix_min[i] = min(timestamps[i+1 .. n-1]), or None past the end.
+    suffix_min: List[Optional[str]] = [None] * n
+    running_min: Optional[str] = None
+    for i in range(n - 1, -1, -1):
+        suffix_min[i] = running_min
+        running_min = timestamps[i] if running_min is None else min(running_min, timestamps[i])
+
+    affected: List[int] = []
+    for w in range(n):
+        wrong_exclusion = envelopes[w] > timestamps[w]
+        wrong_inclusion = suffix_min[w] is not None and suffix_min[w] <= timestamps[w]
+        if wrong_exclusion or wrong_inclusion:
+            affected.append(w)
+    return affected
+
+
+def invert_ms_to_positions(ms: int, ts_positions: Dict[str, List[int]]) -> List[int]:
+    """Map an epoch-millisecond :db/valid-from or :db/valid-to back to the
+    linearization positions whose commit carries that instant.
+
+    Returns [] when no commit matches. The caller MUST treat that as a
+    diagnostic, not as an empty result to skip: an unmappable fact means the
+    inversion assumption is broken, which invalidates the measurement rather
+    than shrinking it.
+    """
+    ts_iso = (
+        datetime.datetime.fromtimestamp(ms / 1000, datetime.timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    return list(ts_positions.get(ts_iso, []))
+
+
+def edge_live_at(
+    vf_positions: List[int],
+    vt_positions: Optional[List[int]],
+    w: int,
+) -> bool:
+    """Is a fact introduced at vf_positions and closed at vt_positions live at
+    position w?
+
+    vt_positions is None for a fact still open (the forever sentinel).
+
+    Ambiguity resolution is deliberately asymmetric, and always in the
+    direction that cannot UNDERSTATE exposure: an ambiguous introduction takes
+    the earliest colliding position, an ambiguous close the latest. Understating
+    is the dangerous direction here -- it would argue for closing #245 as
+    negligible on a number that was rounded in our own favour.
+
+    An empty vf_positions (unmappable introduction) is never live; the driver
+    counts these separately.
+    """
+    if not vf_positions:
+        return False
+    introduced_at = min(vf_positions)
+    if introduced_at > w:
+        return False
+    if vt_positions:
+        return w < max(vt_positions)
+    return True
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/test_at_scale_dep_preload_probe.py -v`
+Expected: all pass.
+
+If `test_inverts_a_unique_timestamp` fails on the literal epoch value, print the actual value and correct the literal in the test — the ISO strings in `META` are the authority, not the hand-computed milliseconds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add evals/at_scale/probe_dep_preload_exposure.py tests/test_at_scale_dep_preload_probe.py
+git commit -m "$(cat <<'EOF'
+Add the #245 probe's affected-position and inversion primitives
+
+affected_positions computes a fact-independent precondition -- T_hi(W) > ts(W)
+for wrong exclusion, min(ts[W+1..]) <= ts(W) for wrong inclusion -- so the
+sweep visits only the positions where the ts(W) bound can misclassify at all.
+
+The timestamp inversion returns a LIST of positions. _git_commits formats to
+second granularity, so distinct commits routinely share an instant; collapsing
+that would silently pick a winner and produce a confidently wrong number.
+Ambiguity is resolved asymmetrically, always away from understating exposure.
+
+Measures only. Refs #245, refs #238.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01T8qWT72sj5ja3wvkcgkK6b
+EOF
+)"
+```
+
+---
+
+### Task 4: Probe driver — ingest, sweep, diff, report
+
+**Files:**
+- Modify: `evals/at_scale/probe_dep_preload_exposure.py`
+- Test: `tests/test_at_scale_dep_preload_probe.py`
+
+**Interfaces:**
+- Consumes: everything Task 3 produced.
+- Produces:
+  - `gitlink_event_count(repo_path: str) -> int`
+  - `load_dep_edges(db) -> list[dict]` — each `{"src": str, "dep": str, "vf_ms": int, "vt_ms": int}`
+  - `position_exact_live_edges(edges, ts_positions, file_entities, w) -> set[tuple[str, str]]`
+  - `sweep(db, repo_path, branch, linearization, commit_metadata) -> dict` — the full report
+  - `main() -> int`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_at_scale_dep_preload_probe.py`:
+
+```python
+import subprocess as _subprocess
+
+import pytest
+
+from evals.at_scale.probe_dep_preload_exposure import (
+    gitlink_event_count,
+    position_exact_live_edges,
+)
+
+
+class TestPositionExactLiveEdges:
+    """The oracle restricts to edges whose SOURCE MODULE is present in
+    file_entities at W, mirroring _preload_known_deps' own ident_to_file
+    filter (mcp_server.py:7526-7535, 7558-7560). That narrowing is already
+    position-correct after #238, so isolating it out leaves the :depends-on
+    bound as the only variable under measurement -- which is exactly #245's
+    residual class."""
+
+    def _edges(self):
+        return [
+            # live from position 1 onward, source module present
+            {"src": ":module/a-py", "dep": ":module/b-py", "vf_ms": 1767225600000, "vt_ms": (1 << 63) - 1},
+            # source module absent from file_entities -- must be excluded
+            {"src": ":module/gone-py", "dep": ":module/b-py", "vf_ms": 1767225600000, "vt_ms": (1 << 63) - 1},
+        ]
+
+    def test_excludes_edges_whose_source_module_is_not_a_live_file_entity(self):
+        ts_positions = {"2026-01-01T00:00:00Z": [1]}
+        live = position_exact_live_edges(
+            self._edges(), ts_positions, file_entities={"a.py": []}, w=2
+        )
+        assert live == {(":module/a-py", ":module/b-py")}
+
+    def test_excludes_edges_introduced_above_the_position(self):
+        ts_positions = {"2026-01-01T00:00:00Z": [1]}
+        live = position_exact_live_edges(
+            self._edges(), ts_positions, file_entities={"a.py": []}, w=0
+        )
+        assert live == set()
+
+
+@pytest.fixture
+def repo_with_submodule(tmp_path):
+    """A repo carrying a real gitlink entry, so gitlink_event_count has
+    something to find."""
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    _subprocess.run(["git", "init"], cwd=inner, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=inner, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.name", "T"], cwd=inner, check=True, capture_output=True)
+    (inner / "x.py").write_text("x = 1\n")
+    _subprocess.run(["git", "add", "."], cwd=inner, check=True, capture_output=True)
+    _subprocess.run(["git", "commit", "-m", "inner"], cwd=inner, check=True, capture_output=True)
+
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    _subprocess.run(["git", "init"], cwd=outer, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=outer, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.name", "T"], cwd=outer, check=True, capture_output=True)
+    (outer / "main.py").write_text("y = 2\n")
+    _subprocess.run(["git", "add", "."], cwd=outer, check=True, capture_output=True)
+    _subprocess.run(["git", "commit", "-m", "outer"], cwd=outer, check=True, capture_output=True)
+    _subprocess.run(
+        ["git", "-c", "protocol.file.allow=always", "submodule", "add", str(inner), "sub"],
+        cwd=outer, check=True, capture_output=True,
+    )
+    _subprocess.run(["git", "commit", "-m", "add sub"], cwd=outer, check=True, capture_output=True)
+    return outer
+
+
+class TestGitlinkEventCount:
+    def test_counts_zero_for_a_repo_without_submodules(self, git_repo):
+        assert gitlink_event_count(str(git_repo)) == 0
+
+    def test_counts_a_real_gitlink_event(self, repo_with_submodule):
+        assert gitlink_event_count(str(repo_with_submodule)) >= 1
+```
+
+Add the `git_repo` fixture to this module too — copy it verbatim from `tests/test_at_scale_ingestion_benchmark.py:20-34`. Do not import it across test modules; pytest fixtures are module-scoped here and the existing file does not export a conftest fixture.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_at_scale_dep_preload_probe.py -v`
+Expected: `ImportError` for `gitlink_event_count` and `position_exact_live_edges`.
+
+- [ ] **Step 3: Add the gitlink check and the oracle**
+
+Append to `evals/at_scale/probe_dep_preload_exposure.py`:
+
+```python
+def gitlink_event_count(repo_path: str) -> int:
+    """Number of raw diff entries across all history touching a gitlink
+    (mode 160000).
+
+    :pinned-commit facts are written only by gitlink handling, so a zero here
+    means this history produces none and its #245 exposure is structurally
+    unmeasurable -- not zero-risk, unmeasurable. That distinction goes in the
+    report verbatim.
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "log", "--all", "--raw", "--no-abbrev", "--format=%H"],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    return sum(
+        1 for line in result.stdout.splitlines()
+        if line.startswith(":") and "160000" in line
+    )
+
+
+def position_exact_live_edges(
+    edges: Sequence[Dict],
+    ts_positions: Dict[str, List[int]],
+    file_entities: Dict[str, List[str]],
+    w: int,
+) -> set:
+    """The (src_ident, dep_ident) edges genuinely live at position w.
+
+    NOT A CANDIDATE FIX, and must never be read as one. This works only
+    because the entire history is in hand at analysis time: it inverts each
+    fact's stored timestamps back to positions. A resuming forward walk has no
+    such thing -- that is the whole reason #245 exists. It is a measurement
+    device and nothing else. None of #245's three options resemble it.
+
+    Restricted to edges whose source module appears in file_entities, mirroring
+    _preload_known_deps' own ident_to_file filter. That narrowing is already
+    position-correct after #238, so holding it fixed leaves the ts(W)
+    :depends-on bound as the single variable under measurement.
+    """
+    import mcp_server
+
+    known_src_idents = {
+        mcp_server._code_ident("module", file_path) for file_path in file_entities
+    }
+
+    live = set()
+    for edge in edges:
+        if edge["src"] not in known_src_idents:
+            continue
+        vf_positions = invert_ms_to_positions(edge["vf_ms"], ts_positions)
+        vt_positions = (
+            None if edge["vt_ms"] >= VALID_TIME_FOREVER_MS
+            else invert_ms_to_positions(edge["vt_ms"], ts_positions)
+        )
+        if edge_live_at(vf_positions, vt_positions, w):
+            live.add((edge["src"], edge["dep"]))
+    return live
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/test_at_scale_dep_preload_probe.py -v`
+Expected: all pass.
+
+- [ ] **Step 5: Add the edge loader and the sweep**
+
+Append to `evals/at_scale/probe_dep_preload_exposure.py`:
+
+```python
+def load_dep_edges(db) -> List[Dict]:
+    """Every :depends-on fact in the graph, current and historical, with its
+    validity window.
+
+    Mirrors _preload_known_deps' own query shape exactly, including the clause
+    ORDER: [?src :ident ?srci] must precede [?src :depends-on ?dep], because
+    minigraf's :db/valid-from / :db/valid-to pseudo-attributes bind to
+    whichever EAV clause on ?src most recently precedes them. Putting :ident
+    between :depends-on and the pseudo-attributes would bind ?vf to the :ident
+    fact's own valid-from instead -- wrong, and silently so.
+    """
+    import json
+
+    import mcp_server
+
+    raw = mcp_server._db_execute(
+        db,
+        "(query [:find ?srci ?dep ?vf ?vt "
+        ":any-valid-time "
+        ":where [?src :ident ?srci] "
+        "[?src :depends-on ?dep] "
+        "[?src :db/valid-from ?vf] "
+        "[?src :db/valid-to ?vt]])",
+    )
+    return [
+        {"src": src, "dep": dep, "vf_ms": int(vf), "vt_ms": int(vt)}
+        for src, dep, vf, vt in json.loads(raw).get("results", [])
+    ]
+
+
+def sweep(
+    db,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: Sequence[CommitMeta],
+) -> Dict:
+    """Drive the REAL preload functions at each affected position and diff
+    against the oracle.
+
+    Calls the functions under test rather than a restatement of what we
+    believe they do. On the #238 branch a reviewer and an implementer both
+    simulated the counterfactual with a date bound instead of the real
+    position-filtered one, which made an inadequate test look adequate and
+    produced a false "bug not reachable" conclusion -- two fix rounds lost.
+    """
+    import mcp_server
+
+    if len(commit_metadata) != len(linearization):
+        raise ValueError(
+            f"commit_metadata has {len(commit_metadata)} entries but "
+            f"linearization has {len(linearization)}; a misaligned pair "
+            "mis-filters the entire sweep"
+        )
+    for i, ((meta_hash, _ts, _a, _s), lin_hash) in enumerate(
+        zip(commit_metadata, linearization)
+    ):
+        if meta_hash != lin_hash:
+            raise ValueError(
+                f"commit_metadata[{i}] is {meta_hash} but linearization[{i}] "
+                f"is {lin_hash}; the two must be positionally aligned"
+            )
+
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+    ts_positions = build_ts_positions(commit_metadata)
+    envelopes = resume_envelopes(commit_metadata)
+    timestamps = [ts for _h, ts, _a, _s in commit_metadata]
+    edges = load_dep_edges(db)
+
+    unmappable = sum(
+        1 for e in edges if not invert_ms_to_positions(e["vf_ms"], ts_positions)
+    )
+    collisions = {ts: pos for ts, pos in ts_positions.items() if len(pos) > 1}
+
+    per_position = []
+    for w in affected_positions(commit_metadata):
+        (
+            _entity_valid_from, _entity_descriptions, _entity_introduced_by,
+            file_entities, _submodule_paths,
+        ) = mcp_server._preload_known_entities(
+            db, repo_path, valid_at=envelopes[w],
+            hash_to_pos=hash_to_pos, watermark_pos=w,
+        )
+        _file_deps, dep_valid_from = mcp_server._preload_known_deps(
+            db, file_entities,
+            valid_at_ms=mcp_server._iso_to_epoch_ms(timestamps[w]),
+        )
+        actual = set(dep_valid_from.keys())
+        expected = position_exact_live_edges(edges, ts_positions, file_entities, w)
+
+        wrongly_included = sorted(actual - expected)
+        wrongly_excluded = sorted(expected - actual)
+        if wrongly_included or wrongly_excluded:
+            per_position.append({
+                "position": w,
+                "commit": linearization[w],
+                "date": timestamps[w],
+                "wrongly_included": [list(e) for e in wrongly_included],
+                "wrongly_excluded": [list(e) for e in wrongly_excluded],
+            })
+
+    return {
+        "repo_path": repo_path,
+        "commits": len(linearization),
+        "dep_edges_total": len(edges),
+        "affected_positions": affected_positions(commit_metadata),
+        "misclassifying_positions": per_position,
+        "wrongly_included_total": sum(
+            len(p["wrongly_included"]) for p in per_position
+        ),
+        "wrongly_excluded_total": sum(
+            len(p["wrongly_excluded"]) for p in per_position
+        ),
+        "timestamp_collisions": len(collisions),
+        "unmappable_valid_from_facts": unmappable,
+        "gitlink_events": gitlink_event_count(repo_path),
+    }
+```
+
+- [ ] **Step 6: Add `main` and the ingestion driver**
+
+Append to `evals/at_scale/probe_dep_preload_exposure.py`:
+
+```python
+async def _ingest_into(repo_path: str, branch: Optional[str], graph_path) -> str:
+    """Ingest repo_path into a fresh scratch graph, using the plain in-process
+    path.
+
+    Deliberately NOT run_ingestion_benchmark: its in-flight poller starved the
+    ingestion it measured (#242, fixed on this same branch). This probe needs
+    a completed ingestion, not a measured one, so it takes the simplest path
+    and no poller at all.
+    """
+    import mcp_server
+
+    mcp_server._db = None
+    mcp_server._graph_path = None
+    mcp_server.open_db(str(graph_path))
+    mcp_server._ingest_progress = {
+        "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+        "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+    }
+    resolved_branch = branch or mcp_server._default_git_branch(repo_path)
+    await mcp_server._run_ingestion(repo_path, resolved_branch)
+    return resolved_branch
+
+
+def main() -> int:
+    import argparse
+    import asyncio
+    import json
+    import sys
+    import tempfile
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent.parent.resolve()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    parser = argparse.ArgumentParser(
+        description="Measure #245's :depends-on preload exposure against real history."
+    )
+    parser.add_argument("--repo-path", default=".")
+    parser.add_argument("--branch", default=None)
+    parser.add_argument("--json-out", default=None)
+    args = parser.parse_args()
+
+    import frontier_registry
+    import mcp_server
+
+    with tempfile.TemporaryDirectory(prefix="minigraf-245-probe-") as tmpdir:
+        graph_path = Path(tmpdir) / "probe.graph"
+        branch = asyncio.run(_ingest_into(args.repo_path, args.branch, graph_path))
+
+        linearization = frontier_registry.build_linearization(args.repo_path, branch)
+        commit_metadata = mcp_server._git_commits(args.repo_path, None, branch)
+        db = mcp_server._db if mcp_server._db is not None else mcp_server.open_db(str(graph_path))
+        report = sweep(db, args.repo_path, linearization, commit_metadata)
+
+    print(json.dumps(report, indent=2))
+    print()
+    print(f"commits:                       {report['commits']}")
+    print(f":depends-on facts:             {report['dep_edges_total']}")
+    print(f"structurally affected W:       {len(report['affected_positions'])}")
+    print(f"W actually misclassifying:     {len(report['misclassifying_positions'])}")
+    print(f"  wrongly INCLUDED edges:      {report['wrongly_included_total']}")
+    print(f"  wrongly EXCLUDED edges:      {report['wrongly_excluded_total']}")
+    print(f"timestamp collisions:          {report['timestamp_collisions']}")
+    print(f"unmappable :valid-from facts:  {report['unmappable_valid_from_facts']}")
+    print(f"gitlink events:                {report['gitlink_events']}")
+    if report["gitlink_events"] == 0:
+        print()
+        print(
+            "NOTE: zero gitlink events -- this history produces no :pinned-commit\n"
+            "facts, so #245's :pinned-commit half is UNMEASURABLE here. That is\n"
+            "not the same as zero risk; its field exposure remains unknown."
+        )
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 7: Verify the module imports cleanly and the CLI parses**
+
+Run: `python -c "from evals.at_scale import probe_dep_preload_exposure as p; print(p.main.__name__)"`
+Expected: prints `main`, no ImportError.
+
+Run: `python -m evals.at_scale.probe_dep_preload_exposure --help`
+Expected: argparse help text, exit 0.
+
+- [ ] **Step 8: Run the full test suite**
+
+Run: `pytest tests/test_at_scale_dep_preload_probe.py tests/test_at_scale_ingestion_benchmark.py tests/test_at_scale_report.py -v`
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add evals/at_scale/probe_dep_preload_exposure.py tests/test_at_scale_dep_preload_probe.py
+git commit -m "$(cat <<'EOF'
+Add the #245 exposure probe driver
+
+Ingests into a scratch graph, then drives the REAL _preload_known_entities and
+_preload_known_deps at each structurally affected position and diffs their
+output against a position-exact oracle. Calling the functions under test
+rather than restating their semantics is deliberate: on the #238 branch a
+date-bound counterfactual made an inadequate test look adequate and cost two
+fix rounds.
+
+The oracle holds _preload_known_deps' own ident_to_file narrowing fixed --
+that filter is already position-correct after #238 -- leaving the ts(W)
+:depends-on bound as the single variable under measurement.
+
+Reports timestamp collisions and unmappable :valid-from facts alongside the
+exposure counts, so a smeared measurement is visible as one. Zero gitlink
+events is reported as UNMEASURABLE, not as zero risk.
+
+Measures only. Refs #245, refs #238, refs #222.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01T8qWT72sj5ja3wvkcgkK6b
+EOF
+)"
+```
+
+---
+
+### Task 5: Run the measurement and record the findings
+
+**Files:**
+- Create: `evals/at_scale/results/245-dep-preload-exposure.json`
+
+**Interfaces:**
+- Consumes: `main()` from Task 4.
+- Produces: the number this whole branch exists to obtain, plus issue comments.
+
+- [ ] **Step 1: Run the probe against this repository**
+
+Run:
+
+```bash
+python -m evals.at_scale.probe_dep_preload_exposure \
+  --repo-path . \
+  --json-out evals/at_scale/results/245-dep-preload-exposure.json
+```
+
+Expect roughly 25-40 minutes for the ingestion, then a fast sweep. Run it in the background and poll with `ps -p <PID>` — **not** `pgrep -f`, which matches the polling shell's own wrapper and never goes false.
+
+- [ ] **Step 2: Sanity-check the output before believing it**
+
+Three checks, in order. Any failure means the number is not yet trustworthy — stop and report rather than recording it:
+
+1. `unmappable_valid_from_facts` should be 0. A non-zero count means the inversion assumption is broken and the exposure figure is unreliable, not merely smaller.
+2. `gitlink_events` must be 0, confirming the spec's structural finding about `:pinned-commit`.
+3. `affected_positions` should be a small set clustered in the low-to-mid 100s, consistent with the five inverted commits at positions 124-128 recorded in the spec. A count in the hundreds means `affected_positions` is over-selecting and needs re-checking against Task 3's tests.
+
+- [ ] **Step 3: Commit the result**
+
+```bash
+git add evals/at_scale/results/245-dep-preload-exposure.json
+git commit -m "$(cat <<'EOF'
+Record the #245 :depends-on exposure measurement
+
+Refs #245
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01T8qWT72sj5ja3wvkcgkK6b
+EOF
+)"
+```
+
+- [ ] **Step 4: Comment the findings on #245**
+
+Post a comment carrying, verbatim from the JSON: the affected-position count, the misclassifying-position count, wrongly-included and wrongly-excluded edge totals, the collision count, the unmappable count, and the `:pinned-commit` structural result.
+
+State plainly which of #245's three options the number argues for — or that it argues for accepting the residual — **without building it**. Include the two caveats: the oracle resolves ambiguity away from understating exposure, so the figure is an upper bound within its collision set; and `:pinned-commit` remains unmeasured, so this number speaks only for `:depends-on`.
+
+Do not use a closing keyword. #245 stays open for the decision the number feeds.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin probe-245-dep-preload-exposure
+```
+
+PR title: `Measure #245's :depends-on preload exposure, and fix the benchmark poller (#242)`
+
+The PR body must use `Closes #242` and `Refs #245`, `Refs #238`, `Refs #222`. Never write a closing keyword beside #238 or #245 in any form, negated or otherwise.
+
+Note in the body that `master` requires an approving review on top of green CI, and ask before using `--admin` to bypass.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| `evals/at_scale/probe_dep_preload_exposure.py` | 3, 4 |
+| `run_ingestion_benchmark.py` poller fix | 1 |
+| `benchmark.md` note | 2 |
+| Tests for both | 1, 2, 3, 4 |
+| Issue comments recording findings | 5 |
+| Out of scope: no preload/fact-model change | Global Constraints; no task touches `mcp_server.py` |
+| `Refs`/`Closes` keyword discipline | Global Constraints; Tasks 1, 5 |
+| Affected-`W` exact definition | Task 3, `affected_positions` |
+| Oracle inverts both `valid_from` and `valid_to` | Task 3 `edge_live_at`; Task 4 `position_exact_live_edges` |
+| Oracle is not a candidate fix | Task 4, docstring |
+| Collisions reported, not hidden | Task 3 `build_ts_positions`; Task 4 `sweep` |
+| `:pinned-commit` structural check | Task 4 `gitlink_event_count`; Task 5 Step 2 |
+| Output: JSON + human summary | Task 4 `main` |
+| `poll_count` / `poll_duty_fraction` | Task 2 |
+| Ablation mandatory | Task 1 Step 2 |
+| Fail-loud error handling | Task 4 `sweep` alignment check; unmappable counted |
+
+No gaps.
+
+**Placeholder scan:** No TBD/TODO. Every code step carries runnable code; every test step carries the test body.
+
+**Type consistency:** `commit_metadata` is `(hash, ts_iso, author, subject)` throughout, matching `_git_commits`. `invert_ms_to_positions` returns `List[int]` everywhere it is consumed. `_poll_during_ingestion`'s 3-tuple is introduced in Task 1 and consumed in Task 2 with matching names. `file_entities` is `Dict[str, List[str]]` in both `_preload_known_deps` and `position_exact_live_edges`. Edge dicts use `src`/`dep`/`vf_ms`/`vt_ms` in Tasks 3 and 4 alike.
+
+**Referenced `mcp_server` symbols, all verified present before this plan was finalized:**
+
+| Symbol | Location |
+|---|---|
+| `_default_git_branch` | `mcp_server.py:4089` |
+| `_iso_to_epoch_ms` | `mcp_server.py:4925` |
+| `_git_commits` | `mcp_server.py:4112` |
+| `_code_ident` | `mcp_server.py:4067` |
+| `_preload_known_entities` | `mcp_server.py:7078` |
+| `_preload_known_deps` | `mcp_server.py:7471` |
+| `_valid_time_window_clauses` | `mcp_server.py:7453` |
+| `_VALID_TIME_FOREVER_MS` | `mcp_server.py:7450` |
+| `_db_execute` | `mcp_server.py:3280` |
+| `frontier_registry.build_linearization` | `frontier_registry.py:26` |
+
+The sentinel is `(1 << 63) - 1` (i64::MAX), **not** a year-9999 epoch value — an earlier draft of this plan had it wrong, which would have misread every open edge as closed at a nonsense position and understated exposure. Task 3's `VALID_TIME_FOREVER_MS` and Task 4's test literals both use `(1 << 63) - 1`.

--- a/docs/superpowers/specs/2026-08-07-dep-preload-exposure-probe-design.md
+++ b/docs/superpowers/specs/2026-08-07-dep-preload-exposure-probe-design.md
@@ -49,7 +49,15 @@ Out of scope, explicitly:
 - Closing #245. The measurement is the deliverable; the decision it feeds is a
   separate spec → plan cycle.
 
-`Closes #242` is correct and intended.
+**Revised 2026-08-07: #242 is NOT closed by this work either.** An earlier version
+of this spec said `Closes #242` was correct and intended. It is not. #242's own
+acceptance criterion is a `poll_duty_fraction` row in a real `benchmark.md`
+entry, and no such entry exists — the probe deliberately bypasses
+`run_ingestion_benchmark` entirely, so the fixed poller has never driven a
+full-history ingestion. Its evidence is ablation-proven unit tests on a
+2-commit fixture plus the lock-share arithmetic, which is good but is not the
+stated criterion. #242 closes on one green at-scale nightly carrying a duty
+row. Every commit message and the PR body therefore use `Refs #242`.
 
 ## Findings that shape the design
 

--- a/docs/superpowers/specs/2026-08-07-dep-preload-exposure-probe-design.md
+++ b/docs/superpowers/specs/2026-08-07-dep-preload-exposure-probe-design.md
@@ -13,9 +13,16 @@ justify a fix. The issue deliberately makes no recommendation and asks for
 exposure to be quantified first, the way #238 quantified its own inverted
 positions. This spec builds that measurement. **It does not fix anything.**
 
-**#242** is folded in because a full-history ingestion is a prerequisite for the
-measurement, and today's benchmark harness cannot finish one: its poller starves
-the ingestion it measures.
+**#242** fixes the benchmark harness's in-flight poller, which starves the
+ingestion it measures.
+
+The two changes are **independent** and are bundled here only for convenience —
+one branch, one review. An earlier version of this spec justified the bundle by
+claiming a full-history ingestion through the benchmark harness was a
+prerequisite for the measurement. It is not: the probe deliberately bypasses
+`run_ingestion_benchmark` entirely and runs the plain in-process ingestion path
+with no poller at all (see `_ingest_into`). #245 would have been measurable with
+#242 unfixed.
 
 ## Scope
 
@@ -83,7 +90,7 @@ from #238's recorded 6 positions at 118–123 (552 commits). The probe must use
 discrepancy is expected — different linearization, larger history — and is not
 evidence that either measurement is wrong.
 
-### #245's option 2 is already half-implemented for `:depends-on`
+### #245's option 2 is *partly* implemented for `:depends-on` — on one side only
 
 `_preload_known_deps` builds `ident_to_file` from `file_entities` and drops any
 row whose source module ident is absent from it (`mcp_server.py:7526-7535`,
@@ -97,19 +104,32 @@ if file_path is None:
     continue
 ```
 
-`file_entities` comes from `_preload_known_entities`, which #238 **did**
-position-filter. So dep edges whose source module failed the position filter are
-already excluded — which is exactly #245's option 2, "narrow via the entity
-preload," applied to the source-module side.
+`file_entities` comes from `_preload_known_entities`, which #238 position-filtered
+— **but on the introduction side only.** Its position clause keys on the
+*introducing* commit (`[?e :introduced-by ?c] [?c :hash ?hash]` → `hash_to_pos`,
+`mcp_server.py:7213-7215`). The function's CLOSE side is still governed by
+`valid_at = T_hi(W)`, a date bound suffering the identical author-date inversion
+#245 is about. The function's own comment says so: *"the date bound above only
+governs how widely entities closed ABOVE the watermark are re-admitted."*
 
-The real residual is therefore only the class #245 names as option 2's leak:
-edges whose source module survived the position filter but whose *edge* was
-introduced or closed inside the inverted window. #245's impact section is
-correspondingly narrower than it reads.
+An earlier version of this section claimed the narrowing was position-correct
+outright, and the probe was built on that claim. **It is false, and it cost the
+measurement a factor of ~16.** A module whose close *date* falls below `ts(W)`
+but whose close *position* sits above `W` vanishes from `file_entities` at `W`,
+so its `:depends-on` edges never reach either side of the probe's diff. On this
+repository that is five modules deleted by `df6b8be` at position 124
+(`vulcan.py` plus four test modules) and 30 misclassified edges.
 
-This is also why the probe must drive the real `_preload_known_deps` rather than
-reimplement its semantics: an offline reimplementation would miss this narrowing
-and overstate the exposure.
+Consequences for the design:
+
+- The residual is *not* only "edges whose source module survived the position
+  filter but whose edge was introduced or closed inside the inverted window."
+  That is the residual **conditional on** #238's close-side leak. The
+  unconditional `:depends-on` residual is larger.
+- The probe must therefore report **two** numbers, not one. See "The oracle".
+- The probe must still drive the real `_preload_known_deps` rather than
+  reimplement its semantics — an offline reimplementation would miss the
+  `ident_to_file` narrowing entirely.
 
 `_preload_pinned_commits` has no equivalent narrowing — it consumes every
 `:pinned-commit` fact the bound admits.
@@ -151,32 +171,82 @@ Approach 2 was already run as a smoke check and is what produced the table above
    `commit_metadata = _git_commits(repo_path, None, branch)`. Both real, and
    validated for positional alignment before use (see Error handling).
 3. Build `ts → [positions]` from `commit_metadata`.
-4. Derive the **affected `W` set**. A position `W` is exposed iff either
-   direction is structurally possible there:
+4. Derive the **affected `W` set** — the *union* of two structural conditions.
+   Neither condition belongs to one misclassification direction; **each enables
+   one of each**, because the bound is half-open containment `[vf, vt) ∋ ts(W)`
+   and a fact's *close* is date-bounded on exactly the same terms as its
+   introduction:
 
-   - **wrong exclusion** — `T_hi(W) > ts(W)`, i.e. some commit at position
-     `≤ W` carries a later date than `W`'s own. A fact introduced there is live
-     at `W` but falls outside the `ts(W)` bound.
-   - **wrong inclusion** — `min(ts[W+1 .. N-1]) <= ts(W)`, i.e. some commit
-     *above* `W` carries a date at or below `W`'s own. A fact introduced there
-     is not yet live at `W` but falls inside the `ts(W)` bound.
+   | mechanism | condition |
+   |---|---|
+   | wrong inclusion via introduction | `min(ts[W+1 .. N-1]) <= ts(W)` |
+   | wrong exclusion via **close** | `min(ts[W+1 .. N-1]) <= ts(W)` |
+   | wrong exclusion via introduction | `T_hi(W) > ts(W)` |
+   | wrong inclusion via **close** | `T_hi(W) > ts(W)` |
 
-   `W` is swept if either holds. This is a position-level precondition computed
-   from `commit_metadata` alone, independent of any fact; it is what keeps the
-   sweep off all 610 positions.
-5. For each affected `W`:
-   - `_preload_known_entities(valid_at=T_hi(W), hash_to_pos=…, watermark_pos=W)`
-   - feed its `file_entities` into
-     `_preload_known_deps(valid_at_ms=ts(W))`
-   - diff the result against the position-exact oracle for `W`.
-6. Emit per-`W` wrong-inclusion and wrong-exclusion counts, the affected edge
-   idents, and the diagnostics below.
+   - `min(ts[W+1 .. N-1]) <= ts(W)` — some commit *above* `W` carries a date at
+     or below `W`'s own. A fact **introduced** there passes the bound but is not
+     yet live (wrong inclusion). A fact **closed** there has `vt <= ts(W)`, so
+     containment rejects it, though its close position is above `W` and it is
+     still live (wrong exclusion).
+   - `T_hi(W) > ts(W)` — some commit at position `≤ W` carries a later date. A
+     fact **introduced** there falls outside the bound though it is live (wrong
+     exclusion). A fact **closed** there has `vt > ts(W)`, so the bound still
+     reads it as open though it is already dead (wrong inclusion).
 
-### The oracle
+   An earlier version of this section labelled the first condition "wrong
+   inclusion" and the second "wrong exclusion" outright. That is wrong, and it
+   was empirically decisive in the wrong direction: positions 118–123 are
+   flagged by the first condition alone, and every one of them misclassifies by
+   wrong **exclusion** — via close, the arm the old labelling did not name.
+
+   The union is a position-level precondition computed from `commit_metadata`
+   alone, independent of any fact; it is what keeps the sweep off all 610
+   positions.
+5. For each affected `W`, run the diff **twice**, changing only the
+   `file_entities` handed to the (unmodified) `_preload_known_deps`:
+   - **narrow** — `file_entities` from
+     `_preload_known_entities(valid_at=T_hi(W), hash_to_pos=…, watermark_pos=W)`
+   - **wide** — `file_entities` rebuilt position-correctly from `:path` facts
+   - `_preload_known_deps(valid_at_ms=ts(W))` on each, diffed against the
+     position-exact oracle restricted to the same entity set.
+6. Emit per-`W` wrong-inclusion and wrong-exclusion counts **in both framings**,
+   the affected edge idents, and the diagnostics below.
+
+### The oracle, and the two entity framings
 
 For each `:depends-on` fact retrieved under `:any-valid-time`, invert **both**
 `:db/valid-from` and `:db/valid-to` to positions through the `ts → [positions]`
 map, then select the facts live at position `W` directly.
+
+The oracle is restricted to edges whose *source module* is in `file_entities`,
+mirroring `_preload_known_deps`' own `ident_to_file` filter. Which
+`file_entities` is passed is the one variable that separates the two reported
+figures:
+
+- **narrow** — `_preload_known_entities`' own output. Position-correct on the
+  introduction side, date-bounded on the close side (see the finding above).
+  This measures the `ts(W)` `:depends-on` bound **conditional on #238's
+  still-open close-side residual**: modules whose own close inverted are
+  already gone, so their edges never reach either side of the diff. This is the
+  figure the shipped code produces today, and the only one the first version of
+  this probe reported.
+- **wide** — `file_entities` rebuilt by `position_correct_file_entities`, from
+  module `:path` facts under `:any-valid-time` with **both** `:db/valid-from`
+  and `:db/valid-to` inverted to positions by the same
+  `invert_ms_to_positions` / `edge_live_at` primitives the edge oracle uses. A
+  module is in the wide set at `W` iff its `:path` fact is live at position
+  `W`. This measures the `ts(W)` `:depends-on` bound **in isolation**.
+
+Both go in the report dict and the printed summary, side by side and labelled.
+**Neither alone is "the" number** — the gap between them is #238's own
+close-side leak, and the comparison is the finding. Reporting only the narrow
+figure understated this repository's exposure by ~16x (2 distinct edges over 6
+positions, vs. 32 wrongly excluded at `W=118` alone).
+
+`position_correct_file_entities` is, like the edge oracle, a **measurement
+device and not a candidate fix**: it needs the whole history in hand, which a
+resuming forward walk does not have.
 
 Both ends matter. `_valid_time_window_clauses` expresses the bound as half-open
 containment `[?vf, ?vt) ∋ valid_at_ms` (`mcp_server.py:7466-7468`), so the
@@ -207,9 +277,15 @@ that exposure is therefore unmeasurable here and unknown in the field.
 ### Output
 
 A JSON report plus a short human-readable summary: total affected positions,
-per-`W` wrong-inclusion and wrong-exclusion counts, affected edge idents,
-timestamp-collision count, unmappable-fact count, and the `:pinned-commit`
-structural result.
+per-`W` wrong-inclusion and wrong-exclusion counts **in both the narrow and the
+wide framing**, affected edge idents, timestamp-collision count,
+unmappable-fact count, and the `:pinned-commit` structural result.
+
+The report also carries its own **provenance** — `repo_path`, `branch`, and the
+ingested `head_commit` (taken from the linearization's last entry, i.e. the
+commit the swept graph actually ends at). The first recorded artifact had
+`repo_path` alone, naming a scratch directory that no longer exists, and so was
+not reproducible from its own record.
 
 ## The #242 poller fix
 
@@ -231,8 +307,13 @@ bounds the instrument's share of that lock.
 - `duty_factor` defaults to 10, exposed as `--poll-duty-factor`. At 10 the
   poller holds `_db_native_lock` for at most ~9% of the run however large the
   scan grows.
-- `_STATUS_QUERY` is **unchanged**, so the recorded latency series stays
-  comparable to existing `benchmark.md` entries.
+- `_STATUS_QUERY` is **unchanged**, so the *query being timed* is the same one
+  every existing `benchmark.md` entry timed. That is not the same as saying the
+  recorded percentiles stay comparable, and the two must not be conflated: the
+  adaptive interval undersamples exactly the late, expensive polls (the scan
+  cost grows all run, and the backoff is proportional to it), so `query_latency`
+  p50/p99 from 2026-08-07 onward are biased **low** against every pre-fix entry.
+  Comparability of the query is not comparability of the percentiles.
 - A dedicated executor, rather than the loop default, keeps the poll off any
   thread the ingestion may want.
 
@@ -247,7 +328,11 @@ are recorded so an irregular sample stays interpretable.
 ### Limitations, recorded rather than papered over
 
 - Latency percentiles are now computed over an **irregular** sample, because the
-  interval adapts. The offsets are recorded for this reason.
+  interval adapts, and the irregularity is *correlated with cost*: the backoff
+  is longest exactly when the polled query is slowest. So post-fix p50/p99 are
+  biased low relative to pre-fix entries, in addition to the pre-fix entries'
+  wall clock being biased high. The offsets are recorded so the sample stays
+  interpretable; `benchmark.md`'s note says both halves of this outright.
 - A cancelled run still waits on an in-flight poll thread at executor shutdown.
   The old code blocked the event loop outright, so this is strictly better, but
   it is not zero.
@@ -255,8 +340,10 @@ are recorded so an irregular sample stays interpretable.
 ### `benchmark.md`
 
 A dated note that every entry recorded before this fix carries poller overhead:
-entry-to-entry comparisons remain valid, absolute figures overstate real
-ingestion cost.
+entry-to-entry comparisons remain valid, absolute wall-clock figures overstate
+real ingestion cost, **and** the latency percentiles move the other way — post-
+fix p50/p99 are biased low by the adaptive interval's cost-correlated
+undersampling, so a pre/post percentile comparison is not a like-for-like one.
 
 ## Testing
 
@@ -280,12 +367,26 @@ The probe's headline output cannot be asserted; the number is what we are trying
 to learn. The two components that could silently produce a *wrong* number can
 be, and are:
 
-- the `valid_from` → position inversion, and
-- the affected-`W` derivation,
+- the `valid_from` → position inversion,
+- the affected-`W` derivation, and
+- `position_correct_file_entities`, the wide framing's entity set — including a
+  module whose close *date* inverts against its close *position*, which is the
+  exact case that was invisible to the narrow-only measurement,
 
-both against a small synthetic fixture with known inverted dates and a
-deliberate timestamp collision. This is the exact error class that cost two fix
-rounds on #238.
+all against a small synthetic fixture with known inverted dates and a deliberate
+timestamp collision. This is the exact error class that cost two fix rounds on
+#238.
+
+Two further guards, both for silent failures rather than wrong arithmetic:
+
+- `VALID_TIME_FOREVER_MS` is asserted equal to
+  `mcp_server._VALID_TIME_FOREVER_MS`. The probe duplicates the sentinel so its
+  primitives stay importable without a graph; a comment said "keep them
+  identical" and nothing enforced it. Divergence would silently reread every
+  open edge as closed.
+- `load_module_path_facts` is exercised against a **real ingested graph**. A
+  wrong clause order or mistyped attribute returns zero rows without raising,
+  which would make the wide figure a confident, meaningless zero.
 
 ### Not tested
 

--- a/docs/superpowers/specs/2026-08-07-dep-preload-exposure-probe-design.md
+++ b/docs/superpowers/specs/2026-08-07-dep-preload-exposure-probe-design.md
@@ -75,7 +75,7 @@ the inverted cluster. Of those five commits, two churn Python imports:
 
 | pos | commit | change |
 |---|---|---|
-| 124 | `df6b8be` | deletes `vulcan.py` and four test modules — heavy dep-edge removal |
+| 124 | `df6b8be` | deletes `vulcan.py` and three test modules — heavy dep-edge removal |
 | 125 | `0496d24` | "style: remove unused imports from conftest.py" — nothing but dep edges |
 | 126 | `2d756e2` | `pyproject.toml`, `requirements.txt` — no `.py` |
 | 127 | `5fbc354` | `ROADMAP.md` only |
@@ -117,8 +117,15 @@ outright, and the probe was built on that claim. **It is false, and it cost the
 measurement a factor of ~16.** A module whose close *date* falls below `ts(W)`
 but whose close *position* sits above `W` vanishes from `file_entities` at `W`,
 so its `:depends-on` edges never reach either side of the probe's diff. On this
-repository that is five modules deleted by `df6b8be` at position 124
-(`vulcan.py` plus four test modules) and 30 misclassified edges.
+repository that is four modules deleted by `df6b8be` at position 124
+(`vulcan.py` plus three test modules) and 30 misclassified edges.
+
+Both figures are now measured, not estimated. The 2026-08-07 run confirms the
+factor exactly: `narrow_wrongly_excluded_distinct_edges` 2 vs
+`wide_wrongly_excluded_distinct_edges` **32**, with `wide_expected_count` 68
+against `narrow_expected_count` 38 at each of positions 118-123, and
+`modules_wide_only` **4**. See
+`evals/at_scale/results/245-dep-preload-exposure.json`.
 
 Consequences for the design:
 

--- a/docs/superpowers/specs/2026-08-07-dep-preload-exposure-probe-design.md
+++ b/docs/superpowers/specs/2026-08-07-dep-preload-exposure-probe-design.md
@@ -1,0 +1,314 @@
+# `:depends-on` preload exposure probe, and the benchmark poller fix
+
+Date: 2026-08-07
+Issues: #245 (measure), #242 (fix), refs #238, refs #222
+
+## Purpose
+
+Two independent changes, one branch.
+
+**#245** asks whether `:depends-on` and `:pinned-commit` preload bounds — the
+one quarter of #238 that its fix did not reach — expose enough real risk to
+justify a fix. The issue deliberately makes no recommendation and asks for
+exposure to be quantified first, the way #238 quantified its own inverted
+positions. This spec builds that measurement. **It does not fix anything.**
+
+**#242** is folded in because a full-history ingestion is a prerequisite for the
+measurement, and today's benchmark harness cannot finish one: its poller starves
+the ingestion it measures.
+
+## Scope
+
+In scope:
+
+- `evals/at_scale/probe_dep_preload_exposure.py` — new exposure probe. Read-only
+  with respect to any existing graph: it ingests into a scratch graph of its
+  own and never writes to one it did not create.
+- `evals/at_scale/run_ingestion_benchmark.py` — #242's poller fix.
+- `evals/at_scale/benchmark.md` — a note that prior entries carry poller overhead.
+- Tests for both, in `tests/test_at_scale_ingestion_benchmark.py` and a new
+  probe test module.
+- Issue comments recording the measured number and the `:pinned-commit` finding.
+
+Out of scope, explicitly:
+
+- Any change to `_preload_known_deps`, `_preload_pinned_commits`, or the fact
+  model. #245's three options stay unbuilt until the number says which, if any,
+  is warranted.
+- Closing #238. It stays open until all four preload sites are resolved. Commit
+  messages and the PR body use `Refs #238` and `Refs #245`, never a closing
+  keyword — GitHub scans both, and on this project a *negated* "does not close
+  #N" has still auto-closed an issue.
+- Closing #245. The measurement is the deliverable; the decision it feeds is a
+  separate spec → plan cycle.
+
+`Closes #242` is correct and intended.
+
+## Findings that shape the design
+
+These were established before writing this spec and change what needs building.
+
+### `:pinned-commit` exposure is unmeasurable on this repository
+
+This repository has never had a submodule: no `.gitmodules` in any commit
+(`git log --all -- .gitmodules` is empty), and no gitlink (mode `160000`)
+entries in `HEAD`. `:pinned-commit` facts are written only by gitlink handling,
+so this history produces none.
+
+Consequence: the probe cannot produce a `:pinned-commit` exposure number, and
+inventing one from a constructed fixture would measure reachability, not
+frequency. The probe therefore asserts the structural fact and records it.
+`:pinned-commit`'s field exposure remains **unknown** and depends on
+submodule-using repositories.
+
+### `:depends-on` exposure is plausibly real
+
+Five positions in this history carry an author date below the running maximum —
+the inverted cluster. Of those five commits, two churn Python imports:
+
+| pos | commit | change |
+|---|---|---|
+| 124 | `df6b8be` | deletes `vulcan.py` and four test modules — heavy dep-edge removal |
+| 125 | `0496d24` | "style: remove unused imports from conftest.py" — nothing but dep edges |
+| 126 | `2d756e2` | `pyproject.toml`, `requirements.txt` — no `.py` |
+| 127 | `5fbc354` | `ROADMAP.md` only |
+| 128 | `f824fd9` | `ROADMAP.md` only |
+
+So the cheap "upper bound is zero" outcome is unavailable, and the exact tier is
+required.
+
+These positions come from `git log --topo-order` over 610 commits, and differ
+from #238's recorded 6 positions at 118–123 (552 commits). The probe must use
+`frontier_registry.build_linearization()`, not this approximation. The
+discrepancy is expected — different linearization, larger history — and is not
+evidence that either measurement is wrong.
+
+### #245's option 2 is already half-implemented for `:depends-on`
+
+`_preload_known_deps` builds `ident_to_file` from `file_entities` and drops any
+row whose source module ident is absent from it (`mcp_server.py:7526-7535`,
+`7558-7560`):
+
+```python
+ident_to_file = {_code_ident("module", p): p for p in file_entities}
+...
+file_path = ident_to_file.get(src_ident)
+if file_path is None:
+    continue
+```
+
+`file_entities` comes from `_preload_known_entities`, which #238 **did**
+position-filter. So dep edges whose source module failed the position filter are
+already excluded — which is exactly #245's option 2, "narrow via the entity
+preload," applied to the source-module side.
+
+The real residual is therefore only the class #245 names as option 2's leak:
+edges whose source module survived the position filter but whose *edge* was
+introduced or closed inside the inverted window. #245's impact section is
+correspondingly narrower than it reads.
+
+This is also why the probe must drive the real `_preload_known_deps` rather than
+reimplement its semantics: an offline reimplementation would miss this narrowing
+and overstate the exposure.
+
+`_preload_pinned_commits` has no equivalent narrowing — it consumes every
+`:pinned-commit` fact the bound admits.
+
+## Approach
+
+Considered three oracles:
+
+1. **Reimplement the bound's semantics offline** — map each fact's
+   `:db/valid-from` and `:db/valid-to` to positions and compute
+   misclassification arithmetically.
+2. **Pure-git upper bound** — per commit, does it touch a `.py` file. Seconds to
+   run, but over-approximates badly and yields no fact counts.
+3. **Differential against the real function** — drive the actual
+   `_preload_known_deps` at each affected position and diff against a
+   position-exact offline oracle.
+
+**Chosen: 3, built on 1's machinery.** The reason is specific to this project.
+On the #238 branch a reviewer and an implementer both simulated the
+counterfactual with a *date* bound instead of the real position-filtered one,
+which made an inadequate test look adequate and produced a false "bug not
+reachable" conclusion — two fix rounds lost. Approach 3 calls the function under
+test rather than a restatement of what we believe it does. The `ident_to_file`
+narrowing above is a concrete instance of what a restatement would miss.
+
+Approach 1 remains the fallback if driving the real function proves awkward.
+Approach 2 was already run as a smoke check and is what produced the table above.
+
+## The probe
+
+`evals/at_scale/probe_dep_preload_exposure.py`.
+
+### Data flow
+
+1. Ingest this repository fully into a scratch graph, via the non-polling
+   in-process path — **not** `run_ingestion_benchmark`, whose poller is the
+   subject of the other half of this branch.
+2. `linearization = frontier_registry.build_linearization(repo_path, branch)`;
+   `commit_metadata = _git_commits(repo_path, None, branch)`. Both real, and
+   validated for positional alignment before use (see Error handling).
+3. Build `ts → [positions]` from `commit_metadata`.
+4. Derive the **affected `W` set**. A position `W` is exposed iff either
+   direction is structurally possible there:
+
+   - **wrong exclusion** — `T_hi(W) > ts(W)`, i.e. some commit at position
+     `≤ W` carries a later date than `W`'s own. A fact introduced there is live
+     at `W` but falls outside the `ts(W)` bound.
+   - **wrong inclusion** — `min(ts[W+1 .. N-1]) <= ts(W)`, i.e. some commit
+     *above* `W` carries a date at or below `W`'s own. A fact introduced there
+     is not yet live at `W` but falls inside the `ts(W)` bound.
+
+   `W` is swept if either holds. This is a position-level precondition computed
+   from `commit_metadata` alone, independent of any fact; it is what keeps the
+   sweep off all 610 positions.
+5. For each affected `W`:
+   - `_preload_known_entities(valid_at=T_hi(W), hash_to_pos=…, watermark_pos=W)`
+   - feed its `file_entities` into
+     `_preload_known_deps(valid_at_ms=ts(W))`
+   - diff the result against the position-exact oracle for `W`.
+6. Emit per-`W` wrong-inclusion and wrong-exclusion counts, the affected edge
+   idents, and the diagnostics below.
+
+### The oracle
+
+For each `:depends-on` fact retrieved under `:any-valid-time`, invert **both**
+`:db/valid-from` and `:db/valid-to` to positions through the `ts → [positions]`
+map, then select the facts live at position `W` directly.
+
+Both ends matter. `_valid_time_window_clauses` expresses the bound as half-open
+containment `[?vf, ?vt) ∋ valid_at_ms` (`mcp_server.py:7466-7468`), so the
+*close* timestamp is subject to date inversion on exactly the same terms as the
+introduction. An oracle that inverted only `valid_from` would miss every edge
+misclassified by its close — which is the direction commit `0496d24` at position
+125 ("remove unused imports from conftest.py") actually exercises. The forever
+sentinel maps to "not closed" and needs no inversion.
+
+Two properties this spec states outright, because both are easy to misread
+later:
+
+- **The oracle is not a candidate fix.** It works only because the entire
+  history is in hand at analysis time. A resuming forward walk has no such
+  thing. It is a measurement device; it must not be read as a shipped bound, and
+  it is not one of #245's three options.
+- **Timestamp collisions are reported, not hidden.** Commits sharing an
+  author-date second collapse to one `valid_from`, making the introducing
+  position of a fact ambiguous. The probe reports the collision count next to
+  the exposure number so a reader can distinguish a clean measurement from a
+  smeared one.
+
+### `:pinned-commit`
+
+Structural check only: assert zero gitlink events across the history, and record
+that exposure is therefore unmeasurable here and unknown in the field.
+
+### Output
+
+A JSON report plus a short human-readable summary: total affected positions,
+per-`W` wrong-inclusion and wrong-exclusion counts, affected edge idents,
+timestamp-collision count, unmappable-fact count, and the `:pinned-commit`
+structural result.
+
+## The #242 poller fix
+
+`_poll_during_ingestion` gains a dedicated single-worker `ThreadPoolExecutor`
+and an adaptive interval:
+
+```python
+await loop.run_in_executor(poll_executor, mcp_server.handle_minigraf_ingest_status)
+await loop.run_in_executor(poll_executor, mcp_server.handle_minigraf_query, _STATUS_QUERY)
+await asyncio.sleep(max(poll_interval, duty_factor * (status_d + query_d)))
+```
+
+Both halves are load-bearing. Moving the query off the event loop alone is
+insufficient: `handle_minigraf_query` acquires `_db_native_lock`
+(`mcp_server.py:3280`), so a growing count-scan would still serialize against
+every ingestion write even from another thread. The adaptive interval is what
+bounds the instrument's share of that lock.
+
+- `duty_factor` defaults to 10, exposed as `--poll-duty-factor`. At 10 the
+  poller holds `_db_native_lock` for at most ~9% of the run however large the
+  scan grows.
+- `_STATUS_QUERY` is **unchanged**, so the recorded latency series stays
+  comparable to existing `benchmark.md` entries.
+- A dedicated executor, rather than the loop default, keeps the poll off any
+  thread the ingestion may want.
+
+### Result-dict additions
+
+`poll_count` and `poll_duty_fraction` (total poll time ÷ wall clock).
+`poll_duty_fraction` is the acceptance criterion for this fix: it is direct
+evidence the instrument is no longer creating the load it measures, and it
+belongs in the `benchmark.md` entry beside the latency percentiles. Poll offsets
+are recorded so an irregular sample stays interpretable.
+
+### Limitations, recorded rather than papered over
+
+- Latency percentiles are now computed over an **irregular** sample, because the
+  interval adapts. The offsets are recorded for this reason.
+- A cancelled run still waits on an in-flight poll thread at executor shutdown.
+  The old code blocked the event loop outright, so this is strictly better, but
+  it is not zero.
+
+### `benchmark.md`
+
+A dated note that every entry recorded before this fix carries poller overhead:
+entry-to-entry comparisons remain valid, absolute figures overstate real
+ingestion cost.
+
+## Testing
+
+### #242 — ablation-proven
+
+A test in `tests/test_at_scale_ingestion_benchmark.py` drives
+`_poll_during_ingestion` against a stub task, with `handle_minigraf_query`
+monkeypatched to block synchronously, while a heartbeat coroutine ticks
+concurrently. Assertions: the heartbeat keeps its cadence, and the sleep
+interval backs off under a slow query.
+
+**The ablation is mandatory.** This test is run against the *current*
+implementation first and must fail there. If it passes on today's code it is not
+testing anything and will be reworked or dropped — and that outcome gets
+reported, not quietly absorbed. This project has already shipped four tests that
+claimed guarantees they did not provide.
+
+### Probe — test the oracle, not the number
+
+The probe's headline output cannot be asserted; the number is what we are trying
+to learn. The two components that could silently produce a *wrong* number can
+be, and are:
+
+- the `valid_from` → position inversion, and
+- the affected-`W` derivation,
+
+both against a small synthetic fixture with known inverted dates and a
+deliberate timestamp collision. This is the exact error class that cost two fix
+rounds on #238.
+
+### Not tested
+
+The ingestion the probe runs on — it is the real pipeline and already covered.
+
+## Error handling
+
+The probe fails loud, in deliberate contrast to the preload functions it drives
+(whose per-`entity_type` `try/except: pass` is correct for their purpose and
+wrong for a measurement):
+
+- A misaligned `linearization`/`commit_metadata` pair raises, reusing
+  `_load_ingestion_preload_state`'s own length-and-per-position-hash check. A
+  misaligned pair mis-filters the entire sweep.
+- A `valid_from` mapping to no known commit is **counted and reported**, not
+  skipped. An unmappable fact means the inversion assumption is broken, which
+  invalidates the measurement rather than shrinking it.
+
+## What this branch does not decide
+
+Whether to build #245's option 1 (record the introducing commit on both
+attributes — a fact-model change requiring `MINIGRAF_SCHEMA` audit, idempotency,
+and migration coverage), option 2's remaining half, option 3 (derive from git),
+or to accept the residual as measured-negligible.
+
+That decision follows the number, in its own spec → plan cycle.

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -28,6 +28,18 @@ that was wrong and has been corrected here.
 > 1,600.55s post-#236 figure, overstate real ingestion cost by an unquantified
 > margin. Entries from 2026-08-07 onward carry a "Poll duty cycle" row; treat
 > its absence as "unmeasured, assume inflated".
+>
+> **The latency percentiles are biased the OTHER way, and by a different
+> mechanism.** `_STATUS_QUERY` is unchanged across the fix, so the query being
+> timed is the same one — but comparability of the query is not comparability of
+> the percentiles. The post-fix poller sleeps `duty_factor × (status + query)`,
+> so it undersamples exactly the late, expensive polls: `_STATUS_QUERY` counts
+> every `:type/commit` entity, and its cost grows monotonically through a run.
+> Pre-fix entries polled every 0.5s regardless and so sampled the expensive tail
+> at full density. `query_latency` p50/p99 from 2026-08-07 onward are therefore
+> biased **low** relative to every earlier entry. Wall-clock comparisons
+> overstate the old runs; percentile comparisons understate the new ones. Do not
+> read a p99 drop across 2026-08-07 as a speedup.
 
 ## Ingestion Run — 20260719T074053Z
 

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -19,6 +19,16 @@ An earlier version of this note incorrectly claimed no such mechanism existed an
 shipped entries 5-6 as a weaker two-query valid-time-bracket workaround instead;
 that was wrong and has been corrected here.
 
+> **2026-08-07 — poller overhead in entries before this date (#242).** Every
+> ingestion entry recorded before 2026-08-07 was measured by a harness whose
+> in-flight poller ran a blocking, cost-growing graph query on the event loop
+> every 0.5s, starving the ingestion it measured. Entry-to-entry comparisons
+> remain valid — both sides carry the same instrument — but the absolute
+> wall-clock figures, including the 78.87s forward-only baseline and the
+> 1,600.55s post-#236 figure, overstate real ingestion cost by an unquantified
+> margin. Entries from 2026-08-07 onward carry a "Poll duty cycle" row; treat
+> its absence as "unmeasured, assume inflated".
+
 ## Ingestion Run — 20260719T074053Z
 
 - Repo: `.` @ `HEAD`

--- a/evals/at_scale/probe_dep_preload_exposure.py
+++ b/evals/at_scale/probe_dep_preload_exposure.py
@@ -1,0 +1,145 @@
+# evals/at_scale/probe_dep_preload_exposure.py
+"""#245 exposure probe: how much does the :depends-on preload's ts(W) bound
+actually misclassify against real history?
+
+#238 replaced the forward-walk entity preload's author-date bound with a
+position-indexed one. That fix reached three of four preload sites.
+_preload_known_deps and _preload_pinned_commits stayed at ts(W) -- the
+watermark commit's own author date -- because those facts carry no commit
+reference to join a :hash to, and so admit no position clause.
+
+This probe MEASURES that residual. It fixes nothing, and the oracle below is
+NOT a candidate fix -- see position_exact_live_edges' docstring.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, List, Optional, Sequence, Tuple
+
+# minigraf's i64::MAX "still open" :db/valid-to sentinel. Mirrors
+# mcp_server._VALID_TIME_FOREVER_MS (mcp_server.py:7450) exactly; duplicated
+# rather than imported so the analysis primitives stay importable without
+# opening a graph. If the two ever diverge, every open edge is misread as
+# closed at a nonsense position, so keep them identical.
+VALID_TIME_FOREVER_MS = (1 << 63) - 1
+
+CommitMeta = Tuple[str, str, str, str]  # (hash, ts_iso, author_email, subject)
+
+
+def build_ts_positions(commit_metadata: Sequence[CommitMeta]) -> Dict[str, List[int]]:
+    """Map each author-date timestamp to every linearization position holding it.
+
+    A LIST, not a single position, and deliberately so: _git_commits formats
+    "%Y-%m-%dT%H:%M:%SZ" (second granularity), so distinct commits routinely
+    share an instant. Collapsing that to one position would silently pick a
+    winner and produce a confidently wrong exposure number.
+    """
+    ts_positions: Dict[str, List[int]] = {}
+    for pos, (_hash, ts_iso, _author, _subject) in enumerate(commit_metadata):
+        ts_positions.setdefault(ts_iso, []).append(pos)
+    return ts_positions
+
+
+def resume_envelopes(commit_metadata: Sequence[CommitMeta]) -> List[str]:
+    """T_hi(W) = max(ts[0..W]) for every W, the bound _preload_known_entities
+    takes after #238.
+
+    Timestamps are fixed-width UTC, so lexicographic max is chronological max
+    -- the same property mcp_server._resume_envelope relies on.
+    """
+    envelopes: List[str] = []
+    running_max = ""
+    for _hash, ts_iso, _author, _subject in commit_metadata:
+        running_max = max(running_max, ts_iso)
+        envelopes.append(running_max)
+    return envelopes
+
+
+def affected_positions(commit_metadata: Sequence[CommitMeta]) -> List[int]:
+    """Positions where the ts(W) bound is structurally capable of misclassifying.
+
+    This is a position-level precondition computed from commit_metadata alone,
+    independent of any fact. It is what keeps the sweep off every position in
+    the history.
+
+    W is exposed iff either direction is possible there:
+
+      wrong exclusion -- T_hi(W) > ts(W): some commit at position <= W carries
+      a LATER date. A fact introduced there is live at W but falls outside the
+      ts(W) bound, so the resuming walk cannot see it.
+
+      wrong inclusion -- min(ts[W+1..]) <= ts(W): some commit ABOVE W carries a
+      date at or below W's own. A fact introduced there is not yet live at W
+      but falls inside the bound, so the resuming walk sees a future edge.
+
+    The wrong-inclusion test uses <=, not <, because the bound is half-open
+    containment [vf, vt) ∋ ts(W) (mcp_server._valid_time_window_clauses), whose
+    vf test is `<=` -- a fact starting exactly at the instant is live.
+    """
+    timestamps = [ts for _h, ts, _a, _s in commit_metadata]
+    n = len(timestamps)
+    if n == 0:
+        return []
+
+    envelopes = resume_envelopes(commit_metadata)
+
+    # suffix_min[i] = min(timestamps[i+1 .. n-1]), or None past the end.
+    suffix_min: List[Optional[str]] = [None] * n
+    running_min: Optional[str] = None
+    for i in range(n - 1, -1, -1):
+        suffix_min[i] = running_min
+        running_min = timestamps[i] if running_min is None else min(running_min, timestamps[i])
+
+    affected: List[int] = []
+    for w in range(n):
+        wrong_exclusion = envelopes[w] > timestamps[w]
+        wrong_inclusion = suffix_min[w] is not None and suffix_min[w] <= timestamps[w]
+        if wrong_exclusion or wrong_inclusion:
+            affected.append(w)
+    return affected
+
+
+def invert_ms_to_positions(ms: int, ts_positions: Dict[str, List[int]]) -> List[int]:
+    """Map an epoch-millisecond :db/valid-from or :db/valid-to back to the
+    linearization positions whose commit carries that instant.
+
+    Returns [] when no commit matches. The caller MUST treat that as a
+    diagnostic, not as an empty result to skip: an unmappable fact means the
+    inversion assumption is broken, which invalidates the measurement rather
+    than shrinking it.
+    """
+    ts_iso = (
+        datetime.datetime.fromtimestamp(ms / 1000, datetime.timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    return list(ts_positions.get(ts_iso, []))
+
+
+def edge_live_at(
+    vf_positions: List[int],
+    vt_positions: Optional[List[int]],
+    w: int,
+) -> bool:
+    """Is a fact introduced at vf_positions and closed at vt_positions live at
+    position w?
+
+    vt_positions is None for a fact still open (the forever sentinel).
+
+    Ambiguity resolution is deliberately asymmetric, and always in the
+    direction that cannot UNDERSTATE exposure: an ambiguous introduction takes
+    the earliest colliding position, an ambiguous close the latest. Understating
+    is the dangerous direction here -- it would argue for closing #245 as
+    negligible on a number that was rounded in our own favour.
+
+    An empty vf_positions (unmappable introduction) is never live; the driver
+    counts these separately.
+    """
+    if not vf_positions:
+        return False
+    introduced_at = min(vf_positions)
+    if introduced_at > w:
+        return False
+    if vt_positions:
+        return w < max(vt_positions)
+    return True

--- a/evals/at_scale/probe_dep_preload_exposure.py
+++ b/evals/at_scale/probe_dep_preload_exposure.py
@@ -143,3 +143,265 @@ def edge_live_at(
     if vt_positions:
         return w < max(vt_positions)
     return True
+
+
+def gitlink_event_count(repo_path: str) -> int:
+    """Number of raw diff entries across all history touching a gitlink
+    (mode 160000).
+
+    :pinned-commit facts are written only by gitlink handling, so a zero here
+    means this history produces none and its #245 exposure is structurally
+    unmeasurable -- not zero-risk, unmeasurable. That distinction goes in the
+    report verbatim.
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "log", "--all", "--raw", "--no-abbrev", "--format=%H"],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    )
+    return sum(
+        1 for line in result.stdout.splitlines()
+        if line.startswith(":") and "160000" in line
+    )
+
+
+def position_exact_live_edges(
+    edges: Sequence[Dict],
+    ts_positions: Dict[str, List[int]],
+    file_entities: Dict[str, List[str]],
+    w: int,
+) -> set:
+    """The (src_ident, dep_ident) edges genuinely live at position w.
+
+    NOT A CANDIDATE FIX, and must never be read as one. This works only
+    because the entire history is in hand at analysis time: it inverts each
+    fact's stored timestamps back to positions. A resuming forward walk has no
+    such thing -- that is the whole reason #245 exists. It is a measurement
+    device and nothing else. None of #245's three options resemble it.
+
+    Restricted to edges whose source module appears in file_entities, mirroring
+    _preload_known_deps' own ident_to_file filter. That narrowing is already
+    position-correct after #238, so holding it fixed leaves the ts(W)
+    :depends-on bound as the single variable under measurement.
+    """
+    import mcp_server
+
+    known_src_idents = {
+        mcp_server._code_ident("module", file_path) for file_path in file_entities
+    }
+
+    live = set()
+    for edge in edges:
+        if edge["src"] not in known_src_idents:
+            continue
+        vf_positions = invert_ms_to_positions(edge["vf_ms"], ts_positions)
+        vt_positions = (
+            None if edge["vt_ms"] >= VALID_TIME_FOREVER_MS
+            else invert_ms_to_positions(edge["vt_ms"], ts_positions)
+        )
+        if edge_live_at(vf_positions, vt_positions, w):
+            live.add((edge["src"], edge["dep"]))
+    return live
+
+
+def load_dep_edges(db) -> List[Dict]:
+    """Every :depends-on fact in the graph, current and historical, with its
+    validity window.
+
+    Mirrors _preload_known_deps' own query shape exactly, including the clause
+    ORDER: [?src :ident ?srci] must precede [?src :depends-on ?dep], because
+    minigraf's :db/valid-from / :db/valid-to pseudo-attributes bind to
+    whichever EAV clause on ?src most recently precedes them. Putting :ident
+    between :depends-on and the pseudo-attributes would bind ?vf to the :ident
+    fact's own valid-from instead -- wrong, and silently so.
+    """
+    import json
+
+    import mcp_server
+
+    raw = mcp_server._db_execute(
+        db,
+        "(query [:find ?srci ?dep ?vf ?vt "
+        ":any-valid-time "
+        ":where [?src :ident ?srci] "
+        "[?src :depends-on ?dep] "
+        "[?src :db/valid-from ?vf] "
+        "[?src :db/valid-to ?vt]])",
+    )
+    return [
+        {"src": src, "dep": dep, "vf_ms": int(vf), "vt_ms": int(vt)}
+        for src, dep, vf, vt in json.loads(raw).get("results", [])
+    ]
+
+
+def sweep(
+    db,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: Sequence[CommitMeta],
+) -> Dict:
+    """Drive the REAL preload functions at each affected position and diff
+    against the oracle.
+
+    Calls the functions under test rather than a restatement of what we
+    believe they do. On the #238 branch a reviewer and an implementer both
+    simulated the counterfactual with a date bound instead of the real
+    position-filtered one, which made an inadequate test look adequate and
+    produced a false "bug not reachable" conclusion -- two fix rounds lost.
+    """
+    import mcp_server
+
+    if len(commit_metadata) != len(linearization):
+        raise ValueError(
+            f"commit_metadata has {len(commit_metadata)} entries but "
+            f"linearization has {len(linearization)}; a misaligned pair "
+            "mis-filters the entire sweep"
+        )
+    for i, ((meta_hash, _ts, _a, _s), lin_hash) in enumerate(
+        zip(commit_metadata, linearization)
+    ):
+        if meta_hash != lin_hash:
+            raise ValueError(
+                f"commit_metadata[{i}] is {meta_hash} but linearization[{i}] "
+                f"is {lin_hash}; the two must be positionally aligned"
+            )
+
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+    ts_positions = build_ts_positions(commit_metadata)
+    envelopes = resume_envelopes(commit_metadata)
+    timestamps = [ts for _h, ts, _a, _s in commit_metadata]
+    edges = load_dep_edges(db)
+
+    unmappable = sum(
+        1 for e in edges if not invert_ms_to_positions(e["vf_ms"], ts_positions)
+    )
+    collisions = {ts: pos for ts, pos in ts_positions.items() if len(pos) > 1}
+
+    per_position = []
+    for w in affected_positions(commit_metadata):
+        (
+            _entity_valid_from, _entity_descriptions, _entity_introduced_by,
+            file_entities, _submodule_paths,
+        ) = mcp_server._preload_known_entities(
+            db, repo_path, valid_at=envelopes[w],
+            hash_to_pos=hash_to_pos, watermark_pos=w,
+        )
+        _file_deps, dep_valid_from = mcp_server._preload_known_deps(
+            db, file_entities,
+            valid_at_ms=mcp_server._iso_to_epoch_ms(timestamps[w]),
+        )
+        actual = set(dep_valid_from.keys())
+        expected = position_exact_live_edges(edges, ts_positions, file_entities, w)
+
+        wrongly_included = sorted(actual - expected)
+        wrongly_excluded = sorted(expected - actual)
+        if wrongly_included or wrongly_excluded:
+            per_position.append({
+                "position": w,
+                "commit": linearization[w],
+                "date": timestamps[w],
+                "wrongly_included": [list(e) for e in wrongly_included],
+                "wrongly_excluded": [list(e) for e in wrongly_excluded],
+            })
+
+    return {
+        "repo_path": repo_path,
+        "commits": len(linearization),
+        "dep_edges_total": len(edges),
+        "affected_positions": affected_positions(commit_metadata),
+        "misclassifying_positions": per_position,
+        "wrongly_included_total": sum(
+            len(p["wrongly_included"]) for p in per_position
+        ),
+        "wrongly_excluded_total": sum(
+            len(p["wrongly_excluded"]) for p in per_position
+        ),
+        "timestamp_collisions": len(collisions),
+        "unmappable_valid_from_facts": unmappable,
+        "gitlink_events": gitlink_event_count(repo_path),
+    }
+
+
+async def _ingest_into(repo_path: str, branch: Optional[str], graph_path) -> str:
+    """Ingest repo_path into a fresh scratch graph, using the plain in-process
+    path.
+
+    Deliberately NOT run_ingestion_benchmark: its in-flight poller starved the
+    ingestion it measured (#242, fixed on this same branch). This probe needs
+    a completed ingestion, not a measured one, so it takes the simplest path
+    and no poller at all.
+    """
+    import mcp_server
+
+    mcp_server._db = None
+    mcp_server._graph_path = None
+    mcp_server.open_db(str(graph_path))
+    mcp_server._ingest_progress = {
+        "status": "idle", "processed": 0, "total": 0, "prior_ingested": 0,
+        "current_commit": "", "error": None, "owner_pid": None, "error_at": None,
+    }
+    resolved_branch = branch or mcp_server._default_git_branch(repo_path)
+    await mcp_server._run_ingestion(repo_path, resolved_branch)
+    return resolved_branch
+
+
+def main() -> int:
+    import argparse
+    import asyncio
+    import json
+    import sys
+    import tempfile
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent.parent.resolve()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    parser = argparse.ArgumentParser(
+        description="Measure #245's :depends-on preload exposure against real history."
+    )
+    parser.add_argument("--repo-path", default=".")
+    parser.add_argument("--branch", default=None)
+    parser.add_argument("--json-out", default=None)
+    args = parser.parse_args()
+
+    import frontier_registry
+    import mcp_server
+
+    with tempfile.TemporaryDirectory(prefix="minigraf-245-probe-") as tmpdir:
+        graph_path = Path(tmpdir) / "probe.graph"
+        branch = asyncio.run(_ingest_into(args.repo_path, args.branch, graph_path))
+
+        linearization = frontier_registry.build_linearization(args.repo_path, branch)
+        commit_metadata = mcp_server._git_commits(args.repo_path, None, branch)
+        db = mcp_server._db if mcp_server._db is not None else mcp_server.open_db(str(graph_path))
+        report = sweep(db, args.repo_path, linearization, commit_metadata)
+
+    print(json.dumps(report, indent=2))
+    print()
+    print(f"commits:                       {report['commits']}")
+    print(f":depends-on facts:             {report['dep_edges_total']}")
+    print(f"structurally affected W:       {len(report['affected_positions'])}")
+    print(f"W actually misclassifying:     {len(report['misclassifying_positions'])}")
+    print(f"  wrongly INCLUDED edges:      {report['wrongly_included_total']}")
+    print(f"  wrongly EXCLUDED edges:      {report['wrongly_excluded_total']}")
+    print(f"timestamp collisions:          {report['timestamp_collisions']}")
+    print(f"unmappable :valid-from facts:  {report['unmappable_valid_from_facts']}")
+    print(f"gitlink events:                {report['gitlink_events']}")
+    if report["gitlink_events"] == 0:
+        print()
+        print(
+            "NOTE: zero gitlink events -- this history produces no :pinned-commit\n"
+            "facts, so #245's :pinned-commit half is UNMEASURABLE here. That is\n"
+            "not the same as zero risk; its field exposure remains unknown."
+        )
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/at_scale/probe_dep_preload_exposure.py
+++ b/evals/at_scale/probe_dep_preload_exposure.py
@@ -420,6 +420,39 @@ def position_correct_file_entities(
     return live
 
 
+def count_unmappable_module_path_facts(
+    path_facts: Sequence[Dict],
+    ts_positions: Dict[str, List[int]],
+) -> Tuple[int, int]:
+    """How many module :path facts carry a vf_ms/vt_ms whose instant matches
+    no commit -- the WIDE framing's own unmappable-fact diagnostic.
+
+    WIDE (position_correct_file_entities) is built entirely from these
+    :path facts, run through the same invert_ms_to_positions/edge_live_at
+    machinery as the :depends-on edges. An unmappable vf silently drops a
+    module from WIDE at every W (understating it); an unmappable non-sentinel
+    vt silently reads it as never-closed (overstating it). Mirrors sweep's
+    own unmappable_valid_from_facts/unmappable_valid_to_facts computation for
+    :depends-on edges, applied to :path instead.
+
+    Runs over ALL of path_facts, not a measured subset: unlike a
+    :depends-on edge, a :path fact has no "did it ever enter consideration"
+    filter to apply first -- it IS file_entities.
+
+    Returns (unmappable_valid_from, unmappable_valid_to).
+    """
+    unmappable_vf = sum(
+        1 for f in path_facts
+        if not invert_ms_to_positions(f["vf_ms"], ts_positions)
+    )
+    unmappable_vt = sum(
+        1 for f in path_facts
+        if f["vt_ms"] < VALID_TIME_FOREVER_MS
+        and not invert_ms_to_positions(f["vt_ms"], ts_positions)
+    )
+    return unmappable_vf, unmappable_vt
+
+
 def sweep(
     db,
     repo_path: str,
@@ -485,6 +518,18 @@ def sweep(
       resolves an unmappable CLOSE by treating the edge as still open (see
       its docstring); that is the correct not-understating direction, but it
       is silent unless counted here.
+
+    - unmappable_module_path_valid_from / unmappable_module_path_valid_to:
+      the same diagnostic applied to the WIDE framing's own raw material.
+      WIDE is built from module :path facts via position_correct_file_entities,
+      which runs :path's vf_ms/vt_ms through the identical
+      invert_ms_to_positions/edge_live_at machinery as the :depends-on edges
+      above -- an unmappable :path vf silently drops a module from WIDE at
+      every W (understating it), and an unmappable :path vt silently reads it
+      as never-closed (overstating it). Counted over ALL of path_facts, not a
+      measured subset: unlike an edge, a :path fact has no "did it ever enter
+      consideration" filter to apply first -- it IS file_entities. Both fold
+      into measurement_invalid below, same as the edge counters.
 
     Every *_total_position_weighted is position-weighted: one edge
     misclassified at all N affected positions contributes N, not 1. The
@@ -606,6 +651,9 @@ def sweep(
         if e["vt_ms"] < VALID_TIME_FOREVER_MS
         and not invert_ms_to_positions(e["vt_ms"], ts_positions)
     )
+    unmappable_module_path_vf, unmappable_module_path_vt = count_unmappable_module_path_facts(
+        path_facts, ts_positions
+    )
 
     # Keyed on the NARROW actual: that is the one produced by the shipped
     # code path, so it is the one whose all-zero signature would mean
@@ -659,6 +707,8 @@ def sweep(
         "timestamp_collisions": len(collisions),
         "unmappable_valid_from_facts": unmappable_vf,
         "unmappable_valid_to_facts": unmappable_vt,
+        "unmappable_module_path_valid_from": unmappable_module_path_vf,
+        "unmappable_module_path_valid_to": unmappable_module_path_vt,
         "gitlink_events": gitlink_event_count(repo_path),
     }
 
@@ -764,8 +814,16 @@ def main() -> int:
     print("  (narrow = file_entities as _preload_known_entities returns it: the")
     print("   ts(W) :depends-on bound CONDITIONAL on #238's open close-side residual.")
     print("   wide = file_entities rebuilt position-correctly at both ends: the")
-    print("   ts(W) :depends-on bound in ISOLATION. The gap between them is #238's")
-    print("   own close-side leak, not #245's.)")
+    print("   ts(W) :depends-on bound in ISOLATION.")
+    print("   EXCLUDED gap = #238's own close-side leak: its date bound drops")
+    print("   modules deleted later but dated earlier, inflating narrow's excluded")
+    print("   count relative to wide's.")
+    print("   INCLUDED gap is a DIFFERENT effect, not #238's leak: _preload_known_")
+    print("   entities pre-seeds file_entities from the current worktree's `git")
+    print("   ls-files` and never removes from it, so narrow admits every current-")
+    print("   worktree module at every W, including ones not yet introduced. A")
+    print("   NEGATIVE included gap (wide < narrow) is expected from that pre-seed")
+    print("   and is NOT evidence #245's inclusion exposure is small.)")
     print(
         f"  wrongly INCLUDED, position-weighted:    "
         f"{report['narrow_wrongly_included_total_position_weighted']:<11}"
@@ -791,26 +849,31 @@ def main() -> int:
     print(f"timestamp collisions:                     {report['timestamp_collisions']}")
     print(f"unmappable :valid-from facts (measured):  {report['unmappable_valid_from_facts']}")
     print(f"unmappable :valid-to facts (measured):    {report['unmappable_valid_to_facts']}")
+    print(f"unmappable module :path valid-from facts: {report['unmappable_module_path_valid_from']}")
+    print(f"unmappable module :path valid-to facts:   {report['unmappable_module_path_valid_to']}")
     print(f"gitlink events:                           {report['gitlink_events']}")
 
     # Emphasis is deliberately inverted from a naive reading: nonzero
     # unmappable facts mean the position-inversion assumption this whole
-    # sweep rests on is broken for at least one fact in the measured
-    # population, which invalidates the wrongly_included/wrongly_excluded
-    # numbers above. Zero gitlink events only NARROWS what was measured; it
-    # does not call the rest of the report into question.
+    # sweep rests on is broken for at least one fact -- either in the
+    # :depends-on measured population, or in the module :path facts that are
+    # WIDE's own raw material -- which invalidates the wrongly_included/
+    # wrongly_excluded numbers above. Zero gitlink events only NARROWS what
+    # was measured; it does not call the rest of the report into question.
     measurement_invalid = (
         report["unmappable_valid_from_facts"] > 0
         or report["unmappable_valid_to_facts"] > 0
+        or report["unmappable_module_path_valid_from"] > 0
+        or report["unmappable_module_path_valid_to"] > 0
     )
     if measurement_invalid:
         print()
         print(
-            "INVALID MEASUREMENT: nonzero unmappable :valid-from/:valid-to facts\n"
-            "mean the timestamp-to-position inversion this sweep depends on is\n"
-            "broken for at least one fact in the measured population. The\n"
-            "wrongly_included/wrongly_excluded numbers above are not trustworthy\n"
-            "until this is zero."
+            "INVALID MEASUREMENT: nonzero unmappable :valid-from/:valid-to facts,\n"
+            "on either the :depends-on edges or the module :path facts WIDE is\n"
+            "built from, mean the timestamp-to-position inversion this sweep\n"
+            "depends on is broken for at least one fact. The wrongly_included/\n"
+            "wrongly_excluded numbers above are not trustworthy until this is zero."
         )
     if report["preload_deps_empty_everywhere"]:
         print()

--- a/evals/at_scale/probe_dep_preload_exposure.py
+++ b/evals/at_scale/probe_dep_preload_exposure.py
@@ -184,6 +184,16 @@ def position_exact_live_edges(
     _preload_known_deps' own ident_to_file filter. That narrowing is already
     position-correct after #238, so holding it fixed leaves the ts(W)
     :depends-on bound as the single variable under measurement.
+
+    An unmappable CLOSE (a non-sentinel vt_ms whose instant matches no commit)
+    falls through here to vt_positions=[], which edge_live_at's `if
+    vt_positions:` treats identically to vt_positions=None -- "still open".
+    That is deliberate, not an oversight: it is the same cannot-understate
+    direction edge_live_at's own ambiguous-position handling takes. It does
+    mean such an edge reads as live at every later w, inflating
+    wrongly_excluded at each of them. The driver (sweep) counts these
+    separately as unmappable_valid_to_facts so that inflation stays visible
+    instead of being silently baked into the headline numbers.
     """
     import mcp_server
 
@@ -215,6 +225,13 @@ def load_dep_edges(db) -> List[Dict]:
     whichever EAV clause on ?src most recently precedes them. Putting :ident
     between :depends-on and the pseudo-attributes would bind ?vf to the :ident
     fact's own valid-from instead -- wrong, and silently so.
+
+    Deduplicated on (src, dep, vf, vt): an entity carrying more than one
+    :ident fact across time (a rename, or a retract/reassert of the same
+    value) makes the [?src :ident ?srci] join under :any-valid-time multiply
+    each of that source's :depends-on rows once per :ident fact, which would
+    otherwise inflate dep_edges_total and the unmappable-fact counts without
+    changing which edges are actually live at any position.
     """
     import json
 
@@ -229,10 +246,15 @@ def load_dep_edges(db) -> List[Dict]:
         "[?src :db/valid-from ?vf] "
         "[?src :db/valid-to ?vt]])",
     )
-    return [
-        {"src": src, "dep": dep, "vf_ms": int(vf), "vt_ms": int(vt)}
-        for src, dep, vf, vt in json.loads(raw).get("results", [])
-    ]
+    seen = set()
+    edges = []
+    for src, dep, vf, vt in json.loads(raw).get("results", []):
+        key = (src, dep, int(vf), int(vt))
+        if key in seen:
+            continue
+        seen.add(key)
+        edges.append({"src": src, "dep": dep, "vf_ms": int(vf), "vt_ms": int(vt)})
+    return edges
 
 
 def sweep(
@@ -249,6 +271,36 @@ def sweep(
     simulated the counterfactual with a date bound instead of the real
     position-filtered one, which made an inadequate test look adequate and
     produced a false "bug not reachable" conclusion -- two fix rounds lost.
+
+    Three report fields exist purely to keep this sweep from lying quietly
+    about itself (#245 review round):
+
+    - actual_dep_counts_by_position / preload_deps_empty_everywhere:
+      _preload_known_deps swallows its own query failure (bare `except
+      Exception: return file_deps, dep_valid_from`, mcp_server.py:7554-7555)
+      and returns ({}, {}) on any runtime error. That failure mode and "this
+      position genuinely has zero live deps" are indistinguishable from
+      wrongly_excluded_total alone -- both make every expected edge look
+      wrongly excluded. Recording len(actual) per position, and flagging the
+      all-positions-zero case explicitly, is what lets a reader tell them
+      apart.
+
+    - unmappable_valid_from_facts / unmappable_valid_to_facts: counted only
+      over the MEASURED population -- edges whose source module ident
+      appears in file_entities at at least one affected position -- not over
+      every row load_dep_edges returns. An edge that never enters the
+      oracle's or the preload's consideration at any position can't corrupt
+      either, so counting it would only make an unrelated, filtered-out
+      corner of the graph look like it invalidated this measurement.
+      unmappable_valid_to_facts exists because position_exact_live_edges
+      resolves an unmappable CLOSE by treating the edge as still open (see
+      its docstring); that is the correct not-understating direction, but it
+      is silent unless counted here.
+
+    wrongly_included_total / wrongly_excluded_total are position-weighted:
+    one edge misclassified at all N affected positions contributes N, not 1.
+    The distinct-edge counts alongside them are the union across positions,
+    for whichever unit the reader actually wants.
     """
     import mcp_server
 
@@ -272,13 +324,11 @@ def sweep(
     envelopes = resume_envelopes(commit_metadata)
     timestamps = [ts for _h, ts, _a, _s in commit_metadata]
     edges = load_dep_edges(db)
-
-    unmappable = sum(
-        1 for e in edges if not invert_ms_to_positions(e["vf_ms"], ts_positions)
-    )
     collisions = {ts: pos for ts, pos in ts_positions.items() if len(pos) > 1}
 
     per_position = []
+    actual_dep_counts_by_position = []
+    measured_src_idents: set = set()
     for w in affected_positions(commit_metadata):
         (
             _entity_valid_from, _entity_descriptions, _entity_introduced_by,
@@ -287,11 +337,15 @@ def sweep(
             db, repo_path, valid_at=envelopes[w],
             hash_to_pos=hash_to_pos, watermark_pos=w,
         )
+        measured_src_idents.update(
+            mcp_server._code_ident("module", file_path) for file_path in file_entities
+        )
         _file_deps, dep_valid_from = mcp_server._preload_known_deps(
             db, file_entities,
             valid_at_ms=mcp_server._iso_to_epoch_ms(timestamps[w]),
         )
         actual = set(dep_valid_from.keys())
+        actual_dep_counts_by_position.append({"position": w, "actual_count": len(actual)})
         expected = position_exact_live_edges(edges, ts_positions, file_entities, w)
 
         wrongly_included = sorted(actual - expected)
@@ -305,25 +359,53 @@ def sweep(
                 "wrongly_excluded": [list(e) for e in wrongly_excluded],
             })
 
+    measured_edges = [e for e in edges if e["src"] in measured_src_idents]
+    unmappable_vf = sum(
+        1 for e in measured_edges
+        if not invert_ms_to_positions(e["vf_ms"], ts_positions)
+    )
+    unmappable_vt = sum(
+        1 for e in measured_edges
+        if e["vt_ms"] < VALID_TIME_FOREVER_MS
+        and not invert_ms_to_positions(e["vt_ms"], ts_positions)
+    )
+
+    preload_deps_empty_everywhere = bool(actual_dep_counts_by_position) and all(
+        c["actual_count"] == 0 for c in actual_dep_counts_by_position
+    )
+
+    distinct_wrongly_included = {
+        tuple(e) for p in per_position for e in p["wrongly_included"]
+    }
+    distinct_wrongly_excluded = {
+        tuple(e) for p in per_position for e in p["wrongly_excluded"]
+    }
+
     return {
         "repo_path": repo_path,
         "commits": len(linearization),
         "dep_edges_total": len(edges),
+        "measured_dep_edges_total": len(measured_edges),
         "affected_positions": affected_positions(commit_metadata),
         "misclassifying_positions": per_position,
-        "wrongly_included_total": sum(
+        "actual_dep_counts_by_position": actual_dep_counts_by_position,
+        "preload_deps_empty_everywhere": preload_deps_empty_everywhere,
+        "wrongly_included_total_position_weighted": sum(
             len(p["wrongly_included"]) for p in per_position
         ),
-        "wrongly_excluded_total": sum(
+        "wrongly_excluded_total_position_weighted": sum(
             len(p["wrongly_excluded"]) for p in per_position
         ),
+        "wrongly_included_distinct_edges": len(distinct_wrongly_included),
+        "wrongly_excluded_distinct_edges": len(distinct_wrongly_excluded),
         "timestamp_collisions": len(collisions),
-        "unmappable_valid_from_facts": unmappable,
+        "unmappable_valid_from_facts": unmappable_vf,
+        "unmappable_valid_to_facts": unmappable_vt,
         "gitlink_events": gitlink_event_count(repo_path),
     }
 
 
-async def _ingest_into(repo_path: str, branch: Optional[str], graph_path) -> str:
+async def _ingest_into(repo_path: str, branch: Optional[str], graph_path) -> Tuple[str, str]:
     """Ingest repo_path into a fresh scratch graph, using the plain in-process
     path.
 
@@ -331,6 +413,18 @@ async def _ingest_into(repo_path: str, branch: Optional[str], graph_path) -> str
     ingestion it measured (#242, fixed on this same branch). This probe needs
     a completed ingestion, not a measured one, so it takes the simplest path
     and no poller at all.
+
+    Returns (resolved_branch, status), where status is
+    mcp_server._ingest_progress["status"] read immediately after
+    _run_ingestion returns. That status is the ONLY signal available:
+    _run_ingestion wraps its whole body in `except Exception` (mcp_server.py:
+    10212-10220), sets status "error" and _db = None, and returns normally --
+    it never raises. A partial run that stopped short of the frontier sets
+    "stopped" the same way (mcp_server.py:10205-10208), also without raising.
+    Either way the caller gets a graph that opened successfully and a status
+    that says not to trust it; surfacing status is what makes that
+    distinguishable from a genuine "complete". Mirrors the sibling pattern in
+    evals/at_scale/run_ingestion_benchmark.py:151-152.
     """
     import mcp_server
 
@@ -343,7 +437,7 @@ async def _ingest_into(repo_path: str, branch: Optional[str], graph_path) -> str
     }
     resolved_branch = branch or mcp_server._default_git_branch(repo_path)
     await mcp_server._run_ingestion(repo_path, resolved_branch)
-    return resolved_branch
+    return resolved_branch, mcp_server._ingest_progress["status"]
 
 
 def main() -> int:
@@ -371,24 +465,77 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="minigraf-245-probe-") as tmpdir:
         graph_path = Path(tmpdir) / "probe.graph"
-        branch = asyncio.run(_ingest_into(args.repo_path, args.branch, graph_path))
+        branch, ingest_status = asyncio.run(
+            _ingest_into(args.repo_path, args.branch, graph_path)
+        )
+
+        # _run_ingestion never raises on failure (see _ingest_into's
+        # docstring) -- ingest_status is the only signal that the graph
+        # underneath this sweep is actually complete. Sweeping a "stopped" or
+        # "error" graph would silently report on a partial ingestion as
+        # though it were the full history; refuse instead.
+        if ingest_status != "complete":
+            error = mcp_server._ingest_progress.get("error")
+            print(
+                f"Ingestion did not complete (status={ingest_status!r}"
+                + (f", error={error!r}" if error else "")
+                + "). Refusing to sweep a partial or failed graph."
+            )
+            return 1
 
         linearization = frontier_registry.build_linearization(args.repo_path, branch)
         commit_metadata = mcp_server._git_commits(args.repo_path, None, branch)
         db = mcp_server._db if mcp_server._db is not None else mcp_server.open_db(str(graph_path))
         report = sweep(db, args.repo_path, linearization, commit_metadata)
+        report["ingest_status"] = ingest_status
 
     print(json.dumps(report, indent=2))
     print()
-    print(f"commits:                       {report['commits']}")
-    print(f":depends-on facts:             {report['dep_edges_total']}")
-    print(f"structurally affected W:       {len(report['affected_positions'])}")
-    print(f"W actually misclassifying:     {len(report['misclassifying_positions'])}")
-    print(f"  wrongly INCLUDED edges:      {report['wrongly_included_total']}")
-    print(f"  wrongly EXCLUDED edges:      {report['wrongly_excluded_total']}")
-    print(f"timestamp collisions:          {report['timestamp_collisions']}")
-    print(f"unmappable :valid-from facts:  {report['unmappable_valid_from_facts']}")
-    print(f"gitlink events:                {report['gitlink_events']}")
+    print(f"commits:                                 {report['commits']}")
+    print(f":depends-on facts (raw, deduped):         {report['dep_edges_total']}")
+    print(f":depends-on facts (measured population):  {report['measured_dep_edges_total']}")
+    print(f"structurally affected W:                  {len(report['affected_positions'])}")
+    print(f"W actually misclassifying:                {len(report['misclassifying_positions'])}")
+    print(f"  wrongly INCLUDED, position-weighted:    {report['wrongly_included_total_position_weighted']}")
+    print(f"  wrongly INCLUDED, distinct edges:       {report['wrongly_included_distinct_edges']}")
+    print(f"  wrongly EXCLUDED, position-weighted:    {report['wrongly_excluded_total_position_weighted']}")
+    print(f"  wrongly EXCLUDED, distinct edges:       {report['wrongly_excluded_distinct_edges']}")
+    print(f"preload returned zero deps at every W:    {report['preload_deps_empty_everywhere']}")
+    print(f"timestamp collisions:                     {report['timestamp_collisions']}")
+    print(f"unmappable :valid-from facts (measured):  {report['unmappable_valid_from_facts']}")
+    print(f"unmappable :valid-to facts (measured):    {report['unmappable_valid_to_facts']}")
+    print(f"gitlink events:                           {report['gitlink_events']}")
+
+    # Emphasis is deliberately inverted from a naive reading: nonzero
+    # unmappable facts mean the position-inversion assumption this whole
+    # sweep rests on is broken for at least one fact in the measured
+    # population, which invalidates the wrongly_included/wrongly_excluded
+    # numbers above. Zero gitlink events only NARROWS what was measured; it
+    # does not call the rest of the report into question.
+    measurement_invalid = (
+        report["unmappable_valid_from_facts"] > 0
+        or report["unmappable_valid_to_facts"] > 0
+    )
+    if measurement_invalid:
+        print()
+        print(
+            "INVALID MEASUREMENT: nonzero unmappable :valid-from/:valid-to facts\n"
+            "mean the timestamp-to-position inversion this sweep depends on is\n"
+            "broken for at least one fact in the measured population. The\n"
+            "wrongly_included/wrongly_excluded numbers above are not trustworthy\n"
+            "until this is zero."
+        )
+    if report["preload_deps_empty_everywhere"]:
+        print()
+        print(
+            "NOTE: _preload_known_deps returned zero live deps at every affected\n"
+            "position. That may be a genuinely dep-free history, or it may be\n"
+            "_preload_known_deps' own bare `except Exception` (mcp_server.py:\n"
+            "7554-7555) swallowing a real query failure -- the two are\n"
+            "indistinguishable from this report alone. Check dep_edges_total\n"
+            "above: nonzero there with zero here is the signature of the latter."
+        )
+
     if report["gitlink_events"] == 0:
         print()
         print(
@@ -400,7 +547,7 @@ def main() -> int:
     if args.json_out:
         Path(args.json_out).write_text(json.dumps(report, indent=2))
         print(f"\nWrote {args.json_out}")
-    return 0
+    return 1 if measurement_invalid else 0
 
 
 if __name__ == "__main__":

--- a/evals/at_scale/probe_dep_preload_exposure.py
+++ b/evals/at_scale/probe_dep_preload_exposure.py
@@ -27,8 +27,9 @@ ABOVE the watermark are re-admitted").
 Consequence: a module whose close DATE falls below ts(W) but whose close
 POSITION sits above W disappears from file_entities at that W, taking its
 :depends-on edges out of BOTH sides of the diff before the diff is computed.
-On this repository that is five modules deleted by df6b8be at position 124,
-and 30 misclassified edges that the narrow figure never saw.
+On this repository that is four modules deleted by df6b8be at position 124,
+and 30 misclassified edges that the narrow figure never saw (measured
+2026-08-07: narrow 2 distinct vs wide 32, a factor of 16).
 
 So the sweep reports both, side by side:
 

--- a/evals/at_scale/probe_dep_preload_exposure.py
+++ b/evals/at_scale/probe_dep_preload_exposure.py
@@ -10,6 +10,40 @@ reference to join a :hash to, and so admit no position clause.
 
 This probe MEASURES that residual. It fixes nothing, and the oracle below is
 NOT a candidate fix -- see position_exact_live_edges' docstring.
+
+TWO figures, not one (final whole-branch review, CRITICAL finding). The first
+version of this probe held file_entities -- the output of
+_preload_known_entities -- fixed on both sides of the diff, on the claim that
+#238 made that narrowing position-correct and so left the ts(W) :depends-on
+bound as the single variable. That claim is FALSE. #238 made
+_preload_known_entities position-correct on the INTRODUCTION side only: its
+position clause keys on the introducing commit ([?e :introduced-by ?c]
+[?c :hash ?hash] -> hash_to_pos, mcp_server.py:7213-7215). Its CLOSE side is
+still governed by valid_at = T_hi(W), a date bound suffering the identical
+author-date inversion this probe exists to measure -- the function's own
+comment says so ("the date bound above only governs how widely entities closed
+ABOVE the watermark are re-admitted").
+
+Consequence: a module whose close DATE falls below ts(W) but whose close
+POSITION sits above W disappears from file_entities at that W, taking its
+:depends-on edges out of BOTH sides of the diff before the diff is computed.
+On this repository that is five modules deleted by df6b8be at position 124,
+and 30 misclassified edges that the narrow figure never saw.
+
+So the sweep reports both, side by side:
+
+  NARROW -- file_entities exactly as _preload_known_entities returns it. This
+    measures the ts(W) :depends-on bound CONDITIONAL ON #238's still-open
+    close-side residual: the entity preload has already discarded the modules
+    whose own close inverted, so what is left is only the edges that survived
+    that discard. It is the figure the shipped code produces today.
+
+  WIDE -- file_entities rebuilt position-correctly, from :path facts whose
+    both ends are inverted to positions. This measures the ts(W) :depends-on
+    bound IN ISOLATION, with the entity preload's own close-side defect
+    removed.
+
+The comparison between the two IS the finding. Neither alone is the number.
 """
 
 from __future__ import annotations
@@ -63,19 +97,40 @@ def affected_positions(commit_metadata: Sequence[CommitMeta]) -> List[int]:
     independent of any fact. It is what keeps the sweep off every position in
     the history.
 
-    W is exposed iff either direction is possible there:
+    W is exposed iff either structural condition holds. The UNION is what this
+    returns, and the union is what matters -- but do not read either condition
+    as belonging to one misclassification direction. Each condition enables one
+    of EACH direction, because the bound is half-open containment
+    [vf, vt) ∋ ts(W) (mcp_server._valid_time_window_clauses) and a fact's
+    CLOSE is date-bounded on exactly the same terms as its introduction:
 
-      wrong exclusion -- T_hi(W) > ts(W): some commit at position <= W carries
-      a LATER date. A fact introduced there is live at W but falls outside the
-      ts(W) bound, so the resuming walk cannot see it.
+      condition A -- min(ts[W+1..]) <= ts(W): some commit ABOVE W carries a
+      date at or below W's own.
+        * wrong INCLUSION via introduction: a fact introduced at that commit
+          has vf <= ts(W), so it passes the bound, but its introducing
+          position is above W -- the walk sees a future edge.
+        * wrong EXCLUSION via close: a fact CLOSED at that commit has
+          vt <= ts(W), so half-open containment rejects it, but its closing
+          position is above W -- the edge is still live at W and the walk
+          cannot see it.
 
-      wrong inclusion -- min(ts[W+1..]) <= ts(W): some commit ABOVE W carries a
-      date at or below W's own. A fact introduced there is not yet live at W
-      but falls inside the bound, so the resuming walk sees a future edge.
+      condition B -- T_hi(W) > ts(W): some commit at position <= W carries a
+      LATER date.
+        * wrong EXCLUSION via introduction: a fact introduced there has
+          vf > ts(W), outside the bound, though it is live at W.
+        * wrong INCLUSION via close: a fact CLOSED there has vt > ts(W), so
+          the bound still reads it as open, though its close position is at
+          or below W and the edge is already dead.
 
-    The wrong-inclusion test uses <=, not <, because the bound is half-open
-    containment [vf, vt) ∋ ts(W) (mcp_server._valid_time_window_clauses), whose
-    vf test is `<=` -- a fact starting exactly at the instant is live.
+    An earlier version of this docstring labelled condition A "wrong
+    inclusion" and condition B "wrong exclusion" outright, which is wrong and
+    was empirically decisive in the wrong direction: on this repository
+    positions 118-123 are flagged by condition A alone, and every one of them
+    misclassifies by wrong EXCLUSION -- via close, the arm the old labelling
+    did not name.
+
+    Condition A uses <=, not <, because the bound's vf test is `<=` -- a fact
+    starting exactly at the instant is live.
     """
     timestamps = [ts for _h, ts, _a, _s in commit_metadata]
     n = len(timestamps)
@@ -93,9 +148,13 @@ def affected_positions(commit_metadata: Sequence[CommitMeta]) -> List[int]:
 
     affected: List[int] = []
     for w in range(n):
-        wrong_exclusion = envelopes[w] > timestamps[w]
-        wrong_inclusion = suffix_min[w] is not None and suffix_min[w] <= timestamps[w]
-        if wrong_exclusion or wrong_inclusion:
+        # Named for the structural conditions, not for directions: see the
+        # docstring -- each one enables a wrong inclusion AND a wrong exclusion.
+        condition_b_later_dated_at_or_below_w = envelopes[w] > timestamps[w]
+        condition_a_earlier_dated_above_w = (
+            suffix_min[w] is not None and suffix_min[w] <= timestamps[w]
+        )
+        if condition_b_later_dated_at_or_below_w or condition_a_earlier_dated_above_w:
             affected.append(w)
     return affected
 
@@ -181,9 +240,24 @@ def position_exact_live_edges(
     device and nothing else. None of #245's three options resemble it.
 
     Restricted to edges whose source module appears in file_entities, mirroring
-    _preload_known_deps' own ident_to_file filter. That narrowing is already
-    position-correct after #238, so holding it fixed leaves the ts(W)
-    :depends-on bound as the single variable under measurement.
+    _preload_known_deps' own ident_to_file filter. WHICH file_entities the
+    caller passes is what selects the NARROW or the WIDE measurement, and the
+    two answer different questions:
+
+    - _preload_known_entities' own output -> NARROW. That narrowing is
+      position-correct on the INTRODUCTION side only; its close side is a
+      T_hi(W) date bound carrying the same inversion defect (see the module
+      docstring). So the narrow figure measures the ts(W) :depends-on bound
+      conditional on #238's still-open close-side residual, not in isolation.
+      An earlier version of this docstring claimed the narrowing was
+      position-correct outright and that holding it fixed left the
+      :depends-on bound as the single variable. It does not, and that claim
+      understated the measured exposure by ~16x.
+
+    - position_correct_file_entities' output -> WIDE. Both ends of each
+      module's :path fact inverted to positions, so the entity preload's own
+      defect is out of the picture and the :depends-on bound is measured
+      alone.
 
     An unmappable CLOSE (a non-sentinel vt_ms whose instant matches no commit)
     falls through here to vt_positions=[], which edge_live_at's `if
@@ -257,20 +331,134 @@ def load_dep_edges(db) -> List[Dict]:
     return edges
 
 
+def load_module_path_facts(db) -> List[Dict]:
+    """Every :path fact on a module entity, current and historical, with its
+    validity window.
+
+    The raw material for the WIDE measurement. Same clause-order rule as
+    load_dep_edges: [?e :path ?path] must be the EAV clause immediately
+    preceding the :db/valid-from / :db/valid-to pseudo-attributes, because
+    those bind to whichever EAV clause on ?e most recently precedes them.
+    Putting :entity-type between them would bind ?vf to the :entity-type
+    fact's window instead -- wrong, and silently so.
+
+    Restricted to :type/module deliberately. :path is also carried by
+    external-dependency entities, but _preload_known_deps keys its
+    ident_to_file on _code_ident("module", path); admitting a submodule path
+    there would synthesize a module ident for an entity that is not one.
+
+    Deduplicated on (path, vf, vt) for the same reason load_dep_edges dedupes:
+    an entity carrying more than one :entity-type fact across time would
+    otherwise multiply each :path row without changing any liveness answer.
+    A rename legitimately produces two DISTINCT (path, vf, vt) rows -- the old
+    path closed, the new one opened -- and both are kept, which is what makes
+    the set position-correct across renames.
+    """
+    import json
+
+    import mcp_server
+
+    raw = mcp_server._db_execute(
+        db,
+        "(query [:find ?path ?vf ?vt "
+        ":any-valid-time "
+        ":where [?e :entity-type :type/module] "
+        "[?e :path ?path] "
+        "[?e :db/valid-from ?vf] "
+        "[?e :db/valid-to ?vt]])",
+    )
+    seen = set()
+    facts = []
+    for path, vf, vt in json.loads(raw).get("results", []):
+        key = (path, int(vf), int(vt))
+        if key in seen:
+            continue
+        seen.add(key)
+        facts.append({"path": path, "vf_ms": int(vf), "vt_ms": int(vt)})
+    return facts
+
+
+def position_correct_file_entities(
+    path_facts: Sequence[Dict],
+    ts_positions: Dict[str, List[int]],
+    w: int,
+) -> Dict[str, List[str]]:
+    """The module paths genuinely live at position w, shaped like the
+    file_entities dict _preload_known_deps and position_exact_live_edges both
+    consume.
+
+    This is the WIDE side's replacement for _preload_known_entities' own
+    file_entities. It is position-correct at BOTH ends -- introduction and
+    close -- because it inverts both :db/valid-from and :db/valid-to through
+    the same primitives the edge oracle uses (invert_ms_to_positions,
+    edge_live_at), rather than trusting either against a date bound.
+
+    That second end is the whole point. A module deleted at a position ABOVE w
+    by a commit whose author date falls BELOW ts(w) -- the exact shape of
+    df6b8be at position 124 on this repository -- reads as already closed to
+    any date bound, and so vanishes from _preload_known_entities' output at w.
+    Here it stays live, because max(close positions) > w.
+
+    Values are empty lists: only the KEYS (the paths) are load-bearing
+    downstream. _preload_known_deps reads only `for file_path in
+    file_entities`, and position_exact_live_edges only
+    _code_ident("module", file_path) over the same keys.
+
+    Like everything else here, this is a measurement device and NOT a
+    candidate fix -- it needs the whole history in hand, which a resuming
+    forward walk does not have.
+    """
+    live: Dict[str, List[str]] = {}
+    for fact in path_facts:
+        vf_positions = invert_ms_to_positions(fact["vf_ms"], ts_positions)
+        vt_positions = (
+            None if fact["vt_ms"] >= VALID_TIME_FOREVER_MS
+            else invert_ms_to_positions(fact["vt_ms"], ts_positions)
+        )
+        if edge_live_at(vf_positions, vt_positions, w):
+            live.setdefault(fact["path"], [])
+    return live
+
+
 def sweep(
     db,
     repo_path: str,
     linearization: List[str],
     commit_metadata: Sequence[CommitMeta],
+    branch: Optional[str] = None,
 ) -> Dict:
     """Drive the REAL preload functions at each affected position and diff
-    against the oracle.
+    against the oracle, in BOTH the narrow and the wide entity framing.
 
     Calls the functions under test rather than a restatement of what we
     believe they do. On the #238 branch a reviewer and an implementer both
     simulated the counterfactual with a date bound instead of the real
     position-filtered one, which made an inadequate test look adequate and
     produced a false "bug not reachable" conclusion -- two fix rounds lost.
+
+    NARROW vs WIDE. Every misclassification count below appears twice. The
+    real _preload_known_deps is driven twice per position, differing only in
+    the file_entities handed to it:
+
+      narrow_* -- file_entities straight from _preload_known_entities. What
+        the shipped code produces today, and the only figure the first
+        version of this probe reported. It measures the ts(W) :depends-on
+        bound CONDITIONAL ON #238's still-open close-side residual: entities
+        whose own close inverted are already gone from file_entities, so
+        their edges never reach either side of the diff.
+
+      wide_* -- file_entities from position_correct_file_entities, both ends
+        inverted to positions. It measures the ts(W) :depends-on bound in
+        ISOLATION.
+
+    Neither is "the" number; the gap between them is the finding, and it is
+    what the module docstring explains. Reporting only the narrow one
+    understated this repository's exposure by ~16x.
+
+    provenance. repo_path alone was not enough to reproduce the first
+    recorded artifact -- it named a scratch directory that no longer exists,
+    with no branch and no head SHA. branch and head_commit are recorded here
+    so a future run carries its own.
 
     Three report fields exist purely to keep this sweep from lying quietly
     about itself (#245 review round):
@@ -279,11 +467,12 @@ def sweep(
       _preload_known_deps swallows its own query failure (bare `except
       Exception: return file_deps, dep_valid_from`, mcp_server.py:7554-7555)
       and returns ({}, {}) on any runtime error. That failure mode and "this
-      position genuinely has zero live deps" are indistinguishable from
-      wrongly_excluded_total alone -- both make every expected edge look
-      wrongly excluded. Recording len(actual) per position, and flagging the
-      all-positions-zero case explicitly, is what lets a reader tell them
-      apart.
+      position genuinely has zero live deps" are indistinguishable from a
+      *_wrongly_excluded_total alone -- both make every expected edge look
+      wrongly excluded. Recording each framing's actual and expected counts
+      per position, and flagging the all-positions-zero case explicitly, is
+      what lets a reader tell them apart. The flag keys on the NARROW actual,
+      the one the shipped code path produces.
 
     - unmappable_valid_from_facts / unmappable_valid_to_facts: counted only
       over the MEASURED population -- edges whose source module ident
@@ -297,10 +486,10 @@ def sweep(
       its docstring); that is the correct not-understating direction, but it
       is silent unless counted here.
 
-    wrongly_included_total / wrongly_excluded_total are position-weighted:
-    one edge misclassified at all N affected positions contributes N, not 1.
-    The distinct-edge counts alongside them are the union across positions,
-    for whichever unit the reader actually wants.
+    Every *_total_position_weighted is position-weighted: one edge
+    misclassified at all N affected positions contributes N, not 1. The
+    distinct-edge counts alongside them are the union across positions, for
+    whichever unit the reader actually wants.
     """
     import mcp_server
 
@@ -324,39 +513,87 @@ def sweep(
     envelopes = resume_envelopes(commit_metadata)
     timestamps = [ts for _h, ts, _a, _s in commit_metadata]
     edges = load_dep_edges(db)
+    path_facts = load_module_path_facts(db)
     collisions = {ts: pos for ts, pos in ts_positions.items() if len(pos) > 1}
 
     per_position = []
     actual_dep_counts_by_position = []
     measured_src_idents: set = set()
     for w in affected_positions(commit_metadata):
+        valid_at_ms = mcp_server._iso_to_epoch_ms(timestamps[w])
+
         (
             _entity_valid_from, _entity_descriptions, _entity_introduced_by,
-            file_entities, _submodule_paths,
+            narrow_file_entities, _submodule_paths,
         ) = mcp_server._preload_known_entities(
             db, repo_path, valid_at=envelopes[w],
             hash_to_pos=hash_to_pos, watermark_pos=w,
         )
-        measured_src_idents.update(
-            mcp_server._code_ident("module", file_path) for file_path in file_entities
-        )
-        _file_deps, dep_valid_from = mcp_server._preload_known_deps(
-            db, file_entities,
-            valid_at_ms=mcp_server._iso_to_epoch_ms(timestamps[w]),
-        )
-        actual = set(dep_valid_from.keys())
-        actual_dep_counts_by_position.append({"position": w, "actual_count": len(actual)})
-        expected = position_exact_live_edges(edges, ts_positions, file_entities, w)
+        wide_file_entities = position_correct_file_entities(path_facts, ts_positions, w)
 
-        wrongly_included = sorted(actual - expected)
-        wrongly_excluded = sorted(expected - actual)
-        if wrongly_included or wrongly_excluded:
+        # The measured population spans BOTH framings: an edge the narrow
+        # entity set drops but the wide one keeps still enters the oracle, so
+        # an unmappable timestamp on it still invalidates a reported number.
+        measured_src_idents.update(
+            mcp_server._code_ident("module", file_path)
+            for file_path in (set(narrow_file_entities) | set(wide_file_entities))
+        )
+
+        # The SAME unmodified _preload_known_deps on both sides. Only the
+        # file_entities differ -- that is the single variable this comparison
+        # isolates.
+        _narrow_file_deps, narrow_dep_valid_from = mcp_server._preload_known_deps(
+            db, narrow_file_entities, valid_at_ms=valid_at_ms,
+        )
+        _wide_file_deps, wide_dep_valid_from = mcp_server._preload_known_deps(
+            db, wide_file_entities, valid_at_ms=valid_at_ms,
+        )
+        narrow_actual = set(narrow_dep_valid_from.keys())
+        wide_actual = set(wide_dep_valid_from.keys())
+
+        narrow_expected = position_exact_live_edges(
+            edges, ts_positions, narrow_file_entities, w
+        )
+        wide_expected = position_exact_live_edges(
+            edges, ts_positions, wide_file_entities, w
+        )
+
+        actual_dep_counts_by_position.append({
+            "position": w,
+            "narrow_actual_count": len(narrow_actual),
+            "narrow_expected_count": len(narrow_expected),
+            "wide_actual_count": len(wide_actual),
+            "wide_expected_count": len(wide_expected),
+            "narrow_module_count": len(narrow_file_entities),
+            "wide_module_count": len(wide_file_entities),
+            # The counts alone are NOT enough: they can match while the sets
+            # differ. Measured on a synthetic inverted-date repo, both sides
+            # held 3 modules at the affected position while the narrow side
+            # had dropped the deleted-later module and admitted a
+            # not-yet-introduced one (_preload_known_entities pre-seeds
+            # file_entities from `git ls-files` on the CURRENT worktree, so
+            # its errors cancel in the count). These two are the direct
+            # evidence of the entity preload's close-side residual.
+            "modules_wide_only": len(set(wide_file_entities) - set(narrow_file_entities)),
+            "modules_narrow_only": len(set(narrow_file_entities) - set(wide_file_entities)),
+        })
+
+        narrow_wrongly_included = sorted(narrow_actual - narrow_expected)
+        narrow_wrongly_excluded = sorted(narrow_expected - narrow_actual)
+        wide_wrongly_included = sorted(wide_actual - wide_expected)
+        wide_wrongly_excluded = sorted(wide_expected - wide_actual)
+        if (
+            narrow_wrongly_included or narrow_wrongly_excluded
+            or wide_wrongly_included or wide_wrongly_excluded
+        ):
             per_position.append({
                 "position": w,
                 "commit": linearization[w],
                 "date": timestamps[w],
-                "wrongly_included": [list(e) for e in wrongly_included],
-                "wrongly_excluded": [list(e) for e in wrongly_excluded],
+                "narrow_wrongly_included": [list(e) for e in narrow_wrongly_included],
+                "narrow_wrongly_excluded": [list(e) for e in narrow_wrongly_excluded],
+                "wide_wrongly_included": [list(e) for e in wide_wrongly_included],
+                "wide_wrongly_excluded": [list(e) for e in wide_wrongly_excluded],
             })
 
     measured_edges = [e for e in edges if e["src"] in measured_src_idents]
@@ -370,34 +607,55 @@ def sweep(
         and not invert_ms_to_positions(e["vt_ms"], ts_positions)
     )
 
+    # Keyed on the NARROW actual: that is the one produced by the shipped
+    # code path, so it is the one whose all-zero signature would mean
+    # _preload_known_deps' bare `except Exception` ate a real failure.
     preload_deps_empty_everywhere = bool(actual_dep_counts_by_position) and all(
-        c["actual_count"] == 0 for c in actual_dep_counts_by_position
+        c["narrow_actual_count"] == 0 for c in actual_dep_counts_by_position
     )
 
-    distinct_wrongly_included = {
-        tuple(e) for p in per_position for e in p["wrongly_included"]
-    }
-    distinct_wrongly_excluded = {
-        tuple(e) for p in per_position for e in p["wrongly_excluded"]
-    }
+    def _distinct(key: str) -> int:
+        return len({tuple(e) for p in per_position for e in p[key]})
 
     return {
         "repo_path": repo_path,
+        "branch": branch,
+        # The ingested head, taken from the linearization rather than from a
+        # fresh `git rev-parse`: it is the commit this sweep's graph actually
+        # ends at, which a later rev-parse of the same branch need not be.
+        "head_commit": linearization[-1] if linearization else None,
         "commits": len(linearization),
         "dep_edges_total": len(edges),
         "measured_dep_edges_total": len(measured_edges),
+        "module_path_facts_total": len(path_facts),
         "affected_positions": affected_positions(commit_metadata),
         "misclassifying_positions": per_position,
         "actual_dep_counts_by_position": actual_dep_counts_by_position,
         "preload_deps_empty_everywhere": preload_deps_empty_everywhere,
-        "wrongly_included_total_position_weighted": sum(
-            len(p["wrongly_included"]) for p in per_position
+
+        # NARROW -- file_entities as _preload_known_entities returns it. The
+        # shipped behaviour, and the ts(W) :depends-on bound measured
+        # CONDITIONAL ON #238's still-open close-side residual.
+        "narrow_wrongly_included_total_position_weighted": sum(
+            len(p["narrow_wrongly_included"]) for p in per_position
         ),
-        "wrongly_excluded_total_position_weighted": sum(
-            len(p["wrongly_excluded"]) for p in per_position
+        "narrow_wrongly_excluded_total_position_weighted": sum(
+            len(p["narrow_wrongly_excluded"]) for p in per_position
         ),
-        "wrongly_included_distinct_edges": len(distinct_wrongly_included),
-        "wrongly_excluded_distinct_edges": len(distinct_wrongly_excluded),
+        "narrow_wrongly_included_distinct_edges": _distinct("narrow_wrongly_included"),
+        "narrow_wrongly_excluded_distinct_edges": _distinct("narrow_wrongly_excluded"),
+
+        # WIDE -- file_entities rebuilt position-correctly at BOTH ends. The
+        # ts(W) :depends-on bound measured in ISOLATION.
+        "wide_wrongly_included_total_position_weighted": sum(
+            len(p["wide_wrongly_included"]) for p in per_position
+        ),
+        "wide_wrongly_excluded_total_position_weighted": sum(
+            len(p["wide_wrongly_excluded"]) for p in per_position
+        ),
+        "wide_wrongly_included_distinct_edges": _distinct("wide_wrongly_included"),
+        "wide_wrongly_excluded_distinct_edges": _distinct("wide_wrongly_excluded"),
+
         "timestamp_collisions": len(collisions),
         "unmappable_valid_from_facts": unmappable_vf,
         "unmappable_valid_to_facts": unmappable_vt,
@@ -486,20 +744,49 @@ def main() -> int:
         linearization = frontier_registry.build_linearization(args.repo_path, branch)
         commit_metadata = mcp_server._git_commits(args.repo_path, None, branch)
         db = mcp_server._db if mcp_server._db is not None else mcp_server.open_db(str(graph_path))
-        report = sweep(db, args.repo_path, linearization, commit_metadata)
+        report = sweep(
+            db, args.repo_path, linearization, commit_metadata, branch=branch
+        )
         report["ingest_status"] = ingest_status
 
     print(json.dumps(report, indent=2))
     print()
-    print(f"commits:                                 {report['commits']}")
+    print(f"repo:                                     {report['repo_path']} @ {report['branch']}")
+    print(f"ingested head:                            {report['head_commit']}")
+    print(f"commits:                                  {report['commits']}")
     print(f":depends-on facts (raw, deduped):         {report['dep_edges_total']}")
     print(f":depends-on facts (measured population):  {report['measured_dep_edges_total']}")
+    print(f"module :path facts (raw, deduped):        {report['module_path_facts_total']}")
     print(f"structurally affected W:                  {len(report['affected_positions'])}")
     print(f"W actually misclassifying:                {len(report['misclassifying_positions'])}")
-    print(f"  wrongly INCLUDED, position-weighted:    {report['wrongly_included_total_position_weighted']}")
-    print(f"  wrongly INCLUDED, distinct edges:       {report['wrongly_included_distinct_edges']}")
-    print(f"  wrongly EXCLUDED, position-weighted:    {report['wrongly_excluded_total_position_weighted']}")
-    print(f"  wrongly EXCLUDED, distinct edges:       {report['wrongly_excluded_distinct_edges']}")
+    print()
+    print("                                          NARROW      WIDE")
+    print("  (narrow = file_entities as _preload_known_entities returns it: the")
+    print("   ts(W) :depends-on bound CONDITIONAL on #238's open close-side residual.")
+    print("   wide = file_entities rebuilt position-correctly at both ends: the")
+    print("   ts(W) :depends-on bound in ISOLATION. The gap between them is #238's")
+    print("   own close-side leak, not #245's.)")
+    print(
+        f"  wrongly INCLUDED, position-weighted:    "
+        f"{report['narrow_wrongly_included_total_position_weighted']:<11}"
+        f"{report['wide_wrongly_included_total_position_weighted']}"
+    )
+    print(
+        f"  wrongly INCLUDED, distinct edges:       "
+        f"{report['narrow_wrongly_included_distinct_edges']:<11}"
+        f"{report['wide_wrongly_included_distinct_edges']}"
+    )
+    print(
+        f"  wrongly EXCLUDED, position-weighted:    "
+        f"{report['narrow_wrongly_excluded_total_position_weighted']:<11}"
+        f"{report['wide_wrongly_excluded_total_position_weighted']}"
+    )
+    print(
+        f"  wrongly EXCLUDED, distinct edges:       "
+        f"{report['narrow_wrongly_excluded_distinct_edges']:<11}"
+        f"{report['wide_wrongly_excluded_distinct_edges']}"
+    )
+    print()
     print(f"preload returned zero deps at every W:    {report['preload_deps_empty_everywhere']}")
     print(f"timestamp collisions:                     {report['timestamp_collisions']}")
     print(f"unmappable :valid-from facts (measured):  {report['unmappable_valid_from_facts']}")

--- a/evals/at_scale/report.py
+++ b/evals/at_scale/report.py
@@ -22,6 +22,28 @@ def write_json_result(metrics: dict[str, Any], results_dir: Path, prefix: str = 
     return path
 
 
+def _poll_duty_row(metrics: dict[str, Any]) -> str:
+    """The "Poll duty cycle" row, rendered whether or not the metrics carry it.
+
+    The row is ALWAYS emitted: benchmark.md's own note tells the reader to
+    treat a missing duty cycle as "unmeasured, assume inflated", which only
+    works if the absence is visible. Reading metrics['poll_duty_fraction']
+    unconditionally instead raised KeyError on any result JSON produced before
+    2026-08-07 (#242), making every pre-fix artifact un-re-renderable -- the
+    opposite of the note's intent.
+    """
+    fraction = metrics.get("poll_duty_fraction")
+    if fraction is None:
+        return (
+            "| Poll duty cycle (#242) | not measured "
+            "(pre-2026-08-07 harness; assume inflated) |"
+        )
+    return (
+        f"| Poll duty cycle (#242) | {fraction*100:.2f}% "
+        f"over {metrics.get('poll_count', 'unknown')} polls |"
+    )
+
+
 def append_ingestion_report(metrics: dict[str, Any], report_path: Path) -> None:
     """Append a dated ingestion-run section to report_path, creating it with
     the shared header first if it doesn't exist yet."""
@@ -53,8 +75,7 @@ def append_ingestion_report(metrics: dict[str, Any], report_path: Path) -> None:
         f"{metrics['query_latency']['p50']*1000:.1f}ms / "
         f"{metrics['query_latency']['p99']*1000:.1f}ms / "
         f"{metrics['query_latency']['max']*1000:.1f}ms |",
-        f"| Poll duty cycle (#242) | {metrics['poll_duty_fraction']*100:.2f}% "
-        f"over {metrics['poll_count']} polls |",
+        _poll_duty_row(metrics),
     ]
     if "ignore_comparison" in metrics:
         comp = metrics["ignore_comparison"]

--- a/evals/at_scale/report.py
+++ b/evals/at_scale/report.py
@@ -53,6 +53,8 @@ def append_ingestion_report(metrics: dict[str, Any], report_path: Path) -> None:
         f"{metrics['query_latency']['p50']*1000:.1f}ms / "
         f"{metrics['query_latency']['p99']*1000:.1f}ms / "
         f"{metrics['query_latency']['max']*1000:.1f}ms |",
+        f"| Poll duty cycle (#242) | {metrics['poll_duty_fraction']*100:.2f}% "
+        f"over {metrics['poll_count']} polls |",
     ]
     if "ignore_comparison" in metrics:
         comp = metrics["ignore_comparison"]

--- a/evals/at_scale/results/245-dep-preload-exposure.json
+++ b/evals/at_scale/results/245-dep-preload-exposure.json
@@ -1,8 +1,11 @@
 {
   "repo_path": "/tmp/claude-1000/-home-aditya-Work-AMC-Minigraf-temporal-reasoning/a14e01bb-ebe0-4f07-b3d1-9318d0c0c0be/scratchpad/master-checkout",
+  "branch": "master",
+  "head_commit": "a1c4a5f777643c9f78238d1c86347c318db14f92",
   "commits": 610,
   "dep_edges_total": 358,
-  "measured_dep_edges_total": 298,
+  "measured_dep_edges_total": 331,
+  "module_path_facts_total": 51,
   "affected_positions": [
     118,
     119,
@@ -21,8 +24,8 @@
       "position": 118,
       "commit": "24d8460b83606a85972adf3fb6e5c45e89925449",
       "date": "2026-04-26T12:57:34Z",
-      "wrongly_included": [],
-      "wrongly_excluded": [
+      "narrow_wrongly_included": [],
+      "narrow_wrongly_excluded": [
         [
           ":module/tests-conftest-py",
           ":module/os"
@@ -30,6 +33,137 @@
         [
           ":module/tests-conftest-py",
           ":module/tempfile"
+        ]
+      ],
+      "wide_wrongly_included": [],
+      "wide_wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/importlib"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/json"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/report-issue-py"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/unittest-mock"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/urllib-parse"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/json"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/logging"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/pathlib"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/re"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/time"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/typing"
         ]
       ]
     },
@@ -37,8 +171,8 @@
       "position": 119,
       "commit": "3ef8a3e7a69bdf58c379d062f6739b7c476bf2fb",
       "date": "2026-04-26T12:58:03Z",
-      "wrongly_included": [],
-      "wrongly_excluded": [
+      "narrow_wrongly_included": [],
+      "narrow_wrongly_excluded": [
         [
           ":module/tests-conftest-py",
           ":module/os"
@@ -46,6 +180,137 @@
         [
           ":module/tests-conftest-py",
           ":module/tempfile"
+        ]
+      ],
+      "wide_wrongly_included": [],
+      "wide_wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/importlib"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/json"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/report-issue-py"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/unittest-mock"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/urllib-parse"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/json"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/logging"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/pathlib"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/re"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/time"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/typing"
         ]
       ]
     },
@@ -53,8 +318,8 @@
       "position": 120,
       "commit": "3d56441394e0c2bae1c30b7c4ed9c8e26cf642ae",
       "date": "2026-04-26T13:00:10Z",
-      "wrongly_included": [],
-      "wrongly_excluded": [
+      "narrow_wrongly_included": [],
+      "narrow_wrongly_excluded": [
         [
           ":module/tests-conftest-py",
           ":module/os"
@@ -62,6 +327,137 @@
         [
           ":module/tests-conftest-py",
           ":module/tempfile"
+        ]
+      ],
+      "wide_wrongly_included": [],
+      "wide_wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/importlib"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/json"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/report-issue-py"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/unittest-mock"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/urllib-parse"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/json"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/logging"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/pathlib"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/re"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/time"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/typing"
         ]
       ]
     },
@@ -69,8 +465,8 @@
       "position": 121,
       "commit": "c1ccc9af9ad97850d520ef0471017891d6013cca",
       "date": "2026-05-02T13:12:41Z",
-      "wrongly_included": [],
-      "wrongly_excluded": [
+      "narrow_wrongly_included": [],
+      "narrow_wrongly_excluded": [
         [
           ":module/tests-conftest-py",
           ":module/os"
@@ -78,6 +474,137 @@
         [
           ":module/tests-conftest-py",
           ":module/tempfile"
+        ]
+      ],
+      "wide_wrongly_included": [],
+      "wide_wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/importlib"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/json"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/report-issue-py"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/unittest-mock"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/urllib-parse"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/json"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/logging"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/pathlib"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/re"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/time"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/typing"
         ]
       ]
     },
@@ -85,8 +612,8 @@
       "position": 122,
       "commit": "ead40c4c97bd705604ad622991aeb44a23c33923",
       "date": "2026-05-02T13:13:10Z",
-      "wrongly_included": [],
-      "wrongly_excluded": [
+      "narrow_wrongly_included": [],
+      "narrow_wrongly_excluded": [
         [
           ":module/tests-conftest-py",
           ":module/os"
@@ -94,6 +621,137 @@
         [
           ":module/tests-conftest-py",
           ":module/tempfile"
+        ]
+      ],
+      "wide_wrongly_included": [],
+      "wide_wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/importlib"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/json"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/report-issue-py"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/unittest-mock"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/urllib-parse"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/json"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/logging"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/pathlib"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/re"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/time"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/typing"
         ]
       ]
     },
@@ -101,8 +759,8 @@
       "position": 123,
       "commit": "3ba7a507db064474bbc2a61b6f9db522e9808b73",
       "date": "2026-05-02T13:13:20Z",
-      "wrongly_included": [],
-      "wrongly_excluded": [
+      "narrow_wrongly_included": [],
+      "narrow_wrongly_excluded": [
         [
           ":module/tests-conftest-py",
           ":module/os"
@@ -111,63 +769,277 @@
           ":module/tests-conftest-py",
           ":module/tempfile"
         ]
+      ],
+      "wide_wrongly_included": [],
+      "wide_wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/importlib"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/json"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/report-issue-py"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/unittest-mock"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/urllib-parse"
+        ],
+        [
+          ":module/tests-test-advanced-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-harness-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/pytest"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/tempfile"
+        ],
+        [
+          ":module/tests-test-vulcan-py",
+          ":module/vulcan-py"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/json"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/logging"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/os"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/pathlib"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/re"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/subprocess"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/sys"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/time"
+        ],
+        [
+          ":module/vulcan-py",
+          ":module/typing"
+        ]
       ]
     }
   ],
   "actual_dep_counts_by_position": [
     {
       "position": 118,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 38,
+      "wide_actual_count": 36,
+      "wide_expected_count": 68,
+      "narrow_module_count": 43,
+      "wide_module_count": 10,
+      "modules_wide_only": 4,
+      "modules_narrow_only": 37
     },
     {
       "position": 119,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 38,
+      "wide_actual_count": 36,
+      "wide_expected_count": 68,
+      "narrow_module_count": 43,
+      "wide_module_count": 10,
+      "modules_wide_only": 4,
+      "modules_narrow_only": 37
     },
     {
       "position": 120,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 38,
+      "wide_actual_count": 36,
+      "wide_expected_count": 68,
+      "narrow_module_count": 43,
+      "wide_module_count": 10,
+      "modules_wide_only": 4,
+      "modules_narrow_only": 37
     },
     {
       "position": 121,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 38,
+      "wide_actual_count": 36,
+      "wide_expected_count": 68,
+      "narrow_module_count": 43,
+      "wide_module_count": 10,
+      "modules_wide_only": 4,
+      "modules_narrow_only": 37
     },
     {
       "position": 122,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 38,
+      "wide_actual_count": 36,
+      "wide_expected_count": 68,
+      "narrow_module_count": 43,
+      "wide_module_count": 10,
+      "modules_wide_only": 4,
+      "modules_narrow_only": 37
     },
     {
       "position": 123,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 38,
+      "wide_actual_count": 36,
+      "wide_expected_count": 68,
+      "narrow_module_count": 43,
+      "wide_module_count": 10,
+      "modules_wide_only": 4,
+      "modules_narrow_only": 37
     },
     {
       "position": 124,
-      "actual_count": 38
+      "narrow_actual_count": 38,
+      "narrow_expected_count": 38,
+      "wide_actual_count": 38,
+      "wide_expected_count": 38,
+      "narrow_module_count": 43,
+      "wide_module_count": 6,
+      "modules_wide_only": 0,
+      "modules_narrow_only": 37
     },
     {
       "position": 125,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 36,
+      "wide_actual_count": 36,
+      "wide_expected_count": 36,
+      "narrow_module_count": 43,
+      "wide_module_count": 6,
+      "modules_wide_only": 0,
+      "modules_narrow_only": 37
     },
     {
       "position": 126,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 36,
+      "wide_actual_count": 36,
+      "wide_expected_count": 36,
+      "narrow_module_count": 43,
+      "wide_module_count": 6,
+      "modules_wide_only": 0,
+      "modules_narrow_only": 37
     },
     {
       "position": 127,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 36,
+      "wide_actual_count": 36,
+      "wide_expected_count": 36,
+      "narrow_module_count": 43,
+      "wide_module_count": 6,
+      "modules_wide_only": 0,
+      "modules_narrow_only": 37
     },
     {
       "position": 128,
-      "actual_count": 36
+      "narrow_actual_count": 36,
+      "narrow_expected_count": 36,
+      "wide_actual_count": 36,
+      "wide_expected_count": 36,
+      "narrow_module_count": 43,
+      "wide_module_count": 6,
+      "modules_wide_only": 0,
+      "modules_narrow_only": 37
     }
   ],
   "preload_deps_empty_everywhere": false,
-  "wrongly_included_total_position_weighted": 0,
-  "wrongly_excluded_total_position_weighted": 12,
-  "wrongly_included_distinct_edges": 0,
-  "wrongly_excluded_distinct_edges": 2,
+  "narrow_wrongly_included_total_position_weighted": 0,
+  "narrow_wrongly_excluded_total_position_weighted": 12,
+  "narrow_wrongly_included_distinct_edges": 0,
+  "narrow_wrongly_excluded_distinct_edges": 2,
+  "wide_wrongly_included_total_position_weighted": 0,
+  "wide_wrongly_excluded_total_position_weighted": 192,
+  "wide_wrongly_included_distinct_edges": 0,
+  "wide_wrongly_excluded_distinct_edges": 32,
   "timestamp_collisions": 0,
   "unmappable_valid_from_facts": 0,
   "unmappable_valid_to_facts": 0,
+  "unmappable_module_path_valid_from": 0,
+  "unmappable_module_path_valid_to": 0,
   "gitlink_events": 0,
   "ingest_status": "complete"
 }

--- a/evals/at_scale/results/245-dep-preload-exposure.json
+++ b/evals/at_scale/results/245-dep-preload-exposure.json
@@ -1,0 +1,173 @@
+{
+  "repo_path": "/tmp/claude-1000/-home-aditya-Work-AMC-Minigraf-temporal-reasoning/a14e01bb-ebe0-4f07-b3d1-9318d0c0c0be/scratchpad/master-checkout",
+  "commits": 610,
+  "dep_edges_total": 358,
+  "measured_dep_edges_total": 298,
+  "affected_positions": [
+    118,
+    119,
+    120,
+    121,
+    122,
+    123,
+    124,
+    125,
+    126,
+    127,
+    128
+  ],
+  "misclassifying_positions": [
+    {
+      "position": 118,
+      "commit": "24d8460b83606a85972adf3fb6e5c45e89925449",
+      "date": "2026-04-26T12:57:34Z",
+      "wrongly_included": [],
+      "wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ]
+      ]
+    },
+    {
+      "position": 119,
+      "commit": "3ef8a3e7a69bdf58c379d062f6739b7c476bf2fb",
+      "date": "2026-04-26T12:58:03Z",
+      "wrongly_included": [],
+      "wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ]
+      ]
+    },
+    {
+      "position": 120,
+      "commit": "3d56441394e0c2bae1c30b7c4ed9c8e26cf642ae",
+      "date": "2026-04-26T13:00:10Z",
+      "wrongly_included": [],
+      "wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ]
+      ]
+    },
+    {
+      "position": 121,
+      "commit": "c1ccc9af9ad97850d520ef0471017891d6013cca",
+      "date": "2026-05-02T13:12:41Z",
+      "wrongly_included": [],
+      "wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ]
+      ]
+    },
+    {
+      "position": 122,
+      "commit": "ead40c4c97bd705604ad622991aeb44a23c33923",
+      "date": "2026-05-02T13:13:10Z",
+      "wrongly_included": [],
+      "wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ]
+      ]
+    },
+    {
+      "position": 123,
+      "commit": "3ba7a507db064474bbc2a61b6f9db522e9808b73",
+      "date": "2026-05-02T13:13:20Z",
+      "wrongly_included": [],
+      "wrongly_excluded": [
+        [
+          ":module/tests-conftest-py",
+          ":module/os"
+        ],
+        [
+          ":module/tests-conftest-py",
+          ":module/tempfile"
+        ]
+      ]
+    }
+  ],
+  "actual_dep_counts_by_position": [
+    {
+      "position": 118,
+      "actual_count": 36
+    },
+    {
+      "position": 119,
+      "actual_count": 36
+    },
+    {
+      "position": 120,
+      "actual_count": 36
+    },
+    {
+      "position": 121,
+      "actual_count": 36
+    },
+    {
+      "position": 122,
+      "actual_count": 36
+    },
+    {
+      "position": 123,
+      "actual_count": 36
+    },
+    {
+      "position": 124,
+      "actual_count": 38
+    },
+    {
+      "position": 125,
+      "actual_count": 36
+    },
+    {
+      "position": 126,
+      "actual_count": 36
+    },
+    {
+      "position": 127,
+      "actual_count": 36
+    },
+    {
+      "position": 128,
+      "actual_count": 36
+    }
+  ],
+  "preload_deps_empty_everywhere": false,
+  "wrongly_included_total_position_weighted": 0,
+  "wrongly_excluded_total_position_weighted": 12,
+  "wrongly_included_distinct_edges": 0,
+  "wrongly_excluded_distinct_edges": 2,
+  "timestamp_collisions": 0,
+  "unmappable_valid_from_facts": 0,
+  "unmappable_valid_to_facts": 0,
+  "gitlink_events": 0,
+  "ingest_status": "complete"
+}

--- a/evals/at_scale/run_ingestion_benchmark.py
+++ b/evals/at_scale/run_ingestion_benchmark.py
@@ -56,8 +56,17 @@ async def _poll_during_ingestion(
     share of that lock: at duty_factor=10 the poller holds it for at most
     ~9% of the run however large the scan grows.
 
-    _STATUS_QUERY is deliberately unchanged, so the recorded latency series
-    stays comparable to the entries already in benchmark.md.
+    _STATUS_QUERY is deliberately unchanged, so the QUERY being timed is the
+    same one every entry already in benchmark.md timed. That is NOT the same
+    claim as "the recorded latency series stays comparable", which an earlier
+    version of this docstring made and which is false. The adaptive interval
+    sleeps in proportion to the poll's own cost, so it undersamples exactly
+    the late, expensive polls -- and _STATUS_QUERY's cost grows monotonically
+    through a run, because it counts every :type/commit entity. Pre-fix
+    entries polled every 0.5s regardless and sampled that expensive tail at
+    full density. So query_latency p50/p99 recorded here are biased LOW
+    against every pre-fix entry, in the opposite direction from the pre-fix
+    wall-clock inflation. benchmark.md's 2026-08-07 note says both halves.
 
     A dedicated executor, rather than the loop default, keeps the poll off any
     thread the ingestion may want.

--- a/evals/at_scale/run_ingestion_benchmark.py
+++ b/evals/at_scale/run_ingestion_benchmark.py
@@ -106,6 +106,7 @@ async def run_ingestion_benchmark(
     branch: Optional[str],
     graph_path: Path,
     poll_interval: float = 0.5,
+    duty_factor: float = 10.0,
     compare_ignore: bool = False,
 ) -> dict[str, Any]:
     """Run a full git ingestion against repo_path into an isolated graph at
@@ -131,7 +132,7 @@ async def run_ingestion_benchmark(
     ingest_task = asyncio.create_task(mcp_server._run_ingestion(repo_path, resolved_branch))
     try:
         status_latencies, query_latencies, poll_offsets = await _poll_during_ingestion(
-            ingest_task, poll_interval
+            ingest_task, poll_interval, duty_factor
         )
         await ingest_task
     except BaseException:
@@ -143,6 +144,9 @@ async def run_ingestion_benchmark(
                 pass
         raise
     wall_clock = time.perf_counter() - start
+
+    poll_seconds = sum(status_latencies) + sum(query_latencies)
+    poll_duty_fraction = (poll_seconds / wall_clock) if wall_clock > 0 else 0.0
 
     commits_ingested = mcp_server._ingest_progress["processed"]
     final_status = mcp_server._ingest_progress["status"]
@@ -164,6 +168,9 @@ async def run_ingestion_benchmark(
         "status_latency": latency_stats(status_latencies),
         "query_latency": latency_stats(query_latencies),
         "final_status": final_status,
+        "poll_count": len(poll_offsets),
+        "poll_duty_fraction": poll_duty_fraction,
+        "poll_offsets": poll_offsets,
     }
 
     if compare_ignore:
@@ -204,6 +211,11 @@ def main() -> int:
     parser.add_argument("--repo-path", default=".")
     parser.add_argument("--branch", default=None)
     parser.add_argument("--poll-interval", type=float, default=0.5)
+    parser.add_argument(
+        "--poll-duty-factor", type=float, default=10.0,
+        help="Sleep max(poll_interval, N * last_poll_duration) between polls, "
+             "bounding the instrument's share of _db_native_lock (#242).",
+    )
     parser.add_argument("--compare-ignore", action="store_true")
     args = parser.parse_args()
 
@@ -212,7 +224,12 @@ def main() -> int:
         graph_path = Path(tmpdir) / "bench.graph"
         metrics = asyncio.run(
             run_ingestion_benchmark(
-                args.repo_path, args.branch, graph_path, args.poll_interval, args.compare_ignore
+                args.repo_path,
+                args.branch,
+                graph_path,
+                poll_interval=args.poll_interval,
+                duty_factor=args.poll_duty_factor,
+                compare_ignore=args.compare_ignore,
             )
         )
 

--- a/evals/at_scale/run_ingestion_benchmark.py
+++ b/evals/at_scale/run_ingestion_benchmark.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import concurrent.futures
 import json
 import os
 import resource
@@ -31,24 +32,73 @@ _STATUS_QUERY = "[:find (count ?e) :where [?e :entity-type :type/commit]]"
 async def _poll_during_ingestion(
     ingest_task: "asyncio.Task[None]",
     poll_interval: float,
-) -> tuple[list[float], list[float]]:
-    """Poll ingest_status and a cheap query at poll_interval while ingest_task
-    runs. Returns (status_latencies, query_latencies) in seconds."""
+    duty_factor: float = 10.0,
+) -> tuple[list[float], list[float], list[float]]:
+    """Poll ingest_status and a graph query while ingest_task runs.
+
+    Returns (status_latencies, query_latencies, poll_offsets); latencies in
+    seconds, offsets in seconds since polling began.
+
+    #242: both halves of this are load-bearing.
+
+    The handlers run on a dedicated single-worker executor rather than inline,
+    because handle_minigraf_query is synchronous -- calling it on the event
+    loop stalls the _run_ingestion coroutine, the process-pool result
+    collection, and every write_executor completion. Two full-history runs
+    were killed at 3h54m and 36m on code measured at +3% before this was
+    understood.
+
+    Off-loop alone is NOT sufficient. handle_minigraf_query acquires
+    _db_native_lock (mcp_server._db_execute), and _STATUS_QUERY counts every
+    :type/commit entity, so its cost grows for the whole run -- a ~1s scan
+    every 0.5s would still serialize against every ingestion write from
+    another thread. The adaptive interval is what bounds the instrument's
+    share of that lock: at duty_factor=10 the poller holds it for at most
+    ~9% of the run however large the scan grows.
+
+    _STATUS_QUERY is deliberately unchanged, so the recorded latency series
+    stays comparable to the entries already in benchmark.md.
+
+    A dedicated executor, rather than the loop default, keeps the poll off any
+    thread the ingestion may want.
+
+    Known limitation: a cancelled run still waits on an in-flight poll thread
+    at executor shutdown. The previous implementation blocked the event loop
+    outright, so this is strictly better, but it is not zero.
+    """
     import mcp_server
 
+    loop = asyncio.get_running_loop()
     status_latencies: list[float] = []
     query_latencies: list[float] = []
-    while not ingest_task.done():
-        t0 = time.perf_counter()
-        mcp_server.handle_minigraf_ingest_status()
-        status_latencies.append(time.perf_counter() - t0)
+    poll_offsets: list[float] = []
+    started = time.perf_counter()
 
-        t0 = time.perf_counter()
-        mcp_server.handle_minigraf_query(_STATUS_QUERY)
-        query_latencies.append(time.perf_counter() - t0)
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="bench-poll"
+    ) as poll_executor:
+        while not ingest_task.done():
+            poll_offsets.append(time.perf_counter() - started)
 
-        await asyncio.sleep(poll_interval)
-    return status_latencies, query_latencies
+            t0 = time.perf_counter()
+            await loop.run_in_executor(
+                poll_executor, mcp_server.handle_minigraf_ingest_status
+            )
+            status_duration = time.perf_counter() - t0
+            status_latencies.append(status_duration)
+
+            t0 = time.perf_counter()
+            await loop.run_in_executor(
+                poll_executor, mcp_server.handle_minigraf_query, _STATUS_QUERY
+            )
+            query_duration = time.perf_counter() - t0
+            query_latencies.append(query_duration)
+
+            await asyncio.sleep(
+                max(poll_interval, duty_factor * (status_duration + query_duration))
+            )
+
+    return status_latencies, query_latencies, poll_offsets
 
 
 async def run_ingestion_benchmark(
@@ -80,7 +130,9 @@ async def run_ingestion_benchmark(
     start = time.perf_counter()
     ingest_task = asyncio.create_task(mcp_server._run_ingestion(repo_path, resolved_branch))
     try:
-        status_latencies, query_latencies = await _poll_during_ingestion(ingest_task, poll_interval)
+        status_latencies, query_latencies, poll_offsets = await _poll_during_ingestion(
+            ingest_task, poll_interval
+        )
         await ingest_task
     except BaseException:
         if not ingest_task.done():

--- a/tests/test_at_scale_dep_preload_probe.py
+++ b/tests/test_at_scale_dep_preload_probe.py
@@ -30,6 +30,22 @@ META = [
 ]
 
 
+class TestSentinelMirrorsMcpServer:
+    """The probe duplicates minigraf's forever sentinel rather than importing
+    it, so the analysis primitives stay importable without opening a graph.
+    That duplication was guarded only by a comment saying "keep them
+    identical" -- and the import of VALID_TIME_FOREVER_MS in this module was
+    left unused (ruff F401), which is the assertion that was written and then
+    lost. If the two ever diverge, every open edge is misread as CLOSED at a
+    nonsense position and the whole measurement silently changes value.
+    """
+
+    def test_forever_sentinel_matches_the_value_mcp_server_writes(self):
+        import mcp_server
+
+        assert VALID_TIME_FOREVER_MS == mcp_server._VALID_TIME_FOREVER_MS
+
+
 class TestBuildTsPositions:
     def test_maps_each_timestamp_to_its_positions(self):
         assert build_ts_positions(META)["2026-01-01T00:00:00Z"] == [0]
@@ -119,17 +135,113 @@ import pytest
 
 from evals.at_scale.probe_dep_preload_exposure import (
     gitlink_event_count,
+    position_correct_file_entities,
     position_exact_live_edges,
 )
+
+# Epoch-ms for META's dates, so a fact can be pinned to a known POSITION.
+MS = {
+    0: 1767225600000,  # 2026-01-01, position 0
+    1: 1767571200000,  # 2026-01-05, position 1
+    2: 1767312000000,  # 2026-01-02, position 2  <- INVERTED: later pos, earlier date
+    3: 1767657600000,  # 2026-01-06, positions 3 AND 4 (collision)
+}
+
+
+class TestPositionCorrectFileEntities:
+    """The WIDE measurement's entity set, and the reason it exists.
+
+    Final whole-branch review, CRITICAL finding: _preload_known_entities is
+    position-correct on the INTRODUCTION side only (its position clause keys
+    on the introducing commit's hash). Its CLOSE side is still valid_at =
+    T_hi(W), a date bound carrying the identical author-date inversion the
+    probe exists to measure. A module whose close DATE falls below ts(W) but
+    whose close POSITION sits above W therefore vanishes from file_entities
+    at W -- taking its :depends-on edges out of BOTH sides of the diff before
+    the diff is computed, and understating the measurement.
+
+    The first test below is that exact case, and it is the one that was
+    invisible: on this repository, five modules deleted by df6b8be at
+    position 124 and 30 misclassified edges.
+    """
+
+    def _ts_positions(self):
+        return build_ts_positions(META)
+
+    def test_close_date_below_the_watermark_but_close_position_above_it_stays_live(self):
+        # vulcan.py is closed by the commit at POSITION 2, whose date
+        # (2026-01-02) is EARLIER than position 1's own (2026-01-05).
+        #
+        # A date bound at W=1 sees vt = 01-02 <= ts(W) = 01-05 and calls the
+        # module closed -- that is _preload_known_entities' close side, and it
+        # is wrong. Position-correctly, the close is at position 2 > 1, so the
+        # module is still live at W=1.
+        facts = [{"path": "vulcan.py", "vf_ms": MS[0], "vt_ms": MS[2]}]
+
+        assert "vulcan.py" in position_correct_file_entities(facts, self._ts_positions(), w=1)
+        # And it is correctly GONE from position 2 onward, where the close
+        # genuinely lands.
+        assert position_correct_file_entities(facts, self._ts_positions(), w=2) == {}
+
+    def test_open_module_is_live_from_its_introduction_onward(self):
+        facts = [{"path": "a.py", "vf_ms": MS[1], "vt_ms": VALID_TIME_FOREVER_MS}]
+        ts_positions = self._ts_positions()
+
+        assert position_correct_file_entities(facts, ts_positions, w=0) == {}
+        assert set(position_correct_file_entities(facts, ts_positions, w=1)) == {"a.py"}
+        assert set(position_correct_file_entities(facts, ts_positions, w=4)) == {"a.py"}
+
+    def test_shape_matches_the_file_entities_dict_its_consumers_expect(self):
+        # _preload_known_deps and position_exact_live_edges both read only the
+        # KEYS; the values must still be lists so the dict is drop-in.
+        facts = [{"path": "a.py", "vf_ms": MS[0], "vt_ms": VALID_TIME_FOREVER_MS}]
+        result = position_correct_file_entities(facts, self._ts_positions(), w=0)
+        assert result == {"a.py": []}
+
+    def test_a_rename_keeps_each_path_live_only_over_its_own_window(self):
+        # Two distinct (path, vf, vt) rows, as load_module_path_facts returns
+        # for a renamed module: old closed at position 2, new opened there.
+        facts = [
+            {"path": "old.py", "vf_ms": MS[0], "vt_ms": MS[2]},
+            {"path": "new.py", "vf_ms": MS[2], "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        ts_positions = self._ts_positions()
+
+        assert set(position_correct_file_entities(facts, ts_positions, w=0)) == {"old.py"}
+        assert set(position_correct_file_entities(facts, ts_positions, w=2)) == {"new.py"}
+
+    def test_ambiguous_close_takes_the_latest_colliding_position(self):
+        # MS[3] collides across positions 3 and 4. edge_live_at resolves an
+        # ambiguous close to the LATEST -- the direction that cannot
+        # understate exposure -- so the module survives w=3 and dies at w=4.
+        facts = [{"path": "a.py", "vf_ms": MS[0], "vt_ms": MS[3]}]
+        ts_positions = self._ts_positions()
+
+        assert set(position_correct_file_entities(facts, ts_positions, w=3)) == {"a.py"}
+        assert position_correct_file_entities(facts, ts_positions, w=4) == {}
+
+    def test_an_unmappable_introduction_is_not_live_anywhere(self):
+        facts = [{"path": "a.py", "vf_ms": 1, "vt_ms": VALID_TIME_FOREVER_MS}]
+        ts_positions = self._ts_positions()
+
+        assert all(
+            position_correct_file_entities(facts, ts_positions, w=w) == {}
+            for w in range(len(META))
+        )
 
 
 class TestPositionExactLiveEdges:
     """The oracle restricts to edges whose SOURCE MODULE is present in
     file_entities at W, mirroring _preload_known_deps' own ident_to_file
-    filter (mcp_server.py:7526-7535, 7558-7560). That narrowing is already
-    position-correct after #238, so isolating it out leaves the :depends-on
-    bound as the only variable under measurement -- which is exactly #245's
-    residual class."""
+    filter (mcp_server.py:7526-7535, 7558-7560).
+
+    WHICH file_entities the caller passes selects the NARROW measurement
+    (_preload_known_entities' own output, position-correct on the
+    introduction side only) or the WIDE one
+    (position_correct_file_entities', correct at both ends). An earlier
+    version of this docstring asserted the narrowing was position-correct
+    outright and that holding it fixed isolated the :depends-on bound. It
+    does not -- see TestPositionCorrectFileEntities."""
 
     def _edges(self):
         return [
@@ -266,3 +378,32 @@ class TestIngestIntoSurfacesStatus:
 
         assert branch == "HEAD"
         assert status == "complete"
+
+
+class TestLoadModulePathFacts:
+    """Against a REAL ingested graph, because the failure mode this guards is
+    silent: a wrong clause order or a mistyped attribute returns zero rows
+    without raising, which would make position_correct_file_entities empty at
+    every position and the WIDE figure a confident, meaningless zero."""
+
+    @pytest.mark.asyncio
+    async def test_returns_a_windowed_fact_for_every_ingested_module(self, git_repo, tmp_path):
+        from evals.at_scale.probe_dep_preload_exposure import load_module_path_facts
+        import mcp_server
+
+        graph_path = tmp_path / "probe.graph"
+        _branch, status = await _ingest_into(str(git_repo), "HEAD", graph_path)
+        assert status == "complete"
+
+        # Same handle recovery main() does: _run_ingestion may leave _db None.
+        db = mcp_server._db or mcp_server.open_db(str(graph_path))
+        facts = load_module_path_facts(db)
+
+        assert {f["path"] for f in facts} == {"auth.py", "models.py"}
+        for f in facts:
+            assert isinstance(f["vf_ms"], int)
+            assert isinstance(f["vt_ms"], int)
+            # Neither module is ever deleted in this fixture, so both must
+            # still carry the open sentinel -- a stray finite vt here would
+            # mean the pseudo-attributes bound to the wrong EAV clause.
+            assert f["vt_ms"] == VALID_TIME_FOREVER_MS

--- a/tests/test_at_scale_dep_preload_probe.py
+++ b/tests/test_at_scale_dep_preload_probe.py
@@ -13,6 +13,7 @@ from evals.at_scale.probe_dep_preload_exposure import (
     VALID_TIME_FOREVER_MS,
     affected_positions,
     build_ts_positions,
+    count_unmappable_module_path_facts,
     edge_live_at,
     invert_ms_to_positions,
     resume_envelopes,
@@ -228,6 +229,56 @@ class TestPositionCorrectFileEntities:
             position_correct_file_entities(facts, ts_positions, w=w) == {}
             for w in range(len(META))
         )
+
+
+class TestCountUnmappableModulePathFacts:
+    """WIDE's own unmappable-fact diagnostic. WIDE is rebuilt entirely from
+    module :path facts, so a :path vf/vt that fails to invert to a position
+    breaks WIDE at every affected W silently -- understating it (unmappable
+    vf drops the module) or overstating it (unmappable vt reads it as never
+    closed) -- unless counted, exactly as unmappable_valid_from_facts /
+    unmappable_valid_to_facts already do for :depends-on edges.
+    """
+
+    def _ts_positions(self):
+        return build_ts_positions(META)
+
+    def test_a_fully_mappable_population_counts_zero_both_ways(self):
+        facts = [
+            {"path": "a.py", "vf_ms": MS[0], "vt_ms": VALID_TIME_FOREVER_MS},
+            {"path": "b.py", "vf_ms": MS[1], "vt_ms": MS[2]},
+        ]
+        assert count_unmappable_module_path_facts(facts, self._ts_positions()) == (0, 0)
+
+    def test_an_unmappable_valid_from_is_counted(self):
+        facts = [{"path": "a.py", "vf_ms": 1, "vt_ms": VALID_TIME_FOREVER_MS}]
+        unmappable_vf, unmappable_vt = count_unmappable_module_path_facts(
+            facts, self._ts_positions()
+        )
+        assert (unmappable_vf, unmappable_vt) == (1, 0)
+
+    def test_an_unmappable_valid_to_is_counted(self):
+        facts = [{"path": "a.py", "vf_ms": MS[0], "vt_ms": 1}]
+        unmappable_vf, unmappable_vt = count_unmappable_module_path_facts(
+            facts, self._ts_positions()
+        )
+        assert (unmappable_vf, unmappable_vt) == (0, 1)
+
+    def test_the_open_sentinel_is_never_counted_as_an_unmappable_valid_to(self):
+        # VALID_TIME_FOREVER_MS does not correspond to any commit's date, so
+        # inverting it directly would always fail -- the sentinel must be
+        # excluded from the valid-to check the same way sweep()'s own
+        # unmappable_vt does for :depends-on edges.
+        facts = [{"path": "a.py", "vf_ms": MS[0], "vt_ms": VALID_TIME_FOREVER_MS}]
+        assert count_unmappable_module_path_facts(facts, self._ts_positions()) == (0, 0)
+
+    def test_each_unmappable_fact_is_counted_independently(self):
+        facts = [
+            {"path": "a.py", "vf_ms": 1, "vt_ms": VALID_TIME_FOREVER_MS},
+            {"path": "b.py", "vf_ms": 1, "vt_ms": VALID_TIME_FOREVER_MS},
+            {"path": "c.py", "vf_ms": MS[0], "vt_ms": 1},
+        ]
+        assert count_unmappable_module_path_facts(facts, self._ts_positions()) == (2, 1)
 
 
 class TestPositionExactLiveEdges:

--- a/tests/test_at_scale_dep_preload_probe.py
+++ b/tests/test_at_scale_dep_preload_probe.py
@@ -153,6 +153,25 @@ class TestPositionExactLiveEdges:
         )
         assert live == set()
 
+    def test_a_closed_edge_is_live_before_its_close_and_excluded_at_and_after_it(self):
+        # Neither of the two tests above ever gives vt_ms < VALID_TIME_FOREVER_MS,
+        # so nothing exercises that comparison's False branch (the actual
+        # invert_ms_to_positions(vt_ms, ...) call) without this. #245 review
+        # round, Important finding 3.
+        ts_positions = {
+            "2026-01-01T00:00:00Z": [1],  # introduction
+            "2026-01-03T00:00:00Z": [3],  # close
+        }
+        edges = [
+            {"src": ":module/a-py", "dep": ":module/b-py", "vf_ms": 1767225600000, "vt_ms": 1767398400000},
+        ]
+        file_entities = {"a.py": []}
+
+        assert position_exact_live_edges(edges, ts_positions, file_entities, w=2) == {
+            (":module/a-py", ":module/b-py")
+        }
+        assert position_exact_live_edges(edges, ts_positions, file_entities, w=3) == set()
+
 
 @pytest.fixture
 def git_repo(tmp_path):
@@ -206,3 +225,44 @@ class TestGitlinkEventCount:
 
     def test_counts_a_real_gitlink_event(self, repo_with_submodule):
         assert gitlink_event_count(str(repo_with_submodule)) >= 1
+
+
+from evals.at_scale.probe_dep_preload_exposure import _ingest_into
+
+
+class TestIngestIntoSurfacesStatus:
+    """#245 review round, CRITICAL finding: mcp_server._run_ingestion swallows
+    every exception internally (mcp_server.py:10212-10220), sets
+    _ingest_progress["status"] to "error" (or "stopped" on a short-circuited
+    run, mcp_server.py:10205-10208), and returns NORMALLY -- it never raises.
+    Without surfacing that status, main() has no way to tell a failed or
+    partial ingestion from a complete one, and its own `_db is not None`
+    fallback would silently sweep whatever partial graph is left behind."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_a_non_complete_status_without_raising(self, tmp_path, monkeypatch):
+        import mcp_server
+
+        async def fake_run_ingestion(_repo_path, _branch):
+            # Mirrors _run_ingestion's own swallowed-exception terminal state:
+            # returns normally, having set status to something other than
+            # "complete".
+            mcp_server._ingest_progress["status"] = "error"
+            mcp_server._ingest_progress["error"] = "simulated failure"
+            mcp_server._db = None
+
+        monkeypatch.setattr(mcp_server, "_run_ingestion", fake_run_ingestion)
+
+        graph_path = tmp_path / "probe.graph"
+        branch, status = await _ingest_into(str(tmp_path), "main", graph_path)
+
+        assert branch == "main"
+        assert status == "error"
+
+    @pytest.mark.asyncio
+    async def test_surfaces_complete_status_on_a_real_successful_ingestion(self, git_repo, tmp_path):
+        graph_path = tmp_path / "probe.graph"
+        branch, status = await _ingest_into(str(git_repo), "HEAD", graph_path)
+
+        assert branch == "HEAD"
+        assert status == "complete"

--- a/tests/test_at_scale_dep_preload_probe.py
+++ b/tests/test_at_scale_dep_preload_probe.py
@@ -1,0 +1,113 @@
+# tests/test_at_scale_dep_preload_probe.py
+"""Unit tests for the #245 exposure probe's analysis primitives.
+
+The probe's headline number cannot be asserted -- it is what the probe exists
+to discover. What CAN be asserted are the two components that could silently
+produce a WRONG number: the timestamp-to-position inversion and the
+affected-position derivation. That is the exact error class that cost two fix
+rounds on #238, where a date-bound counterfactual made an inadequate test look
+adequate.
+"""
+
+from evals.at_scale.probe_dep_preload_exposure import (
+    VALID_TIME_FOREVER_MS,
+    affected_positions,
+    build_ts_positions,
+    edge_live_at,
+    invert_ms_to_positions,
+    resume_envelopes,
+)
+
+# Position 2 is inverted: it sits above position 1 but carries an earlier date.
+# Positions 3 and 4 share a timestamp, so inversion of that instant is
+# ambiguous and must yield both.
+META = [
+    ("h0", "2026-01-01T00:00:00Z", "a@b.com", "s0"),
+    ("h1", "2026-01-05T00:00:00Z", "a@b.com", "s1"),
+    ("h2", "2026-01-02T00:00:00Z", "a@b.com", "s2"),
+    ("h3", "2026-01-06T00:00:00Z", "a@b.com", "s3"),
+    ("h4", "2026-01-06T00:00:00Z", "a@b.com", "s4"),
+]
+
+
+class TestBuildTsPositions:
+    def test_maps_each_timestamp_to_its_positions(self):
+        assert build_ts_positions(META)["2026-01-01T00:00:00Z"] == [0]
+
+    def test_collision_yields_every_colliding_position(self):
+        assert build_ts_positions(META)["2026-01-06T00:00:00Z"] == [3, 4]
+
+
+class TestResumeEnvelopes:
+    def test_envelope_is_the_running_maximum(self):
+        assert resume_envelopes(META) == [
+            "2026-01-01T00:00:00Z",
+            "2026-01-05T00:00:00Z",
+            "2026-01-05T00:00:00Z",
+            "2026-01-06T00:00:00Z",
+            "2026-01-06T00:00:00Z",
+        ]
+
+
+class TestAffectedPositions:
+    def test_selects_exactly_the_structurally_exposed_positions(self):
+        # W=0: T_hi == ts, and no later position carries a date <= 01-01. Clean.
+        # W=1: position 2 is above it with an earlier date -> wrong inclusion.
+        # W=2: T_hi (01-05) > ts (01-02)             -> wrong exclusion.
+        # W=3: position 4 is above it and ties its date -> wrong inclusion,
+        #      because the bound is half-open containment [vf, vt) ∋ ts(W)
+        #      and vf <= ts(W) admits an exact tie.
+        # W=4: last position; T_hi == ts and nothing above. Clean.
+        assert affected_positions(META) == [1, 2, 3]
+
+    def test_a_strictly_monotonic_history_exposes_nothing(self):
+        monotonic = [
+            ("h0", "2026-01-01T00:00:00Z", "a@b.com", "s0"),
+            ("h1", "2026-01-02T00:00:00Z", "a@b.com", "s1"),
+            ("h2", "2026-01-03T00:00:00Z", "a@b.com", "s2"),
+        ]
+        assert affected_positions(monotonic) == []
+
+    def test_empty_history_is_handled(self):
+        assert affected_positions([]) == []
+
+
+class TestInvertMsToPositions:
+    def test_inverts_a_unique_timestamp(self):
+        ts_positions = build_ts_positions(META)
+        # 2026-01-02T00:00:00Z
+        assert invert_ms_to_positions(1767312000000, ts_positions) == [2]
+
+    def test_inverts_a_collided_timestamp_to_both_positions(self):
+        ts_positions = build_ts_positions(META)
+        # 2026-01-06T00:00:00Z
+        assert invert_ms_to_positions(1767657600000, ts_positions) == [3, 4]
+
+    def test_unknown_timestamp_yields_no_positions(self):
+        assert invert_ms_to_positions(1, build_ts_positions(META)) == []
+
+
+class TestEdgeLiveAt:
+    def test_open_edge_is_live_at_and_after_its_introduction(self):
+        assert edge_live_at([1], None, 1) is True
+        assert edge_live_at([1], None, 4) is True
+
+    def test_open_edge_is_not_live_below_its_introduction(self):
+        assert edge_live_at([1], None, 0) is False
+
+    def test_closed_edge_is_not_live_at_or_after_its_close(self):
+        assert edge_live_at([1], [3], 3) is False
+        assert edge_live_at([1], [3], 2) is True
+
+    def test_ambiguous_introduction_uses_the_earliest_colliding_position(self):
+        # A collided vf could be either position; the earliest is the only
+        # choice that cannot understate exposure.
+        assert edge_live_at([3, 4], None, 3) is True
+
+    def test_ambiguous_close_uses_the_latest_colliding_position(self):
+        # Symmetrically, the latest close cannot understate exposure.
+        assert edge_live_at([1], [3, 4], 3) is True
+        assert edge_live_at([1], [3, 4], 4) is False
+
+    def test_unmappable_introduction_is_not_live_anywhere(self):
+        assert edge_live_at([], None, 0) is False

--- a/tests/test_at_scale_dep_preload_probe.py
+++ b/tests/test_at_scale_dep_preload_probe.py
@@ -162,7 +162,7 @@ class TestPositionCorrectFileEntities:
     the diff is computed, and understating the measurement.
 
     The first test below is that exact case, and it is the one that was
-    invisible: on this repository, five modules deleted by df6b8be at
+    invisible: on this repository, four modules deleted by df6b8be at
     position 124 and 30 misclassified edges.
     """
 

--- a/tests/test_at_scale_dep_preload_probe.py
+++ b/tests/test_at_scale_dep_preload_probe.py
@@ -111,3 +111,98 @@ class TestEdgeLiveAt:
 
     def test_unmappable_introduction_is_not_live_anywhere(self):
         assert edge_live_at([], None, 0) is False
+
+
+import subprocess as _subprocess
+
+import pytest
+
+from evals.at_scale.probe_dep_preload_exposure import (
+    gitlink_event_count,
+    position_exact_live_edges,
+)
+
+
+class TestPositionExactLiveEdges:
+    """The oracle restricts to edges whose SOURCE MODULE is present in
+    file_entities at W, mirroring _preload_known_deps' own ident_to_file
+    filter (mcp_server.py:7526-7535, 7558-7560). That narrowing is already
+    position-correct after #238, so isolating it out leaves the :depends-on
+    bound as the only variable under measurement -- which is exactly #245's
+    residual class."""
+
+    def _edges(self):
+        return [
+            # live from position 1 onward, source module present
+            {"src": ":module/a-py", "dep": ":module/b-py", "vf_ms": 1767225600000, "vt_ms": (1 << 63) - 1},
+            # source module absent from file_entities -- must be excluded
+            {"src": ":module/gone-py", "dep": ":module/b-py", "vf_ms": 1767225600000, "vt_ms": (1 << 63) - 1},
+        ]
+
+    def test_excludes_edges_whose_source_module_is_not_a_live_file_entity(self):
+        ts_positions = {"2026-01-01T00:00:00Z": [1]}
+        live = position_exact_live_edges(
+            self._edges(), ts_positions, file_entities={"a.py": []}, w=2
+        )
+        assert live == {(":module/a-py", ":module/b-py")}
+
+    def test_excludes_edges_introduced_above_the_position(self):
+        ts_positions = {"2026-01-01T00:00:00Z": [1]}
+        live = position_exact_live_edges(
+            self._edges(), ts_positions, file_entities={"a.py": []}, w=0
+        )
+        assert live == set()
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """Minimal git repo with two commits (mirrors tests/test_mcp_server.py's fixture)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+    (repo / "auth.py").write_text("def login(): pass\n")
+    _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    _subprocess.run(["git", "commit", "-m", "add auth"], cwd=repo, check=True, capture_output=True)
+    (repo / "models.py").write_text("class User: pass\n")
+    _subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    _subprocess.run(["git", "commit", "-m", "add models"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+@pytest.fixture
+def repo_with_submodule(tmp_path):
+    """A repo carrying a real gitlink entry, so gitlink_event_count has
+    something to find."""
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    _subprocess.run(["git", "init"], cwd=inner, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=inner, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.name", "T"], cwd=inner, check=True, capture_output=True)
+    (inner / "x.py").write_text("x = 1\n")
+    _subprocess.run(["git", "add", "."], cwd=inner, check=True, capture_output=True)
+    _subprocess.run(["git", "commit", "-m", "inner"], cwd=inner, check=True, capture_output=True)
+
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    _subprocess.run(["git", "init"], cwd=outer, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=outer, check=True, capture_output=True)
+    _subprocess.run(["git", "config", "user.name", "T"], cwd=outer, check=True, capture_output=True)
+    (outer / "main.py").write_text("y = 2\n")
+    _subprocess.run(["git", "add", "."], cwd=outer, check=True, capture_output=True)
+    _subprocess.run(["git", "commit", "-m", "outer"], cwd=outer, check=True, capture_output=True)
+    _subprocess.run(
+        ["git", "-c", "protocol.file.allow=always", "submodule", "add", str(inner), "sub"],
+        cwd=outer, check=True, capture_output=True,
+    )
+    _subprocess.run(["git", "commit", "-m", "add sub"], cwd=outer, check=True, capture_output=True)
+    return outer
+
+
+class TestGitlinkEventCount:
+    def test_counts_zero_for_a_repo_without_submodules(self, git_repo):
+        assert gitlink_event_count(str(git_repo)) == 0
+
+    def test_counts_a_real_gitlink_event(self, repo_with_submodule):
+        assert gitlink_event_count(str(repo_with_submodule)) >= 1

--- a/tests/test_at_scale_ingestion_benchmark.py
+++ b/tests/test_at_scale_ingestion_benchmark.py
@@ -91,3 +91,75 @@ class TestCompareIgnore:
         graph_path = tmp_path / "bench.graph"
         metrics = await run_ingestion_benchmark(str(git_repo), "HEAD", graph_path, poll_interval=0.05)
         assert "ignore_comparison" not in metrics
+
+
+import asyncio
+import time as _time
+
+from evals.at_scale.run_ingestion_benchmark import _poll_during_ingestion
+
+
+class TestPollerDoesNotStarveTheEventLoop:
+    """#242: the poll must not block the event loop, and its share of
+    _db_native_lock must stay bounded as the polled query grows."""
+
+    @pytest.mark.asyncio
+    async def test_event_loop_stays_responsive_while_poll_query_blocks(self, monkeypatch):
+        import mcp_server
+
+        monkeypatch.setattr(mcp_server, "handle_minigraf_ingest_status", lambda: None)
+        monkeypatch.setattr(mcp_server, "handle_minigraf_query", lambda _q: _time.sleep(0.05))
+
+        ticks: list[float] = []
+
+        async def heartbeat(stop: asyncio.Event) -> None:
+            while not stop.is_set():
+                ticks.append(_time.perf_counter())
+                await asyncio.sleep(0.01)
+
+        stop = asyncio.Event()
+        ingest_task = asyncio.create_task(asyncio.sleep(0.6))
+        hb = asyncio.create_task(heartbeat(stop))
+        await _poll_during_ingestion(ingest_task, poll_interval=0.0, duty_factor=0.0)
+        await ingest_task
+        stop.set()
+        await hb
+
+        # A free 0.6s loop ticking every 10ms yields ~60 ticks. With the poll
+        # blocking the loop for 50ms per iteration it yields ~12 (one per poll).
+        # 30 sits well clear of both.
+        assert len(ticks) >= 30, f"event loop was starved: only {len(ticks)} ticks"
+
+    @pytest.mark.asyncio
+    async def test_interval_backs_off_when_the_polled_query_is_slow(self, monkeypatch):
+        import mcp_server
+
+        monkeypatch.setattr(mcp_server, "handle_minigraf_ingest_status", lambda: None)
+        monkeypatch.setattr(mcp_server, "handle_minigraf_query", lambda _q: _time.sleep(0.05))
+
+        ingest_task = asyncio.create_task(asyncio.sleep(1.1))
+        _status, query_latencies, _offsets = await _poll_during_ingestion(
+            ingest_task, poll_interval=0.0, duty_factor=10.0
+        )
+        await ingest_task
+
+        # duty_factor=10 against a 50ms query forces a ~500ms sleep, so a 1.1s
+        # run admits about 2-3 polls. Without the backoff it would poll
+        # continuously and record ~20.
+        assert len(query_latencies) <= 5, f"interval did not back off: {len(query_latencies)} polls"
+
+    @pytest.mark.asyncio
+    async def test_returns_poll_offsets_aligned_with_samples(self, monkeypatch):
+        import mcp_server
+
+        monkeypatch.setattr(mcp_server, "handle_minigraf_ingest_status", lambda: None)
+        monkeypatch.setattr(mcp_server, "handle_minigraf_query", lambda _q: None)
+
+        ingest_task = asyncio.create_task(asyncio.sleep(0.2))
+        status_latencies, query_latencies, poll_offsets = await _poll_during_ingestion(
+            ingest_task, poll_interval=0.02, duty_factor=10.0
+        )
+        await ingest_task
+
+        assert len(poll_offsets) == len(status_latencies) == len(query_latencies)
+        assert poll_offsets == sorted(poll_offsets)

--- a/tests/test_at_scale_ingestion_benchmark.py
+++ b/tests/test_at_scale_ingestion_benchmark.py
@@ -43,7 +43,15 @@ class TestRunIngestionBenchmark:
             "repo_path", "branch", "commits_ingested", "wall_clock_seconds",
             "throughput_per_minute", "peak_rss_kb", "graph_size_bytes",
             "index_size_bytes", "status_latency", "query_latency", "final_status",
+            "poll_count", "poll_duty_fraction", "poll_offsets",
         }
+
+    @pytest.mark.asyncio
+    async def test_poll_duty_fraction_is_a_bounded_fraction(self, git_repo, tmp_path):
+        graph_path = tmp_path / "bench.graph"
+        metrics = await run_ingestion_benchmark(str(git_repo), "HEAD", graph_path, poll_interval=0.05)
+        assert metrics["poll_count"] == len(metrics["poll_offsets"])
+        assert 0.0 <= metrics["poll_duty_fraction"] <= 1.0
 
     @pytest.mark.asyncio
     async def test_ingests_all_commits(self, git_repo, tmp_path):

--- a/tests/test_at_scale_ingestion_benchmark.py
+++ b/tests/test_at_scale_ingestion_benchmark.py
@@ -46,12 +46,18 @@ class TestRunIngestionBenchmark:
             "poll_count", "poll_duty_fraction", "poll_offsets",
         }
 
-    @pytest.mark.asyncio
-    async def test_poll_duty_fraction_is_a_bounded_fraction(self, git_repo, tmp_path):
-        graph_path = tmp_path / "bench.graph"
-        metrics = await run_ingestion_benchmark(str(git_repo), "HEAD", graph_path, poll_interval=0.05)
-        assert metrics["poll_count"] == len(metrics["poll_offsets"])
-        assert 0.0 <= metrics["poll_duty_fraction"] <= 1.0
+    # test_poll_duty_fraction_is_a_bounded_fraction was DELETED here (final
+    # whole-branch review). Both of its assertions were tautologies:
+    # poll_count is *defined* as len(poll_offsets)
+    # (run_ingestion_benchmark.py:171), and poll_duty_fraction is a serial sum
+    # of latencies measured INSIDE the same wall_clock it divides by
+    # (:148-149), so 0.0 <= f <= 1.0 cannot fail. It had zero discriminating
+    # power while being counted as #242 coverage -- the exact pattern this
+    # project has already shipped four times. Its only non-vacuous content
+    # (key presence) is covered by test_returns_expected_metric_keys above,
+    # and the real offsets/samples alignment by
+    # TestPollerDoesNotStarveTheEventLoop::test_returns_poll_offsets_aligned_with_samples,
+    # which is ablation-proven.
 
     @pytest.mark.asyncio
     async def test_ingests_all_commits(self, git_repo, tmp_path):

--- a/tests/test_at_scale_report.py
+++ b/tests/test_at_scale_report.py
@@ -56,6 +56,21 @@ class TestAppendIngestionReport:
         assert "4.20%" in text  # poll_duty_fraction=0.042 -> 4.20%
         assert "over 5 polls" in text  # poll_count=5
 
+    def test_poll_duty_cycle_row_still_renders_for_a_pre_fix_result(self, tmp_path):
+        # Every result JSON written before 2026-08-07 lacks the #242 poll
+        # keys. Re-rendering one used to raise KeyError; the row must instead
+        # render and say so, matching benchmark.md's own "treat its absence as
+        # unmeasured, assume inflated" framing.
+        pre_fix = {
+            k: v for k, v in SAMPLE_METRICS.items()
+            if k not in ("poll_count", "poll_duty_fraction")
+        }
+        report_path = tmp_path / "benchmark.md"
+        append_ingestion_report(pre_fix, report_path)
+        text = report_path.read_text()
+        assert "Poll duty cycle (#242)" in text
+        assert "not measured" in text
+
 
 SAMPLE_QUERY_RESULTS = [
     {

--- a/tests/test_at_scale_report.py
+++ b/tests/test_at_scale_report.py
@@ -9,6 +9,7 @@ SAMPLE_METRICS = {
     "status_latency": {"min": 0.001, "p50": 0.002, "p99": 0.004, "max": 0.005},
     "query_latency": {"min": 0.002, "p50": 0.003, "p99": 0.006, "max": 0.008},
     "final_status": "complete",
+    "poll_count": 5, "poll_duty_fraction": 0.042,
 }
 
 

--- a/tests/test_at_scale_report.py
+++ b/tests/test_at_scale_report.py
@@ -48,6 +48,14 @@ class TestAppendIngestionReport:
         assert len(report_path.read_text()) > first_len
         assert report_path.read_text().count("## Ingestion Run") == 2
 
+    def test_poll_duty_cycle_row_renders_with_formatted_values(self, tmp_path):
+        report_path = tmp_path / "benchmark.md"
+        append_ingestion_report(SAMPLE_METRICS, report_path)
+        text = report_path.read_text()
+        assert "Poll duty cycle (#242)" in text
+        assert "4.20%" in text  # poll_duty_fraction=0.042 -> 4.20%
+        assert "over 5 polls" in text  # poll_count=5
+
 
 SAMPLE_QUERY_RESULTS = [
     {


### PR DESCRIPTION
Two independent changes, bundled for one review.

## 1. Measure #245's `:depends-on` exposure

New read-only probe (`evals/at_scale/probe_dep_preload_exposure.py`). It ingests a
repo into a scratch graph, then drives the **real** `_preload_known_entities` +
`_preload_known_deps` at each structurally affected watermark position and diffs
them against a position-exact oracle. It **fixes nothing** — it produces the number
that decides #245.

Measured on `master` (610 commits, head `a1c4a5f`):

| | narrow — as the preloads behave today | wide — position-correct entity set |
|---|---:|---:|
| wrongly **excluded**, distinct edges | **2** | **32** |
| wrongly excluded, position-weighted | 12 | 192 |
| wrongly **included** | 0 | 0 |
| live edges at an affected position | 38 | 68 |

At positions 118–123 the `ts(W)` bound wrongly excludes **32 of 68 live edges (47%)**.
Only 2 are observable today, because `_preload_known_entities`' own **close**-side date
bound already removed the other 30 from both sides of the diff — that gap is #238's
still-open residual. Full write-up on
[#245](https://github.com/project-minigraf/temporal_reasoning/issues/245#issuecomment-5216128050)
and [#238](https://github.com/project-minigraf/temporal_reasoning/issues/238#issuecomment-5216134915).

Validity: `ingest_status: complete`, 11 affected positions, 0 timestamp collisions,
0 unmappable facts on all four counters, `preload_deps_empty_everywhere: false`.

`:pinned-commit` is **unmeasurable** here — 0 gitlink events in 610 commits. Not the
same as zero risk.

## 2. Fix the benchmark poller (#242)

`_poll_during_ingestion` now runs its handlers on a dedicated single-worker executor
**and** sleeps `max(poll_interval, duty_factor * last_poll_duration)`. Both halves are
needed: off-loop alone still lets a growing scan serialize against every ingestion
write via `_db_native_lock` (`mcp_server.py:3280`). Ablation-proven — pre-fix, the
event loop got 5 heartbeat ticks where the test requires ≥30, and polled 25 times where
it requires ≤5.

## Review history worth knowing

The first measurement reported **2 edges** and I was about to recommend closing #245 as
negligible. The final whole-branch review found that number understated 16×, because
the probe held `file_entities` fixed on both sides of its diff on the strength of a
claim in my own spec — that `_preload_known_entities` is position-correct — which is
true of its introduction side and **false of its close side**. The probe now reports
both framings; the comparison between them is the finding.

Separately, an earlier spec draft had the oracle inverting only `:db/valid-from`. The
entire narrow finding is driven by `:db/valid-to`. Had that not been caught in spec
review, the probe would have reported zero and argued for closing #245.

## Notes

- `mcp_server.py` is **untouched**. Everything here is under `evals/`, `tests/`, and `docs/`.
- **No issue is closed by this PR.** #245 stays open for the fix decision; #238 stays open
  until all four preload sites are resolved; #242 stays open until one green at-scale
  nightly carries a `Poll duty cycle` row — its stated acceptance criterion, which this
  branch does not exercise because the probe bypasses the benchmark harness.
- `CLAUDE.md` updated for the new probe/`results/` artifacts. `SKILL.md` needs no change —
  no fact-model, query-syntax, or tool-signature change.

Refs #245
Refs #238
Refs #242
Refs #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8qWT72sj5ja3wvkcgkK6b
