### PR TITLE
Adopt minigraf 1.2.3 and fix the handle leaks behind the flaky page-bounds error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,17 @@ process that opens the graph. See #241.
 The fact index is bi-temporal: it includes historical (retracted/superseded) facts
 alongside current ones, labeled with their validity window.
 
+**Single-handle invariant.** At most one live `MiniGrafDb` handle may exist per
+process. Two handles on one file each cache their own `page_count` and corrupt
+each other — the flaky `Page N out of bounds (total pages: M)` (#251, #253,
+project-minigraf/minigraf#304). `mcp_server.py` does not enforce this: `_db =
+None` is its "release the lock" idiom, but it only releases when it drops the
+LAST reference, and a local `db` on a stack (e.g. `_run_ingestion`'s per-commit
+handle, held across awaits) keeps the handle alive while a concurrent
+`call_tool`'s `finally` clears the global. Before touching DB lifecycle, read the
+invariant comment above `_db_native_lock`. Enforcing it in Python by reusing the
+live handle was tried and rejected — it changes handle lifetime and segfaults.
+
 ## Claude Code Plugin Publishing
 
 The plugin is published via a stub architecture — `install.py` handles all registration automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,10 @@ alongside current ones, labeled with their validity window.
 **Single-handle invariant.** At most one live `MiniGrafDb` handle may exist per
 process. Two handles on one file each cache their own `page_count` and corrupt
 each other — the flaky `Page N out of bounds (total pages: M)` (#251, #253,
-project-minigraf/minigraf#304). `mcp_server.py` does not enforce this: `_db =
+project-minigraf/minigraf#304). minigraf enforces this as of 1.2.2 (hence the
+`minigraf>=1.2.3` floor): a second open now raises `Database is already open in
+this process` instead of silently succeeding. That makes the bug visible, not
+absent — `mcp_server.py` still does not enforce it: `_db =
 None` is its "release the lock" idiom, but it only releases when it drops the
 LAST reference, and a local `db` on a stack (e.g. `_run_ingestion`'s per-commit
 handle, held across awaits) keeps the handle alive while a concurrent

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -76,8 +76,9 @@ _db_native_lock = threading.Lock()
 # THE SINGLE-HANDLE INVARIANT (#253, #251, project-minigraf/minigraf#304)
 #
 # Everything below assumes at most one live MiniGrafDb handle per process.
-# Nothing in this module enforces that, and until the minigraf#304 fix nothing
-# in minigraf did either.
+# Nothing in this module enforces that. minigraf did not either until 1.2.2
+# (project-minigraf/minigraf#304); this project now requires >= 1.2.3, so the
+# corruption path below is closed at the source rather than here.
 #
 # `_db = None` is this module's "release the graph file lock" idiom, but it
 # only releases when it drops the LAST reference. Any local `db` still on a
@@ -102,9 +103,9 @@ _db_native_lock = threading.Lock()
 # FileLock::drop, deleting the lock file that by then belongs to the survivor,
 # leaving a live handle with no lock at all and letting other *processes* in.
 #
-# The minigraf#304 fix makes FileLock::acquire steal only a DEAD holder's lock,
-# so the second open now fails loudly with "Database is locked by another
-# process" instead of silently corrupting. That converts this from data
+# Since minigraf 1.2.2, FileLock::acquire steals only a DEAD holder's lock, so
+# the second open fails loudly with "Database is already open in this process"
+# instead of silently corrupting. That converts this from data
 # corruption into a lock error on the retry path — the right trade, but it does
 # not make the interleaving above correct. Clearing _db while another caller
 # still holds the handle is still a bug here; it is now merely a visible one.
@@ -3042,11 +3043,13 @@ def _open_db_at(path: str, *, force: bool = True) -> MiniGrafDb:
     e.g. _refresh_if_stale().
 
     #107 recorded that second open as surfacing loudly — "Database is locked by
-    another process", with the lock file's PID equal to *our* PID. As of
-    minigraf 1.2.1 that is NOT what happens, and assuming it did is what let
-    #253/#251 hide: FileLock::acquire treats a lock held by our own PID as
-    stale, deletes it, and opens anyway. The second handle is created silently
-    and the two corrupt each other.
+    another process", with the lock file's PID equal to *our* PID. That was not
+    true of minigraf 1.2.1 and earlier, and assuming it was is what let
+    #253/#251 hide: FileLock::acquire treated a lock held by our own PID as
+    stale, deleted it, and opened anyway, so the second handle was created
+    silently and the two corrupted each other. Fixed in minigraf 1.2.2
+    (project-minigraf/minigraf#304), which now raises "Database is already open
+    in this process".
 
     NOTE: neither branch below can currently detect a handle that is live but
     no longer reachable through _db — see the module comment on the
@@ -3109,7 +3112,26 @@ def _refresh_if_stale() -> None:
 
 
 def _is_lock_error(exc: Exception) -> bool:
-    return "locked" in str(exc).lower()
+    """True for the two "someone else has the graph" opens, both retryable.
+
+    minigraf raises two distinct messages, and only one contains "locked":
+
+      * "Database is locked by another process"       -- another PROCESS
+      * "Database is already open in this process"    -- another handle HERE
+        (project-minigraf/minigraf#304, minigraf >= 1.2.2)
+
+    The second must be matched too. It is transient in exactly the same way:
+    the other holder is usually a poller or a call_tool worker about to drop
+    its reference, so backing off and retrying is the right response. Matching
+    only "locked" made it fall through as a fatal non-lock error and abort the
+    caller on the first attempt, turning a momentary overlap into a failed
+    ingestion.
+
+    Retrying does NOT paper over the invariant: a genuinely leaked handle still
+    exhausts the retry budget and surfaces. It only absorbs the races.
+    """
+    msg = str(exc).lower()
+    return "locked" in msg or "already open in this process" in msg
 
 
 def _stale_lock_holder_pid(exc: Exception) -> Optional[int]:
@@ -10275,8 +10297,21 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                             file=sys.stderr,
                         )
                     finally:
-                        _db = None  # release file lock between commits
-                        db = None   # drop local reference too — see note above
+                        # Order matters, and it is not cosmetic. Clearing _db
+                        # first leaves a window in which the global says "no
+                        # handle" while this frame's `db` still holds one --
+                        # and other OS THREADS (the ingestion status/query
+                        # poller, any call_tool worker) can call get_db() inside
+                        # it. They see _db is None, open a second handle on the
+                        # same file, and since minigraf 1.2.2 that raises
+                        # "Database is already open in this process"; before it
+                        # silently corrupted the graph, which is the #251
+                        # mechanism. No await separates these two statements,
+                        # so no other *coroutine* interleaves -- but threads do.
+                        # Dropping the local first makes the clearing of _db the
+                        # moment the handle is genuinely released.
+                        db = None   # drop local reference FIRST
+                        _db = None  # now this actually releases the file lock
 
                     _ingest_progress["processed"] += 1
                     await asyncio.sleep(0)  # yield to event loop
@@ -10365,6 +10400,18 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                                     f"[_run_ingestion] correction sweep aborted at {sweep_hash}: {e}",
                                     file=sys.stderr,
                                 )
+                                # Drop the traceback before leaving the loop.
+                                # It chains back through _WorkItem.run to the
+                                # frame that raised, and that frame's argument
+                                # tuple still holds `db` -- so the handle stays
+                                # alive no matter how carefully the finallys
+                                # below clear their locals. The outer finally's
+                                # final checkpoint then cannot open the graph
+                                # ("Database is already open in this process")
+                                # and an interrupted run silently skips its WAL
+                                # compaction. Only the message is used above, so
+                                # nothing is lost by dropping the traceback.
+                                e.__traceback__ = None
                                 completed_all = False
                                 break
                             await asyncio.sleep(0)  # yield to event loop
@@ -10383,8 +10430,10 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                             )
                             await loop.run_in_executor(write_executor, _db_checkpoint_gated, db)
                     finally:
-                        _db = None
+                        # Local first, then the global -- see the per-commit
+                        # finally above for why the order is load-bearing.
                         db = None
+                        _db = None
 
                 # Call _ingest_tags and _last_run_write before closing index_con
                 # so they use the batched connection instead of opening new ones
@@ -10404,6 +10453,18 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                         # with nothing dirty in between -- the same
                         # structural duplicate #241 removed from Stage B.
                     finally:
+                        # `db` must be cleared too, and before `_db`. This block
+                        # was the one release site that cleared only the global,
+                        # so the handle stayed alive in this coroutine's frame
+                        # all the way into the outer finally below -- whose
+                        # _ensure_db_async() then tried to open a SECOND handle
+                        # on the same file. Since minigraf 1.2.2 that raises and
+                        # the final WAL compaction is skipped; before it, it
+                        # silently produced the two divergent page tables of
+                        # #251. Confirmed by instrumenting the outer finally:
+                        # the sole live handle was reachable from this frame's
+                        # `db`.
+                        db = None
                         _db = None
             finally:
                 # Compact the WAL on EVERY terminal path, not just
@@ -10426,6 +10487,13 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
                 except Exception as e:
                     print(f"[_run_ingestion] final checkpoint failed: {e}", file=sys.stderr)
                 finally:
+                    # Clear the local before the global, as everywhere else in
+                    # this function: `final_db` outliving `_db = None` leaves a
+                    # live handle unreachable through the global, and the
+                    # ingestion status poller -- which runs on its own thread
+                    # and is still polling until this run returns -- then sees
+                    # _db is None and opens a second handle on the same file.
+                    final_db = None
                     _db = None
                 # ProcessPoolExecutor.shutdown(wait=True) blocks joining the
                 # worker OS processes — measured ~90ms even for a pool that

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -67,7 +67,53 @@ _db: Optional[MiniGrafDb] = None
 # call/checkpoint on the same (or a handle open concurrently with another's
 # in-flight write) can observe a torn header or a mid-write index, producing
 # silently wrong query results or a transient "Header checksum mismatch" (#110).
+#
+# It serializes calls into ONE handle. It does not, and cannot, stop a second
+# handle being opened on the same file — those are distinct Rust objects with
+# distinct internal mutexes. See the single-handle invariant below.
 _db_native_lock = threading.Lock()
+
+# THE SINGLE-HANDLE INVARIANT (#253, #251, project-minigraf/minigraf#304)
+#
+# Everything below assumes at most one live MiniGrafDb handle per process.
+# Nothing in this module enforces that, and until the minigraf#304 fix nothing
+# in minigraf did either.
+#
+# `_db = None` is this module's "release the graph file lock" idiom, but it
+# only releases when it drops the LAST reference. Any local `db` still on a
+# stack keeps the handle — and its lock — alive: _run_ingestion holds one
+# across the awaits in its per-commit loop, and a concurrent call_tool's
+# `finally: _db = None` clears the global underneath it.
+#
+# The next MiniGrafDb.open() then does NOT fail. minigraf's FileLock::acquire
+# (src/storage/backend/file.rs) removes the lock file and retries whenever the
+# holder PID equals our own:
+#
+#     if pid == our_pid || !Self::is_process_alive(pid) {
+#         let _ = std::fs::remove_file(&lock_path);
+#         return Self::acquire(db_path);
+#     }
+#
+# So we silently get two live handles on one file. Each FileBackend caches its
+# own FileHeader.page_count, allocates new pages from it, and bounds-checks
+# read_page against it — which is exactly where the flaky
+# "Page N out of bounds (total pages: M)" comes from (#253, #251,
+# project-minigraf/minigraf#304). Worse, whichever handle drops first runs
+# FileLock::drop, deleting the lock file that by then belongs to the survivor,
+# leaving a live handle with no lock at all and letting other *processes* in.
+#
+# The minigraf#304 fix makes FileLock::acquire steal only a DEAD holder's lock,
+# so the second open now fails loudly with "Database is locked by another
+# process" instead of silently corrupting. That converts this from data
+# corruption into a lock error on the retry path — the right trade, but it does
+# not make the interleaving above correct. Clearing _db while another caller
+# still holds the handle is still a bug here; it is now merely a visible one.
+#
+# Enforcing the invariant in Python was tried and rejected (#253): a weakref
+# guard that reuses the still-live handle instead of opening a second one fixes
+# the corruption but changes handle LIFETIME, resurrecting handles whose backing
+# file is gone — it segfaulted the suite reproducibly. The durable local fix is
+# an explicit lease/refcount protocol replacing the `_db = None` idiom.
 
 # Track graph path and last-known mtime so we can detect external modifications.
 # minigraf's Drop impl writes to the file even for read-only handles, which
@@ -2991,11 +3037,23 @@ def _open_db_at(path: str, *, force: bool = True) -> MiniGrafDb:
     both observe _db as None (e.g. the ingestion preload thread and an
     _ensure_db_async() caller racing during the "starting" phase, before
     _run_ingestion flips status to "running") each call MiniGrafDb.open() on
-    the same path from this same process. The second open collides with the
-    first handle's still-held lock file and surfaces as "Database is locked
-    by another process", with the lock file's own PID equal to *our* PID
-    (#107). force=True (the default) is for callers that need a genuine
-    reopen regardless of any existing handle, e.g. _refresh_if_stale().
+    the same path from this same process (#107). force=True (the default) is
+    for callers that need a genuine reopen regardless of any existing handle,
+    e.g. _refresh_if_stale().
+
+    #107 recorded that second open as surfacing loudly — "Database is locked by
+    another process", with the lock file's PID equal to *our* PID. As of
+    minigraf 1.2.1 that is NOT what happens, and assuming it did is what let
+    #253/#251 hide: FileLock::acquire treats a lock held by our own PID as
+    stale, deletes it, and opens anyway. The second handle is created silently
+    and the two corrupt each other.
+
+    NOTE: neither branch below can currently detect a handle that is live but
+    no longer reachable through _db — see the module comment on the
+    single-handle invariant. Guarding that in Python was tried and rejected
+    (#253): reusing a still-referenced handle changes its lifetime, which
+    resurrects handles whose backing file is gone. The enforcement belongs in
+    minigraf's FileLock, where the fix is one condition.
     """
     global _db, _graph_path, _db_mtime
     with _db_native_lock:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,16 @@ classifiers = [
 ]
 
 dependencies = [
-    "minigraf>=1.2.1",
+    # Floor is a correctness requirement, not a preference. Before the
+    # project-minigraf/minigraf#304 fix, FileLock::acquire treated a lock held
+    # by our own PID as stale and opened anyway, so a second handle on one file
+    # was created silently. Two handles each cache their own page_count and
+    # corrupt each other -- the flaky "Page N out of bounds" of #251/#253.
+    # mcp_server reaches that state through normal operation, so an older
+    # minigraf here means silent graph corruption under concurrent load.
+    # The core fix shipped in 1.2.2; 1.2.3 is the release this is verified
+    # against (1.2.2's Node binding was withdrawn for an unrelated gap).
+    "minigraf>=1.2.3",
     # Capped below 2.0: mcp 2.0.0 removed Server.list_tools, which
     # mcp_server.py registers its handlers through. With the bound open, CI
     # resolved 2.0.0 and every test that imports mcp_server errored at import

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11385,6 +11385,14 @@ class TestRunIngestionShutdown:
         stop_once = {"done": False}
 
         async def stop_after_first(t):
+            # Only the per-commit yield, `asyncio.sleep(0)`, marks a commit
+            # boundary. _ensure_db_async's lock-contention backoff also sleeps,
+            # with a non-zero delay, and tripping the shutdown on that would
+            # stop the run at an arbitrary point instead of after commit 1 --
+            # see the same guard in TestResumeWithInvertedAuthorDates.
+            if t:
+                await original_sleep(t)
+                return
             if not stop_once["done"]:
                 stop_once["done"] = True
                 mcp_server._shutdown_requested.set()
@@ -19698,6 +19706,18 @@ class TestResumeWithInvertedAuthorDates:
         sleep_calls = {"n": 0}
 
         async def stop_after_fourth(t):
+            # Count only the per-commit yield, `asyncio.sleep(0)`. Counting
+            # every sleep made this a proxy for "commits processed" that any
+            # other sleeper could perturb -- notably _ensure_db_async's
+            # lock-contention backoff, which sleeps with a non-zero delay. Once
+            # the same-process open became retryable (#253), a single retry
+            # under load consumed one of these counts and tripped the shutdown
+            # a commit early, so `processed` came out 3 instead of 4. That was
+            # a real failure on CI and invisible locally, because only a
+            # contended machine retries at all.
+            if t:
+                await original_sleep(t)
+                return
             sleep_calls["n"] += 1
             if sleep_calls["n"] == 4:
                 mcp_server._shutdown_requested.set()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6138,6 +6138,12 @@ class TestFrontierPersistClaim:
 
         mcp_server._frontier_persist_claim(db, linearization, 0, from_low=True, commit_ts_iso="2026-01-01T00:00:00Z")
         mcp_server._db_checkpoint(db)
+        # Both references, and the local first. Clearing only the global left
+        # this frame's `db` holding the handle, so the "genuine reopen" below
+        # was really a second handle on one file -- which minigraf now refuses
+        # outright (project-minigraf/minigraf#304) and used to let through as
+        # silent corruption. Dropping `db` first is what makes the reopen real.
+        del db
         mcp_server._db = None  # release lock, force a genuine reopen below
 
         mcp_server.open_db(str(tmp_path / "t.graph"))
@@ -11397,6 +11403,14 @@ class TestRunIngestionShutdown:
         watermark = mcp_server._watermark_query(db)
         assert watermark, "run 1's watermark must be durably persisted for run 2 to resume from"
         assert mcp_server._count_commit_entities(db) == 1
+        # Hand the handle back before run 2. _run_ingestion owns the DB
+        # lifecycle -- it releases and reopens per commit -- so a handle still
+        # held in this frame makes its next open a second handle on one file.
+        # minigraf refuses that outright now (project-minigraf/minigraf#304);
+        # it used to be silent corruption. Production has no such frame; this
+        # is the test putting the process into a state the server never is.
+        del db
+        mcp_server._db = None
 
         mcp_server._ingest_progress = {
             "status": "idle", "processed": 0, "total": 0,
@@ -20421,12 +20435,6 @@ class TestSingleHandlePerProcess:
     stale and deleted it.
     """
 
-    @pytest.mark.xfail(
-        reason="needs the minigraf#304 FileLock fix; pinned minigraf 1.2.1 "
-               "silently steals a lock held by our own PID. Remove this marker "
-               "when the minigraf dependency is bumped.",
-        strict=False,
-    )
     def test_second_open_in_same_process_is_refused(self, tmp_path):
         """A second open while a handle is live must fail loudly, not succeed."""
         from minigraf import MiniGrafDb
@@ -20469,3 +20477,69 @@ class TestSingleHandlePerProcess:
 
         del held
         mcp_server._db = None
+
+
+class TestLockErrorRecognisesSameProcessOpen:
+    """#253: minigraf raises two distinct "someone else has the graph" messages
+    and only one contains the word "locked".
+
+    `_is_lock_error` gates the retry/backoff path in `_open_db_at_with_retry`,
+    `_open_db_at_with_extended_retry` and `_ensure_db_async`. Matching only
+    "locked" made the same-process message fall through as a fatal non-lock
+    error, aborting the caller on the first attempt instead of backing off --
+    which turned a momentary handle overlap into a failed ingestion.
+    """
+
+    def test_recognises_both_minigraf_lock_messages(self):
+        import mcp_server
+
+        cross_process = (
+            "Database is locked by another process (lock file: /tmp/x.graph.lock, "
+            "holder PID: 4242). If no other process is using this database, "
+            "delete the lock file manually."
+        )
+        same_process = (
+            "Database is already open in this process (lock file: /tmp/x.graph.lock, "
+            "holder PID: 4242 == our own). A second handle on one file would give "
+            "each its own page table and corrupt both — reuse the existing handle "
+            "instead."
+        )
+
+        assert mcp_server._is_lock_error(Exception(cross_process))
+        assert mcp_server._is_lock_error(Exception(same_process)), (
+            "the same-process message contains no 'locked', so matching that word "
+            "alone drops it onto the fatal path instead of the retry path"
+        )
+
+    def test_genuine_non_lock_errors_are_still_fatal(self):
+        """The widening must not swallow unrelated failures into the retry loop."""
+        import mcp_server
+
+        for msg in (
+            "Is a directory (os error 21)",
+            "Failed to read header from existing file (size=4096): bad magic",
+            "Page 130 out of bounds (total pages: 113)",
+        ):
+            assert not mcp_server._is_lock_error(Exception(msg)), msg
+
+    def test_real_same_process_open_is_classified_as_retryable(self, tmp_path):
+        """End-to-end against real minigraf, not a hand-written string.
+
+        Pins the classification to what minigraf actually raises, so a reworded
+        upstream message fails here rather than silently reverting the retry
+        path to fatal.
+        """
+        import mcp_server
+        from minigraf import MiniGrafDb
+
+        path = str(tmp_path / "t.graph")
+        first = MiniGrafDb.open(path)
+        try:
+            with pytest.raises(Exception) as exc_info:
+                MiniGrafDb.open(path)
+            assert mcp_server._is_lock_error(exc_info.value), (
+                f"minigraf's same-process open error is not classified as "
+                f"retryable: {exc_info.value}"
+            )
+        finally:
+            del first

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -20394,3 +20394,78 @@ class TestCheckpointDutySummaryPublication:
         assert summary["checkpoints"] == 0, "no checkpoint ever ran before the injected failure"
         assert summary["total_seconds"] == 0.0
         assert summary["realised_duty"] == 0.0
+
+
+class TestSingleHandlePerProcess:
+    """#253/#251: two live MiniGrafDb handles on one file must be impossible.
+
+    `_db = None` is this module's "release the graph file lock" idiom, but it
+    only releases when it drops the LAST reference. Any local `db` still on a
+    stack keeps the handle alive -- _run_ingestion holds one across the awaits
+    in its per-commit loop, and a concurrent call_tool's `finally: _db = None`
+    clears the global underneath it. The next open then creates a SECOND handle.
+
+    Each FileBackend caches its own FileHeader.page_count, allocates new pages
+    from it, and bounds-checks read_page against it, so two handles diverge and
+    corrupt each other. That is the source of the flaky
+    "Page N out of bounds (total pages: M)" (project-minigraf/minigraf#304).
+    Driving this interleaving for 40 rounds against minigraf 1.2.1 produces
+    "Page 130 out of bounds (total pages: 113)" on the first round, then
+    'Serde Deserialization Error' and
+    'stream_all_entries: expected leaf page at page_id=68' on later ones.
+
+    _db_native_lock cannot prevent this -- the two handles are distinct Rust
+    objects with distinct internal mutexes -- and enforcing it in Python was
+    tried and rejected (see the module comment in mcp_server.py). The fix is in
+    minigraf's FileLock::acquire, which treated a lock held by our own PID as
+    stale and deleted it.
+    """
+
+    @pytest.mark.xfail(
+        reason="needs the minigraf#304 FileLock fix; pinned minigraf 1.2.1 "
+               "silently steals a lock held by our own PID. Remove this marker "
+               "when the minigraf dependency is bumped.",
+        strict=False,
+    )
+    def test_second_open_in_same_process_is_refused(self, tmp_path):
+        """A second open while a handle is live must fail loudly, not succeed."""
+        from minigraf import MiniGrafDb
+
+        path = str(tmp_path / "t.graph")
+        first = MiniGrafDb.open(path)
+        try:
+            with pytest.raises(Exception) as exc_info:
+                MiniGrafDb.open(path)
+            assert "already open in this process" in str(exc_info.value), exc_info.value
+        finally:
+            del first
+
+    def test_release_idiom_does_not_drop_a_handle_others_still_hold(self, tmp_path, monkeypatch):
+        """Pins the precondition that makes the above reachable.
+
+        This is the half we control: `_db = None` does not destroy the handle
+        while another caller still references it, so `_db is None` is NOT
+        evidence that the graph file lock was released.
+        """
+        import mcp_server
+
+        graph = str(tmp_path / "t.graph")
+        monkeypatch.setenv("MINIGRAF_GRAPH_PATH", graph)
+        mcp_server._db = None
+        mcp_server._graph_path = ""
+
+        held = mcp_server._open_db_at(graph)          # _run_ingestion's local `db`
+        mcp_server._db = None                          # call_tool's finally
+        assert mcp_server._db is None
+
+        # The handle is still fully usable, which is exactly the problem: the
+        # lock is still held, so the next open is a second handle, not a reopen.
+        raw = mcp_server._db_execute(held, "(query [:find ?e :where [?e :ident ?v]])")
+        assert "out of bounds" not in raw
+        assert os.path.exists(graph + ".lock"), (
+            "_db = None released the lock even though a reference is still held "
+            "-- if this ever becomes true, the #253 interleaving is gone"
+        )
+
+        del held
+        mcp_server._db = None


### PR DESCRIPTION
Root-causes the intermittent `Page N out of bounds (total pages: M)` from #251, which #253 hypothesised about, then adopts the upstream fix and repairs everything it exposed.

**The cause is neither an allocation off-by-one nor the unserialized handle drop #253 proposed.** It is two live `MiniGrafDb` handles on one file inside this process.

## What was happening

minigraf's `FileLock::acquire` treated a lock held by our own PID as stale, deleted it, and opened anyway — so a second open **silently succeeded**. Each `FileBackend` caches its own `header.page_count`, allocates pages from it, and bounds-checks `read_page` against it, so the two page tables diverge.

Reproduced deterministically against 1.2.1, same payloads either way:

| mode | result |
|---|---|
| one handle at a time | **0 errors** in 40 rounds |
| second handle opened while the first is live | **40 errors**, first round `Page 130 out of bounds (total pages: 113)` |

Fixed upstream in project-minigraf/minigraf#314 (shipped in 1.2.2). This PR raises the floor to `minigraf>=1.2.3` and drops the xfail marker that was waiting on it.

## What the fix exposed

Turning silent corruption into a loud error put 13 tests red on one root cause. **All of them were real** — the graph had been quietly corrupting in those paths all along.

**Four release sites cleared the module global while a local still held the handle.** `_db = None` only releases when it drops the *last* reference, so the global said "no handle" while one was very much alive — and any other **OS thread** (the ingestion status/query poller, a `call_tool` worker) calling `get_db()` in that window opened a second one. No `await` separates the two statements, so no coroutine interleaves; threads do. Fixed by clearing the local first:

- the per-commit `finally` (wrong order)
- Stage B's `finally` (wrong order)
- the `completed_all` tags/last-run block (cleared only the global — held the handle all the way into the outer `finally`)
- the outer `finally`'s `final_db` (same)

Each was found by instrumenting the failing open and walking `gc` referrers back to the holder, not by reading the code and guessing.

**The Stage B failure path needed something else.** Its caught exception's traceback chains back through `_WorkItem.run` to the frame that raised, whose argument tuple still holds `db` — so no amount of careful local-clearing helps. The handler now drops `e.__traceback__`; only the message was ever used. Without this, **any interrupted run silently skipped its final WAL compaction**.

**`_is_lock_error` matched only `"locked"`**, but the new same-process message doesn't contain that word, so it fell through as a fatal non-lock error and aborted callers on the first attempt instead of backing off. Both messages are transient in the same way — the other holder is usually about to drop its reference — so both belong on the retry path. A genuinely leaked handle still exhausts the budget and surfaces.

## Tests

Two tests were themselves the problem, holding a handle across a call that owns the DB lifecycle; production has no such frame. Both now release first, which is also what makes their "genuine reopen" genuine rather than a second handle.

Two shutdown sentinels counted `asyncio.sleep` calls as a proxy for commits processed. That was never true — the lock-contention backoff sleeps too — and once the same-process open became retryable, one retry under load tripped the shutdown a commit early. **This failed on CI while passing locally three runs in a row**, because only a contended machine retries at all. They now count only `asyncio.sleep(0)`, the per-commit yield; backoff starts at 0.05s and is never zero.

New `_is_lock_error` tests are ablation-proven, including one asserting against minigraf's **real** error rather than a hand-written string, so a reworded upstream message fails loudly instead of silently reverting the retry path to fatal.

**Full suite: 1170 passed**, three consecutive local runs plus green CI on 3.10/3.11/3.12.

## Rejected approach, recorded in the code

A weakref guard in `_open_db_at` that reuses the still-live handle **does** fix the corruption — both regression tests passed. It was rejected because it changes handle *lifetime* as a side effect: it can resurrect a handle whose backing file is gone. It segfaulted the suite reproducibly (3/3 runs, identical stack) where master is clean.

## Still open

**#253 does not close with this.** Four instances of the pattern are gone; the pattern is not. The durable fix is an explicit lease/refcount protocol replacing the `_db = None` idiom, so a release genuinely releases and no second open can be attempted while a handle is outstanding.

#251 wants an at-scale ingestion against a **persistent** graph path to confirm non-recurrence.

Refs #253, #251, project-minigraf/minigraf#304

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK