### PR TITLE
Measure #257: the :description preload's date-bounded values

### DIFF
--- a/docs/superpowers/plans/2026-08-11-description-preload-exposure-probe.md
+++ b/docs/superpowers/plans/2026-08-11-description-preload-exposure-probe.md
@@ -1,0 +1,1401 @@
+# #257 `:description` Preload Exposure Probe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure whether `_preload_known_entities`' date-bounded `:description` seeding ever returns a value a position-bounded query would not, on this repository's real commit history.
+
+**Architecture:** A read-only probe module in `evals/at_scale/` that reuses the #245 probe's pure timestamp-to-position primitives. Stage 1 censuses how many idents carry more than one distinct `:description` value across all time — if zero, the mechanism cannot fire. Stage 2 drives the real, shipped `_preload_known_entities` at each structurally affected watermark position and diffs the `entity_descriptions` it returns against a position-correct oracle. Nothing in `mcp_server.py` changes.
+
+**Tech Stack:** Python 3, `minigraf` (Datalog graph, bi-temporal), pytest, the existing `evals/at_scale/probe_dep_preload_exposure.py` primitives.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-description-preload-exposure-probe-design.md`
+
+## Global Constraints
+
+- **ALWAYS use `.venv/bin/python`.** System python has minigraf 1.1.1 against a `minigraf>=1.2.3` floor; it fakes 122 test failures, runs queries ~7x slower, and has already produced one wrong diagnosis on this project. Every command in this plan uses it.
+- **Single-handle invariant.** At most one live `MiniGrafDb` handle per process. Reuse `mcp_server._db` when it is already set; never open a second handle on the same file. minigraf 1.2.3 raises `Database is already open in this process` if you do.
+- **Clause order in every `:any-valid-time` query.** `[?e :description ?desc]` MUST be the EAV clause immediately preceding `[?e :db/valid-from ?vf]` / `[?e :db/valid-to ?vt]`. Those pseudo-attributes bind to whichever EAV clause on `?e` most recently precedes them. Putting `[?e :ident ?ident]` between them binds the window to the `:ident` fact instead — wrong, and silently so.
+- **No closing keywords for #257 or #222.** Commit messages and any PR body use `Refs #257` / `Refs #222` only. GitHub scans BOTH commit messages and the PR body, and a keyword/`#N` pair spans blank lines. Verify with `gh pr view --json closingIssuesReferences` before any merge.
+- **The exit code reflects measurement validity, not the finding.** A nonzero mismatch count is the number #257 asks for and must never fail the run.
+- **Entity types, exactly these six, in this order:** `module`, `function`, `class`, `variable`, `field`, `external-dependency`. This mirrors `_preload_known_entities`' own loop (`mcp_server.py:7429-7432`).
+
+## File Structure
+
+- **Create `evals/at_scale/probe_description_preload_exposure.py`** — the whole probe. Pure analysis primitives at the top (importable without opening a graph, matching the sibling probe's contract), then the DB loader, then `sweep()`, then `main()`. Single module because every piece exists to produce one report; splitting it would separate functions that only ever run together.
+- **Create `tests/test_at_scale_description_preload_probe.py`** — unit tests for the pure primitives plus one real-backend test pinning the clause-order rule.
+- **Generated, committed in Task 8:** `evals/at_scale/results/257-description-preload-exposure.json`.
+
+Shared fact-record shape used by every function below:
+
+```python
+{"entity_type": "module", "ident": ":module/foo-py", "desc": "foo.py", "vf_ms": 1735689600000, "vt_ms": 1735776000000}
+```
+
+---
+
+### Task 1: Census primitive — `census_distinct_values`
+
+**Files:**
+- Create: `evals/at_scale/probe_description_preload_exposure.py`
+- Test: `tests/test_at_scale_description_preload_probe.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `ENTITY_TYPES: Tuple[str, ...]` and `census_distinct_values(facts: Sequence[Dict]) -> Dict[str, Dict]`. The returned dict is keyed by entity type; each value has keys `idents_total: int`, `idents_with_multiple_values: int`, `offending_idents: Dict[str, List[str]]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_at_scale_description_preload_probe.py`:
+
+```python
+# tests/test_at_scale_description_preload_probe.py
+"""Unit tests for the #257 :description exposure probe's analysis primitives.
+
+The probe's headline numbers cannot be asserted -- they are what the probe
+exists to discover. What CAN be asserted are the components that could
+silently produce a WRONG number: the census's distinct-VALUE (not
+distinct-interval) counting, the position-correct oracle, the diff's
+separation of value exposure from membership disagreement, and the
+unmappable-fact diagnostics.
+
+Every test that pins a position-versus-date distinction is ablation-proven:
+its docstring names the date-bounded answer, and that answer differs from the
+asserted one. A test whose date-bounded and position-bounded answers agree
+proves nothing about #257.
+"""
+
+from evals.at_scale.probe_description_preload_exposure import (
+    ENTITY_TYPES,
+    census_distinct_values,
+)
+
+
+class TestCensusDistinctValues:
+    def test_two_intervals_carrying_one_value_are_not_exposure(self):
+        """An entity deleted and re-added has two :description intervals and
+        one value. That is the modal case on any real history and must not be
+        counted -- counting intervals instead of values would report the whole
+        repository as exposed.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "a.py",
+             "vf_ms": 100, "vt_ms": 200},
+            {"entity_type": "module", "ident": ":module/a", "desc": "a.py",
+             "vf_ms": 300, "vt_ms": 400},
+        ]
+        report = census_distinct_values(facts)
+        assert report["module"]["idents_total"] == 1
+        assert report["module"]["idents_with_multiple_values"] == 0
+        assert report["module"]["offending_idents"] == {}
+
+    def test_one_ident_with_two_values_is_counted_and_named(self):
+        """The offending values are reported verbatim, not just counted: a
+        nonzero census escalates this work to a full sweep, and the escalation
+        needs to start from which idents fired, not from an integer.
+        """
+        facts = [
+            {"entity_type": "external-dependency", "ident": ":module/sub",
+             "desc": "old-name", "vf_ms": 100, "vt_ms": 200},
+            {"entity_type": "external-dependency", "ident": ":module/sub",
+             "desc": "new-name", "vf_ms": 200, "vt_ms": 300},
+        ]
+        report = census_distinct_values(facts)
+        assert report["external-dependency"]["idents_with_multiple_values"] == 1
+        assert report["external-dependency"]["offending_idents"] == {
+            ":module/sub": ["new-name", "old-name"]
+        }
+
+    def test_every_entity_type_appears_even_with_no_facts(self):
+        """A type missing from the report and a type with zero exposure are
+        different claims. Absent types would let a query failure for one type
+        (_collect swallows those) read as a clean zero.
+        """
+        report = census_distinct_values([])
+        assert set(report) == set(ENTITY_TYPES)
+        assert all(report[t]["idents_total"] == 0 for t in ENTITY_TYPES)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'evals.at_scale.probe_description_preload_exposure'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `evals/at_scale/probe_description_preload_exposure.py`:
+
+```python
+# evals/at_scale/probe_description_preload_exposure.py
+"""#257 exposure probe: does the entity preload's DATE-bounded :description
+seeding ever return a value a POSITION-bounded query would not?
+
+#238 and #245 (PR #258) made _preload_known_entities' MEMBERSHIP decision
+position-exact in both directions. The VALUES it seeds were left behind:
+entity_descriptions[ident] still comes from whichever :description version was
+live at :valid-at T_hi(W), a date query. T_hi(W) = max(ts[0..W]) is the
+monotone envelope of author dates at or below the watermark, and author dates
+are not monotonic in topological order, so a version written ABOVE the
+watermark carrying an EARLIER author date can be the version that query
+returns.
+
+This module measures how often that happens on real history. The #245 probe
+(probe_dep_preload_exposure.py) compared membership only and says nothing
+about it.
+
+TWO STAGES, and the first one may make the second moot:
+
+  Stage 1 -- CENSUS. How many idents carry more than one DISTINCT :description
+    value across all time? If none do, a date-bounded and a position-bounded
+    query return the same string for every ident and the mechanism cannot
+    fire, whatever the dates do. Counted per entity type, over distinct
+    VALUES and not distinct intervals: an entity deleted and re-added has two
+    intervals and one value, which is not exposure.
+
+  Stage 2 -- VALUE DIFF. Drive the real, shipped _preload_known_entities at
+    each structurally affected watermark and diff the entity_descriptions it
+    returns against a position-correct oracle. This answers #257 on its own
+    terms rather than resting on Stage 1's structural argument.
+
+Stage 2 is not redundant with Stage 1. Stage 1's zero implies Stage 2's zero
+only through an argument about how :description is written; Stage 2 checks the
+shipped query's actual output and needs no such argument.
+
+ONE MODE, unlike the #245 probe's date-only/--verify-fix pair. #257 is the
+residual in the SHIPPED code, so _preload_known_entities is always driven with
+its full post-#238/#245 argument set. There is no pre-fix leg to measure.
+
+WHAT THE PREDICTION WAS, fixed in the design spec before any data existed:
+census zero, mismatches zero. The spec records the argument for it (see its
+"The issue's stated mechanism does not match the code" section). A nonzero
+census is the falsifier and escalates to the per-position sweep Stage 2
+already implements.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+
+# The entity types _preload_known_entities loads, in its own order
+# (mcp_server.py:7429-7432). Mirrored rather than imported so these analysis
+# primitives stay importable without opening a graph, matching
+# probe_dep_preload_exposure's contract. If the two ever diverge, this probe
+# silently measures a different population than the function under test.
+ENTITY_TYPES = (
+    "module", "function", "class", "variable", "field", "external-dependency",
+)
+
+
+def census_distinct_values(facts: Sequence[Dict]) -> Dict[str, Dict]:
+    """Per entity type: how many idents carry more than one DISTINCT
+    :description value across all time.
+
+    Distinct VALUES, not distinct intervals. An entity that was deleted and
+    re-added carries two :description intervals and one value; counting
+    intervals would report essentially every long-lived entity as exposed and
+    drown the real signal.
+
+    Every type in ENTITY_TYPES appears in the output even with no facts. A
+    type missing from the report and a type with zero exposure are different
+    claims, and _collect's per-type `except Exception: pass`
+    (mcp_server.py:7491-7492) makes the difference load-bearing: a swallowed
+    query failure for one type must not read as a clean zero.
+
+    offending_idents carries the values verbatim, sorted, because a nonzero
+    census escalates this work to a full sweep and the escalation starts from
+    which idents fired, not from an integer.
+    """
+    by_type: Dict[str, Dict[str, set]] = {t: {} for t in ENTITY_TYPES}
+    for fact in facts:
+        entity_type = fact["entity_type"]
+        if entity_type not in by_type:
+            continue
+        by_type[entity_type].setdefault(fact["ident"], set()).add(fact["desc"])
+
+    report: Dict[str, Dict] = {}
+    for entity_type in ENTITY_TYPES:
+        idents = by_type[entity_type]
+        offenders = {
+            ident: sorted(values)
+            for ident, values in idents.items()
+            if len(values) > 1
+        }
+        report[entity_type] = {
+            "idents_total": len(idents),
+            "idents_with_multiple_values": len(offenders),
+            "offending_idents": offenders,
+        }
+    return report
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: PASS, 3 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add evals/at_scale/probe_description_preload_exposure.py tests/test_at_scale_description_preload_probe.py
+git commit -m "Add the #257 probe's distinct-value census
+
+Counts distinct :description VALUES per ident, not distinct intervals: a
+deleted-and-re-added entity has two intervals and one value, which is not
+exposure. Every entity type appears even with no facts so a swallowed
+per-type query failure cannot read as a clean zero.
+
+Refs #257"
+```
+
+---
+
+### Task 2: The position-correct oracle — `position_correct_descriptions`
+
+**Files:**
+- Modify: `evals/at_scale/probe_description_preload_exposure.py`
+- Test: `tests/test_at_scale_description_preload_probe.py`
+
+**Interfaces:**
+- Consumes: `ENTITY_TYPES` (Task 1). From `probe_dep_preload_exposure`: `VALID_TIME_FOREVER_MS`, `invert_ms_to_positions(ms, ts_positions) -> List[int]`, `edge_live_at(vf_positions, vt_positions, w) -> bool`, `build_ts_positions(commit_metadata) -> Dict[str, List[int]]`.
+- Produces: `position_correct_descriptions(facts: Sequence[Dict], ts_positions: Dict[str, List[int]], w: int) -> Dict[str, set]` — ident to the set of distinct `:description` values live at position `w`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_at_scale_description_preload_probe.py`, and extend the existing import block at the top of the file to also import `position_correct_descriptions`:
+
+```python
+from evals.at_scale.probe_dep_preload_exposure import (
+    VALID_TIME_FOREVER_MS,
+    build_ts_positions,
+)
+
+# Position 2 is INVERTED: it sits above position 1 but carries an earlier
+# author date (Jan 2 against Jan 5). That inversion is the whole of #257, and
+# it is the same fixture shape tests/test_at_scale_dep_preload_probe.py uses.
+#
+#   pos 0: 2026-01-01   T_hi(0) = 2026-01-01
+#   pos 1: 2026-01-05   T_hi(1) = 2026-01-05
+#   pos 2: 2026-01-02   T_hi(2) = 2026-01-05
+META = [
+    ("h0", "2026-01-01T00:00:00Z", "a@b.com", "s0"),
+    ("h1", "2026-01-05T00:00:00Z", "a@b.com", "s1"),
+    ("h2", "2026-01-02T00:00:00Z", "a@b.com", "s2"),
+]
+
+MS_JAN_01 = 1767225600000  # 2026-01-01T00:00:00Z
+MS_JAN_02 = 1767312000000  # 2026-01-02T00:00:00Z
+MS_JAN_05 = 1767571200000  # 2026-01-05T00:00:00Z
+
+
+class TestPositionCorrectDescriptions:
+    def test_a_version_written_above_w_with_an_earlier_date_is_not_live(self):
+        """THE #257 SHAPE, and the ablation that proves this test.
+
+        Entity :module/a carries "old" from position 0, superseded at position
+        2 by "new". Position 2 is above the watermark W=1 but dated Jan 2,
+        earlier than T_hi(1) = Jan 5.
+
+        A DATE-bounded query at T_hi(1) = Jan 5 answers {"new"}: "old" closed
+        at Jan 2 <= Jan 5 so it reads as already dead, and "new" opened at
+        Jan 2 <= Jan 5 so it reads as already live. Both readings are wrong at
+        position 1.
+
+        The position-correct answer is {"old"}. The two differ, which is what
+        makes this test evidence about #257 rather than a tautology.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "old",
+             "vf_ms": MS_JAN_01, "vt_ms": MS_JAN_02},
+            {"entity_type": "module", "ident": ":module/a", "desc": "new",
+             "vf_ms": MS_JAN_02, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        live = position_correct_descriptions(facts, build_ts_positions(META), 1)
+        assert live == {":module/a": {"old"}}
+
+    def test_the_same_facts_at_the_higher_position_select_the_new_value(self):
+        """At W=2 the superseding version IS live. Without this the previous
+        test would also pass against an oracle that simply never advances.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "old",
+             "vf_ms": MS_JAN_01, "vt_ms": MS_JAN_02},
+            {"entity_type": "module", "ident": ":module/a", "desc": "new",
+             "vf_ms": MS_JAN_02, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        live = position_correct_descriptions(facts, build_ts_positions(META), 2)
+        assert live == {":module/a": {"new"}}
+
+    def test_an_unmappable_introduction_is_never_live(self):
+        """edge_live_at treats an empty vf_positions as not live. Asserted here
+        so the oracle's behaviour on a broken inversion is pinned rather than
+        inherited silently -- the count of these is a validity gate, and a
+        fact that is both uncounted and silently live would corrupt the
+        finding.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/ghost", "desc": "g",
+             "vf_ms": 1, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        assert position_correct_descriptions(facts, build_ts_positions(META), 2) == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: FAIL with `ImportError: cannot import name 'position_correct_descriptions'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to the import block at the top of `evals/at_scale/probe_description_preload_exposure.py`:
+
+```python
+from evals.at_scale.probe_dep_preload_exposure import (
+    VALID_TIME_FOREVER_MS,
+    edge_live_at,
+    invert_ms_to_positions,
+)
+```
+
+Then append:
+
+```python
+def position_correct_descriptions(
+    facts: Sequence[Dict],
+    ts_positions: Dict[str, List[int]],
+    w: int,
+) -> Dict[str, set]:
+    """Ident -> the set of DISTINCT :description values genuinely live at
+    position w.
+
+    Position-correct at BOTH ends. Each fact's own :db/valid-from and
+    :db/valid-to are inverted to positions and tested with edge_live_at; no
+    date bound appears anywhere. That second end is what separates this from
+    the shipped query: a version superseded at a position ABOVE w by a commit
+    whose author date falls BELOW T_hi(w) reads as already dead to any date
+    bound, and the superseding version reads as already live. Both are wrong
+    at w, and their combination is exactly #257.
+
+    Returns a SET per ident, not a single value, and never picks a winner
+    among several. edge_live_at's asymmetric collision policy exists to avoid
+    UNDERSTATING a membership answer; applied to a value it would fabricate
+    one. diff_descriptions counts a multi-member set as ambiguous instead.
+
+    Like everything else here this is a measurement device and NOT a candidate
+    fix -- it needs the whole history in hand, which a resuming forward walk
+    does not have.
+    """
+    live: Dict[str, set] = {}
+    for fact in facts:
+        vf_positions = invert_ms_to_positions(fact["vf_ms"], ts_positions)
+        vt_positions = (
+            None if fact["vt_ms"] >= VALID_TIME_FOREVER_MS
+            else invert_ms_to_positions(fact["vt_ms"], ts_positions)
+        )
+        if edge_live_at(vf_positions, vt_positions, w):
+            live.setdefault(fact["ident"], set()).add(fact["desc"])
+    return live
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: PASS, 6 tests
+
+- [ ] **Step 5: Verify the ablation is real**
+
+The first test's docstring claims a date-bounded oracle answers `{"new"}` at W=1. Confirm that rather than trusting it. Run:
+
+```bash
+.venv/bin/python -c "
+MS_JAN_01, MS_JAN_02, MS_JAN_05 = 1767225600000, 1767312000000, 1767571200000
+facts = [('old', MS_JAN_01, MS_JAN_02), ('new', MS_JAN_02, (1<<63)-1)]
+t_hi = MS_JAN_05
+print(sorted(d for d, vf, vt in facts if vf <= t_hi < vt))
+"
+```
+
+Expected output: `['new']` — different from the asserted `{'old'}`, so the test discriminates position from date. If this prints `['old']` the fixture is wrong and the test proves nothing; fix the fixture before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add evals/at_scale/probe_description_preload_exposure.py tests/test_at_scale_description_preload_probe.py
+git commit -m "Add the #257 probe's position-correct :description oracle
+
+Inverts each :description fact's own valid-from and valid-to to positions,
+with no date bound anywhere. Returns a SET per ident and never picks a
+winner among several: edge_live_at's asymmetric collision policy avoids
+understating a MEMBERSHIP answer and would fabricate a VALUE.
+
+The oracle test is ablation-proven -- a date bound at T_hi(1) answers
+{new} where the position-correct answer is {old}.
+
+Refs #257"
+```
+
+---
+
+### Task 3: The diff — `diff_descriptions`
+
+**Files:**
+- Modify: `evals/at_scale/probe_description_preload_exposure.py`
+- Test: `tests/test_at_scale_description_preload_probe.py`
+
+**Interfaces:**
+- Consumes: `position_correct_descriptions`' return shape (Task 2) — `Dict[str, set]`.
+- Produces: `diff_descriptions(actual: Dict[str, str], oracle: Dict[str, set]) -> Dict` with keys `value_mismatches: Dict[str, Dict]` (ident -> `{"preloaded": str, "live": List[str]}`), `ambiguous_idents: List[str]`, `preloaded_not_live: List[str]`, `live_not_preloaded: List[str]`. All list values sorted for stable JSON.
+
+- [ ] **Step 1: Write the failing test**
+
+Add `diff_descriptions` to the probe import block at the top of the test file, then append:
+
+```python
+class TestDiffDescriptions:
+    def test_a_preloaded_value_absent_from_the_live_set_is_a_mismatch(self):
+        """The finding itself. Both the preloaded value and the live set are
+        recorded, because a bare count would not say which direction the
+        preload erred in.
+        """
+        result = diff_descriptions({":module/a": "new"}, {":module/a": {"old"}})
+        assert result["value_mismatches"] == {
+            ":module/a": {"preloaded": "new", "live": ["old"]}
+        }
+        assert result["ambiguous_idents"] == []
+
+    def test_a_matching_value_is_not_a_mismatch(self):
+        result = diff_descriptions({":module/a": "old"}, {":module/a": {"old"}})
+        assert result["value_mismatches"] == {}
+
+    def test_an_ambiguous_live_set_is_counted_and_never_compared(self):
+        """When the oracle cannot name a single correct value there is nothing
+        to be wrong against. Letting such an ident fall through to the
+        membership test would score it as a match whenever the preloaded value
+        happened to be one of several -- inventing agreement out of ambiguity.
+        """
+        result = diff_descriptions(
+            {":module/a": "x"}, {":module/a": {"x", "y"}}
+        )
+        assert result["ambiguous_idents"] == [":module/a"]
+        assert result["value_mismatches"] == {}
+
+    def test_membership_disagreements_are_diagnostics_not_findings(self):
+        """#238 and #245 measured and fixed membership. Folding a membership
+        disagreement into #257's number would re-measure a closed issue and
+        inflate this one.
+        """
+        result = diff_descriptions(
+            {":module/only-preloaded": "p"}, {":module/only-live": {"l"}}
+        )
+        assert result["preloaded_not_live"] == [":module/only-preloaded"]
+        assert result["live_not_preloaded"] == [":module/only-live"]
+        assert result["value_mismatches"] == {}
+        assert result["ambiguous_idents"] == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: FAIL with `ImportError: cannot import name 'diff_descriptions'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `evals/at_scale/probe_description_preload_exposure.py`:
+
+```python
+def diff_descriptions(
+    actual: Dict[str, str],
+    oracle: Dict[str, set],
+) -> Dict:
+    """Compare the shipped preload's entity_descriptions against the
+    position-correct oracle at one position.
+
+    THREE quantities are separated deliberately, and only the first is #257's
+    finding:
+
+      value_mismatches -- the preloaded value is not among the values live at
+        this position. This is the exposure #257 asks about.
+
+      ambiguous_idents -- the oracle's live set has more than one member, so
+        no single correct value exists to compare against. Counted and
+        skipped, never resolved. Letting these fall through would score an
+        ident as matching whenever the preloaded value happened to be one of
+        several, inventing agreement out of ambiguity.
+
+      preloaded_not_live / live_not_preloaded -- MEMBERSHIP disagreements.
+        #238 and #245 measured and fixed membership; folding these into #257's
+        number would re-measure a closed issue and inflate this one. They are
+        reported because a large count here means the two sides are talking
+        about different entity populations and the value comparison covers
+        less than it appears to -- but they are not the finding.
+
+    Ordering matters: ambiguity is tested BEFORE the value comparison, so an
+    ambiguous ident contributes to neither the mismatch count nor the
+    membership counters.
+    """
+    value_mismatches: Dict[str, Dict] = {}
+    ambiguous: List[str] = []
+    preloaded_not_live: List[str] = []
+
+    for ident, preloaded_value in actual.items():
+        live_values = oracle.get(ident)
+        if not live_values:
+            preloaded_not_live.append(ident)
+            continue
+        if len(live_values) > 1:
+            ambiguous.append(ident)
+            continue
+        if preloaded_value not in live_values:
+            value_mismatches[ident] = {
+                "preloaded": preloaded_value,
+                "live": sorted(live_values),
+            }
+
+    live_not_preloaded = [ident for ident in oracle if ident not in actual]
+
+    return {
+        "value_mismatches": value_mismatches,
+        "ambiguous_idents": sorted(ambiguous),
+        "preloaded_not_live": sorted(preloaded_not_live),
+        "live_not_preloaded": sorted(live_not_preloaded),
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: PASS, 10 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add evals/at_scale/probe_description_preload_exposure.py tests/test_at_scale_description_preload_probe.py
+git commit -m "Add the #257 probe's value diff, with membership kept out of it
+
+Separates three quantities and counts only the first as the finding: a
+preloaded value absent from the position-live set; an ambiguous live set,
+counted and skipped rather than resolved; and membership disagreements,
+which are #238/#245's already-fixed territory and would inflate #257 if
+folded in.
+
+Ambiguity is tested before the value comparison so an ambiguous ident
+contributes to no counter.
+
+Refs #257"
+```
+
+---
+
+### Task 4: Unmappable-fact diagnostics — `count_unmappable_description_facts`
+
+**Files:**
+- Modify: `evals/at_scale/probe_description_preload_exposure.py`
+- Test: `tests/test_at_scale_description_preload_probe.py`
+
+**Interfaces:**
+- Consumes: `invert_ms_to_positions`, `VALID_TIME_FOREVER_MS` (already imported in Task 2).
+- Produces: `count_unmappable_description_facts(facts: Sequence[Dict], ts_positions: Dict[str, List[int]]) -> Tuple[int, int]` returning `(unmappable_valid_from, unmappable_valid_to)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add `count_unmappable_description_facts` to the probe import block, then append:
+
+```python
+class TestCountUnmappableDescriptionFacts:
+    def test_an_unmappable_valid_from_is_counted(self):
+        """An unmappable introduction silently drops the fact from the oracle
+        at every W, understating the finding. It has to fail the run rather
+        than shrink it.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "a",
+             "vf_ms": 1, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        assert count_unmappable_description_facts(
+            facts, build_ts_positions(META)
+        ) == (1, 0)
+
+    def test_an_unmappable_non_sentinel_valid_to_is_counted(self):
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "a",
+             "vf_ms": MS_JAN_01, "vt_ms": 7},
+        ]
+        assert count_unmappable_description_facts(
+            facts, build_ts_positions(META)
+        ) == (0, 1)
+
+    def test_the_forever_sentinel_is_not_an_unmappable_close(self):
+        """The sentinel is an open fact, not a broken inversion. Counting it
+        would fail every run on every graph, since most facts are open.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "a",
+             "vf_ms": MS_JAN_01, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        assert count_unmappable_description_facts(
+            facts, build_ts_positions(META)
+        ) == (0, 0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: FAIL with `ImportError: cannot import name 'count_unmappable_description_facts'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `evals/at_scale/probe_description_preload_exposure.py`:
+
+```python
+def count_unmappable_description_facts(
+    facts: Sequence[Dict],
+    ts_positions: Dict[str, List[int]],
+) -> tuple:
+    """How many :description facts carry a vf_ms/vt_ms whose instant matches no
+    commit -- this probe's validity diagnostic.
+
+    Mirrors probe_dep_preload_exposure.count_unmappable_module_path_facts,
+    applied to :description. An unmappable vf silently drops the fact from the
+    oracle at every W (understating the finding); an unmappable non-sentinel vt
+    silently reads it as never-superseded (overstating it). Either way the
+    timestamp-to-position inversion the whole oracle rests on is broken for at
+    least one fact, so a nonzero count INVALIDATES the measurement rather than
+    adjusting it -- see main()'s exit gate.
+
+    The forever sentinel is an open fact, not a broken inversion, and is
+    excluded from the vt count. Most facts on a live graph are open; counting
+    them would fail every run.
+
+    Returns (unmappable_valid_from, unmappable_valid_to).
+    """
+    unmappable_vf = sum(
+        1 for f in facts
+        if not invert_ms_to_positions(f["vf_ms"], ts_positions)
+    )
+    unmappable_vt = sum(
+        1 for f in facts
+        if f["vt_ms"] < VALID_TIME_FOREVER_MS
+        and not invert_ms_to_positions(f["vt_ms"], ts_positions)
+    )
+    return unmappable_vf, unmappable_vt
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: PASS, 13 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add evals/at_scale/probe_description_preload_exposure.py tests/test_at_scale_description_preload_probe.py
+git commit -m "Add the #257 probe's unmappable-fact diagnostics
+
+An unmappable valid-from drops a fact from the oracle at every W and an
+unmappable non-sentinel valid-to reads it as never-superseded, so a nonzero
+count invalidates the measurement rather than adjusting it. The forever
+sentinel is an open fact, not a broken inversion, and is excluded.
+
+Refs #257"
+```
+
+---
+
+### Task 5: The DB loader — `load_description_facts`
+
+**Files:**
+- Modify: `evals/at_scale/probe_description_preload_exposure.py`
+- Test: `tests/test_at_scale_description_preload_probe.py`
+
+**Interfaces:**
+- Consumes: `ENTITY_TYPES` (Task 1).
+- Produces: `load_description_facts(db) -> List[Dict]` returning the shared fact-record shape, deduplicated on `(entity_type, ident, desc, vf_ms, vt_ms)`.
+
+This task's test uses a REAL minigraf backend, following `docs/testing-conventions.md` Pattern 1. That is deliberate: the clause-order rule is the one silent-failure mode in this module, and no pure-function test can reach it — only a real query can show `?vf` binding to the wrong fact's window.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_at_scale_description_preload_probe.py`:
+
+```python
+import pytest
+
+
+@pytest.fixture
+def real_db(monkeypatch, tmp_path):
+    """A real in-memory MiniGrafDb, per docs/testing-conventions.md Pattern 1.
+
+    Not a MagicMock: a fake never parses the Datalog string, and the clause
+    ordering this task exists to pin is only observable when minigraf actually
+    parses and executes the query.
+    """
+    from minigraf import MiniGrafDb
+
+    real_open_in_memory = MiniGrafDb.open_in_memory
+    monkeypatch.setattr(
+        MiniGrafDb, "open", staticmethod(lambda path: real_open_in_memory())
+    )
+    import mcp_server
+
+    mcp_server.open_db(str(tmp_path / "t.graph"))
+    yield mcp_server.get_db()
+
+
+class TestLoadDescriptionFacts:
+    def test_an_open_description_carries_the_forever_sentinel(self, real_db):
+        import mcp_server
+
+        mcp_server._transact(
+            real_db,
+            '[[:module/a :entity-type :type/module] '
+            '[:module/a :ident ":module/a"] '
+            '[:module/a :description "a.py"]]',
+            "2026-01-01T00:00:00Z",
+        )
+        facts = load_description_facts(real_db)
+        assert len(facts) == 1
+        assert facts[0]["entity_type"] == "module"
+        assert facts[0]["ident"] == ":module/a"
+        assert facts[0]["desc"] == "a.py"
+        assert facts[0]["vt_ms"] >= VALID_TIME_FOREVER_MS
+
+    def test_the_window_belongs_to_the_description_fact_not_the_ident_fact(
+        self, real_db
+    ):
+        """THE CLAUSE-ORDER ABLATION.
+
+        :db/valid-from and :db/valid-to bind to whichever EAV clause on ?e most
+        recently precedes them. Here :description is closed while :ident stays
+        open. The correct query returns the CLOSED window; a query with
+        [?e :ident ?ident] moved between :description and the pseudo-attributes
+        returns the ident fact's OPEN window instead -- the forever sentinel --
+        and every superseded description would silently read as still live,
+        making the oracle's live set wrong at every position.
+        """
+        import mcp_server
+
+        mcp_server._transact(
+            real_db,
+            '[[:module/a :entity-type :type/module] '
+            '[:module/a :ident ":module/a"] '
+            '[:module/a :description "a.py"]]',
+            "2026-01-01T00:00:00Z",
+        )
+        mcp_server._ingest_close(
+            real_db,
+            ['[:module/a :description "a.py"]'],
+            "2026-01-01T00:00:00Z",
+            "2026-01-02T00:00:00Z",
+            "test close",
+        )
+        facts = load_description_facts(real_db)
+        closed = [f for f in facts if f["vt_ms"] < VALID_TIME_FOREVER_MS]
+        assert closed, (
+            "no closed :description window found -- the query is binding "
+            "?vt to the still-open :ident fact, which is the clause-order bug"
+        )
+        assert closed[0]["vt_ms"] == mcp_server._iso_to_epoch_ms(
+            "2026-01-02T00:00:00Z"
+        )
+
+    def test_rows_are_deduplicated(self, real_db):
+        """An entity carrying several :entity-type or :ident versions across
+        time multiplies each :description row under :any-valid-time without
+        changing any answer. load_dep_edges dedupes for the same reason.
+        """
+        import mcp_server
+
+        mcp_server._transact(
+            real_db,
+            '[[:module/a :entity-type :type/module] '
+            '[:module/a :ident ":module/a"] '
+            '[:module/a :description "a.py"]]',
+            "2026-01-01T00:00:00Z",
+        )
+        facts = load_description_facts(real_db)
+        keys = {(f["entity_type"], f["ident"], f["desc"], f["vf_ms"], f["vt_ms"])
+                for f in facts}
+        assert len(keys) == len(facts)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: FAIL with `ImportError: cannot import name 'load_description_facts'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `evals/at_scale/probe_description_preload_exposure.py`:
+
+```python
+def load_description_facts(db) -> List[Dict]:
+    """Every :description fact on a preloaded entity type, current and
+    historical, with its validity window.
+
+    The raw material for BOTH stages. One query per entity type, matching
+    _preload_known_entities' own per-type loop, so the population measured is
+    the population that function actually loads.
+
+    CLAUSE ORDER IS LOAD-BEARING. [?e :description ?desc] must be the EAV
+    clause immediately preceding the :db/valid-from / :db/valid-to
+    pseudo-attributes, because those bind to whichever EAV clause on ?e most
+    recently precedes them. [?e :ident ?ident] therefore goes BEFORE
+    :description, never between: moving it would bind ?vf/?vt to the ident
+    fact's window instead -- and since :ident outlives every :description
+    version it supersedes, every closed description would read as still live
+    and the oracle would be wrong at every position. Silently. This is
+    load_module_path_facts' documented rule applied to :description, and
+    test_the_window_belongs_to_the_description_fact_not_the_ident_fact pins it
+    against a real backend.
+
+    Deduplicated on (entity_type, ident, desc, vf, vt). An entity carrying more
+    than one :entity-type or :ident version across time otherwise multiplies
+    each :description row under :any-valid-time without changing any answer --
+    the same reason load_dep_edges dedupes. Two DISTINCT windows on the same
+    (ident, desc) pair are legitimately kept: that is a delete-and-re-add, and
+    the census must see both intervals to report them as one value.
+
+    A per-type query failure raises rather than being swallowed. That is a
+    deliberate difference from _preload_known_entities' own `except Exception:
+    pass` (mcp_server.py:7491-7492): this function is a measurement device, and
+    a silently empty population here would read as a clean zero exposure.
+    """
+    import json
+
+    import mcp_server
+
+    seen = set()
+    facts: List[Dict] = []
+    for entity_type in ENTITY_TYPES:
+        raw = mcp_server._db_execute(
+            db,
+            "(query [:find ?ident ?desc ?vf ?vt "
+            ":any-valid-time "
+            f":where [?e :entity-type :type/{entity_type}] "
+            "[?e :ident ?ident] "
+            "[?e :description ?desc] "
+            "[?e :db/valid-from ?vf] "
+            "[?e :db/valid-to ?vt]])",
+        )
+        for ident, desc, vf, vt in json.loads(raw).get("results", []):
+            key = (entity_type, ident, desc, int(vf), int(vt))
+            if key in seen:
+                continue
+            seen.add(key)
+            facts.append({
+                "entity_type": entity_type,
+                "ident": ident,
+                "desc": desc,
+                "vf_ms": int(vf),
+                "vt_ms": int(vt),
+            })
+    return facts
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: PASS, 16 tests
+
+- [ ] **Step 5: Prove the clause-order test actually discriminates**
+
+Temporarily move `[?e :ident ?ident]` to sit between `[?e :description ?desc]` and `[?e :db/valid-from ?vf]` in `load_description_facts`, then run:
+
+`.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py::TestLoadDescriptionFacts -v`
+
+Expected: `test_the_window_belongs_to_the_description_fact_not_the_ident_fact` FAILS with the "no closed :description window found" message. **Then revert the reordering** and re-run to confirm PASS. If the test passes in both orders it does not pin the rule and must be strengthened before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add evals/at_scale/probe_description_preload_exposure.py tests/test_at_scale_description_preload_probe.py
+git commit -m "Add the #257 probe's :description fact loader
+
+One :any-valid-time query per entity type, matching the population
+_preload_known_entities actually loads. Clause order is load-bearing --
+:ident goes before :description, never between it and the valid-time
+pseudo-attributes, or every closed description reads as still live.
+Ablation-proven against a real backend.
+
+Raises on a per-type query failure rather than swallowing it the way
+_preload_known_entities does: a silently empty population here would read
+as clean zero exposure.
+
+Refs #257"
+```
+
+---
+
+### Task 6: The sweep driver — `sweep`
+
+**Files:**
+- Modify: `evals/at_scale/probe_description_preload_exposure.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5, plus from `probe_dep_preload_exposure`: `affected_positions(commit_metadata) -> List[int]`, `build_ts_positions`, `resume_envelopes(commit_metadata) -> List[str]`, `gitlink_event_count(repo_path) -> int`. From `mcp_server`: `_preload_known_entities`, `_iso_to_epoch_ms`.
+- Produces: `sweep(db, repo_path, linearization, commit_metadata, branch=None) -> Dict` — the full report dict consumed by `main()`.
+
+- [ ] **Step 1: Write the implementation**
+
+Add `affected_positions`, `build_ts_positions`, `resume_envelopes`, `gitlink_event_count` to the `probe_dep_preload_exposure` import block, then append:
+
+```python
+def sweep(
+    db,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: Sequence,
+    branch: str = None,
+) -> Dict:
+    """Run Stage 1's census and Stage 2's per-position value diff, and assemble
+    the report.
+
+    ONE MODE. _preload_known_entities is always driven with its full
+    post-#238/#245 argument set -- valid_at, hash_to_pos, watermark_pos,
+    ts_positions, t_hi_ms -- because #257 is the residual in the SHIPPED code.
+    Passing a subset would silently turn position_mode off inside the function
+    (its gate is watermark_pos AND ts_positions AND t_hi_ms) and this sweep
+    would measure the pre-fix path while believing it measured the shipped one.
+
+    Calls the function under test rather than a restatement of what we believe
+    it does. On the #238 branch a reviewer and an implementer both simulated
+    the counterfactual with a date bound instead of the real position-filtered
+    one, which made an inadequate test look adequate and cost two fix rounds.
+
+    STAGE 1 MAY MAKE STAGE 2 MOOT, but Stage 2 runs regardless. A zero census
+    implies zero mismatches only through an argument about how :description is
+    written; Stage 2 checks the shipped query's actual output and rests on no
+    such argument. Two independent lines of evidence for the price of one
+    ingest.
+
+    provenance: repo_path alone was not enough to reproduce the first #245
+    artifact -- it named a scratch directory that no longer existed, with no
+    branch and no head SHA. branch and head_commit are recorded here so a
+    future run carries its own.
+    """
+    import subprocess
+
+    import mcp_server
+
+    if len(commit_metadata) != len(linearization):
+        raise ValueError(
+            f"commit_metadata has {len(commit_metadata)} entries but "
+            f"linearization has {len(linearization)}; a misaligned pair "
+            "mis-filters the entire sweep"
+        )
+    for i, ((meta_hash, _ts, _a, _s), lin_hash) in enumerate(
+        zip(commit_metadata, linearization)
+    ):
+        if meta_hash != lin_hash:
+            raise ValueError(
+                f"commit_metadata[{i}] is {meta_hash} but linearization[{i}] "
+                f"is {lin_hash}; the two must be positionally aligned"
+            )
+
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+    ts_positions = build_ts_positions(commit_metadata)
+    envelopes = resume_envelopes(commit_metadata)
+    collisions = {ts: pos for ts, pos in ts_positions.items() if len(pos) > 1}
+
+    facts = load_description_facts(db)
+    census = census_distinct_values(facts)
+    unmappable_vf, unmappable_vt = count_unmappable_description_facts(
+        facts, ts_positions
+    )
+
+    positions = affected_positions(commit_metadata)
+    per_position = []
+    mismatch_distinct: set = set()
+    mismatch_weighted = 0
+    ambiguous_total = 0
+    preloaded_not_live_total = 0
+    live_not_preloaded_total = 0
+    preload_sizes = []
+
+    for w in positions:
+        (
+            _entity_valid_from, entity_descriptions, _entity_introduced_by,
+            _file_entities, _submodule_paths,
+        ) = mcp_server._preload_known_entities(
+            db, repo_path,
+            valid_at=envelopes[w],
+            hash_to_pos=hash_to_pos,
+            watermark_pos=w,
+            ts_positions=ts_positions,
+            t_hi_ms=mcp_server._iso_to_epoch_ms(envelopes[w]),
+        )
+        oracle = position_correct_descriptions(facts, ts_positions, w)
+        result = diff_descriptions(entity_descriptions, oracle)
+
+        preload_sizes.append(len(entity_descriptions))
+        mismatch_weighted += len(result["value_mismatches"])
+        mismatch_distinct.update(result["value_mismatches"])
+        ambiguous_total += len(result["ambiguous_idents"])
+        preloaded_not_live_total += len(result["preloaded_not_live"])
+        live_not_preloaded_total += len(result["live_not_preloaded"])
+
+        per_position.append({
+            "position": w,
+            "envelope": envelopes[w],
+            "preloaded_idents": len(entity_descriptions),
+            "oracle_idents": len(oracle),
+            "value_mismatches": result["value_mismatches"],
+            "ambiguous_idents": result["ambiguous_idents"],
+            "preloaded_not_live": len(result["preloaded_not_live"]),
+            "live_not_preloaded": len(result["live_not_preloaded"]),
+        })
+
+    head_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    return {
+        "repo_path": repo_path,
+        "branch": branch,
+        "head_commit": head_commit,
+        "commits": len(commit_metadata),
+        "affected_positions": positions,
+        "misclassifying_positions": [
+            p["position"] for p in per_position if p["value_mismatches"]
+        ],
+        "description_facts_total": len(facts),
+        "census": census,
+        "census_idents_with_multiple_values": sum(
+            census[t]["idents_with_multiple_values"] for t in ENTITY_TYPES
+        ),
+        "value_mismatch_total_position_weighted": mismatch_weighted,
+        "value_mismatch_distinct_idents": len(mismatch_distinct),
+        "ambiguous_idents_total": ambiguous_total,
+        "preloaded_not_live_total": preloaded_not_live_total,
+        "live_not_preloaded_total": live_not_preloaded_total,
+        "unmappable_description_valid_from": unmappable_vf,
+        "unmappable_description_valid_to": unmappable_vt,
+        "timestamp_collisions": len(collisions),
+        "preload_descriptions_empty_everywhere": (
+            bool(preload_sizes) and all(n == 0 for n in preload_sizes)
+        ),
+        "gitlink_events": gitlink_event_count(repo_path),
+        "per_position": per_position,
+    }
+```
+
+- [ ] **Step 2: Verify the module imports and the existing tests still pass**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: PASS, 16 tests — `sweep` has no unit test of its own (it needs a real ingested graph; Task 7's smoke run exercises it), but a syntax or import error here fails collection.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add evals/at_scale/probe_description_preload_exposure.py
+git commit -m "Add the #257 probe's sweep driver
+
+Drives the real _preload_known_entities with its full post-#238/#245
+argument set at every structurally affected position and diffs its
+entity_descriptions against the position-correct oracle. One mode only:
+#257 is the residual in the shipped code, and passing a subset of the
+position arguments would silently measure the pre-fix path instead.
+
+Stage 2 runs even when Stage 1's census is zero. The census implies zero
+mismatches only through an argument about how :description is written;
+the sweep checks the shipped query's output and needs no such argument.
+
+Refs #257"
+```
+
+---
+
+### Task 7: CLI and exit gate — `main`
+
+**Files:**
+- Modify: `evals/at_scale/probe_description_preload_exposure.py`
+
+**Interfaces:**
+- Consumes: `sweep` (Task 6). From `probe_dep_preload_exposure`: `_ingest_into(repo_path, branch, graph_path) -> Tuple[str, str]` (async). From `frontier_registry`: `build_linearization(repo_path, branch) -> List[str]`. From `mcp_server`: `_git_commits`, `_default_git_branch`, `open_db`, `_db`.
+- Produces: `main() -> int`, and `if __name__ == "__main__": raise SystemExit(main())`.
+
+- [ ] **Step 1: Write the implementation**
+
+Append to `evals/at_scale/probe_description_preload_exposure.py`:
+
+```python
+def main() -> int:
+    import argparse
+    import asyncio
+    import json
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent.parent.resolve()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure #257's :description preload exposure against real history."
+        )
+    )
+    parser.add_argument("--repo-path", default=".")
+    parser.add_argument("--branch", default=None)
+    parser.add_argument("--json-out", "--output", dest="json_out", default=None)
+    parser.add_argument(
+        "--graph-path", default=None,
+        help=(
+            "Sweep an EXISTING graph instead of ingesting into a scratch one. "
+            "The graph's commit count must match the linearization length or "
+            "the run is refused -- a partial graph swept silently would "
+            "understate exposure. Exists because a ~30-minute ingest per "
+            "iteration is otherwise the entire cost of this measurement."
+        ),
+    )
+    args = parser.parse_args()
+
+    import frontier_registry
+    import mcp_server
+    from evals.at_scale.probe_dep_preload_exposure import _ingest_into
+
+    def _run_sweep(branch, ingest_status):
+        linearization = frontier_registry.build_linearization(
+            args.repo_path, branch
+        )
+        commit_metadata = mcp_server._git_commits(args.repo_path, None, branch)
+        # Single-handle invariant (CLAUDE.md): reuse the live handle when one
+        # exists. Opening a second on the same file raises as of minigraf
+        # 1.2.3, and used to corrupt the page table silently (#251/#253).
+        db = (
+            mcp_server._db if mcp_server._db is not None
+            else mcp_server.open_db(str(graph_path))
+        )
+        report = sweep(
+            db, args.repo_path, linearization, commit_metadata, branch=branch,
+        )
+        report["ingest_status"] = ingest_status
+        return report
+
+    if args.graph_path:
+        graph_path = Path(args.graph_path)
+        if not graph_path.exists():
+            print(f"No graph at {graph_path}. Refusing to sweep nothing.")
+            return 1
+        mcp_server._db = None
+        mcp_server._graph_path = None
+        mcp_server.open_db(str(graph_path))
+        branch = args.branch or mcp_server._default_git_branch(args.repo_path)
+        linearization = frontier_registry.build_linearization(
+            args.repo_path, branch
+        )
+        raw = mcp_server._db_execute(
+            mcp_server._db,
+            "(query [:find (count ?c) :where [?c :entity-type :type/commit]])",
+        )
+        rows = json.loads(raw).get("results", [])
+        ingested = int(rows[0][0]) if rows else 0
+        if ingested != len(linearization):
+            print(
+                f"Graph holds {ingested} commits but the linearization has "
+                f"{len(linearization)}. Refusing to sweep a partial graph -- "
+                "an incomplete ingestion understates exposure everywhere."
+            )
+            return 1
+        report = _run_sweep(branch, "pre-existing")
+    else:
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="minigraf-257-probe-") as tmpdir:
+            graph_path = Path(tmpdir) / "probe.graph"
+            branch, ingest_status = asyncio.run(
+                _ingest_into(args.repo_path, args.branch, graph_path)
+            )
+            # _run_ingestion never raises on failure -- it wraps its whole body
+            # in `except Exception`, sets status and returns normally. This
+            # status is the only signal that the graph underneath is whole.
+            if ingest_status != "complete":
+                error = mcp_server._ingest_progress.get("error")
+                print(
+                    f"Ingestion did not complete (status={ingest_status!r}"
+                    + (f", error={error!r}" if error else "")
+                    + "). Refusing to sweep a partial or failed graph."
+                )
+                return 1
+            report = _run_sweep(branch, ingest_status)
+
+    print(json.dumps(report, indent=2))
+    print()
+    print(f"repo:                              {report['repo_path']} @ {report['branch']}")
+    print(f"ingested head:                     {report['head_commit']}")
+    print(f"commits:                           {report['commits']}")
+    print(f":description facts (deduped):      {report['description_facts_total']}")
+    print(f"structurally affected W:           {len(report['affected_positions'])}")
+    print(f"W actually mismatching:            {len(report['misclassifying_positions'])}")
+    print()
+    print("STAGE 1 -- census (idents carrying >1 DISTINCT :description value)")
+    for entity_type in ENTITY_TYPES:
+        row = report["census"][entity_type]
+        print(
+            f"  {entity_type:<22} {row['idents_with_multiple_values']:>6} "
+            f"of {row['idents_total']}"
+        )
+    print(f"  TOTAL                  {report['census_idents_with_multiple_values']:>6}")
+    print()
+    print("STAGE 2 -- value diff against the position-correct oracle")
+    print(f"  mismatches, position-weighted:   {report['value_mismatch_total_position_weighted']}")
+    print(f"  mismatches, distinct idents:     {report['value_mismatch_distinct_idents']}")
+    print()
+    print("  (counted separately, NOT the finding:)")
+    print(f"  ambiguous idents:                {report['ambiguous_idents_total']}")
+    print(f"  preloaded but not live:          {report['preloaded_not_live_total']}")
+    print(f"  live but not preloaded:          {report['live_not_preloaded_total']}")
+    print()
+    print(f"preload empty at every W:          {report['preload_descriptions_empty_everywhere']}")
+    print(f"timestamp collisions:              {report['timestamp_collisions']}")
+    print(f"unmappable :description vf:        {report['unmappable_description_valid_from']}")
+    print(f"unmappable :description vt:        {report['unmappable_description_valid_to']}")
+    print(f"gitlink events:                    {report['gitlink_events']}")
+
+    # The exit code reflects measurement VALIDITY, not the finding. A nonzero
+    # mismatch count is the number #257 asks for and must never fail the run.
+    measurement_invalid = (
+        report["unmappable_description_valid_from"] > 0
+        or report["unmappable_description_valid_to"] > 0
+        or report["timestamp_collisions"] > 0
+    )
+    if measurement_invalid:
+        print()
+        print(
+            "INVALID MEASUREMENT. Either a :description fact carries a\n"
+            "valid-from/valid-to matching no commit -- so the timestamp-to-\n"
+            "position inversion the oracle rests on is broken -- or the history\n"
+            "has colliding timestamps. Collisions invalidate rather than widen:\n"
+            "the shipped _position_of_valid_time and this probe's edge_live_at\n"
+            "resolve a collision in OPPOSITE directions, so the comparison is\n"
+            "no longer meaningful. Do not adjust this gate to make a run pass."
+        )
+
+    if report["preload_descriptions_empty_everywhere"]:
+        print()
+        print(
+            "NOTE: _preload_known_entities returned zero descriptions at every\n"
+            "affected position. That may be a genuinely empty population, or it\n"
+            "may be _collect's per-type `except Exception: pass`\n"
+            "(mcp_server.py:7491-7492) swallowing a real query failure -- the\n"
+            "two are indistinguishable from the mismatch count alone. Check\n"
+            ":description facts above: nonzero there with zero here is the\n"
+            "signature of the latter."
+        )
+
+    if report["gitlink_events"] == 0:
+        print()
+        print(
+            "NOTE: zero gitlink events. Submodule external-dependency entities\n"
+            "are the ONE preloaded type whose :description is not a function of\n"
+            "its ident -- it is `name or path` read from .gitmodules, and the\n"
+            "name can change while the path, and so the ident, stays fixed. This\n"
+            "history produces none, so that arm is UNMEASURABLE here. That is\n"
+            "not the same as zero risk, and any close written for #257 has to\n"
+            "name it. #245 recorded :pinned-commit the same way."
+        )
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.json_out}")
+    return 1 if measurement_invalid else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Verify `--help` works and the module is importable**
+
+Run: `.venv/bin/python -m evals.at_scale.probe_description_preload_exposure --help`
+Expected: argparse usage text listing `--repo-path`, `--branch`, `--json-out`, `--graph-path`. No traceback.
+
+- [ ] **Step 3: Verify the partial-graph refusal fires**
+
+Run: `.venv/bin/python -m evals.at_scale.probe_description_preload_exposure --graph-path /nonexistent/x.graph`
+Expected: prints `No graph at /nonexistent/x.graph. Refusing to sweep nothing.` and exits 1. Confirm with `echo $?`.
+
+- [ ] **Step 4: Run the full unit suite**
+
+Run: `.venv/bin/python -m pytest tests/test_at_scale_description_preload_probe.py -v`
+Expected: PASS, 16 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add evals/at_scale/probe_description_preload_exposure.py
+git commit -m "Add the #257 probe's CLI, with validity-only exit gate
+
+The exit code reflects measurement validity, never the finding: nonzero
+mismatches are the number #257 asks for. Unmappable facts and timestamp
+collisions fail the run -- collisions invalidate rather than widen, since
+the shipped _position_of_valid_time and this probe's edge_live_at resolve
+one in opposite directions.
+
+--graph-path sweeps an existing graph, gated on its commit count matching
+the linearization, so a ~30-minute ingest is not the cost of every
+iteration. Zero gitlink events is reported as UNMEASURABLE for the
+submodule arm, not as zero, following #245's :pinned-commit wording.
+
+Refs #257"
+```
+
+---
+
+### Task 8: Run it, record the artifact, report the verdict
+
+**Files:**
+- Create: `evals/at_scale/results/257-description-preload-exposure.json`
+- Modify: `evals/at_scale/benchmark.md`
+
+- [ ] **Step 1: Run the probe against this repository**
+
+Run (expect roughly 30-40 minutes, dominated by ingestion):
+
+```bash
+.venv/bin/python -m evals.at_scale.probe_description_preload_exposure \
+  --repo-path . \
+  --json-out evals/at_scale/results/257-description-preload-exposure.json
+```
+
+- [ ] **Step 2: Check the validity gate before reading any finding**
+
+Confirm the exit code is 0 (`echo $?`). If it is 1, the measurement is invalid — unmappable facts or timestamp collisions — and the finding must NOT be reported. Investigate the cause; do not adjust the gate.
+
+- [ ] **Step 3: Read the result against the prediction**
+
+The design spec predicted **census zero, mismatches zero**, fixed before any data existed.
+
+- **If both are zero:** the prediction holds. The mechanism cannot fire on the five ident-determined types, and the submodule arm is unmeasurable here. Proceed to Step 4.
+- **If the census is nonzero:** the falsifier fired. Do not proceed to Step 4's close-oriented wording. Report the offending idents and their values, and open the question of whether the per-attribute interval-inversion fix #257 sketches is now justified. This is a real finding, not noise.
+- **If the census is zero but mismatches are nonzero:** the two stages disagree, which means one of them is wrong. Stop and investigate before reporting anything — a census-zero graph cannot produce a value mismatch, so this outcome indicates a bug in the probe itself.
+
+- [ ] **Step 4: Add a benchmark.md entry**
+
+Append an entry to `evals/at_scale/benchmark.md` following the format of the existing `239-introduced-by-query-cost` entry: date, what was measured, the prediction fixed in advance, the result, and the verdict. State the submodule arm as UNMEASURABLE explicitly.
+
+- [ ] **Step 5: Commit the artifact**
+
+```bash
+git add evals/at_scale/results/257-description-preload-exposure.json evals/at_scale/benchmark.md
+git commit -m "Record the #257 :description preload exposure measurement
+
+Refs #257"
+```
+
+- [ ] **Step 6: Report to the user before touching GitHub**
+
+Summarise: the census per entity type, the Stage 2 mismatch counts, the validity diagnostics, and whether the pre-registered prediction held. Then ask whether to post the #257 comment.
+
+**Do not post to GitHub without asking.** The comment carries two parts and the user should approve both: the measurement verdict, and the correction to #257's body — that `:description` is written once per entity lifetime rather than on every body edit, and that no code path reads `entity_descriptions` for body-change detection (every read feeds `_build_close_triples`' retract value). The real consequence, if the mechanism ever fires, is a retract value that fails to match and leaves the fact live past its window — a stale-fact bug, not a lost body edit.
+
+**The comment must not contain a closing keyword.** `Refs #257` only. Whether a zero result closes #257 is the user's judgement call, and the unmeasurable submodule arm has to be named in whatever close is written.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every spec section maps to a task: architecture and graph acquisition → Tasks 6-7; Stage 1 census → Task 1 (primitive) and Task 5 (loader, incl. the clause-order rule); Stage 2 oracle and diff → Tasks 2-3; report fields → Task 6; exit code → Task 7; the five listed tests → Tasks 1-5, each ablation-proven where it pins a position-versus-date distinction (explicit ablation steps in Tasks 2 and 5); deliverables → Task 8. The spec's "does NOT do" list is honoured: no `mcp_server.py` change appears in any task, no interval-inversion fix is built, and Task 8 Step 6 explicitly declines to close #257.
+
+**Placeholder scan.** No TBD/TODO, no "add error handling", no "similar to Task N". Every code step carries the actual code. Task 8's Step 4 describes a prose entry rather than showing it, because its content is the measurement result, which does not exist until Step 1 runs; the step names the format to follow and the required elements.
+
+**Type consistency.** The fact-record shape (`entity_type`, `ident`, `desc`, `vf_ms`, `vt_ms`) is fixed in the File Structure section and used identically in Tasks 1, 2, 4, 5, 6. `position_correct_descriptions` returns `Dict[str, set]` in Task 2 and is consumed as such by `diff_descriptions` in Task 3 and `sweep` in Task 6. `diff_descriptions`' four output keys are defined in Task 3 and read by the same names in Task 6. `ENTITY_TYPES` is defined in Task 1 and used in Tasks 5, 6, 7.

--- a/docs/superpowers/specs/2026-08-11-description-preload-exposure-probe-design.md
+++ b/docs/superpowers/specs/2026-08-11-description-preload-exposure-probe-design.md
@@ -1,0 +1,286 @@
+# #257 — `:description` preload exposure probe: design
+
+Issue: project-minigraf/temporal_reasoning#257
+Date: 2026-08-11
+Status: design approved, not yet implemented
+
+## What this measures
+
+`_preload_known_entities` decides preload MEMBERSHIP by position after #238 and
+#245 (PR #258). It seeds `entity_descriptions[ident]` from whichever
+`:description` fact version was live at `:valid-at T_hi(W)` — a DATE query.
+`T_hi(W) = max(ts[0..W])` is the monotone envelope of author dates at or below
+the watermark, and author dates are not monotonic in topological order, so a
+version written by a commit ABOVE the watermark but carrying an EARLIER author
+date can be the version that query returns.
+
+#257 asks how often that actually happens on real history. It is UNMEASURED:
+the #245 probe (`evals/at_scale/probe_dep_preload_exposure.py`) compared
+membership only.
+
+## The issue's stated mechanism does not match the code
+
+Three checks against master `1dceec1`, all of which the reader should
+re-verify rather than take from this document:
+
+1. **`:description` is written ONCE per entity lifetime**, not "on essentially
+   every body edit" as #257's body claims. `_build_code_triples`' docstring
+   states it (`mcp_server.py:7182-7186`) and the code matches: every
+   `entity_descriptions[ident] = …` assignment (7228, 7243, 7257, 7271, 7283)
+   sits inside the `if ident not in entity_valid_from` introduction branch. The
+   `elif` branch for an already-known entity appends a `:modified-in` triple and
+   nothing else. The "per-attribute interval history is large" premise — #257's
+   stated reason for scoping this out of #238/#245 — is therefore false.
+
+2. **Nothing uses `entity_descriptions` for body-change detection.** Every read
+   in `_forward_apply` (9216, 9254, 9396, 9464, 9507, 9583) feeds
+   `_build_close_triples`' `desc` argument, i.e. the RETRACT VALUE at close
+   time. Body-change detection is `unchanged_idents`, computed in
+   `_precompute_file_triples` from parsed node text (#221). The failure #257
+   describes — "the comparison reports unchanged and the edit is never
+   recorded" — has no code path.
+
+3. **For five of the six preloaded entity types the value is a deterministic
+   function of the ident.** module → `file_path`; function/class/variable →
+   name; field → `qualified_name`. `_code_ident(entity_type, file_path, name)`
+   (mcp_server.py:4288) is built from exactly those inputs. A `:description`
+   version written above the watermark therefore carries the SAME string, so
+   the date-versus-position choice cannot change the value returned.
+
+Two places where the value is genuinely NOT ident-determined:
+
+- **submodule external-dependency**: `description = name or path`, read from
+  `.gitmodules` (mcp_server.py:9546). The name can change while the path, and
+  so the ident, stays fixed.
+- **`_canonical_ident` slug collisions**: `_code_ident`'s own docstring calls
+  the ident best-effort and says collisions remain possible for contrived
+  path/name combinations, so two distinct names could share one ident while
+  carrying different descriptions.
+
+**The real consequence, if the mechanism ever fires, is different from the one
+#257 describes.** A wrong preloaded `desc` becomes a retract value that does not
+match the stored fact, so the `:description` fails to close and stays live past
+its window. That is a stale-fact bug, not a lost body edit.
+
+This spec does not act on the above as settled. It is the reason the work is
+scoped as a measurement, and it is what the measurement is expected to confirm
+or refute.
+
+## Prediction, fixed before any data exists
+
+Following the #239 discipline of fixing the threshold in the spec before
+running anything:
+
+> **Census zero. Mismatches zero.**
+
+on the argument in the section above. A nonzero census is the falsifier. If it
+fires, the work escalates to the full per-position value sweep described in
+#257's "How to measure it", which Stage 2 below already implements.
+
+Recording the prediction here is what keeps a zero result from being read as
+"the probe was built to return zero".
+
+## Scope decisions
+
+- **Probe first, fix never (yet).** No interval-inversion machinery is built.
+  The measurement decides whether any is justified, per the project's standing
+  rule that a real code path is not a real problem until measured.
+- **The submodule arm is reported UNMEASURABLE, not zero.** This repository
+  produced 0 gitlink events when #245 measured it over 610 commits, so no
+  submodule `:description` facts exist to count. The probe recomputes the count
+  rather than assuming it. #245 recorded `:pinned-commit` the same way, and that wording is
+  reused verbatim. A zero census therefore reads "zero on the five
+  ident-determined types, unmeasurable on submodules" and is not by itself
+  sufficient to close #257 — the residual must be named explicitly in whatever
+  close is written.
+- **Step 4 of #257's sketch is dropped.** It is conditional on step 3 being
+  nonzero, and it asks to replay a body-change comparison against
+  `entity_descriptions` that does not exist. If step 3 fires, the correct
+  follow-up is to check whether the retract value matched, not whether a body
+  edit was suppressed.
+
+## Architecture
+
+New module `evals/at_scale/probe_description_preload_exposure.py`. It imports
+the pure analysis primitives from `probe_dep_preload_exposure`:
+`VALID_TIME_FOREVER_MS`, `build_ts_positions`, `resume_envelopes`,
+`affected_positions`, `invert_ms_to_positions`, `edge_live_at`,
+`gitlink_event_count`. That module's docstring already commits to those staying
+importable without opening a graph.
+
+Separate module rather than a `--mode` flag on the existing probe:
+`probe_dep_preload_exposure.py` is 1128 lines organised around a NARROW/WIDE
+entity framing with no analogue here, and CLAUDE.md already describes
+`evals/at_scale/` as holding one-off read-only probes alongside the recurring
+benchmark.
+
+### Obtaining a graph
+
+Default: temp-dir ingest via `probe_dep_preload_exposure._ingest_into`,
+refusing to proceed unless `ingest_status == "complete"` — `_run_ingestion`
+never raises on failure, so that status is the only signal the graph underneath
+is whole.
+
+Optional `--graph-path` runs against an existing persistent graph, gated on the
+graph's commit count matching the linearization length so a partial graph
+cannot be swept silently. This exists because a ~30-minute ingest per iteration
+would otherwise be the entire cost of the work. It overlaps #256's want for a
+persistent-graph option and is deliberately kept minimal here: read an existing
+graph or refuse, no ingest-if-absent behaviour.
+
+**Single-handle invariant** (CLAUDE.md): at most one live `MiniGrafDb` per
+process. Follow `probe_dep_preload_exposure.main`'s pattern exactly — reuse
+`mcp_server._db` when it is already set, and open one only when it is not.
+
+## Stage 1 — the distinct-value census
+
+Six queries, one per entity type `_preload_known_entities` loads (`module`,
+`function`, `class`, `variable`, `field`, `external-dependency`):
+
+```
+[:find ?ident ?desc ?vf ?vt :any-valid-time
+ :where [?e :entity-type :type/<T>]
+        [?e :ident ?ident]
+        [?e :description ?desc]
+        [?e :db/valid-from ?vf]
+        [?e :db/valid-to ?vt]]
+```
+
+**Clause order is load-bearing.** `[?e :description ?desc]` MUST be the EAV
+clause immediately preceding the two pseudo-attributes: they bind to whichever
+EAV clause on `?e` most recently precedes them, so putting `[?e :ident ?ident]`
+between them would bind `?vf`/`?vt` to the `:ident` fact's window instead —
+wrong, and silently so. This is `load_module_path_facts`' documented rule,
+applied to `:description`.
+
+Rows dedupe on `(ident, desc, vf, vt)`. An entity carrying several
+`:entity-type` or `:ident` versions across time otherwise multiplies each
+`:description` row under `:any-valid-time` without changing any answer, exactly
+as `load_dep_edges` dedupes for the same reason.
+
+Census output, per entity type: total distinct idents, count of idents carrying
+more than one distinct `:description` VALUE (not more than one interval — an
+entity deleted and re-added has two intervals and one value, and that is not
+exposure), and the offending `(ident, sorted values)` pairs verbatim so a
+nonzero result is diagnosable rather than merely counted.
+
+Reported alongside `gitlink_event_count(repo_path)`, with a zero submodule
+population labelled UNMEASURABLE.
+
+## Stage 2 — the position-correct value diff
+
+**One mode only.** Unlike the #245 probe's date-only/`--verify-fix` pair, #257
+is the residual in the SHIPPED code, so `_preload_known_entities` is always
+driven with the full post-#238/#245 argument set: `valid_at=envelopes[w]`,
+`hash_to_pos`, `watermark_pos=w`, `ts_positions`, and
+`t_hi_ms=_iso_to_epoch_ms(envelopes[w])`. There is no pre-fix leg to measure.
+
+For each `w` in `affected_positions(commit_metadata)`:
+
+1. **Oracle** — for each ident, the set of DISTINCT `:description` values whose
+   own fact interval is live at `w`, computed by running that fact's `vf_ms` and
+   `vt_ms` through `invert_ms_to_positions` and `edge_live_at`. Both ends
+   inverted to positions; no date bound anywhere in the oracle.
+2. **Actual** — the `entity_descriptions` dict `_preload_known_entities`
+   returns at that `w`.
+3. **Finding** — `value_mismatch` where an ident's preloaded value is not a
+   member of the oracle's live-value set for that ident. Reported both
+   position-weighted (one ident mismatching at all N affected positions counts
+   N) and as distinct idents (the union across positions), matching every #245
+   counter's convention.
+
+Three quantities are counted separately and deliberately EXCLUDED from the
+finding:
+
+- **`ambiguous_idents`** — the oracle's live-value set has more than one member,
+  so no single correct value exists to compare against. `edge_live_at`'s
+  asymmetric collision policy exists to avoid understating a MEMBERSHIP answer;
+  applied to a value it would fabricate one. Counted, never resolved.
+- **`preloaded_not_live`** and **`live_not_preloaded`** — membership
+  disagreements between the preload and the oracle. This is #238/#245's
+  already-measured, already-fixed territory. Folding it into #257's number
+  would re-measure a closed issue and inflate this one. Diagnostics only.
+
+## Report fields
+
+Provenance (the #245 probe added these after its first artifact named a scratch
+directory that no longer existed): `repo_path`, `branch`, `head_commit`,
+`commits`, `ingest_status`, `affected_positions`.
+
+Finding: `census_idents_with_multiple_values` (per type and total),
+`census_offending_idents`, `value_mismatch_total_position_weighted`,
+`value_mismatch_distinct_idents`, `ambiguous_idents_total`,
+`preloaded_not_live_total`, `live_not_preloaded_total`, `gitlink_events`.
+
+Validity: `unmappable_description_valid_from`, `unmappable_description_valid_to`,
+`timestamp_collisions`, `preload_descriptions_empty_everywhere`.
+
+`preload_descriptions_empty_everywhere` is a lie-detector, not a statistic.
+`_collect` swallows its own query failure with a bare `except Exception: pass`
+per entity type (`mcp_server.py:7491-7492`), so "this history genuinely has no
+descriptions" and "every query failed" produce identical mismatch counts. The
+report records the actual per-position `entity_descriptions` size and flags the
+all-positions-empty case explicitly, mirroring what #245 built for
+`_preload_known_deps`.
+
+## Exit code
+
+**The exit code reflects measurement VALIDITY, not the finding.** A nonzero
+mismatch count is the number #257 asks for; it must not fail the run.
+
+Exit 1 iff `unmappable_description_valid_from > 0`, or
+`unmappable_description_valid_to > 0`, or `timestamp_collisions > 0`.
+
+Unmappable facts mean the timestamp-to-position inversion the whole oracle
+rests on is broken for at least one fact. Nonzero collisions belong in the same
+gate rather than merely widening error bars, because the shipped
+`_position_of_valid_time` and the oracle's `edge_live_at` resolve a collision in
+OPPOSITE directions — a collision makes the comparison invalid, not just noisy.
+The #245 acceptance run recorded 0 collisions on this repository, so this gate
+is expected to pass.
+
+## Testing
+
+`tests/test_at_scale_description_preload_probe.py`, mirroring
+`tests/test_at_scale_dep_preload_probe.py`. Synthetic fact sets only — the
+primitives are pure, so no graph is opened:
+
+1. The oracle rejects a `:description` version introduced ABOVE `w` carrying an
+   EARLIER author date, and selects the version live at `w` — the #257 shape
+   itself.
+2. An ident whose oracle live-value set has more than one member is counted in
+   `ambiguous_idents` and contributes nothing to `value_mismatch`.
+3. An ident present in the preload but absent from the oracle's live set (and
+   vice versa) contributes to the membership diagnostics and nothing to
+   `value_mismatch`.
+4. A `:description` fact whose `vf` or non-sentinel `vt` inverts to no position
+   is counted in the unmappable diagnostics rather than skipped.
+5. The census counts distinct VALUES per ident, so an entity with two intervals
+   carrying one value is not counted as exposure, while one interval pair
+   carrying two values is.
+
+**Every one of these must be ablation-proven** before it is accepted: each test
+must be shown to FAIL against a date-bounded oracle, with the counterfactual
+matching the real date-bounded code rather than a convenient restatement of it.
+This is the standing rule after four tests on an earlier branch claimed
+guarantees they did not provide.
+
+## Deliverables
+
+- `evals/at_scale/probe_description_preload_exposure.py`
+- `tests/test_at_scale_description_preload_probe.py`
+- `evals/at_scale/results/257-description-preload-exposure.json` — the recorded
+  measurement, committed as an analysis artifact the way #239's and #245's were.
+- A comment on #257 carrying the verdict AND correcting the two false premises
+  in its body (written-once, and the nonexistent body-change consumer), so the
+  record does not keep pointing at a mechanism that has no code path.
+
+## What this explicitly does NOT do
+
+- Build the per-attribute position-indexed interval reconstruction #257
+  sketches as the eventual fix. That is justified only by a nonzero
+  measurement.
+- Change any behaviour in `mcp_server.py`. The probe is read-only over an
+  already-ingested graph.
+- Close #257. Whether a zero result closes it is a judgement call, and the
+  unmeasurable submodule arm has to be named in whatever close is written.

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -706,7 +706,11 @@ standard for measurement corrections.
 
 ## Description Preload Exposure Probe — 257-description-preload-exposure
 
-- Repo: `.` @ `master` (`8310f7d`, full history, 656 commits)
+- Repo: `.` @ `master` (`1dceec1`, full history, 656 commits) — the head is
+  taken from the linearization, i.e. the commit the swept graph actually ends
+  at. An earlier version of this entry named `8310f7d`, a commit on the probe
+  branch that is not on `master` at all: `sweep()` was recording `git rev-parse
+  HEAD` instead. Fixed in the probe; the artifact was regenerated.
 - Script: `evals/at_scale/probe_description_preload_exposure.py`
 - Raw: `evals/at_scale/results/257-description-preload-exposure.json`
 - Question: does `_preload_known_entities`' date-bounded `:description`
@@ -731,6 +735,8 @@ standard for measurement corrections.
 | &nbsp;&nbsp;external-dependency | 0 of 76 |
 | Stage 2 — value mismatches, position-weighted | 0 |
 | Stage 2 — value mismatches, distinct idents | 0 |
+| Stage 2 — value comparisons actually made | 12685 |
+| **Stage 2 — of those, on a census offender** | **0** |
 | Ambiguous idents (not the finding) | 15 |
 | Preloaded but not live (not the finding) | 0 |
 | Live but not preloaded (not the finding) | 677 |
@@ -740,9 +746,11 @@ standard for measurement corrections.
 | Gitlink events | 0 |
 
 **Verdict: the census half of the prediction is FALSIFIED; the mismatch half
-holds on this history.** This is Outcome 2 of the design spec's three-way
-read, not Outcome 1 — reported as a real finding, not folded into a
-close-oriented "prediction holds" framing.
+is UNTESTED where it mattered — not confirmed.** The mismatch count is 0, but
+zero of those comparisons were on an ident that could have produced a mismatch
+(see item 2), so the 0 is not a null result. This is Outcome 2 of the design
+spec's three-way read, not Outcome 1 — reported as a real finding, not folded
+into a close-oriented "prediction holds" framing.
 
 1. **Three `function` idents carry two distinct `:description` values each,
    contradicting the spec's premise that description is a deterministic
@@ -769,18 +777,38 @@ close-oriented "prediction holds" framing.
    alone would be enough to break the "description is a deterministic
    function of ident" premise for `function`; here both are present.
 
-2. **Stage 2 (the shipped `_preload_known_entities` driven against a
-   position-correct oracle at all 16 structurally affected watermarks) found
-   zero value mismatches** — `W actually mismatching: 0`, both
-   position-weighted and distinct-ident mismatch counts are 0. The census
-   firing did not translate into an observed wrong value anywhere in this
-   repository's history: none of the 16 structurally affected watermarks
-   happened to straddle a window where the date-envelope-selected version of
-   `_commit`/`commit`, `_snapshot`/`snapshot`, or `_main`/`main` diverged from
-   the position-correct one. A census-nonzero, mismatch-zero result is
-   internally consistent (the census is necessary but not sufficient for a
-   mismatch — it also requires an affected watermark to land inside the
-   window the two competing versions bracket), not a contradiction.
+2. **Stage 2's zero is zero out of ZERO informative comparisons, and settles
+   nothing about the mechanism.** The shipped `_preload_known_entities` was
+   driven against the position-correct oracle at all 16 affected watermarks and
+   12685 value comparisons were made, but **not one of them was on a census
+   offender** (`offender_value_comparisons: 0`). A mismatch is only recordable
+   for an ident carrying at least two distinct values across time — i.e. a
+   census offender — so `value_mismatches` is always a strict subset of item
+   1's three idents. Those three were excluded at every position where the
+   question could have been put:
+
+   | Positions | Offenders in the preload | Disposition |
+   |---|---|---|
+   | 118–128 (11 W) | 0 of 3 | not preloaded at all — none of the three functions existed yet |
+   | 645–649 (5 W) | 3 of 3 | **both values simultaneously live → classified `ambiguous`, comparison skipped** |
+
+   So the probe *declined to compare* at 645–649; it did not find agreement
+   there. Stage 2 therefore **neither confirms nor refutes** #257's mechanism
+   at those positions. What Stage 2 does establish is narrower and still worth
+   having: across the 12685 comparisons it did make — the whole preloaded
+   population at every affected watermark — the shipped query's output never
+   diverged from the position-correct oracle for any ident where a single
+   correct value existed. That is a real check on the query, not evidence about
+   the three idents that could actually exhibit the defect.
+
+   The exclusion is not incidental, either. The ambiguity rule removes exactly
+   the case where the mechanism is most likely to fire: two competing versions
+   contemporaneous at a position is both what makes the oracle unable to name a
+   single right answer and what gives a date bound a wrong version to pick. The
+   probe now prints this as a NOTE and records `compared_idents`,
+   `offenders_present` and `offenders_compared` per position, so the limitation
+   is checkable from the artifact rather than by re-derivation.
+
 3. **The submodule `external-dependency` arm is UNMEASURABLE on this
    history, not zero.** `gitlink events: 0` — this repository has no
    `.gitmodules` changes, so the one entity type whose `:description` is
@@ -794,7 +822,10 @@ close-oriented "prediction holds" framing.
    repository (for reasons unrelated to #257's stated `entity_descriptions`
    mechanism — a slug-collision bug in `_code_ident`/`_canonical_ident`, not
    a `:valid-at` date-vs-position bug), while the mechanism #257 actually
-   describes produced zero observed mismatches here. A single repository's
-   656 commits finding 0 of 16 affected watermarks landing on a divergent
-   window does not bound the risk on a larger or differently-shaped history;
-   it is one data point, not a proof of absence.
+   describes was never put to the test on those three idents at all (item 2).
+   This run neither bounds the risk nor demonstrates it. It is one repository,
+   and on that repository the only candidates were unmeasurable — which is
+   weaker than "one data point against"; it is not a data point about the
+   mechanism at all. The two arms it does close off are narrower: the shipped
+   query agreed with the oracle on 12685 unambiguous comparisons, and no
+   entity type other than `function` has an ident carrying two values.

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -703,3 +703,98 @@ standard for measurement corrections.
    flat here across a 50x graph-size range and a 50x ident-population range.
    Whatever drives ingestion cost up with history, it is something other than
    these two queries, and fixing #239 will not touch it.
+
+## Description Preload Exposure Probe — 257-description-preload-exposure
+
+- Repo: `.` @ `master` (`8310f7d`, full history, 656 commits)
+- Script: `evals/at_scale/probe_description_preload_exposure.py`
+- Raw: `evals/at_scale/results/257-description-preload-exposure.json`
+- Question: does `_preload_known_entities`' date-bounded `:description`
+  seeding (`entity_descriptions[ident]` = whichever version was live at
+  `:valid-at T_hi(W)`) ever return a value a position-bounded query would
+  not? #257's stated mechanism.
+- Prediction, fixed in the design spec before any data existed: **census
+  zero, mismatches zero.**
+
+| Metric | Value |
+|---|---|
+| Exit code | 0 (valid measurement) |
+| `:description` facts (deduped) | 2737 |
+| Structurally affected watermarks (W) | 16 of 656 |
+| W actually mismatching | 0 |
+| **Stage 1 — census (idents with >1 distinct `:description` value)** | **3 total** |
+| &nbsp;&nbsp;module | 0 of 55 |
+| &nbsp;&nbsp;function | **3 of 2030** |
+| &nbsp;&nbsp;class | 0 of 284 |
+| &nbsp;&nbsp;variable | 0 of 227 |
+| &nbsp;&nbsp;field | 0 of 62 |
+| &nbsp;&nbsp;external-dependency | 0 of 76 |
+| Stage 2 — value mismatches, position-weighted | 0 |
+| Stage 2 — value mismatches, distinct idents | 0 |
+| Ambiguous idents (not the finding) | 15 |
+| Preloaded but not live (not the finding) | 0 |
+| Live but not preloaded (not the finding) | 677 |
+| Timestamp collisions | 0 |
+| Unmappable `:description` valid-from / valid-to | 0 / 0 |
+| Preload descriptions empty everywhere | False |
+| Gitlink events | 0 |
+
+**Verdict: the census half of the prediction is FALSIFIED; the mismatch half
+holds on this history.** This is Outcome 2 of the design spec's three-way
+read, not Outcome 1 — reported as a real finding, not folded into a
+close-oriented "prediction holds" framing.
+
+1. **Three `function` idents carry two distinct `:description` values each,
+   contradicting the spec's premise that description is a deterministic
+   function of ident for this type:**
+
+   | Ident | Values |
+   |---|---|
+   | `:function/tests-test-mcp-server-py-commit` | `_commit`, `commit` |
+   | `:function/tests-test-mcp-server-py-snapshot` | `_snapshot`, `snapshot` |
+   | `:function/evals-at-scale-profile-forward-reconcile-attribution-py-main` | `_main`, `main` |
+
+   Root cause, confirmed by reading `_canonical_ident` (`mcp_server.py:4090-4099`):
+   the slug step replaces every non-`[a-z0-9-]` character (including `_` and
+   the `::` name separator) with `-`, then collapses consecutive hyphens. A
+   name with a leading underscore (`_commit`) and its bare form (`commit`)
+   both slug to the identical `...-commit` suffix once the run of hyphens
+   from `::_` collapses — the ident scheme is underscore-blind at a name
+   boundary. `tests/test_mcp_server.py` defines many distinct local helper
+   functions named `commit`/`_commit` and `snapshot`/`_snapshot` nested
+   inside different test functions (confirmed by grep: 10+ occurrences of
+   `def _commit`/`def commit` alone), and `_code_ident` does not qualify by
+   enclosing scope — so unrelated nested functions across the file collide
+   onto one ident in addition to the underscore collapse. Either mechanism
+   alone would be enough to break the "description is a deterministic
+   function of ident" premise for `function`; here both are present.
+
+2. **Stage 2 (the shipped `_preload_known_entities` driven against a
+   position-correct oracle at all 16 structurally affected watermarks) found
+   zero value mismatches** — `W actually mismatching: 0`, both
+   position-weighted and distinct-ident mismatch counts are 0. The census
+   firing did not translate into an observed wrong value anywhere in this
+   repository's history: none of the 16 structurally affected watermarks
+   happened to straddle a window where the date-envelope-selected version of
+   `_commit`/`commit`, `_snapshot`/`snapshot`, or `_main`/`main` diverged from
+   the position-correct one. A census-nonzero, mismatch-zero result is
+   internally consistent (the census is necessary but not sufficient for a
+   mismatch — it also requires an affected watermark to land inside the
+   window the two competing versions bracket), not a contradiction.
+3. **The submodule `external-dependency` arm is UNMEASURABLE on this
+   history, not zero.** `gitlink events: 0` — this repository has no
+   `.gitmodules` changes, so the one entity type whose `:description` is
+   read from `.gitmodules` (`name or path`, independently variable from the
+   ident-bearing path) rather than derived from the ident never gets a
+   chance to exercise the mechanism. The `external-dependency` row above
+   (`0 of 76`) reflects an absence of opportunity, not an absence of risk.
+4. **Whether #257's per-attribute interval-inversion fix is justified is
+   left open, not answered, by this run.** The census result shows the
+   ident-determinism premise is false for at least three real idents in this
+   repository (for reasons unrelated to #257's stated `entity_descriptions`
+   mechanism — a slug-collision bug in `_code_ident`/`_canonical_ident`, not
+   a `:valid-at` date-vs-position bug), while the mechanism #257 actually
+   describes produced zero observed mismatches here. A single repository's
+   656 commits finding 0 of 16 affected watermarks landing on a divergent
+   window does not bound the risk on a larger or differently-shaped history;
+   it is one data point, not a proof of absence.

--- a/evals/at_scale/probe_description_preload_exposure.py
+++ b/evals/at_scale/probe_description_preload_exposure.py
@@ -199,3 +199,36 @@ def diff_descriptions(
         "preloaded_not_live": sorted(preloaded_not_live),
         "live_not_preloaded": sorted(live_not_preloaded),
     }
+
+
+def count_unmappable_description_facts(
+    facts: Sequence[Dict],
+    ts_positions: Dict[str, List[int]],
+) -> tuple:
+    """How many :description facts carry a vf_ms/vt_ms whose instant matches no
+    commit -- this probe's validity diagnostic.
+
+    Mirrors probe_dep_preload_exposure.count_unmappable_module_path_facts,
+    applied to :description. An unmappable vf silently drops the fact from the
+    oracle at every W (understating the finding); an unmappable non-sentinel vt
+    silently reads it as never-superseded (overstating it). Either way the
+    timestamp-to-position inversion the whole oracle rests on is broken for at
+    least one fact, so a nonzero count INVALIDATES the measurement rather than
+    adjusting it -- see main()'s exit gate.
+
+    The forever sentinel is an open fact, not a broken inversion, and is
+    excluded from the vt count. Most facts on a live graph are open; counting
+    them would fail every run.
+
+    Returns (unmappable_valid_from, unmappable_valid_to).
+    """
+    unmappable_vf = sum(
+        1 for f in facts
+        if not invert_ms_to_positions(f["vf_ms"], ts_positions)
+    )
+    unmappable_vt = sum(
+        1 for f in facts
+        if f["vt_ms"] < VALID_TIME_FOREVER_MS
+        and not invert_ms_to_positions(f["vt_ms"], ts_positions)
+    )
+    return unmappable_vf, unmappable_vt

--- a/evals/at_scale/probe_description_preload_exposure.py
+++ b/evals/at_scale/probe_description_preload_exposure.py
@@ -141,3 +141,61 @@ def position_correct_descriptions(
         if edge_live_at(vf_positions, vt_positions, w):
             live.setdefault(fact["ident"], set()).add(fact["desc"])
     return live
+
+
+def diff_descriptions(
+    actual: Dict[str, str],
+    oracle: Dict[str, set],
+) -> Dict:
+    """Compare the shipped preload's entity_descriptions against the
+    position-correct oracle at one position.
+
+    THREE quantities are separated deliberately, and only the first is #257's
+    finding:
+
+      value_mismatches -- the preloaded value is not among the values live at
+        this position. This is the exposure #257 asks about.
+
+      ambiguous_idents -- the oracle's live set has more than one member, so
+        no single correct value exists to compare against. Counted and
+        skipped, never resolved. Letting these fall through would score an
+        ident as matching whenever the preloaded value happened to be one of
+        several, inventing agreement out of ambiguity.
+
+      preloaded_not_live / live_not_preloaded -- MEMBERSHIP disagreements.
+        #238 and #245 measured and fixed membership; folding these into #257's
+        number would re-measure a closed issue and inflate this one. They are
+        reported because a large count here means the two sides are talking
+        about different entity populations and the value comparison covers
+        less than it appears to -- but they are not the finding.
+
+    Ordering matters: ambiguity is tested BEFORE the value comparison, so an
+    ambiguous ident contributes to neither the mismatch count nor the
+    membership counters.
+    """
+    value_mismatches: Dict[str, Dict] = {}
+    ambiguous: List[str] = []
+    preloaded_not_live: List[str] = []
+
+    for ident, preloaded_value in actual.items():
+        live_values = oracle.get(ident)
+        if not live_values:
+            preloaded_not_live.append(ident)
+            continue
+        if len(live_values) > 1:
+            ambiguous.append(ident)
+            continue
+        if preloaded_value not in live_values:
+            value_mismatches[ident] = {
+                "preloaded": preloaded_value,
+                "live": sorted(live_values),
+            }
+
+    live_not_preloaded = [ident for ident in oracle if ident not in actual]
+
+    return {
+        "value_mismatches": value_mismatches,
+        "ambiguous_idents": sorted(ambiguous),
+        "preloaded_not_live": sorted(preloaded_not_live),
+        "live_not_preloaded": sorted(live_not_preloaded),
+    }

--- a/evals/at_scale/probe_description_preload_exposure.py
+++ b/evals/at_scale/probe_description_preload_exposure.py
@@ -50,8 +50,12 @@ from typing import Dict, List, Sequence
 
 from evals.at_scale.probe_dep_preload_exposure import (
     VALID_TIME_FOREVER_MS,
+    affected_positions,
+    build_ts_positions,
     edge_live_at,
+    gitlink_event_count,
     invert_ms_to_positions,
+    resume_envelopes,
 )
 
 # The entity types _preload_known_entities loads, in its own order
@@ -296,3 +300,143 @@ def load_description_facts(db) -> List[Dict]:
                 "vt_ms": int(vt),
             })
     return facts
+
+
+def sweep(
+    db,
+    repo_path: str,
+    linearization: List[str],
+    commit_metadata: Sequence,
+    branch: str = None,
+) -> Dict:
+    """Run Stage 1's census and Stage 2's per-position value diff, and assemble
+    the report.
+
+    ONE MODE. _preload_known_entities is always driven with its full
+    post-#238/#245 argument set -- valid_at, hash_to_pos, watermark_pos,
+    ts_positions, t_hi_ms -- because #257 is the residual in the SHIPPED code.
+    Passing a subset would silently turn position_mode off inside the function
+    (its gate is watermark_pos AND ts_positions AND t_hi_ms) and this sweep
+    would measure the pre-fix path while believing it measured the shipped one.
+
+    Calls the function under test rather than a restatement of what we believe
+    it does. On the #238 branch a reviewer and an implementer both simulated
+    the counterfactual with a date bound instead of the real position-filtered
+    one, which made an inadequate test look adequate and cost two fix rounds.
+
+    STAGE 1 MAY MAKE STAGE 2 MOOT, but Stage 2 runs regardless. A zero census
+    implies zero mismatches only through an argument about how :description is
+    written; Stage 2 checks the shipped query's actual output and rests on no
+    such argument. Two independent lines of evidence for the price of one
+    ingest.
+
+    provenance: repo_path alone was not enough to reproduce the first #245
+    artifact -- it named a scratch directory that no longer existed, with no
+    branch and no head SHA. branch and head_commit are recorded here so a
+    future run carries its own.
+    """
+    import subprocess
+
+    import mcp_server
+
+    if len(commit_metadata) != len(linearization):
+        raise ValueError(
+            f"commit_metadata has {len(commit_metadata)} entries but "
+            f"linearization has {len(linearization)}; a misaligned pair "
+            "mis-filters the entire sweep"
+        )
+    for i, ((meta_hash, _ts, _a, _s), lin_hash) in enumerate(
+        zip(commit_metadata, linearization)
+    ):
+        if meta_hash != lin_hash:
+            raise ValueError(
+                f"commit_metadata[{i}] is {meta_hash} but linearization[{i}] "
+                f"is {lin_hash}; the two must be positionally aligned"
+            )
+
+    hash_to_pos = {h: i for i, h in enumerate(linearization)}
+    ts_positions = build_ts_positions(commit_metadata)
+    envelopes = resume_envelopes(commit_metadata)
+    collisions = {ts: pos for ts, pos in ts_positions.items() if len(pos) > 1}
+
+    facts = load_description_facts(db)
+    census = census_distinct_values(facts)
+    unmappable_vf, unmappable_vt = count_unmappable_description_facts(
+        facts, ts_positions
+    )
+
+    positions = affected_positions(commit_metadata)
+    per_position = []
+    mismatch_distinct: set = set()
+    mismatch_weighted = 0
+    ambiguous_total = 0
+    preloaded_not_live_total = 0
+    live_not_preloaded_total = 0
+    preload_sizes = []
+
+    for w in positions:
+        (
+            _entity_valid_from, entity_descriptions, _entity_introduced_by,
+            _file_entities, _submodule_paths,
+        ) = mcp_server._preload_known_entities(
+            db, repo_path,
+            valid_at=envelopes[w],
+            hash_to_pos=hash_to_pos,
+            watermark_pos=w,
+            ts_positions=ts_positions,
+            t_hi_ms=mcp_server._iso_to_epoch_ms(envelopes[w]),
+        )
+        oracle = position_correct_descriptions(facts, ts_positions, w)
+        result = diff_descriptions(entity_descriptions, oracle)
+
+        preload_sizes.append(len(entity_descriptions))
+        mismatch_weighted += len(result["value_mismatches"])
+        mismatch_distinct.update(result["value_mismatches"])
+        ambiguous_total += len(result["ambiguous_idents"])
+        preloaded_not_live_total += len(result["preloaded_not_live"])
+        live_not_preloaded_total += len(result["live_not_preloaded"])
+
+        per_position.append({
+            "position": w,
+            "envelope": envelopes[w],
+            "preloaded_idents": len(entity_descriptions),
+            "oracle_idents": len(oracle),
+            "value_mismatches": result["value_mismatches"],
+            "ambiguous_idents": result["ambiguous_idents"],
+            "preloaded_not_live": len(result["preloaded_not_live"]),
+            "live_not_preloaded": len(result["live_not_preloaded"]),
+        })
+
+    head_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_path, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    return {
+        "repo_path": repo_path,
+        "branch": branch,
+        "head_commit": head_commit,
+        "commits": len(commit_metadata),
+        "affected_positions": positions,
+        "misclassifying_positions": [
+            p["position"] for p in per_position if p["value_mismatches"]
+        ],
+        "description_facts_total": len(facts),
+        "census": census,
+        "census_idents_with_multiple_values": sum(
+            census[t]["idents_with_multiple_values"] for t in ENTITY_TYPES
+        ),
+        "value_mismatch_total_position_weighted": mismatch_weighted,
+        "value_mismatch_distinct_idents": len(mismatch_distinct),
+        "ambiguous_idents_total": ambiguous_total,
+        "preloaded_not_live_total": preloaded_not_live_total,
+        "live_not_preloaded_total": live_not_preloaded_total,
+        "unmappable_description_valid_from": unmappable_vf,
+        "unmappable_description_valid_to": unmappable_vt,
+        "timestamp_collisions": len(collisions),
+        "preload_descriptions_empty_everywhere": (
+            bool(preload_sizes) and all(n == 0 for n in preload_sizes)
+        ),
+        "gitlink_events": gitlink_event_count(repo_path),
+        "per_position": per_position,
+    }

--- a/evals/at_scale/probe_description_preload_exposure.py
+++ b/evals/at_scale/probe_description_preload_exposure.py
@@ -1,0 +1,100 @@
+# evals/at_scale/probe_description_preload_exposure.py
+"""#257 exposure probe: does the entity preload's DATE-bounded :description
+seeding ever return a value a POSITION-bounded query would not?
+
+#238 and #245 (PR #258) made _preload_known_entities' MEMBERSHIP decision
+position-exact in both directions. The VALUES it seeds were left behind:
+entity_descriptions[ident] still comes from whichever :description version was
+live at :valid-at T_hi(W), a date query. T_hi(W) = max(ts[0..W]) is the
+monotone envelope of author dates at or below the watermark, and author dates
+are not monotonic in topological order, so a version written ABOVE the
+watermark carrying an EARLIER author date can be the version that query
+returns.
+
+This module measures how often that happens on real history. The #245 probe
+(probe_dep_preload_exposure.py) compared membership only and says nothing
+about it.
+
+TWO STAGES, and the first one may make the second moot:
+
+  Stage 1 -- CENSUS. How many idents carry more than one DISTINCT :description
+    value across all time? If none do, a date-bounded and a position-bounded
+    query return the same string for every ident and the mechanism cannot
+    fire, whatever the dates do. Counted per entity type, over distinct
+    VALUES and not distinct intervals: an entity deleted and re-added has two
+    intervals and one value, which is not exposure.
+
+  Stage 2 -- VALUE DIFF. Drive the real, shipped _preload_known_entities at
+    each structurally affected watermark and diff the entity_descriptions it
+    returns against a position-correct oracle. This answers #257 on its own
+    terms rather than resting on Stage 1's structural argument.
+
+Stage 2 is not redundant with Stage 1. Stage 1's zero implies Stage 2's zero
+only through an argument about how :description is written; Stage 2 checks the
+shipped query's actual output and needs no such argument.
+
+ONE MODE, unlike the #245 probe's date-only/--verify-fix pair. #257 is the
+residual in the SHIPPED code, so _preload_known_entities is always driven with
+its full post-#238/#245 argument set. There is no pre-fix leg to measure.
+
+WHAT THE PREDICTION WAS, fixed in the design spec before any data existed:
+census zero, mismatches zero. The spec records the argument for it (see its
+"The issue's stated mechanism does not match the code" section). A nonzero
+census is the falsifier and escalates to the per-position sweep Stage 2
+already implements.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+
+# The entity types _preload_known_entities loads, in its own order
+# (mcp_server.py:7429-7432). Mirrored rather than imported so these analysis
+# primitives stay importable without opening a graph, matching
+# probe_dep_preload_exposure's contract. If the two ever diverge, this probe
+# silently measures a different population than the function under test.
+ENTITY_TYPES = (
+    "module", "function", "class", "variable", "field", "external-dependency",
+)
+
+
+def census_distinct_values(facts: Sequence[Dict]) -> Dict[str, Dict]:
+    """Per entity type: how many idents carry more than one DISTINCT
+    :description value across all time.
+
+    Distinct VALUES, not distinct intervals. An entity that was deleted and
+    re-added carries two :description intervals and one value; counting
+    intervals would report essentially every long-lived entity as exposed and
+    drown the real signal.
+
+    Every type in ENTITY_TYPES appears in the output even with no facts. A
+    type missing from the report and a type with zero exposure are different
+    claims, and _collect's per-type `except Exception: pass`
+    (mcp_server.py:7491-7492) makes the difference load-bearing: a swallowed
+    query failure for one type must not read as a clean zero.
+
+    offending_idents carries the values verbatim, sorted, because a nonzero
+    census escalates this work to a full sweep and the escalation starts from
+    which idents fired, not from an integer.
+    """
+    by_type: Dict[str, Dict[str, set]] = {t: {} for t in ENTITY_TYPES}
+    for fact in facts:
+        entity_type = fact["entity_type"]
+        if entity_type not in by_type:
+            continue
+        by_type[entity_type].setdefault(fact["ident"], set()).add(fact["desc"])
+
+    report: Dict[str, Dict] = {}
+    for entity_type in ENTITY_TYPES:
+        idents = by_type[entity_type]
+        offenders = {
+            ident: sorted(values)
+            for ident, values in idents.items()
+            if len(values) > 1
+        }
+        report[entity_type] = {
+            "idents_total": len(idents),
+            "idents_with_multiple_values": len(offenders),
+            "offending_idents": offenders,
+        }
+    return report

--- a/evals/at_scale/probe_description_preload_exposure.py
+++ b/evals/at_scale/probe_description_preload_exposure.py
@@ -232,3 +232,67 @@ def count_unmappable_description_facts(
         and not invert_ms_to_positions(f["vt_ms"], ts_positions)
     )
     return unmappable_vf, unmappable_vt
+
+
+def load_description_facts(db) -> List[Dict]:
+    """Every :description fact on a preloaded entity type, current and
+    historical, with its validity window.
+
+    The raw material for BOTH stages. One query per entity type, matching
+    _preload_known_entities' own per-type loop, so the population measured is
+    the population that function actually loads.
+
+    CLAUSE ORDER IS LOAD-BEARING. [?e :description ?desc] must be the EAV
+    clause immediately preceding the :db/valid-from / :db/valid-to
+    pseudo-attributes, because those bind to whichever EAV clause on ?e most
+    recently precedes them. [?e :ident ?ident] therefore goes BEFORE
+    :description, never between: moving it would bind ?vf/?vt to the ident
+    fact's window instead -- and since :ident outlives every :description
+    version it supersedes, every closed description would read as still live
+    and the oracle would be wrong at every position. Silently. This is
+    load_module_path_facts' documented rule applied to :description, and
+    test_the_window_belongs_to_the_description_fact_not_the_ident_fact pins it
+    against a real backend.
+
+    Deduplicated on (entity_type, ident, desc, vf, vt). An entity carrying more
+    than one :entity-type or :ident version across time otherwise multiplies
+    each :description row under :any-valid-time without changing any answer --
+    the same reason load_dep_edges dedupes. Two DISTINCT windows on the same
+    (ident, desc) pair are legitimately kept: that is a delete-and-re-add, and
+    the census must see both intervals to report them as one value.
+
+    A per-type query failure raises rather than being swallowed. That is a
+    deliberate difference from _preload_known_entities' own `except Exception:
+    pass` (mcp_server.py:7491-7492): this function is a measurement device, and
+    a silently empty population here would read as a clean zero exposure.
+    """
+    import json
+
+    import mcp_server
+
+    seen = set()
+    facts: List[Dict] = []
+    for entity_type in ENTITY_TYPES:
+        raw = mcp_server._db_execute(
+            db,
+            "(query [:find ?ident ?desc ?vf ?vt "
+            ":any-valid-time "
+            f":where [?e :entity-type :type/{entity_type}] "
+            "[?e :ident ?ident] "
+            "[?e :description ?desc] "
+            "[?e :db/valid-from ?vf] "
+            "[?e :db/valid-to ?vt]])",
+        )
+        for ident, desc, vf, vt in json.loads(raw).get("results", []):
+            key = (entity_type, ident, desc, int(vf), int(vt))
+            if key in seen:
+                continue
+            seen.add(key)
+            facts.append({
+                "entity_type": entity_type,
+                "ident": ident,
+                "desc": desc,
+                "vf_ms": int(vf),
+                "vt_ms": int(vt),
+            })
+    return facts

--- a/evals/at_scale/probe_description_preload_exposure.py
+++ b/evals/at_scale/probe_description_preload_exposure.py
@@ -440,3 +440,189 @@ def sweep(
         "gitlink_events": gitlink_event_count(repo_path),
         "per_position": per_position,
     }
+
+
+def main() -> int:
+    import argparse
+    import asyncio
+    import json
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent.parent.resolve()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure #257's :description preload exposure against real history."
+        )
+    )
+    parser.add_argument("--repo-path", default=".")
+    parser.add_argument("--branch", default=None)
+    parser.add_argument("--json-out", "--output", dest="json_out", default=None)
+    parser.add_argument(
+        "--graph-path", default=None,
+        help=(
+            "Sweep an EXISTING graph instead of ingesting into a scratch one. "
+            "The graph's commit count must match the linearization length or "
+            "the run is refused -- a partial graph swept silently would "
+            "understate exposure. Exists because a ~30-minute ingest per "
+            "iteration is otherwise the entire cost of this measurement."
+        ),
+    )
+    args = parser.parse_args()
+
+    import frontier_registry
+    import mcp_server
+    from evals.at_scale.probe_dep_preload_exposure import _ingest_into
+
+    def _run_sweep(branch, ingest_status):
+        linearization = frontier_registry.build_linearization(
+            args.repo_path, branch
+        )
+        commit_metadata = mcp_server._git_commits(args.repo_path, None, branch)
+        # Single-handle invariant (CLAUDE.md): reuse the live handle when one
+        # exists. Opening a second on the same file raises as of minigraf
+        # 1.2.3, and used to corrupt the page table silently (#251/#253).
+        db = (
+            mcp_server._db if mcp_server._db is not None
+            else mcp_server.open_db(str(graph_path))
+        )
+        report = sweep(
+            db, args.repo_path, linearization, commit_metadata, branch=branch,
+        )
+        report["ingest_status"] = ingest_status
+        return report
+
+    if args.graph_path:
+        graph_path = Path(args.graph_path)
+        if not graph_path.exists():
+            print(f"No graph at {graph_path}. Refusing to sweep nothing.")
+            return 1
+        mcp_server._db = None
+        mcp_server._graph_path = None
+        mcp_server.open_db(str(graph_path))
+        branch = args.branch or mcp_server._default_git_branch(args.repo_path)
+        linearization = frontier_registry.build_linearization(
+            args.repo_path, branch
+        )
+        raw = mcp_server._db_execute(
+            mcp_server._db,
+            "(query [:find (count ?c) :where [?c :entity-type :type/commit]])",
+        )
+        rows = json.loads(raw).get("results", [])
+        ingested = int(rows[0][0]) if rows else 0
+        if ingested != len(linearization):
+            print(
+                f"Graph holds {ingested} commits but the linearization has "
+                f"{len(linearization)}. Refusing to sweep a partial graph -- "
+                "an incomplete ingestion understates exposure everywhere."
+            )
+            return 1
+        report = _run_sweep(branch, "pre-existing")
+    else:
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="minigraf-257-probe-") as tmpdir:
+            graph_path = Path(tmpdir) / "probe.graph"
+            branch, ingest_status = asyncio.run(
+                _ingest_into(args.repo_path, args.branch, graph_path)
+            )
+            # _run_ingestion never raises on failure -- it wraps its whole body
+            # in `except Exception`, sets status and returns normally. This
+            # status is the only signal that the graph underneath is whole.
+            if ingest_status != "complete":
+                error = mcp_server._ingest_progress.get("error")
+                print(
+                    f"Ingestion did not complete (status={ingest_status!r}"
+                    + (f", error={error!r}" if error else "")
+                    + "). Refusing to sweep a partial or failed graph."
+                )
+                return 1
+            report = _run_sweep(branch, ingest_status)
+
+    print(json.dumps(report, indent=2))
+    print()
+    print(f"repo:                              {report['repo_path']} @ {report['branch']}")
+    print(f"ingested head:                     {report['head_commit']}")
+    print(f"commits:                           {report['commits']}")
+    print(f":description facts (deduped):      {report['description_facts_total']}")
+    print(f"structurally affected W:           {len(report['affected_positions'])}")
+    print(f"W actually mismatching:            {len(report['misclassifying_positions'])}")
+    print()
+    print("STAGE 1 -- census (idents carrying >1 DISTINCT :description value)")
+    for entity_type in ENTITY_TYPES:
+        row = report["census"][entity_type]
+        print(
+            f"  {entity_type:<22} {row['idents_with_multiple_values']:>6} "
+            f"of {row['idents_total']}"
+        )
+    print(f"  TOTAL                  {report['census_idents_with_multiple_values']:>6}")
+    print()
+    print("STAGE 2 -- value diff against the position-correct oracle")
+    print(f"  mismatches, position-weighted:   {report['value_mismatch_total_position_weighted']}")
+    print(f"  mismatches, distinct idents:     {report['value_mismatch_distinct_idents']}")
+    print()
+    print("  (counted separately, NOT the finding:)")
+    print(f"  ambiguous idents:                {report['ambiguous_idents_total']}")
+    print(f"  preloaded but not live:          {report['preloaded_not_live_total']}")
+    print(f"  live but not preloaded:          {report['live_not_preloaded_total']}")
+    print()
+    print(f"preload empty at every W:          {report['preload_descriptions_empty_everywhere']}")
+    print(f"timestamp collisions:              {report['timestamp_collisions']}")
+    print(f"unmappable :description vf:        {report['unmappable_description_valid_from']}")
+    print(f"unmappable :description vt:        {report['unmappable_description_valid_to']}")
+    print(f"gitlink events:                    {report['gitlink_events']}")
+
+    # The exit code reflects measurement VALIDITY, not the finding. A nonzero
+    # mismatch count is the number #257 asks for and must never fail the run.
+    measurement_invalid = (
+        report["unmappable_description_valid_from"] > 0
+        or report["unmappable_description_valid_to"] > 0
+        or report["timestamp_collisions"] > 0
+    )
+    if measurement_invalid:
+        print()
+        print(
+            "INVALID MEASUREMENT. Either a :description fact carries a\n"
+            "valid-from/valid-to matching no commit -- so the timestamp-to-\n"
+            "position inversion the oracle rests on is broken -- or the history\n"
+            "has colliding timestamps. Collisions invalidate rather than widen:\n"
+            "the shipped _position_of_valid_time and this probe's edge_live_at\n"
+            "resolve a collision in OPPOSITE directions, so the comparison is\n"
+            "no longer meaningful. Do not adjust this gate to make a run pass."
+        )
+
+    if report["preload_descriptions_empty_everywhere"]:
+        print()
+        print(
+            "NOTE: _preload_known_entities returned zero descriptions at every\n"
+            "affected position. That may be a genuinely empty population, or it\n"
+            "may be _collect's per-type `except Exception: pass`\n"
+            "(mcp_server.py:7491-7492) swallowing a real query failure -- the\n"
+            "two are indistinguishable from the mismatch count alone. Check\n"
+            ":description facts above: nonzero there with zero here is the\n"
+            "signature of the latter."
+        )
+
+    if report["gitlink_events"] == 0:
+        print()
+        print(
+            "NOTE: zero gitlink events. Submodule external-dependency entities\n"
+            "are the ONE preloaded type whose :description is not a function of\n"
+            "its ident -- it is `name or path` read from .gitmodules, and the\n"
+            "name can change while the path, and so the ident, stays fixed. This\n"
+            "history produces none, so that arm is UNMEASURABLE here. That is\n"
+            "not the same as zero risk, and any close written for #257 has to\n"
+            "name it. #245 recorded :pinned-commit the same way."
+        )
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.json_out}")
+    return 1 if measurement_invalid else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/at_scale/probe_description_preload_exposure.py
+++ b/evals/at_scale/probe_description_preload_exposure.py
@@ -48,6 +48,12 @@ from __future__ import annotations
 
 from typing import Dict, List, Sequence
 
+from evals.at_scale.probe_dep_preload_exposure import (
+    VALID_TIME_FOREVER_MS,
+    edge_live_at,
+    invert_ms_to_positions,
+)
+
 # The entity types _preload_known_entities loads, in its own order
 # (mcp_server.py:7429-7432). Mirrored rather than imported so these analysis
 # primitives stay importable without opening a graph, matching
@@ -98,3 +104,40 @@ def census_distinct_values(facts: Sequence[Dict]) -> Dict[str, Dict]:
             "offending_idents": offenders,
         }
     return report
+
+
+def position_correct_descriptions(
+    facts: Sequence[Dict],
+    ts_positions: Dict[str, List[int]],
+    w: int,
+) -> Dict[str, set]:
+    """Ident -> the set of DISTINCT :description values genuinely live at
+    position w.
+
+    Position-correct at BOTH ends. Each fact's own :db/valid-from and
+    :db/valid-to are inverted to positions and tested with edge_live_at; no
+    date bound appears anywhere. That second end is what separates this from
+    the shipped query: a version superseded at a position ABOVE w by a commit
+    whose author date falls BELOW T_hi(w) reads as already dead to any date
+    bound, and the superseding version reads as already live. Both are wrong
+    at w, and their combination is exactly #257.
+
+    Returns a SET per ident, not a single value, and never picks a winner
+    among several. edge_live_at's asymmetric collision policy exists to avoid
+    UNDERSTATING a membership answer; applied to a value it would fabricate
+    one. diff_descriptions counts a multi-member set as ambiguous instead.
+
+    Like everything else here this is a measurement device and NOT a candidate
+    fix -- it needs the whole history in hand, which a resuming forward walk
+    does not have.
+    """
+    live: Dict[str, set] = {}
+    for fact in facts:
+        vf_positions = invert_ms_to_positions(fact["vf_ms"], ts_positions)
+        vt_positions = (
+            None if fact["vt_ms"] >= VALID_TIME_FOREVER_MS
+            else invert_ms_to_positions(fact["vt_ms"], ts_positions)
+        )
+        if edge_live_at(vf_positions, vt_positions, w):
+            live.setdefault(fact["ident"], set()).add(fact["desc"])
+    return live

--- a/evals/at_scale/probe_description_preload_exposure.py
+++ b/evals/at_scale/probe_description_preload_exposure.py
@@ -29,9 +29,23 @@ TWO STAGES, and the first one may make the second moot:
     returns against a position-correct oracle. This answers #257 on its own
     terms rather than resting on Stage 1's structural argument.
 
-Stage 2 is not redundant with Stage 1. Stage 1's zero implies Stage 2's zero
-only through an argument about how :description is written; Stage 2 checks the
-shipped query's actual output and needs no such argument.
+Stage 2 is not redundant with Stage 1, but it is NOT independent of it either.
+What Stage 2 adds is coverage: it drives the shipped query over the WHOLE
+preloaded population at every affected watermark and checks its actual output,
+rather than reasoning from how :description is written.
+
+What Stage 2 cannot do is find a mismatch outside Stage 1's census.
+diff_descriptions can only record a mismatch for an ident whose preloaded value
+is absent from the values live at that position, which requires the ident to
+carry at least two DISTINCT values across time -- i.e. to be a census offender.
+So value_mismatches is ALWAYS a subset of the census offenders. Worse, the
+ambiguity rule removes exactly that subset in the case where the mechanism is
+most likely to fire: when the two competing versions are contemporaneous at a
+position, the oracle's live set has two members, the ident is classified
+ambiguous, and no comparison happens at all. A zero from Stage 2 must therefore
+be read against per_position's compared_idents and offenders_present, which say
+whether any offender was ever actually compared. Zero mismatches out of zero
+informative comparisons is not a null result.
 
 ONE MODE, unlike the #245 probe's date-only/--verify-fix pair. #257 is the
 residual in the SHIPPED code, so _preload_known_entities is always driven with
@@ -176,10 +190,19 @@ def diff_descriptions(
     Ordering matters: ambiguity is tested BEFORE the value comparison, so an
     ambiguous ident contributes to neither the mismatch count nor the
     membership counters.
+
+    compared_idents counts the fourth quantity, and it is what makes a zero in
+    value_mismatches interpretable: how many idents actually REACHED the value
+    comparison -- neither ambiguous nor excluded by membership. Without it,
+    "zero mismatches" cannot be distinguished from "zero comparisons", and the
+    two mean opposite things. Only an ident that carries more than one distinct
+    value across time can ever be a mismatch, and that is exactly the ident the
+    ambiguity rule removes when its versions overlap at a position.
     """
     value_mismatches: Dict[str, Dict] = {}
     ambiguous: List[str] = []
     preloaded_not_live: List[str] = []
+    compared = 0
 
     for ident, preloaded_value in actual.items():
         live_values = oracle.get(ident)
@@ -189,6 +212,7 @@ def diff_descriptions(
         if len(live_values) > 1:
             ambiguous.append(ident)
             continue
+        compared += 1
         if preloaded_value not in live_values:
             value_mismatches[ident] = {
                 "preloaded": preloaded_value,
@@ -199,6 +223,7 @@ def diff_descriptions(
 
     return {
         "value_mismatches": value_mismatches,
+        "compared_idents": compared,
         "ambiguous_idents": sorted(ambiguous),
         "preloaded_not_live": sorted(preloaded_not_live),
         "live_not_preloaded": sorted(live_not_preloaded),
@@ -326,17 +351,25 @@ def sweep(
 
     STAGE 1 MAY MAKE STAGE 2 MOOT, but Stage 2 runs regardless. A zero census
     implies zero mismatches only through an argument about how :description is
-    written; Stage 2 checks the shipped query's actual output and rests on no
-    such argument. Two independent lines of evidence for the price of one
-    ingest.
+    written; Stage 2 verifies the shipped query's actual output over the whole
+    preloaded population at every affected watermark and rests on no such
+    argument.
+
+    The two stages are NOT independent, though, and this sweep's output must
+    not be read as if they were. A mismatch is only recordable for an ident
+    carrying more than one distinct value, so Stage 2's finding is a strict
+    SUBSET of Stage 1's offenders -- and diff_descriptions skips exactly that
+    subset as ambiguous whenever the competing versions are contemporaneous at
+    a position. per_position therefore records compared_idents (how many idents
+    reached the value comparison) and offenders_present (which census offenders
+    were in the preload at all), so a reader can tell a genuine zero from zero
+    informative comparisons without re-deriving it from the raw lists.
 
     provenance: repo_path alone was not enough to reproduce the first #245
     artifact -- it named a scratch directory that no longer existed, with no
     branch and no head SHA. branch and head_commit are recorded here so a
     future run carries its own.
     """
-    import subprocess
-
     import mcp_server
 
     if len(commit_metadata) != len(linearization):
@@ -364,11 +397,23 @@ def sweep(
     unmappable_vf, unmappable_vt = count_unmappable_description_facts(
         facts, ts_positions
     )
+    # The ONLY idents that can ever produce a value mismatch: a mismatch needs
+    # the preloaded value to be absent from the live set, which needs at least
+    # two distinct values on the ident. Tracked per position (offenders_present)
+    # so the artifact says whether the mechanism even had a candidate there,
+    # instead of leaving that to be re-derived from the census by hand.
+    census_offenders = {
+        ident
+        for entity_type in ENTITY_TYPES
+        for ident in census[entity_type]["offending_idents"]
+    }
 
     positions = affected_positions(commit_metadata)
     per_position = []
     mismatch_distinct: set = set()
     mismatch_weighted = 0
+    compared_total = 0
+    offender_comparisons = 0
     ambiguous_total = 0
     preloaded_not_live_total = 0
     live_not_preloaded_total = 0
@@ -389,7 +434,20 @@ def sweep(
         oracle = position_correct_descriptions(facts, ts_positions, w)
         result = diff_descriptions(entity_descriptions, oracle)
 
+        offenders_present = census_offenders & set(entity_descriptions)
+        # An offender that was preloaded still may not have been COMPARED: it
+        # is dropped if the oracle called it ambiguous, or if it was preloaded
+        # while nothing was live for it. Subtracting both is what turns
+        # "0 mismatches" into a claim with a denominator.
+        offenders_compared = (
+            offenders_present
+            - set(result["ambiguous_idents"])
+            - set(result["preloaded_not_live"])
+        )
+
         preload_sizes.append(len(entity_descriptions))
+        compared_total += result["compared_idents"]
+        offender_comparisons += len(offenders_compared)
         mismatch_weighted += len(result["value_mismatches"])
         mismatch_distinct.update(result["value_mismatches"])
         ambiguous_total += len(result["ambiguous_idents"])
@@ -402,20 +460,24 @@ def sweep(
             "preloaded_idents": len(entity_descriptions),
             "oracle_idents": len(oracle),
             "value_mismatches": result["value_mismatches"],
+            "compared_idents": result["compared_idents"],
+            "offenders_present": sorted(offenders_present),
+            "offenders_compared": sorted(offenders_compared),
             "ambiguous_idents": result["ambiguous_idents"],
             "preloaded_not_live": len(result["preloaded_not_live"]),
             "live_not_preloaded": len(result["live_not_preloaded"]),
         })
 
-    head_commit = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=repo_path, capture_output=True, text=True, check=True,
-    ).stdout.strip()
-
     return {
         "repo_path": repo_path,
         "branch": branch,
-        "head_commit": head_commit,
+        # The ingested head, taken from the linearization rather than from a
+        # fresh `git rev-parse HEAD`: it is the commit this sweep's graph
+        # actually ends at. A rev-parse would name whatever the working tree
+        # is checked out to -- on a probe branch, a commit that is not on the
+        # swept branch at all -- and the artifact would claim provenance it
+        # does not have. probe_dep_preload_exposure.py:829-832 does the same.
+        "head_commit": linearization[-1] if linearization else None,
         "commits": len(commit_metadata),
         "affected_positions": positions,
         "misclassifying_positions": [
@@ -428,6 +490,14 @@ def sweep(
         ),
         "value_mismatch_total_position_weighted": mismatch_weighted,
         "value_mismatch_distinct_idents": len(mismatch_distinct),
+        # The denominators for the two numbers above. compared_idents_total is
+        # how many (position, ident) pairs reached the value comparison at all;
+        # offender_value_comparisons is how many of those were on a census
+        # offender -- the only idents a mismatch is possible for. A zero
+        # mismatch count with offender_value_comparisons == 0 means the
+        # mechanism was never given a chance to show, not that it did not fire.
+        "compared_idents_total": compared_total,
+        "offender_value_comparisons": offender_comparisons,
         "ambiguous_idents_total": ambiguous_total,
         "preloaded_not_live_total": preloaded_not_live_total,
         "live_not_preloaded_total": live_not_preloaded_total,
@@ -564,6 +634,11 @@ def main() -> int:
     print(f"  mismatches, position-weighted:   {report['value_mismatch_total_position_weighted']}")
     print(f"  mismatches, distinct idents:     {report['value_mismatch_distinct_idents']}")
     print()
+    print("  (the denominators -- a zero above is only a null result if these")
+    print("   are nonzero; only a census offender can ever mismatch:)")
+    print(f"  value comparisons made:          {report['compared_idents_total']}")
+    print(f"  of those, on a census offender:  {report['offender_value_comparisons']}")
+    print()
     print("  (counted separately, NOT the finding:)")
     print(f"  ambiguous idents:                {report['ambiguous_idents_total']}")
     print(f"  preloaded but not live:          {report['preloaded_not_live_total']}")
@@ -604,6 +679,21 @@ def main() -> int:
             "two are indistinguishable from the mismatch count alone. Check\n"
             ":description facts above: nonzero there with zero here is the\n"
             "signature of the latter."
+        )
+
+    if (
+        report["census_idents_with_multiple_values"] > 0
+        and report["offender_value_comparisons"] == 0
+    ):
+        print()
+        print(
+            "NOTE: the census found offenders but NOT ONE of them ever reached\n"
+            "the value comparison -- at every affected position each was either\n"
+            "ambiguous (both values live at once) or not preloaded. Since only a\n"
+            "census offender can produce a mismatch, Stage 2's mismatch count is\n"
+            "zero out of zero informative comparisons here. It neither confirms\n"
+            "nor refutes #257's mechanism on this history; do not write it up as\n"
+            "agreement. See per_position's offenders_present/offenders_compared."
         )
 
     if report["gitlink_events"] == 0:

--- a/evals/at_scale/results/257-description-preload-exposure.json
+++ b/evals/at_scale/results/257-description-preload-exposure.json
@@ -1,7 +1,7 @@
 {
   "repo_path": ".",
   "branch": "master",
-  "head_commit": "8310f7d01a5736c3170653117b6bc0f38439f877",
+  "head_commit": "1dceec17f7fb41b3d5d2b3f35edb54048d2f3ebf",
   "commits": 656,
   "affected_positions": [
     118,
@@ -71,6 +71,8 @@
   "census_idents_with_multiple_values": 3,
   "value_mismatch_total_position_weighted": 0,
   "value_mismatch_distinct_idents": 0,
+  "compared_idents_total": 12685,
+  "offender_value_comparisons": 0,
   "ambiguous_idents_total": 15,
   "preloaded_not_live_total": 0,
   "live_not_preloaded_total": 677,
@@ -86,6 +88,9 @@
       "preloaded_idents": 147,
       "oracle_idents": 174,
       "value_mismatches": {},
+      "compared_idents": 147,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -96,6 +101,9 @@
       "preloaded_idents": 147,
       "oracle_idents": 174,
       "value_mismatches": {},
+      "compared_idents": 147,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -106,6 +114,9 @@
       "preloaded_idents": 147,
       "oracle_idents": 174,
       "value_mismatches": {},
+      "compared_idents": 147,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -116,6 +127,9 @@
       "preloaded_idents": 147,
       "oracle_idents": 174,
       "value_mismatches": {},
+      "compared_idents": 147,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -126,6 +140,9 @@
       "preloaded_idents": 147,
       "oracle_idents": 174,
       "value_mismatches": {},
+      "compared_idents": 147,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -136,6 +153,9 @@
       "preloaded_idents": 147,
       "oracle_idents": 174,
       "value_mismatches": {},
+      "compared_idents": 147,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -146,6 +166,9 @@
       "preloaded_idents": 72,
       "oracle_idents": 99,
       "value_mismatches": {},
+      "compared_idents": 72,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -156,6 +179,9 @@
       "preloaded_idents": 72,
       "oracle_idents": 99,
       "value_mismatches": {},
+      "compared_idents": 72,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -166,6 +192,9 @@
       "preloaded_idents": 72,
       "oracle_idents": 99,
       "value_mismatches": {},
+      "compared_idents": 72,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -176,6 +205,9 @@
       "preloaded_idents": 72,
       "oracle_idents": 99,
       "value_mismatches": {},
+      "compared_idents": 72,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -186,6 +218,9 @@
       "preloaded_idents": 72,
       "oracle_idents": 99,
       "value_mismatches": {},
+      "compared_idents": 72,
+      "offenders_present": [],
+      "offenders_compared": [],
       "ambiguous_idents": [],
       "preloaded_not_live": 0,
       "live_not_preloaded": 27
@@ -196,6 +231,13 @@
       "preloaded_idents": 2285,
       "oracle_idents": 2361,
       "value_mismatches": {},
+      "compared_idents": 2282,
+      "offenders_present": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "offenders_compared": [],
       "ambiguous_idents": [
         ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
         ":function/tests-test-mcp-server-py-commit",
@@ -210,6 +252,13 @@
       "preloaded_idents": 2285,
       "oracle_idents": 2361,
       "value_mismatches": {},
+      "compared_idents": 2282,
+      "offenders_present": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "offenders_compared": [],
       "ambiguous_idents": [
         ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
         ":function/tests-test-mcp-server-py-commit",
@@ -224,6 +273,13 @@
       "preloaded_idents": 2285,
       "oracle_idents": 2361,
       "value_mismatches": {},
+      "compared_idents": 2282,
+      "offenders_present": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "offenders_compared": [],
       "ambiguous_idents": [
         ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
         ":function/tests-test-mcp-server-py-commit",
@@ -238,6 +294,13 @@
       "preloaded_idents": 2300,
       "oracle_idents": 2376,
       "value_mismatches": {},
+      "compared_idents": 2297,
+      "offenders_present": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "offenders_compared": [],
       "ambiguous_idents": [
         ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
         ":function/tests-test-mcp-server-py-commit",
@@ -252,6 +315,13 @@
       "preloaded_idents": 2303,
       "oracle_idents": 2379,
       "value_mismatches": {},
+      "compared_idents": 2300,
+      "offenders_present": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "offenders_compared": [],
       "ambiguous_idents": [
         ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
         ":function/tests-test-mcp-server-py-commit",

--- a/evals/at_scale/results/257-description-preload-exposure.json
+++ b/evals/at_scale/results/257-description-preload-exposure.json
@@ -1,0 +1,265 @@
+{
+  "repo_path": ".",
+  "branch": "master",
+  "head_commit": "8310f7d01a5736c3170653117b6bc0f38439f877",
+  "commits": 656,
+  "affected_positions": [
+    118,
+    119,
+    120,
+    121,
+    122,
+    123,
+    124,
+    125,
+    126,
+    127,
+    128,
+    645,
+    646,
+    647,
+    648,
+    649
+  ],
+  "misclassifying_positions": [],
+  "description_facts_total": 2737,
+  "census": {
+    "module": {
+      "idents_total": 55,
+      "idents_with_multiple_values": 0,
+      "offending_idents": {}
+    },
+    "function": {
+      "idents_total": 2030,
+      "idents_with_multiple_values": 3,
+      "offending_idents": {
+        ":function/tests-test-mcp-server-py-commit": [
+          "_commit",
+          "commit"
+        ],
+        ":function/tests-test-mcp-server-py-snapshot": [
+          "_snapshot",
+          "snapshot"
+        ],
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main": [
+          "_main",
+          "main"
+        ]
+      }
+    },
+    "class": {
+      "idents_total": 284,
+      "idents_with_multiple_values": 0,
+      "offending_idents": {}
+    },
+    "variable": {
+      "idents_total": 227,
+      "idents_with_multiple_values": 0,
+      "offending_idents": {}
+    },
+    "field": {
+      "idents_total": 62,
+      "idents_with_multiple_values": 0,
+      "offending_idents": {}
+    },
+    "external-dependency": {
+      "idents_total": 76,
+      "idents_with_multiple_values": 0,
+      "offending_idents": {}
+    }
+  },
+  "census_idents_with_multiple_values": 3,
+  "value_mismatch_total_position_weighted": 0,
+  "value_mismatch_distinct_idents": 0,
+  "ambiguous_idents_total": 15,
+  "preloaded_not_live_total": 0,
+  "live_not_preloaded_total": 677,
+  "unmappable_description_valid_from": 0,
+  "unmappable_description_valid_to": 0,
+  "timestamp_collisions": 0,
+  "preload_descriptions_empty_everywhere": false,
+  "gitlink_events": 0,
+  "per_position": [
+    {
+      "position": 118,
+      "envelope": "2026-04-26T12:57:34Z",
+      "preloaded_idents": 147,
+      "oracle_idents": 174,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 119,
+      "envelope": "2026-04-26T12:58:03Z",
+      "preloaded_idents": 147,
+      "oracle_idents": 174,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 120,
+      "envelope": "2026-04-26T13:00:10Z",
+      "preloaded_idents": 147,
+      "oracle_idents": 174,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 121,
+      "envelope": "2026-05-02T13:12:41Z",
+      "preloaded_idents": 147,
+      "oracle_idents": 174,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 122,
+      "envelope": "2026-05-02T13:13:10Z",
+      "preloaded_idents": 147,
+      "oracle_idents": 174,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 123,
+      "envelope": "2026-05-02T13:13:20Z",
+      "preloaded_idents": 147,
+      "oracle_idents": 174,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 124,
+      "envelope": "2026-05-02T13:13:20Z",
+      "preloaded_idents": 72,
+      "oracle_idents": 99,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 125,
+      "envelope": "2026-05-02T13:13:20Z",
+      "preloaded_idents": 72,
+      "oracle_idents": 99,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 126,
+      "envelope": "2026-05-02T13:13:20Z",
+      "preloaded_idents": 72,
+      "oracle_idents": 99,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 127,
+      "envelope": "2026-05-02T13:13:20Z",
+      "preloaded_idents": 72,
+      "oracle_idents": 99,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 128,
+      "envelope": "2026-05-02T13:13:20Z",
+      "preloaded_idents": 72,
+      "oracle_idents": 99,
+      "value_mismatches": {},
+      "ambiguous_idents": [],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 27
+    },
+    {
+      "position": 645,
+      "envelope": "2026-08-11T04:04:35Z",
+      "preloaded_idents": 2285,
+      "oracle_idents": 2361,
+      "value_mismatches": {},
+      "ambiguous_idents": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 76
+    },
+    {
+      "position": 646,
+      "envelope": "2026-08-11T04:04:35Z",
+      "preloaded_idents": 2285,
+      "oracle_idents": 2361,
+      "value_mismatches": {},
+      "ambiguous_idents": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 76
+    },
+    {
+      "position": 647,
+      "envelope": "2026-08-11T04:04:35Z",
+      "preloaded_idents": 2285,
+      "oracle_idents": 2361,
+      "value_mismatches": {},
+      "ambiguous_idents": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 76
+    },
+    {
+      "position": 648,
+      "envelope": "2026-08-11T04:04:35Z",
+      "preloaded_idents": 2300,
+      "oracle_idents": 2376,
+      "value_mismatches": {},
+      "ambiguous_idents": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 76
+    },
+    {
+      "position": 649,
+      "envelope": "2026-08-11T04:04:35Z",
+      "preloaded_idents": 2303,
+      "oracle_idents": 2379,
+      "value_mismatches": {},
+      "ambiguous_idents": [
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main",
+        ":function/tests-test-mcp-server-py-commit",
+        ":function/tests-test-mcp-server-py-snapshot"
+      ],
+      "preloaded_not_live": 0,
+      "live_not_preloaded": 76
+    }
+  ],
+  "ingest_status": "complete"
+}

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7355,11 +7355,26 @@ def _preload_known_entities(
 
     What survives is VALUES. entity_descriptions still carries whichever
     :description version was live at DATE T_hi(W), which can be a version
-    written above W with an inverted author date. The forward walk uses this
-    dict for body-change detection, so a from-the-future description makes a
-    real change compare equal and go unrecorded. Membership is position-exact;
-    values are not. UNMEASURED -- the #245 exposure probe measured membership
-    only -- and tracked as #257.
+    written above W with an inverted author date. Membership is position-exact;
+    values are not. That is #257.
+
+    What the consequence is NOT: body-change detection. An earlier version of
+    this paragraph claimed the forward walk diffs descriptions to decide
+    whether a body changed, so a from-the-future value would make a real change
+    compare equal and go unrecorded. That is false. Body-change detection is
+    unchanged_idents, computed in _precompute_file_triples from the parsed node
+    text (#221) and consumed by _build_code_triples; entity_descriptions is
+    only ever WRITTEN there. Every READ of it in _forward_apply feeds
+    _build_close_triples' `desc` argument.
+
+    What the consequence IS: `desc` is the value _build_close_triples retracts
+    when an entity closes. A wrong value there retracts a :description fact
+    that was never asserted, so the one that IS live never gets closed and
+    stays live past its window -- a stale-fact bug, not a lost body edit.
+    MEASURED on this repository's history and recorded in
+    evals/at_scale/results/257-description-preload-exposure.json (the #245
+    probe measured membership only); read that artifact's limitations before
+    treating its mismatch count as a bound.
 
     _preload_known_deps and _preload_pinned_commits are position-filtered the
     same way (#245). This function's close side is what made their exposure

--- a/tests/test_at_scale_description_preload_probe.py
+++ b/tests/test_at_scale_description_preload_probe.py
@@ -17,6 +17,7 @@ proves nothing about #257.
 from evals.at_scale.probe_description_preload_exposure import (
     ENTITY_TYPES,
     census_distinct_values,
+    diff_descriptions,
     position_correct_descriptions,
 )
 from evals.at_scale.probe_dep_preload_exposure import (
@@ -138,3 +139,45 @@ class TestPositionCorrectDescriptions:
              "vf_ms": 1, "vt_ms": VALID_TIME_FOREVER_MS},
         ]
         assert position_correct_descriptions(facts, build_ts_positions(META), 2) == {}
+
+
+class TestDiffDescriptions:
+    def test_a_preloaded_value_absent_from_the_live_set_is_a_mismatch(self):
+        """The finding itself. Both the preloaded value and the live set are
+        recorded, because a bare count would not say which direction the
+        preload erred in.
+        """
+        result = diff_descriptions({":module/a": "new"}, {":module/a": {"old"}})
+        assert result["value_mismatches"] == {
+            ":module/a": {"preloaded": "new", "live": ["old"]}
+        }
+        assert result["ambiguous_idents"] == []
+
+    def test_a_matching_value_is_not_a_mismatch(self):
+        result = diff_descriptions({":module/a": "old"}, {":module/a": {"old"}})
+        assert result["value_mismatches"] == {}
+
+    def test_an_ambiguous_live_set_is_counted_and_never_compared(self):
+        """When the oracle cannot name a single correct value there is nothing
+        to be wrong against. Letting such an ident fall through to the
+        membership test would score it as a match whenever the preloaded value
+        happened to be one of several -- inventing agreement out of ambiguity.
+        """
+        result = diff_descriptions(
+            {":module/a": "x"}, {":module/a": {"x", "y"}}
+        )
+        assert result["ambiguous_idents"] == [":module/a"]
+        assert result["value_mismatches"] == {}
+
+    def test_membership_disagreements_are_diagnostics_not_findings(self):
+        """#238 and #245 measured and fixed membership. Folding a membership
+        disagreement into #257's number would re-measure a closed issue and
+        inflate this one.
+        """
+        result = diff_descriptions(
+            {":module/only-preloaded": "p"}, {":module/only-live": {"l"}}
+        )
+        assert result["preloaded_not_live"] == [":module/only-preloaded"]
+        assert result["live_not_preloaded"] == [":module/only-live"]
+        assert result["value_mismatches"] == {}
+        assert result["ambiguous_idents"] == []

--- a/tests/test_at_scale_description_preload_probe.py
+++ b/tests/test_at_scale_description_preload_probe.py
@@ -17,6 +17,11 @@ proves nothing about #257.
 from evals.at_scale.probe_description_preload_exposure import (
     ENTITY_TYPES,
     census_distinct_values,
+    position_correct_descriptions,
+)
+from evals.at_scale.probe_dep_preload_exposure import (
+    VALID_TIME_FOREVER_MS,
+    build_ts_positions,
 )
 
 
@@ -63,3 +68,73 @@ class TestCensusDistinctValues:
         report = census_distinct_values([])
         assert set(report) == set(ENTITY_TYPES)
         assert all(report[t]["idents_total"] == 0 for t in ENTITY_TYPES)
+
+
+# Position 2 is INVERTED: it sits above position 1 but carries an earlier
+# author date (Jan 2 against Jan 5). That inversion is the whole of #257, and
+# it is the same fixture shape tests/test_at_scale_dep_preload_probe.py uses.
+#
+#   pos 0: 2026-01-01   T_hi(0) = 2026-01-01
+#   pos 1: 2026-01-05   T_hi(1) = 2026-01-05
+#   pos 2: 2026-01-02   T_hi(2) = 2026-01-05
+META = [
+    ("h0", "2026-01-01T00:00:00Z", "a@b.com", "s0"),
+    ("h1", "2026-01-05T00:00:00Z", "a@b.com", "s1"),
+    ("h2", "2026-01-02T00:00:00Z", "a@b.com", "s2"),
+]
+
+MS_JAN_01 = 1767225600000  # 2026-01-01T00:00:00Z
+MS_JAN_02 = 1767312000000  # 2026-01-02T00:00:00Z
+MS_JAN_05 = 1767571200000  # 2026-01-05T00:00:00Z
+
+
+class TestPositionCorrectDescriptions:
+    def test_a_version_written_above_w_with_an_earlier_date_is_not_live(self):
+        """THE #257 SHAPE, and the ablation that proves this test.
+
+        Entity :module/a carries "old" from position 0, superseded at position
+        2 by "new". Position 2 is above the watermark W=1 but dated Jan 2,
+        earlier than T_hi(1) = Jan 5.
+
+        A DATE-bounded query at T_hi(1) = Jan 5 answers {"new"}: "old" closed
+        at Jan 2 <= Jan 5 so it reads as already dead, and "new" opened at
+        Jan 2 <= Jan 5 so it reads as already live. Both readings are wrong at
+        position 1.
+
+        The position-correct answer is {"old"}. The two differ, which is what
+        makes this test evidence about #257 rather than a tautology.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "old",
+             "vf_ms": MS_JAN_01, "vt_ms": MS_JAN_02},
+            {"entity_type": "module", "ident": ":module/a", "desc": "new",
+             "vf_ms": MS_JAN_02, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        live = position_correct_descriptions(facts, build_ts_positions(META), 1)
+        assert live == {":module/a": {"old"}}
+
+    def test_the_same_facts_at_the_higher_position_select_the_new_value(self):
+        """At W=2 the superseding version IS live. Without this the previous
+        test would also pass against an oracle that simply never advances.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "old",
+             "vf_ms": MS_JAN_01, "vt_ms": MS_JAN_02},
+            {"entity_type": "module", "ident": ":module/a", "desc": "new",
+             "vf_ms": MS_JAN_02, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        live = position_correct_descriptions(facts, build_ts_positions(META), 2)
+        assert live == {":module/a": {"new"}}
+
+    def test_an_unmappable_introduction_is_never_live(self):
+        """edge_live_at treats an empty vf_positions as not live. Asserted here
+        so the oracle's behaviour on a broken inversion is pinned rather than
+        inherited silently -- the count of these is a validity gate, and a
+        fact that is both uncounted and silently live would corrupt the
+        finding.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/ghost", "desc": "g",
+             "vf_ms": 1, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        assert position_correct_descriptions(facts, build_ts_positions(META), 2) == {}

--- a/tests/test_at_scale_description_preload_probe.py
+++ b/tests/test_at_scale_description_preload_probe.py
@@ -19,6 +19,7 @@ from evals.at_scale.probe_description_preload_exposure import (
     census_distinct_values,
     count_unmappable_description_facts,
     diff_descriptions,
+    load_description_facts,
     position_correct_descriptions,
 )
 from evals.at_scale.probe_dep_preload_exposure import (
@@ -224,3 +225,103 @@ class TestCountUnmappableDescriptionFacts:
         assert count_unmappable_description_facts(
             facts, build_ts_positions(META)
         ) == (0, 0)
+
+
+import pytest
+
+
+@pytest.fixture
+def real_db(monkeypatch, tmp_path):
+    """A real in-memory MiniGrafDb, per docs/testing-conventions.md Pattern 1.
+
+    Not a MagicMock: a fake never parses the Datalog string, and the clause
+    ordering this task exists to pin is only observable when minigraf actually
+    parses and executes the query.
+    """
+    from minigraf import MiniGrafDb
+
+    real_open_in_memory = MiniGrafDb.open_in_memory
+    monkeypatch.setattr(
+        MiniGrafDb, "open", staticmethod(lambda path: real_open_in_memory())
+    )
+    import mcp_server
+
+    mcp_server.open_db(str(tmp_path / "t.graph"))
+    yield mcp_server.get_db()
+
+
+class TestLoadDescriptionFacts:
+    def test_an_open_description_carries_the_forever_sentinel(self, real_db):
+        import mcp_server
+
+        mcp_server._transact(
+            real_db,
+            '[[:module/a :entity-type :type/module] '
+            '[:module/a :ident ":module/a"] '
+            '[:module/a :description "a.py"]]',
+            "2026-01-01T00:00:00Z",
+        )
+        facts = load_description_facts(real_db)
+        assert len(facts) == 1
+        assert facts[0]["entity_type"] == "module"
+        assert facts[0]["ident"] == ":module/a"
+        assert facts[0]["desc"] == "a.py"
+        assert facts[0]["vt_ms"] >= VALID_TIME_FOREVER_MS
+
+    def test_the_window_belongs_to_the_description_fact_not_the_ident_fact(
+        self, real_db
+    ):
+        """THE CLAUSE-ORDER ABLATION.
+
+        :db/valid-from and :db/valid-to bind to whichever EAV clause on ?e most
+        recently precedes them. Here :description is closed while :ident stays
+        open. The correct query returns the CLOSED window; a query with
+        [?e :ident ?ident] moved between :description and the pseudo-attributes
+        returns the ident fact's OPEN window instead -- the forever sentinel --
+        and every superseded description would silently read as still live,
+        making the oracle's live set wrong at every position.
+        """
+        import mcp_server
+
+        mcp_server._transact(
+            real_db,
+            '[[:module/a :entity-type :type/module] '
+            '[:module/a :ident ":module/a"] '
+            '[:module/a :description "a.py"]]',
+            "2026-01-01T00:00:00Z",
+        )
+        mcp_server._ingest_close(
+            real_db,
+            ['[:module/a :description "a.py"]'],
+            "2026-01-01T00:00:00Z",
+            "2026-01-02T00:00:00Z",
+            "test close",
+        )
+        facts = load_description_facts(real_db)
+        closed = [f for f in facts if f["vt_ms"] < VALID_TIME_FOREVER_MS]
+        assert closed, (
+            "no closed :description window found -- the query is binding "
+            "?vt to the still-open :ident fact, which is the clause-order bug"
+        )
+        assert closed[0]["vt_ms"] == mcp_server._iso_to_epoch_ms(
+            "2026-01-02T00:00:00Z"
+        )
+
+    def test_rows_are_deduplicated(self, real_db):
+        """An entity carrying several :entity-type or :ident versions across
+        time multiplies each :description row under :any-valid-time without
+        changing any answer. load_dep_edges dedupes for the same reason.
+        """
+        import mcp_server
+
+        mcp_server._transact(
+            real_db,
+            '[[:module/a :entity-type :type/module] '
+            '[:module/a :ident ":module/a"] '
+            '[:module/a :description "a.py"]]',
+            "2026-01-01T00:00:00Z",
+        )
+        facts = load_description_facts(real_db)
+        keys = {(f["entity_type"], f["ident"], f["desc"], f["vf_ms"], f["vt_ms"])
+                for f in facts}
+        assert len(keys) == len(facts)

--- a/tests/test_at_scale_description_preload_probe.py
+++ b/tests/test_at_scale_description_preload_probe.py
@@ -17,6 +17,7 @@ proves nothing about #257.
 from evals.at_scale.probe_description_preload_exposure import (
     ENTITY_TYPES,
     census_distinct_values,
+    count_unmappable_description_facts,
     diff_descriptions,
     position_correct_descriptions,
 )
@@ -187,3 +188,39 @@ class TestDiffDescriptions:
         assert result["live_not_preloaded"] == [":module/only-live"]
         assert result["value_mismatches"] == {}
         assert result["ambiguous_idents"] == []
+
+
+class TestCountUnmappableDescriptionFacts:
+    def test_an_unmappable_valid_from_is_counted(self):
+        """An unmappable introduction silently drops the fact from the oracle
+        at every W, understating the finding. It has to fail the run rather
+        than shrink it.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "a",
+             "vf_ms": 1, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        assert count_unmappable_description_facts(
+            facts, build_ts_positions(META)
+        ) == (1, 0)
+
+    def test_an_unmappable_non_sentinel_valid_to_is_counted(self):
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "a",
+             "vf_ms": MS_JAN_01, "vt_ms": 7},
+        ]
+        assert count_unmappable_description_facts(
+            facts, build_ts_positions(META)
+        ) == (0, 1)
+
+    def test_the_forever_sentinel_is_not_an_unmappable_close(self):
+        """The sentinel is an open fact, not a broken inversion. Counting it
+        would fail every run on every graph, since most facts are open.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "a",
+             "vf_ms": MS_JAN_01, "vt_ms": VALID_TIME_FOREVER_MS},
+        ]
+        assert count_unmappable_description_facts(
+            facts, build_ts_positions(META)
+        ) == (0, 0)

--- a/tests/test_at_scale_description_preload_probe.py
+++ b/tests/test_at_scale_description_preload_probe.py
@@ -308,9 +308,25 @@ class TestLoadDescriptionFacts:
         )
 
     def test_rows_are_deduplicated(self, real_db):
-        """An entity carrying several :entity-type or :ident versions across
-        time multiplies each :description row under :any-valid-time without
-        changing any answer. load_dep_edges dedupes for the same reason.
+        """An entity carrying several :ident versions across time multiplies
+        each :description row under :any-valid-time without changing any
+        answer. load_dep_edges dedupes for the same reason.
+
+        Constructed to actually produce the duplication, not just assert its
+        absence: :module/a's :ident fact is closed and re-opened with the SAME
+        value (":module/a" both times), giving it two distinct time-versions
+        while :entity-type and :description each keep exactly one. Because ?vf
+        and ?vt bind to :description's own window regardless of how many
+        :ident versions exist, both :ident versions join against the same
+        :description row and produce two IDENTICAL
+        (entity_type, ident, desc, vf, vt) tuples from the raw query -- this
+        was confirmed empirically against this real backend before writing
+        the assertion below, not assumed. A dedup-count assertion is used
+        instead of a pairwise-distinctness assertion (`len(keys) ==
+        len(facts)`) because pairwise distinctness holds trivially whenever
+        only one record is ever produced in the first place; asserting the
+        exact count of 1 is what actually fails if the `seen`/`continue` dedup
+        logic in load_description_facts is deleted.
         """
         import mcp_server
 
@@ -321,7 +337,23 @@ class TestLoadDescriptionFacts:
             '[:module/a :description "a.py"]]',
             "2026-01-01T00:00:00Z",
         )
+        mcp_server._ingest_close(
+            real_db,
+            ['[:module/a :ident ":module/a"]'],
+            "2026-01-01T00:00:00Z",
+            "2026-01-02T00:00:00Z",
+            "test close ident v1",
+        )
+        mcp_server._transact(
+            real_db,
+            '[[:module/a :ident ":module/a"]]',
+            "2026-01-02T00:00:00Z",
+        )
         facts = load_description_facts(real_db)
+        assert len(facts) == 1, (
+            "expected the two :ident versions' duplicate rows to collapse to "
+            "one record; got %d -- dedup did not fire" % len(facts)
+        )
         keys = {(f["entity_type"], f["ident"], f["desc"], f["vf_ms"], f["vt_ms"])
                 for f in facts}
         assert len(keys) == len(facts)

--- a/tests/test_at_scale_description_preload_probe.py
+++ b/tests/test_at_scale_description_preload_probe.py
@@ -1,0 +1,65 @@
+# tests/test_at_scale_description_preload_probe.py
+"""Unit tests for the #257 :description exposure probe's analysis primitives.
+
+The probe's headline numbers cannot be asserted -- they are what the probe
+exists to discover. What CAN be asserted are the components that could
+silently produce a WRONG number: the census's distinct-VALUE (not
+distinct-interval) counting, the position-correct oracle, the diff's
+separation of value exposure from membership disagreement, and the
+unmappable-fact diagnostics.
+
+Every test that pins a position-versus-date distinction is ablation-proven:
+its docstring names the date-bounded answer, and that answer differs from the
+asserted one. A test whose date-bounded and position-bounded answers agree
+proves nothing about #257.
+"""
+
+from evals.at_scale.probe_description_preload_exposure import (
+    ENTITY_TYPES,
+    census_distinct_values,
+)
+
+
+class TestCensusDistinctValues:
+    def test_two_intervals_carrying_one_value_are_not_exposure(self):
+        """An entity deleted and re-added has two :description intervals and
+        one value. That is the modal case on any real history and must not be
+        counted -- counting intervals instead of values would report the whole
+        repository as exposed.
+        """
+        facts = [
+            {"entity_type": "module", "ident": ":module/a", "desc": "a.py",
+             "vf_ms": 100, "vt_ms": 200},
+            {"entity_type": "module", "ident": ":module/a", "desc": "a.py",
+             "vf_ms": 300, "vt_ms": 400},
+        ]
+        report = census_distinct_values(facts)
+        assert report["module"]["idents_total"] == 1
+        assert report["module"]["idents_with_multiple_values"] == 0
+        assert report["module"]["offending_idents"] == {}
+
+    def test_one_ident_with_two_values_is_counted_and_named(self):
+        """The offending values are reported verbatim, not just counted: a
+        nonzero census escalates this work to a full sweep, and the escalation
+        needs to start from which idents fired, not from an integer.
+        """
+        facts = [
+            {"entity_type": "external-dependency", "ident": ":module/sub",
+             "desc": "old-name", "vf_ms": 100, "vt_ms": 200},
+            {"entity_type": "external-dependency", "ident": ":module/sub",
+             "desc": "new-name", "vf_ms": 200, "vt_ms": 300},
+        ]
+        report = census_distinct_values(facts)
+        assert report["external-dependency"]["idents_with_multiple_values"] == 1
+        assert report["external-dependency"]["offending_idents"] == {
+            ":module/sub": ["new-name", "old-name"]
+        }
+
+    def test_every_entity_type_appears_even_with_no_facts(self):
+        """A type missing from the report and a type with zero exposure are
+        different claims. Absent types would let a query failure for one type
+        (_collect swallows those) read as a clean zero.
+        """
+        report = census_distinct_values([])
+        assert set(report) == set(ENTITY_TYPES)
+        assert all(report[t]["idents_total"] == 0 for t in ENTITY_TYPES)

--- a/tests/test_at_scale_description_preload_probe.py
+++ b/tests/test_at_scale_description_preload_probe.py
@@ -162,9 +162,15 @@ class TestDiffDescriptions:
         to be wrong against. Letting such an ident fall through to the
         membership test would score it as a match whenever the preloaded value
         happened to be one of several -- inventing agreement out of ambiguity.
+
+        The fixture uses preloaded value "z" absent from the live set {"x", "y"}
+        to discriminate ordering: ambiguity must be checked BEFORE value
+        comparison, so the value mismatch never fires. If value comparison ran
+        first, the mismatch would be recorded and the ident would appear in
+        both value_mismatches and ambiguous_idents.
         """
         result = diff_descriptions(
-            {":module/a": "x"}, {":module/a": {"x", "y"}}
+            {":module/a": "z"}, {":module/a": {"x", "y"}}
         )
         assert result["ambiguous_idents"] == [":module/a"]
         assert result["value_mismatches"] == {}

--- a/tests/test_at_scale_description_preload_probe.py
+++ b/tests/test_at_scale_description_preload_probe.py
@@ -14,6 +14,8 @@ asserted one. A test whose date-bounded and position-bounded answers agree
 proves nothing about #257.
 """
 
+import pytest
+
 from evals.at_scale.probe_description_preload_exposure import (
     ENTITY_TYPES,
     census_distinct_values,
@@ -225,9 +227,6 @@ class TestCountUnmappableDescriptionFacts:
         assert count_unmappable_description_facts(
             facts, build_ts_positions(META)
         ) == (0, 0)
-
-
-import pytest
 
 
 @pytest.fixture

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10552,6 +10552,146 @@ class TestPreloadKnownEntitiesCloseSide:
         assert ":module/intro-above-w" not in entity_valid_from
 
 
+class TestPreloadKnownEntitiesDescriptionValueIsDateBounded:
+    """#257: membership is position-exact after #238/#245, VALUES are not.
+
+    _preload_known_entities decides WHICH entities to preload by position on
+    both ends now. It still seeds entity_descriptions from whichever
+    :description version was live at the DATE envelope T_hi(W). Author dates
+    are not monotonic in topological order, so a version written ABOVE the
+    watermark carrying an EARLIER date is the one that query returns.
+
+    THIS CLASS ESTABLISHES REACHABILITY, NOT FREQUENCY, and the distinction is
+    the whole reason it exists. The #257 exposure probe
+    (evals/at_scale/probe_description_preload_exposure.py) swept this
+    repository's 656-commit history and made 12,685 value comparisons without
+    ever comparing an ident that could exhibit the defect -- a mismatch
+    requires an ident carrying two distinct :description values, and this
+    history's only three such idents were ambiguous at every position where
+    they were live. So the probe's zero says nothing either way, and the open
+    question it could not answer is exactly the one below: given two values
+    AND an inverted date, does the shipped preload return the future one?
+
+    It does. That is what the xfail below pins.
+
+    Same linearization as TestPreloadKnownEntitiesCloseSide, and the inversion
+    is the same one: 0 = c0 @ 2026-04-01, 1 = c1 (WATERMARK) @ 2026-05-02,
+    2 = c2 @ 2026-04-26. Position 2 sits above the watermark but carries the
+    earlier date.
+
+    Why the entity's stable attributes are transacted OPEN while only
+    :description is windowed: if :ident/:path/:introduced-by were closed too,
+    the entity would drop out of phase 1's :valid-at T_hi query altogether and
+    this would become a MEMBERSHIP test, which #238/#245 already cover. Every
+    attribute except :description stays open precisely so the only variable
+    left is the value.
+    """
+
+    LINEARIZATION = ["c0" * 20, "c1" * 20, "c2" * 20]
+    HASH_TO_POS = {h: i for i, h in enumerate(LINEARIZATION)}
+    T_HI = "2026-05-02T00:00:00Z"
+    TS_POSITIONS = {
+        "2026-04-01T00:00:00Z": [0],
+        "2026-05-02T00:00:00Z": [1],
+        "2026-04-26T00:00:00Z": [2],
+    }
+    IDENT = ":module/inverted-desc"
+
+    def _seed(self, real_db):
+        """One entity, introduced at c0, whose :description is superseded at
+        c2 -- above the watermark, dated below the envelope.
+
+        The two :description windows abut at 2026-04-26: "old" is
+        [04-01, 04-26) and "new" is [04-26, forever). At the envelope
+        T_hi(1) = 2026-05-02 only "new" is live, which is the defect. At
+        POSITION 1 only "old" is live, because "new" is introduced at
+        position 2.
+        """
+        real_db.execute(
+            '(transact {:valid-from "2026-04-01T00:00:00Z"} '
+            f'[[:commit/c0 :hash "{self.LINEARIZATION[0]}"] '
+            '[:commit/c0 :date "2026-04-01T00:00:00Z"]])'
+        )
+        real_db.execute(
+            '(transact {:valid-from "2026-04-01T00:00:00Z"} '
+            f'[[{self.IDENT} :entity-type :type/module] '
+            f'[{self.IDENT} :ident "{self.IDENT}"] '
+            f'[{self.IDENT} :path "inverted.py"] '
+            f'[{self.IDENT} :introduced-by :commit/c0]])'
+        )
+        real_db.execute(
+            '(transact {:valid-from "2026-04-01T00:00:00Z" '
+            ':valid-to "2026-04-26T00:00:00Z"} '
+            f'[[{self.IDENT} :description "old"]])'
+        )
+        real_db.execute(
+            '(transact {:valid-from "2026-04-26T00:00:00Z"} '
+            f'[[{self.IDENT} :description "new"]])'
+        )
+
+    def _run(self, real_db, tmp_path, watermark_pos):
+        import mcp_server
+        return mcp_server._preload_known_entities(
+            real_db, str(tmp_path), valid_at=self.T_HI,
+            hash_to_pos=self.HASH_TO_POS, watermark_pos=watermark_pos,
+            ts_positions=self.TS_POSITIONS,
+            t_hi_ms=mcp_server._iso_to_epoch_ms(self.T_HI),
+        )
+
+    def test_the_entity_is_preloaded_at_the_inverted_watermark(
+        self, real_db, tmp_path
+    ):
+        """Membership is intact -- this is a VALUE defect, not a membership
+        one, and without this the xfail below could be passing for the wrong
+        reason (an entity that never reaches the dict at all)."""
+        self._seed(real_db)
+        entity_valid_from, *_ = self._run(real_db, tmp_path, 1)
+        assert self.IDENT in entity_valid_from
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "#257: entity_descriptions is seeded at the DATE envelope T_hi(W), "
+            "so a version introduced above W with an earlier author date wins. "
+            "Remove this marker when #257 is fixed -- strict=True makes the "
+            "suite fail if it starts passing, which is the point."
+        ),
+    )
+    def test_preload_returns_the_position_live_description(
+        self, real_db, tmp_path
+    ):
+        """THE #257 DEFECT, pinned.
+
+        At W=1 the position-correct value is "old": "new" is introduced at
+        position 2, above the watermark. The shipped preload returns "new",
+        because at the envelope 2026-05-02 the "old" window ([04-01, 04-26))
+        has already closed and "new"'s has already opened -- both readings
+        wrong at position 1.
+
+        This is the assertion a position-correct preload would satisfy, which
+        is why it states "old" rather than characterising today's "new": the
+        test should express the contract, not the bug.
+        """
+        self._seed(real_db)
+        _vf, descriptions, *_ = self._run(real_db, tmp_path, 1)
+        assert descriptions[self.IDENT] == "old"
+
+    def test_the_superseding_value_is_returned_once_the_watermark_reaches_it(
+        self, real_db, tmp_path
+    ):
+        """The discriminator for the xfail above.
+
+        At W=2 "new" IS the position-correct answer, and the preload returns
+        it. Without this, the xfail could be an assertion that can never hold
+        under any watermark -- a broken fixture rather than a real defect.
+        Note the envelope is unchanged (T_hi(2) == T_hi(1) == 2026-05-02), so
+        the only thing that varies between the two tests is the position.
+        """
+        self._seed(real_db)
+        _vf, descriptions, *_ = self._run(real_db, tmp_path, 2)
+        assert descriptions[self.IDENT] == "new"
+
+
 class TestPreloadStateUnmappableAnnounce:
     """An unplaceable :db/valid-from or :db/valid-to means the position
     inversion's assumption is broken for that fact. Excluding is the


### PR DESCRIPTION
Measures the residual #238/#245 left behind: `_preload_known_entities` decides preload MEMBERSHIP by position, but seeds `entity_descriptions` from whichever `:description` version was live at the DATE envelope `T_hi(W)`. Read-only — no behavioural change to `mcp_server.py`.

Refs #257
Refs #222

## Verdict: the mechanism was never in a position to fire on this history

That is a weaker claim than "it does not fire", and the distinction is the whole finding.

| | |
|---|---|
| Census: idents with >1 distinct `:description` value | **3** of 2,734 |
| Stage 2 mismatches (position-weighted / distinct) | **0 / 0** |
| Value comparisons made | **12,685** |
| ...of those, on a census offender | **0** |

A mismatch is structurally possible only for an ident carrying at least two distinct values, so `value_mismatches` is always a subset of the census offenders. Not one offender ever reached the comparison: at positions 645-649 all three had both values live simultaneously and were classified ambiguous; at 118-128 they were not preloaded. So the zero is uninformative about the date-vs-position mechanism rather than evidence against it.

All three offenders come from an **unrelated pre-existing bug**: `_canonical_ident` (`mcp_server.py:4090-4099`) replaces `_` with `-` and collapses runs, so `commit`/`_commit`, `snapshot`/`_snapshot` and `main`/`_main` each collide onto one ident. Not the mechanism #257 describes — but it is the precondition that mechanism would need.

Validity gate passed: 0 unmappable facts, 0 timestamp collisions, `preloaded_not_live` 0 at every position. The submodule `external-dependency` arm is **UNMEASURABLE** here (0 gitlink events), not zero — same blind spot #245 recorded for `:pinned-commit`.

## Two premises in #257's body are false

Both verified against master, and the design spec records the evidence:

1. **`:description` is written once per entity lifetime**, not "on essentially every body edit". `_build_code_triples`' docstring says so (`mcp_server.py:7182-7186`) and every assignment sits in the introduction branch. This was #257's stated reason for scoping the work out of #238/#245.
2. **Nothing reads `entity_descriptions` for body-change detection.** All six reads in `_forward_apply` feed `_build_close_triples`' `desc` — the retract value at close time. Body-change detection is `unchanged_idents` from `_precompute_file_triples` (#221).

The real consequence, if the mechanism ever fires, is a retract value that fails to match, leaving the `:description` live past its window — a stale-fact bug, not a lost body edit. This PR corrects that paragraph in `_preload_known_entities`' docstring. **Docstring-only: +20/-5, zero executable lines changed.**

## What is here

- `evals/at_scale/probe_description_preload_exposure.py` — two stages over one ingest. Census, then a per-position diff of the real shipped preload against a position-correct oracle that inverts each fact's own `vf`/`vt` to commit positions.
- `tests/test_at_scale_description_preload_probe.py` — 16 tests. Every position-vs-date test is **ablation-proven**: the counterfactual was built, watched to fail, then reverted. Two rounds of review caught tests that passed under both the right and wrong implementation, and both were strengthened.
- `evals/at_scale/results/257-description-preload-exposure.json` + a `benchmark.md` entry.
- Design spec and implementation plan under `docs/superpowers/`.

The exit code reflects measurement validity, never the finding — a nonzero mismatch count is what the probe exists to discover and must not fail a run.

## Reachability: pinned, and the answer is yes

The measurement left one bounded question open — given two distinct values AND an author-date inversion, does the shipped preload return the future one? This history could not answer it, because its only multi-value idents were always ambiguous.

`TestPreloadKnownEntitiesDescriptionValueIsDateBounded` in `tests/test_mcp_server.py` answers it directly against a real backend: **it does.** At W=1 the position-correct value is `old`; the preload returns `new`. Pinned as `xfail(strict=True)` asserting the *contract* rather than characterising the defect, so fixing this trips the suite instead of leaving a stale marker.

Built as a unit test rather than a fabricated repo on purpose: the question is reachability, not frequency, and a repo constructed to make the bug fire would only restate what reading the code already says.

Two companion tests exist to stop the xfail passing for the wrong reason — membership is asserted separately, so it cannot be a missing dict entry; and at W=2 the same machinery returns `new` when `new` is position-correct, so it cannot be an assertion that never holds. The envelope is identical at both watermarks, so position is the only variable. Ablated both ways: the xfail fails as `assert 'new' == 'old'`, and the probe's own position-correct oracle returns `{'old'}` at W=1 and `{'new'}` at W=2.

**This does not change the field picture.** The mechanism is reachable but has no observed occurrence on real history, and its preconditions are narrow: once #263 is fixed, submodule `.gitmodules` renames become the sole remaining source of two distinct values — the one arm this repository structurally cannot measure.

## Not done here

No interval-inversion fix is built; that is justified by a measurement showing the mechanism fires in the field, and this is not one. Whether the reachability proof plus the null field result is enough to resolve the issue is a judgement call, and the unmeasurable submodule arm has to be named in whatever wording is chosen.

Full suite: 1229 passed, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK


