### PR TITLE
Audit: how many _code_ident values collide on real history (#263)

### DIFF
--- a/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
+++ b/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
@@ -1,0 +1,1573 @@
+# #263 Ident Collision Audit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a read-only audit that counts, exactly, how many `_code_ident` values in this repository's real history are reachable from more than one distinct `(entity_type, file_path, name)` input — and scores five candidate replacement derivations against the same data.
+
+**Architecture:** One pass over branch history drives `mcp_server._extract_commit` (already read-only, stateless and DB-free) on a `ProcessPoolExecutor`, harvesting every `(entity_type, file_path, name)` input that ever existed plus every unresolved-import specifier. Those inputs are then grouped by the ident the current rule produces (Stage 2, with per-offender shape classification) and re-grouped under each candidate rule (Stage 3, scoring residual collisions and rename cost). Nothing is written to any graph; no `MiniGrafDb` handle is opened.
+
+**Tech Stack:** Python 3.10+, pytest, `mcp_server`'s existing tree-sitter extraction pipeline, `concurrent.futures.ProcessPoolExecutor`.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-ident-collision-audit-design.md` — read it before Task 1. Where this plan and the spec disagree, the spec wins.
+
+## Global Constraints
+
+- **Interpreter is always `.venv/bin/python`.** The system `python` carries minigraf 1.1.1 against a `minigraf>=1.2.3` floor; it fakes ~122 test failures and misdiagnoses runs. Every command in this plan uses `.venv/bin/python`.
+- **This audit opens no `MiniGrafDb` handle and writes no facts.** It is read-only by construction. Do not add a graph query "for cross-checking" — the spec's scope decisions rule that out, with a reason.
+- **Never monkeypatch `mcp_server._canonical_ident` or `mcp_server._code_ident`.** Candidate rules are standalone pure functions in the probe module. The audit must not mutate the module it measures.
+- **Entity types are exactly** `("module", "function", "class", "variable", "field")`. `external-dependency` is not a sixth type — it shares the `:module/` namespace (`mcp_server.py:7396`).
+- **Where a mapping mirrors `_precompute_file_triples`** (`mcp_server.py:7044-7129`), that function is authoritative. Re-read it rather than trusting this plan's table.
+- **Commit messages must contain no GitHub closing keyword** (`close`/`closes`/`closed`/`fix`/`fixes`/`fixed`/`resolve`/`resolves`/`resolved`). Use `Refs #263`. The keyword/`#N` pair is scanned across blank lines, so avoid the words entirely.
+- **Every commit ends with:**
+  ```
+  Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK
+  ```
+- **Branch:** `audit-263-ident-collision-census` (already created, spec already committed on it).
+- **Ablation requirement.** Every test below names the counterfactual it was checked against. A test that passes against both the real implementation and a degenerate stub proves nothing — if you cannot make a test fail by degrading the code it guards, the test is wrong and must be rewritten before the task is done.
+
+---
+
+### Task 1: Input model, current-rule grouping, and offenders
+
+**Files:**
+- Create: `evals/at_scale/probe_ident_collision_census.py`
+- Test: `tests/test_at_scale_ident_collision_census.py`
+
+**Interfaces:**
+- Consumes: `mcp_server._code_ident` (read-only import).
+- Produces:
+  - `EntityInput(NamedTuple)` with fields `entity_type: str`, `producer: str`, `file_path: str`, `name: Optional[str]`
+  - `ENTITY_TYPES: Tuple[str, ...]`
+  - `PRODUCERS: Tuple[str, ...]`
+  - `raw_value(inp: EntityInput) -> str`
+  - `current_ident(inp: EntityInput) -> str`
+  - `group_by_ident(inputs: Iterable[EntityInput], ident_fn) -> Dict[str, List[EntityInput]]`
+  - `offenders(groups: Dict[str, List[EntityInput]]) -> Dict[str, List[EntityInput]]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_at_scale_ident_collision_census.py`:
+
+```python
+# tests/test_at_scale_ident_collision_census.py
+"""Unit tests for the #263 _code_ident collision audit's analysis primitives.
+
+The audit's headline number cannot be asserted -- it is what the audit exists
+to discover. What CAN be asserted are the components that could silently
+produce a WRONG number: the ident grouping, the shape classifier, and the
+candidate-rule scorer.
+
+Every test names the counterfactual it was checked against. A test that passes
+against a degenerate stub as well as against the real implementation proves
+nothing and does not belong here.
+"""
+
+import pytest
+
+from evals.at_scale.probe_ident_collision_census import (
+    EntityInput,
+    current_ident,
+    group_by_ident,
+    offenders,
+    raw_value,
+)
+
+
+# The three collisions #257's census actually found on this repository's
+# history, as their (file_path, name) inputs. Used as a fixture throughout:
+# a run that does not reproduce these is not measuring the right thing.
+KNOWN_COLLISIONS = [
+    ("tests/test_mcp_server.py", "_commit", "commit"),
+    ("tests/test_mcp_server.py", "_snapshot", "snapshot"),
+    ("evals/at_scale/profile_forward_reconcile_attribution.py", "_main", "main"),
+]
+
+
+def _fn(file_path, name):
+    return EntityInput("function", "code", file_path, name)
+
+
+class TestRawValue:
+    def test_named_input_uses_the_double_colon_separator(self):
+        """raw_value must reproduce _code_ident's own input construction
+        (mcp_server.py:4298-4301) exactly -- the candidate rules in Task 3 all
+        re-slug this string, so a different separator here would score every
+        rule against a value production never actually builds.
+        """
+        assert raw_value(_fn("a/b.py", "c")) == "a/b.py::c"
+
+    def test_unnamed_input_is_the_bare_path(self):
+        assert raw_value(EntityInput("module", "code", "a/b.py", None)) == "a/b.py"
+
+
+class TestCurrentIdentCollapse:
+    def test_private_and_public_helper_collapse_onto_one_ident(self):
+        """This is #263's mechanism. Counterfactual: if _canonical_ident did
+        not collapse consecutive hyphens, these two would differ
+        ('...py---commit' vs '...py--commit') and this assert would fail.
+        """
+        private = current_ident(_fn("tests/test_mcp_server.py", "_commit"))
+        public = current_ident(_fn("tests/test_mcp_server.py", "commit"))
+        assert private == public == ":function/tests-test-mcp-server-py-commit"
+
+    def test_unrelated_names_in_one_file_stay_distinct(self):
+        """Guards against a stub current_ident that returns a constant, which
+        would pass the collapse test above and make every grouping test
+        vacuous.
+        """
+        assert current_ident(_fn("a/b.py", "alpha")) != current_ident(_fn("a/b.py", "beta"))
+
+
+class TestGroupAndOffenders:
+    def test_the_three_known_collisions_are_reported_as_offenders(self):
+        inputs = []
+        for file_path, private, public in KNOWN_COLLISIONS:
+            inputs.append(_fn(file_path, private))
+            inputs.append(_fn(file_path, public))
+        found = offenders(group_by_ident(inputs, current_ident))
+        assert len(found) == 3
+        for members in found.values():
+            assert len(members) == 2
+
+    def test_public_members_alone_yield_zero_offenders(self):
+        """The counterfactual for the test above. Feeding only the public half
+        of each pair must report nothing -- otherwise the offender count is
+        being produced by something other than the collision.
+        """
+        inputs = [_fn(file_path, public) for file_path, _, public in KNOWN_COLLISIONS]
+        assert offenders(group_by_ident(inputs, current_ident)) == {}
+
+    def test_the_same_input_twice_is_not_an_offender(self):
+        """A name unchanged across 400 commits arrives 400 times. Counting
+        occurrences instead of DISTINCT inputs would report the whole
+        repository as colliding.
+        """
+        inputs = [_fn("a/b.py", "c")] * 400
+        assert offenders(group_by_ident(inputs, current_ident)) == {}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v
+```
+
+Expected: collection error — `ModuleNotFoundError: No module named 'evals.at_scale.probe_ident_collision_census'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `evals/at_scale/probe_ident_collision_census.py`:
+
+```python
+# evals/at_scale/probe_ident_collision_census.py
+"""#263 audit: how many _code_ident values on real history are reachable from
+more than one distinct (entity_type, file_path, name) input?
+
+_canonical_ident (mcp_server.py:4090) maps every character outside [a-z0-9-]
+to a hyphen and then collapses runs of hyphens. _code_ident builds its input as
+f"{file_path}::{name}", so the separator and a leading underscore in the name
+both become hyphens and the collapse merges them:
+
+    tests/test_mcp_server.py::_commit -> tests-test-mcp-server-py-commit
+    tests/test_mcp_server.py::commit  -> tests-test-mcp-server-py-commit
+
+WHY THIS AUDIT IS SOURCE-DERIVED AND NOT GRAPH-DERIVED. When two entities
+collide, the second one parsed takes _build_code_triples' `ident in
+entity_valid_from` branch, which appends a :modified-in triple and NOTHING
+else -- no :entity-type, no :ident, no :description, no :file. The graph
+therefore holds no record of the losing entity's (file_path, name) pair at
+all, and widening #257's census key from :description to (:file, :description)
+does not recover it. The three collisions #257 found were visible only because
+those entities were closed and reopened, which re-runs the introduction branch.
+Any graph-side count is a bound; only the inputs give an exact one.
+
+READ-ONLY BY CONSTRUCTION. This module opens no MiniGrafDb handle, writes no
+facts, and never mutates mcp_server. The candidate rules below are standalone
+pure functions, deliberately NOT monkeypatches of _canonical_ident -- an audit
+must not mutate the module it measures.
+
+See docs/superpowers/specs/2026-08-11-ident-collision-audit-design.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, NamedTuple, Optional
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import mcp_server  # noqa: E402
+
+
+# The five types _code_ident actually produces. external-dependency is NOT a
+# sixth: it shares the :module/ namespace (mcp_server.py:7396), which is why
+# the module bucket below is pooled across producers rather than split.
+ENTITY_TYPES = ("module", "function", "class", "variable", "field")
+
+# Which call site produced an input. Only ever used to label a collision as
+# cross-producer -- it is deliberately NOT part of the ident, because the
+# whole point is that these three feed one namespace.
+#   "code"    -- _code_ident over a parsed file (mcp_server.py:7044-7122)
+#   "gitlink" -- _code_ident("module", path) for a submodule (mcp_server.py:9556)
+#   "import"  -- _canonical_ident("module", specifier), the unresolved-import
+#                fallback (mcp_server.py:4250, 4285)
+PRODUCERS = ("code", "gitlink", "import")
+
+
+class EntityInput(NamedTuple):
+    """One (entity_type, file_path, name) triple that ever reached _code_ident.
+
+    For producer "import", file_path holds the raw import specifier and name is
+    None -- _canonical_ident("module", spec) is exactly _code_ident("module",
+    spec, None), so no separate ident path is needed.
+    """
+
+    entity_type: str
+    producer: str
+    file_path: str
+    name: Optional[str]
+
+
+def raw_value(inp: EntityInput) -> str:
+    """The string _code_ident slugs, reproducing mcp_server.py:4298-4301."""
+    if inp.name:
+        return f"{inp.file_path}::{inp.name}"
+    return inp.file_path
+
+
+def current_ident(inp: EntityInput) -> str:
+    """The ident production builds for this input, today."""
+    return mcp_server._code_ident(inp.entity_type, inp.file_path, inp.name)
+
+
+def group_by_ident(
+    inputs: Iterable[EntityInput],
+    ident_fn: Callable[[EntityInput], str],
+) -> Dict[str, List[EntityInput]]:
+    """Group DISTINCT inputs by the ident ident_fn assigns them.
+
+    Distinct is load-bearing: an unchanged name arrives once per commit that
+    touched its file, and counting occurrences would report every entity in
+    the repository as colliding with itself.
+    """
+    groups: Dict[str, Dict[EntityInput, None] ] = {}
+    for inp in inputs:
+        groups.setdefault(ident_fn(inp), {})[inp] = None
+    return {ident: list(members) for ident, members in groups.items()}
+
+
+def offenders(
+    groups: Dict[str, List[EntityInput]],
+) -> Dict[str, List[EntityInput]]:
+    """The groups reachable from more than one distinct input."""
+    return {
+        ident: members for ident, members in groups.items() if len(members) > 1
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Prove the ablation**
+
+Temporarily change `group_by_ident` to count occurrences rather than distinct inputs (replace the inner `Dict[EntityInput, None]` with a `list` and `.append`). Re-run.
+
+Expected: `test_the_same_input_twice_is_not_an_offender` FAILS. Revert the change and confirm the suite is green again. If the test passed under the degraded version, it is not guarding anything — rewrite it before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add evals/at_scale/probe_ident_collision_census.py tests/test_at_scale_ident_collision_census.py
+git commit -F - <<'EOF'
+Add the #263 audit's input model and current-rule grouping
+
+EntityInput carries the producer alongside the (entity_type, file_path,
+name) triple. The producer is deliberately not part of the ident: the
+:module/ namespace is shared by in-tree modules, gitlinks and unresolved
+imports, so pooling them is what makes a cross-producer collision visible.
+
+group_by_ident groups DISTINCT inputs. An unchanged name arrives once per
+commit that touched its file, so counting occurrences would report every
+entity as colliding with itself.
+
+Refs #263
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK
+EOF
+```
+
+---
+
+### Task 2: Collision shape classification
+
+**Files:**
+- Modify: `evals/at_scale/probe_ident_collision_census.py`
+- Test: `tests/test_at_scale_ident_collision_census.py`
+
+**Interfaces:**
+- Consumes: `EntityInput`, `raw_value` from Task 1.
+- Produces:
+  - `SHAPES: Tuple[str, ...]` = `("leading-underscore", "case-only", "separator-vs-path", "cross-producer", "other")`
+  - `classify_shapes(members: Sequence[EntityInput]) -> Set[str]`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_at_scale_ident_collision_census.py`:
+
+```python
+from evals.at_scale.probe_ident_collision_census import (  # noqa: E402
+    SHAPES,
+    classify_shapes,
+)
+
+
+class TestClassifyShapes:
+    def test_private_public_pair_in_one_file_is_leading_underscore(self):
+        members = [_fn("a/b.py", "_foo"), _fn("a/b.py", "foo")]
+        assert "leading-underscore" in classify_shapes(members)
+
+    def test_private_public_field_on_one_class_is_leading_underscore(self):
+        """Fields arrive qualified as 'Cls.field', so the private marker sits
+        on the LAST dot-segment, not at the string's start. A classifier using
+        a bare lstrip('_') on the whole qualified name reports 'other' here.
+        """
+        members = [
+            EntityInput("field", "code", "a/b.py", "Cls._x"),
+            EntityInput("field", "code", "a/b.py", "Cls.x"),
+        ]
+        assert "leading-underscore" in classify_shapes(members)
+
+    def test_case_only_pair_is_not_labelled_leading_underscore(self):
+        """The labels must separate. A classifier returning a constant label
+        passes the two tests above and fails this one.
+        """
+        members = [_fn("a/b.py", "Foo"), _fn("a/b.py", "foo")]
+        shapes = classify_shapes(members)
+        assert "case-only" in shapes
+        assert "leading-underscore" not in shapes
+
+    def test_inputs_from_different_files_are_separator_vs_path(self):
+        """The path/name boundary fell differently on the two inputs -- the
+        case _code_ident's own docstring anticipates.
+        """
+        members = [_fn("a/b.py", "c"), _fn("a/b_py", "c")]
+        assert "separator-vs-path" in classify_shapes(members)
+
+    def test_import_and_in_tree_module_are_cross_producer(self):
+        members = [
+            EntityInput("module", "code", "a/b.py", None),
+            EntityInput("module", "import", "a.b.py", None),
+        ]
+        assert "cross-producer" in classify_shapes(members)
+
+    def test_an_unclassifiable_pair_falls_through_to_other(self):
+        """'other' is the interesting bucket -- it is where a collision nobody
+        predicted shows up. It must be reachable, not vestigial.
+        """
+        members = [_fn("a/b.py", "x-y"), _fn("a/b.py", "x.y")]
+        assert classify_shapes(members) == {"other"}
+
+    def test_every_emitted_label_is_declared_in_SHAPES(self):
+        members = [_fn("a/b.py", "_foo"), _fn("a/b.py", "foo")]
+        assert classify_shapes(members) <= set(SHAPES)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v -k Shapes
+```
+
+Expected: `ImportError: cannot import name 'SHAPES'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `evals/at_scale/probe_ident_collision_census.py`:
+
+```python
+from itertools import combinations
+from typing import Sequence, Set
+
+SHAPES = (
+    "leading-underscore",
+    "case-only",
+    "separator-vs-path",
+    "cross-producer",
+    "other",
+)
+
+
+def _strip_private(name: Optional[str]) -> str:
+    """Drop leading underscores from the LAST dot-segment of a name.
+
+    Fields reach _code_ident qualified as "Cls.field" (mcp_server.py:7098), so
+    the private marker sits mid-string. A bare name.lstrip("_") would miss
+    "Cls._x" against "Cls.x" entirely.
+    """
+    if not name:
+        return ""
+    head, dot, last = name.rpartition(".")
+    stripped = last.lstrip("_")
+    return f"{head}{dot}{stripped}" if dot else stripped
+
+
+def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
+    shapes: Set[str] = set()
+    if a.producer != b.producer:
+        shapes.add("cross-producer")
+    a_raw, b_raw = raw_value(a), raw_value(b)
+    if a_raw.casefold() == b_raw.casefold():
+        shapes.add("case-only")
+    elif a.file_path == b.file_path and _strip_private(a.name) == _strip_private(b.name):
+        shapes.add("leading-underscore")
+    elif a.file_path != b.file_path or (a.name is None) != (b.name is None):
+        # The two inputs put the path/name boundary in different places, so
+        # the ident cannot say where the path ended -- the collision family
+        # _code_ident's docstring already anticipates.
+        shapes.add("separator-vs-path")
+    return shapes
+
+
+def classify_shapes(members: Sequence[EntityInput]) -> Set[str]:
+    """Label an offender by every collision family present among its inputs.
+
+    An offender may carry more than one label (a cross-producer collision is
+    usually also something else), so this returns a set rather than picking a
+    single winner. "other" is emitted only when nothing else applied: it is
+    where an unpredicted collision family would surface, and collapsing it
+    into any named label would hide exactly the finding worth having.
+    """
+    shapes: Set[str] = set()
+    for a, b in combinations(members, 2):
+        shapes |= _pair_shapes(a, b)
+    if not shapes - {"cross-producer"}:
+        shapes.add("other")
+    return shapes
+```
+
+Note the `elif` chain in `_pair_shapes`: `case-only` is checked before
+`leading-underscore` because `_Foo`/`foo` is genuinely both, and attributing it
+to case is the narrower claim.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v
+```
+
+Expected: 14 passed.
+
+- [ ] **Step 5: Prove the ablation**
+
+Temporarily replace `classify_shapes`' body with `return {"leading-underscore"}`. Re-run.
+
+Expected: `test_case_only_pair_is_not_labelled_leading_underscore` and `test_an_unclassifiable_pair_falls_through_to_other` FAIL. Separately, temporarily replace `_strip_private` with `return (name or "").lstrip("_")` and confirm `test_private_public_field_on_one_class_is_leading_underscore` FAILS. Revert both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add evals/at_scale/probe_ident_collision_census.py tests/test_at_scale_ident_collision_census.py
+git commit -F - <<'EOF'
+Add the #263 audit's collision shape classifier
+
+Labels each offender by every collision family present among its inputs,
+not by a single winner -- a cross-producer collision is usually also
+something else.
+
+_strip_private works on the last dot-segment because fields reach
+_code_ident qualified as "Cls.field", so a bare lstrip("_") on the whole
+name would miss "Cls._x" against "Cls.x".
+
+"other" is emitted only when nothing named applied. It is where an
+unpredicted collision family would surface, so it stays reachable.
+
+Refs #263
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK
+EOF
+```
+
+---
+
+### Task 3: Candidate rules and scoring
+
+**Files:**
+- Modify: `evals/at_scale/probe_ident_collision_census.py`
+- Test: `tests/test_at_scale_ident_collision_census.py`
+
+**Interfaces:**
+- Consumes: `EntityInput`, `raw_value`, `current_ident`, `group_by_ident`, `offenders` from Task 1.
+- Produces:
+  - `RULES: Dict[str, Tuple[str, Callable[[EntityInput], str]]]` — rule id → `(description, ident_fn)`, keys `"R1".."R5"`
+  - `score_rule(inputs, ident_fn, baseline_groups) -> Dict[str, int]` returning `{"residual": int, "renames": int}`
+  - `score_all_rules(inputs, baseline_groups) -> Dict[str, Dict]`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_at_scale_ident_collision_census.py`:
+
+```python
+from evals.at_scale.probe_ident_collision_census import (  # noqa: E402
+    RULES,
+    score_all_rules,
+    score_rule,
+)
+
+
+def _known_collision_inputs():
+    inputs = []
+    for file_path, private, public in KNOWN_COLLISIONS:
+        inputs.append(_fn(file_path, private))
+        inputs.append(_fn(file_path, public))
+    return inputs
+
+
+class TestCandidateRules:
+    @pytest.mark.parametrize("rule_id", ["R1", "R2", "R3", "R4"])
+    def test_separating_rules_leave_no_residual(self, rule_id):
+        inputs = _known_collision_inputs()
+        _, ident_fn = RULES[rule_id]
+        assert offenders(group_by_ident(inputs, ident_fn)) == {}
+
+    def test_R5_still_collides_and_is_the_scorer_s_known_negative(self):
+        """R5 slugs path and name independently, so strip("-") still eats the
+        leading underscore and _commit/commit both reduce to "commit". R5 is
+        in the table precisely BECAUSE it does not work: a scorer that reports
+        R5 clean is broken, and every other row it produced is suspect.
+        """
+        inputs = _known_collision_inputs()
+        _, ident_fn = RULES["R5"]
+        assert len(offenders(group_by_ident(inputs, ident_fn))) == 3
+
+    @pytest.mark.parametrize("rule_id", ["R1", "R2", "R3", "R4"])
+    def test_every_separating_rule_renames_something(self, rule_id):
+        """A rule that renames nothing cannot have changed derivation, so a
+        zero residual from it would be arithmetic rather than a finding.
+        """
+        inputs = _known_collision_inputs()
+        baseline = group_by_ident(inputs, current_ident)
+        _, ident_fn = RULES[rule_id]
+        assert score_rule(inputs, ident_fn, baseline)["renames"] > 0
+
+    def test_R4_renames_every_ident(self):
+        """Every ident gains a hash suffix, so the rename count equals the
+        baseline ident count. Counterfactual: a renames metric that counted
+        only COLLIDING idents would report 3, not 3-of-3 plus the rest.
+        """
+        inputs = _known_collision_inputs() + [_fn("z/z.py", "solo")]
+        baseline = group_by_ident(inputs, current_ident)
+        _, ident_fn = RULES["R4"]
+        scored = score_rule(inputs, ident_fn, baseline)
+        assert scored["renames"] == len(baseline)
+        assert scored["residual"] == 0
+
+    def test_R2_leaves_a_plain_module_ident_unrenamed(self):
+        """R2 only drops the hyphen collapse. A module input has no '::'
+        separator, so a path with no adjacent non-alphanumerics is untouched.
+        This is what makes R2's rename cost differ by entity type.
+        """
+        module = EntityInput("module", "code", "a/b.py", None)
+        _, ident_fn = RULES["R2"]
+        assert ident_fn(module) == current_ident(module)
+
+    def test_R1_does_rename_that_same_module_ident(self):
+        """The counterfactual for the test above: R1 changes the charset, so
+        an underscore anywhere in the path moves the ident even with no name.
+        """
+        module = EntityInput("module", "code", "a/b_c.py", None)
+        _, ident_fn = RULES["R1"]
+        assert ident_fn(module) != current_ident(module)
+
+    def test_score_all_rules_covers_every_declared_rule(self):
+        inputs = _known_collision_inputs()
+        baseline = group_by_ident(inputs, current_ident)
+        scored = score_all_rules(inputs, baseline)
+        assert set(scored) == set(RULES)
+        for row in scored.values():
+            assert set(row) == {"description", "residual", "renames"}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v -k CandidateRules
+```
+
+Expected: `ImportError: cannot import name 'RULES'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `evals/at_scale/probe_ident_collision_census.py`:
+
+```python
+import hashlib
+import re
+from typing import Tuple
+
+
+def _slug_current(value: str) -> str:
+    """_canonical_ident's slug, verbatim (mcp_server.py:4097-4098)."""
+    slug = re.sub(r"[^a-z0-9-]", "-", value.lower())
+    return re.sub(r"-+", "-", slug).strip("-")
+
+
+def _slug_keep_underscore(value: str) -> str:
+    """R1: '_' joins the allowed charset, so a private marker survives."""
+    slug = re.sub(r"[^a-z0-9_-]", "-", value.lower())
+    return re.sub(r"-+", "-", slug).strip("-")
+
+
+def _slug_no_collapse(value: str) -> str:
+    """R2: hyphen runs are preserved, so separator arity carries the marker
+    ('py---commit' against 'py--commit')."""
+    return re.sub(r"[^a-z0-9-]", "-", value.lower()).strip("-")
+
+
+def _slug_keep_underscore_no_collapse(value: str) -> str:
+    """R3: R1 and R2 together."""
+    return re.sub(r"[^a-z0-9_-]", "-", value.lower()).strip("-")
+
+
+def _ident_from_slug(slug_fn: Callable[[str], str]) -> Callable[[EntityInput], str]:
+    def ident(inp: EntityInput) -> str:
+        return f":{inp.entity_type}/{slug_fn(raw_value(inp))}"
+
+    return ident
+
+
+def _ident_hash_suffix(inp: EntityInput) -> str:
+    """R4: the current slug plus 8 hex of sha256 over the RAW value.
+
+    Hashing the raw value, before lowercasing, is what separates a case-only
+    collision as well -- the slug alone cannot.
+    """
+    value = raw_value(inp)
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
+    return f":{inp.entity_type}/{_slug_current(value)}-{digest}"
+
+
+def _ident_independent_parts(inp: EntityInput) -> str:
+    """R5, the CONTROL. Slugs file_path and name separately and joins them
+    with a fixed token.
+
+    This is expected to FAIL. _slug_current strips leading hyphens, so a name
+    of "_commit" reduces to "commit" exactly as "commit" does, and the pair
+    still collides. R5 exists so score_all_rules has a known-negative: if it
+    ever reports zero residual on a history with leading-underscore pairs, the
+    scorer is wrong and every other row it produced is suspect.
+    """
+    path_slug = _slug_current(inp.file_path)
+    if inp.name is None:
+        return f":{inp.entity_type}/{path_slug}"
+    return f":{inp.entity_type}/{path_slug}--{_slug_current(inp.name)}"
+
+
+RULES: Dict[str, Tuple[str, Callable[[EntityInput], str]]] = {
+    "R1": (
+        "keep underscores: charset becomes [^a-z0-9_-]",
+        _ident_from_slug(_slug_keep_underscore),
+    ),
+    "R2": (
+        "no hyphen collapse: drop re.sub(r'-+', '-', slug)",
+        _ident_from_slug(_slug_no_collapse),
+    ),
+    "R3": (
+        "R1 + R2: keep underscores and drop the collapse",
+        _ident_from_slug(_slug_keep_underscore_no_collapse),
+    ),
+    "R4": (
+        "hash suffix: current slug + '-' + sha256(raw value)[:8]",
+        _ident_hash_suffix,
+    ),
+    "R5": (
+        "CONTROL, expected to still collide: slug file_path and name "
+        "independently, join with '--'",
+        _ident_independent_parts,
+    ),
+}
+
+
+def score_rule(
+    inputs: Sequence[EntityInput],
+    ident_fn: Callable[[EntityInput], str],
+    baseline_groups: Dict[str, List[EntityInput]],
+) -> Dict[str, int]:
+    """Residual collisions and rename cost for one candidate rule.
+
+    renames counts BASELINE idents, not inputs: a baseline ident is renamed
+    when any input in its group maps somewhere other than that same ident.
+    Rename cost is not a footnote to residual -- every change to derivation
+    renames entities in every existing graph, and that cost is what decides
+    forward-fix against migration.
+    """
+    residual = len(offenders(group_by_ident(inputs, ident_fn)))
+    renames = sum(
+        1
+        for ident, members in baseline_groups.items()
+        if any(ident_fn(member) != ident for member in members)
+    )
+    return {"residual": residual, "renames": renames}
+
+
+def score_all_rules(
+    inputs: Sequence[EntityInput],
+    baseline_groups: Dict[str, List[EntityInput]],
+) -> Dict[str, Dict]:
+    scored = {}
+    for rule_id, (description, ident_fn) in RULES.items():
+        row = score_rule(inputs, ident_fn, baseline_groups)
+        row["description"] = description
+        scored[rule_id] = row
+    return scored
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v
+```
+
+Expected: 27 passed.
+
+- [ ] **Step 5: Prove the ablation**
+
+Temporarily change `score_rule`'s `renames` to count only offender groups (`if len(members) > 1 and ...`). Re-run.
+
+Expected: `test_R4_renames_every_ident` FAILS. Revert. Then temporarily change `_ident_independent_parts` to append the unslugged name; expected: `test_R5_still_collides_and_is_the_scorer_s_known_negative` FAILS. Revert both and confirm green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add evals/at_scale/probe_ident_collision_census.py tests/test_at_scale_ident_collision_census.py
+git commit -F - <<'EOF'
+Add the #263 audit's candidate rules and scorer
+
+Five rules, each scored on residual collisions AND rename cost. Rename
+cost is not a footnote: any change to derivation renames entities in
+every existing graph, and that is what decides forward-fix against
+migration.
+
+R5 is a control expected to keep colliding -- slugging the name
+independently still runs strip("-") over it, so _commit and commit both
+reduce to "commit". It is the scorer's known-negative: a run reporting
+R5 clean means the scorer is broken and every other row is suspect.
+
+Rules are standalone pure functions, not monkeypatches of
+_canonical_ident. An audit must not mutate the module it measures.
+
+Refs #263
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK
+EOF
+```
+
+---
+
+### Task 4: Stage 1 — collect inputs through the real extractor
+
+**Files:**
+- Modify: `evals/at_scale/probe_ident_collision_census.py`
+- Test: `tests/test_at_scale_ident_collision_census.py`
+
+**Interfaces:**
+- Consumes: `EntityInput` from Task 1; `mcp_server._extract_commit`, `mcp_server._git_commits`, `mcp_server._load_ignore_patterns`, `mcp_server._default_git_branch`.
+- Produces:
+  - `inputs_from_commit_extraction(file_results, gitlink_changes) -> List[EntityInput]`
+  - `collect_inputs(repo_path, branch, jobs=None) -> Tuple[List[EntityInput], Dict[str, Any]]` where the diagnostics dict carries `commits`, `head_commit`, `extraction_failures`, `failed_commits`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_at_scale_ident_collision_census.py`:
+
+```python
+import subprocess  # noqa: E402
+
+from evals.at_scale.probe_ident_collision_census import (  # noqa: E402
+    collect_inputs,
+    inputs_from_commit_extraction,
+)
+
+
+class TestInputsFromCommitExtraction:
+    def test_deleted_files_carry_no_extraction_and_are_skipped(self):
+        """_extract_commit returns extracted=None and precomputed=None for a
+        "D" entry (mcp_server.py:8477-8480). Dereferencing either would raise;
+        treating the path as a live module input would invent an entity.
+        """
+        file_results = [("D", "a/gone.py", None, None, "")]
+        assert inputs_from_commit_extraction(file_results, []) == []
+
+    def test_a_parsed_file_yields_module_and_every_named_entity(self):
+        extracted = {
+            "functions": ["foo", "_foo"],
+            "classes": ["Cls"],
+            "globals": ["CONST"],
+            "fields": [("x", "Cls", False)],
+            "imports": [],
+            "calls": [],
+        }
+        precomputed = {"resolved_imports": []}
+        got = inputs_from_commit_extraction(
+            [("A", "a/b.py", extracted, precomputed, "")], []
+        )
+        assert EntityInput("module", "code", "a/b.py", None) in got
+        assert EntityInput("function", "code", "a/b.py", "_foo") in got
+        assert EntityInput("class", "code", "a/b.py", "Cls") in got
+        assert EntityInput("variable", "code", "a/b.py", "CONST") in got
+
+    def test_fields_are_qualified_with_their_owning_class(self):
+        """_precompute_file_triples builds the field name as
+        f"{owning_class}.{field_name}" (mcp_server.py:7098). An audit keying on
+        the bare field name would merge Cls.x and Other.x and overstate the
+        collision count.
+        """
+        extracted = {
+            "functions": [], "classes": ["Cls"], "globals": [],
+            "fields": [("x", "Cls", False)], "imports": [], "calls": [],
+        }
+        got = inputs_from_commit_extraction(
+            [("M", "a/b.py", extracted, {"resolved_imports": []}, "")], []
+        )
+        assert EntityInput("field", "code", "a/b.py", "Cls.x") in got
+        assert EntityInput("field", "code", "a/b.py", "x") not in got
+
+    def test_only_unresolved_imports_become_import_inputs(self):
+        """A resolved import already points at an in-tree module ident that the
+        module producer contributes. Counting it again would manufacture a
+        cross-producer collision on every internal import in the repository.
+        """
+        extracted = {
+            "functions": [], "classes": [], "globals": [],
+            "fields": [], "imports": [], "calls": [],
+        }
+        precomputed = {
+            "resolved_imports": [
+                ("a.b", ":module/a-b-py", True),
+                ("requests", ":module/requests", False),
+            ]
+        }
+        got = inputs_from_commit_extraction(
+            [("A", "z.py", extracted, precomputed, "")], []
+        )
+        assert EntityInput("module", "import", "requests", None) in got
+        assert EntityInput("module", "import", "a.b", None) not in got
+
+    def test_gitlink_paths_of_every_kind_become_module_inputs(self):
+        """_gitlink_changes emits add/bump/remove; all three name a submodule
+        entity at that path (mcp_server.py:9556).
+        """
+        got = inputs_from_commit_extraction(
+            [], [("add", "sha1", "vendor/x"), ("bump", "sha2", "vendor/y"),
+                 ("remove", "sha3", "vendor/z")]
+        )
+        paths = {inp.file_path for inp in got if inp.producer == "gitlink"}
+        assert paths == {"vendor/x", "vendor/y", "vendor/z"}
+
+
+class TestCollectInputsEndToEnd:
+    def test_a_private_public_pair_collides_through_real_extraction(self, tmp_path):
+        """Drives the REAL _extract_commit over a purpose-built repo. Every
+        other test in this file would still pass if Stage 1 collected the wrong
+        triples -- this is the one that catches the audit mis-driving the
+        extractor.
+
+        Counterfactual: with only `def foo` in the file, offenders is empty.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "mod.py").write_text("def _helper():\n    pass\n\ndef helper():\n    pass\n")
+        for cmd in (
+            ["git", "init", "-q", "-b", "main"],
+            ["git", "config", "user.email", "t@example.com"],
+            ["git", "config", "user.name", "t"],
+            ["git", "add", "-A"],
+            ["git", "commit", "-q", "-m", "init"],
+        ):
+            subprocess.run(cmd, cwd=repo, check=True)
+
+        inputs, diagnostics = collect_inputs(str(repo), "main", jobs=1)
+
+        assert diagnostics["commits"] == 1
+        assert diagnostics["extraction_failures"] == 0
+        found = offenders(group_by_ident(inputs, current_ident))
+        assert len(found) == 1
+        names = {inp.name for inp in next(iter(found.values()))}
+        assert names == {"_helper", "helper"}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v -k "CommitExtraction or EndToEnd"
+```
+
+Expected: `ImportError: cannot import name 'collect_inputs'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `evals/at_scale/probe_ident_collision_census.py`:
+
+```python
+from concurrent.futures import ProcessPoolExecutor
+from typing import Any, Sequence as _Sequence
+
+
+def inputs_from_commit_extraction(
+    file_results: _Sequence[tuple],
+    gitlink_changes: _Sequence[tuple],
+) -> List[EntityInput]:
+    """Harvest every _code_ident input one commit's extraction implies.
+
+    file_results entries are (status, file_path, extracted, precomputed,
+    old_path) per _extract_commit's contract (mcp_server.py:8475-8484). A "D"
+    entry carries extracted=None and precomputed=None and is skipped: the path
+    names an entity being CLOSED, not one being introduced, and its inputs were
+    already collected when it was introduced.
+
+    The category-to-entity_type mapping and the field qualification mirror
+    _precompute_file_triples (mcp_server.py:7044-7122). If that function and
+    this one ever disagree, that one is right.
+    """
+    collected: List[EntityInput] = []
+
+    for status, file_path, extracted, precomputed, _old_path in file_results:
+        if extracted is None:
+            continue
+        collected.append(EntityInput("module", "code", file_path, None))
+        for fn_name in extracted.get("functions", []):
+            collected.append(EntityInput("function", "code", file_path, fn_name))
+        for cls_name in extracted.get("classes", []):
+            collected.append(EntityInput("class", "code", file_path, cls_name))
+        for gvar_name in extracted.get("globals", []):
+            collected.append(EntityInput("variable", "code", file_path, gvar_name))
+        for field_name, owning_class, _is_static in extracted.get("fields", []):
+            collected.append(
+                EntityInput("field", "code", file_path, f"{owning_class}.{field_name}")
+            )
+        # Only UNRESOLVED imports. A resolved one already points at the in-tree
+        # module ident the module producer above contributes, so counting it
+        # again would manufacture a cross-producer collision on every internal
+        # import in the repository.
+        for import_name, _dep_ident, is_resolved in (
+            (precomputed or {}).get("resolved_imports", [])
+        ):
+            if not is_resolved:
+                collected.append(EntityInput("module", "import", import_name, None))
+
+    # add/bump/remove all name a submodule entity at that path
+    # (mcp_server.py:9556), so every kind contributes.
+    for _kind, _sha, path in gitlink_changes:
+        collected.append(EntityInput("module", "gitlink", path, None))
+
+    return collected
+
+
+def collect_inputs(
+    repo_path: str,
+    branch: Optional[str] = None,
+    jobs: Optional[int] = None,
+) -> Tuple[List[EntityInput], Dict[str, Any]]:
+    """Walk the branch and collect every input that ever reached _code_ident.
+
+    Drives mcp_server._extract_commit rather than re-implementing parsing.
+    That function is documented read-only, stateless and DB-free
+    (mcp_server.py:8455) and is exactly what _run_ingestion's worker pool
+    runs, so this audit measures the code that actually produces idents in
+    production rather than a reimplementation that could drift from it.
+
+    Walking A/M/R across every commit reaches every version of every file that
+    ever existed on the branch: each distinct blob at each path is introduced
+    by exactly one such entry, so no separate initial-tree pass is needed.
+
+    Inputs are deduplicated here. A name unchanged across 400 commits costs one
+    entry, not 400.
+    """
+    resolved_branch = branch or mcp_server._default_git_branch(repo_path)
+    ignore_patterns = mcp_server._load_ignore_patterns(repo_path)
+    commits = mcp_server._git_commits(repo_path, None, resolved_branch)
+    hashes = [row[0] for row in commits]
+
+    seen: Dict[EntityInput, None] = {}
+    failed: List[str] = []
+
+    with ProcessPoolExecutor(max_workers=jobs) as executor:
+        futures = {
+            executor.submit(
+                mcp_server._extract_commit, repo_path, commit_hash, ignore_patterns
+            ): commit_hash
+            for commit_hash in hashes
+        }
+        for future, commit_hash in futures.items():
+            try:
+                file_results, gitlink_changes, _gitmodules, _renamed = future.result()
+            except Exception:
+                # Per-commit failure must not abort the audit -- it is a
+                # measurement diagnostic, and the exit gate below decides
+                # whether there were too many for the run to mean anything.
+                failed.append(commit_hash)
+                continue
+            for inp in inputs_from_commit_extraction(file_results, gitlink_changes):
+                seen[inp] = None
+
+    return list(seen), {
+        # Taken from the walked list, not a separate git rev-parse, so it
+        # cannot disagree with what was actually measured.
+        "head_commit": hashes[-1] if hashes else None,
+        "branch": resolved_branch,
+        "commits": len(hashes),
+        "extraction_failures": len(failed),
+        "failed_commits": failed,
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v
+```
+
+Expected: 33 passed.
+
+- [ ] **Step 5: Prove the ablation**
+
+Temporarily drop the `if not is_resolved:` guard so every import becomes an input. Re-run; expected: `test_only_unresolved_imports_become_import_inputs` FAILS. Revert. Then temporarily change the field loop to use the bare `field_name`; expected: `test_fields_are_qualified_with_their_owning_class` FAILS. Revert both.
+
+Then run the end-to-end test's own counterfactual by hand: change the temp repo's file to contain only `def helper()`, confirm `offenders(...)` is empty, and restore the test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add evals/at_scale/probe_ident_collision_census.py tests/test_at_scale_ident_collision_census.py
+git commit -F - <<'EOF'
+Add the #263 audit's Stage 1 input collection
+
+Drives mcp_server._extract_commit rather than re-implementing parsing.
+That function is already read-only, stateless and DB-free, and is what
+_run_ingestion's worker pool runs -- so the audit measures the code that
+actually produces idents, not a reimplementation that could drift.
+
+Walking A/M/R across every commit reaches every version of every file
+that ever existed: each distinct blob at each path is introduced by
+exactly one such entry, so no separate initial-tree pass is needed.
+
+Only UNRESOLVED imports become import inputs. A resolved one already
+points at the in-tree module ident the module producer contributes, so
+counting it again would manufacture a cross-producer collision on every
+internal import in the repository.
+
+Refs #263
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK
+EOF
+```
+
+---
+
+### Task 5: Report assembly, predictions, CLI and exit gate
+
+**Files:**
+- Modify: `evals/at_scale/probe_ident_collision_census.py`
+- Test: `tests/test_at_scale_ident_collision_census.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+- Produces:
+  - `PREDICTIONS: Tuple[Tuple[str, str], ...]` — `(id, statement)` pairs
+  - `evaluate_predictions(report) -> Dict[str, Dict]` — id → `{"statement", "outcome", "evidence"}` with outcome in `{"held", "failed"}`
+  - `build_report(inputs, diagnostics, repo_path) -> Dict[str, Any]`
+  - `measurement_invalid(report) -> Optional[str]` — None when valid, else the reason
+  - `main() -> int`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_at_scale_ident_collision_census.py`:
+
+```python
+from evals.at_scale.probe_ident_collision_census import (  # noqa: E402
+    PREDICTIONS,
+    build_report,
+    evaluate_predictions,
+    measurement_invalid,
+)
+
+
+def _report_over(inputs, **diag):
+    diagnostics = {
+        "head_commit": "abc123", "branch": "main", "commits": 10,
+        "extraction_failures": 0, "failed_commits": [],
+    }
+    diagnostics.update(diag)
+    return build_report(inputs, diagnostics, "/repo")
+
+
+class TestBuildReport:
+    def test_offenders_are_reported_verbatim_not_only_counted(self):
+        """A nonzero count escalates this to fix design, and that work should
+        start from the data rather than re-deriving it by hand. Counterfactual:
+        a report carrying only counts passes every other test in this class.
+        """
+        report = _report_over(_known_collision_inputs())
+        rows = report["offenders"]["function"]["idents"]
+        assert len(rows) == 3
+        members = rows[":function/tests-test-mcp-server-py-commit"]
+        assert sorted(m["name"] for m in members) == ["_commit", "commit"]
+        assert all(m["file_path"] == "tests/test_mcp_server.py" for m in members)
+        assert all(m["producer"] == "code" for m in members)
+
+    def test_every_entity_type_appears_even_at_zero(self):
+        """A missing key and a zero are different claims. Only the second one
+        says "measured, found none".
+        """
+        report = _report_over([_fn("a/b.py", "solo")])
+        assert set(report["offenders"]) == set(ENTITY_TYPES)
+        assert report["offenders"]["class"]["count"] == 0
+
+    def test_candidate_table_carries_every_rule(self):
+        report = _report_over(_known_collision_inputs())
+        assert set(report["candidates"]) == set(RULES)
+
+
+class TestExitGate:
+    def test_finding_collisions_is_not_an_invalid_measurement(self):
+        """The exit code reflects measurement VALIDITY, never the finding.
+        Collisions are the number #263 asks for and must never fail the run.
+        Do not adjust this gate to make a run pass.
+        """
+        report = _report_over(_known_collision_inputs())
+        assert report["offenders"]["function"]["count"] == 3
+        assert measurement_invalid(report) is None
+
+    def test_zero_commits_is_invalid(self):
+        assert measurement_invalid(_report_over([], commits=0)) is not None
+
+    def test_zero_triples_is_invalid(self):
+        """Distinguishes "measured, found none" from "measured nothing". A run
+        that collected no inputs cannot report zero collisions as a finding.
+        """
+        assert measurement_invalid(_report_over([])) is not None
+
+    def test_extraction_failures_above_one_percent_are_invalid(self):
+        inputs = _known_collision_inputs()
+        assert measurement_invalid(
+            _report_over(inputs, commits=100, extraction_failures=2)
+        ) is not None
+        assert measurement_invalid(
+            _report_over(inputs, commits=100, extraction_failures=1)
+        ) is None
+
+
+class TestPredictions:
+    def test_every_declared_prediction_is_evaluated(self):
+        report = _report_over(_known_collision_inputs())
+        evaluated = evaluate_predictions(report)
+        assert set(evaluated) == {pid for pid, _ in PREDICTIONS}
+        for row in evaluated.values():
+            assert row["outcome"] in ("held", "failed")
+
+    def test_a_prediction_can_actually_fail(self):
+        """Predictions exist to be falsifiable. An evaluator that returns
+        "held" unconditionally is worse than none, because it launders a
+        failed prediction as confirmation. Three offenders is exactly the
+        count P1 says the audit must EXCEED.
+        """
+        evaluated = evaluate_predictions(_report_over(_known_collision_inputs()))
+        assert evaluated["P1"]["outcome"] == "failed"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v -k "BuildReport or ExitGate or Predictions"
+```
+
+Expected: `ImportError: cannot import name 'PREDICTIONS'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `evals/at_scale/probe_ident_collision_census.py`:
+
+```python
+import datetime
+import json
+
+# Fixed BEFORE any data exists, so the run cannot be rationalized afterwards.
+# A prediction that fails is a finding about the design, not noise to be
+# smoothed over: it is recorded in the result either way.
+PREDICTIONS: Tuple[Tuple[str, str], ...] = (
+    ("P1", "The true collision count exceeds the 3 #257's census found, "
+           "because that census can only see collisions whose loser was "
+           "closed and reopened."),
+    ("P2", "leading-underscore is the dominant named shape among all "
+           "offenders."),
+    ("P3", "R5, the control, reports a nonzero residual at least as large as "
+           "the leading-underscore offender count."),
+    ("P4", "R2's rename count is proportionally lower on module idents than "
+           "on function idents, because a module input has no '::' separator."),
+    ("P5", "R4's rename count equals the total ident count."),
+)
+
+
+def build_report(
+    inputs: Sequence[EntityInput],
+    diagnostics: Dict[str, Any],
+    repo_path: str,
+) -> Dict[str, Any]:
+    baseline = group_by_ident(inputs, current_ident)
+    all_offenders = offenders(baseline)
+
+    per_type: Dict[str, Dict[str, Any]] = {}
+    for entity_type in ENTITY_TYPES:
+        rows = {
+            ident: members
+            for ident, members in all_offenders.items()
+            if members[0].entity_type == entity_type
+        }
+        per_type[entity_type] = {
+            # A missing key and a zero are different claims; only the second
+            # says "measured, found none". Every type appears unconditionally.
+            "idents_total": sum(
+                1 for _ident, members in baseline.items()
+                if members[0].entity_type == entity_type
+            ),
+            "count": len(rows),
+            "idents": {
+                ident: [
+                    {"producer": m.producer, "file_path": m.file_path, "name": m.name}
+                    for m in members
+                ]
+                for ident, members in rows.items()
+            },
+        }
+
+    shape_counts: Dict[str, int] = {shape: 0 for shape in SHAPES}
+    for members in all_offenders.values():
+        for shape in classify_shapes(members):
+            shape_counts[shape] += 1
+
+    report: Dict[str, Any] = {
+        "repo_path": repo_path,
+        "branch": diagnostics["branch"],
+        "head_commit": diagnostics["head_commit"],
+        "commits": diagnostics["commits"],
+        "extraction_failures": diagnostics["extraction_failures"],
+        "failed_commits": diagnostics["failed_commits"],
+        "triples_total": len(inputs),
+        "idents_total": len(baseline),
+        "offenders": per_type,
+        "offenders_total": len(all_offenders),
+        "offenders_by_shape": shape_counts,
+        "candidates": score_all_rules(inputs, baseline),
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
+    }
+    report["predictions"] = evaluate_predictions(report)
+    return report
+
+
+def evaluate_predictions(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    statements = dict(PREDICTIONS)
+    shape_counts = report["offenders_by_shape"]
+    leading = shape_counts.get("leading-underscore", 0)
+
+    def _row(pid: str, held: bool, evidence: str) -> Dict[str, Any]:
+        return {
+            "statement": statements[pid],
+            "outcome": "held" if held else "failed",
+            "evidence": evidence,
+        }
+
+    total = report["offenders_total"]
+    dominant = max(
+        (s for s in SHAPES if s != "other"),
+        key=lambda s: shape_counts.get(s, 0),
+        default="other",
+    )
+    r5 = report["candidates"]["R5"]["residual"]
+    r4 = report["candidates"]["R4"]["renames"]
+    r2 = report["candidates"]["R2"]["renames"]
+
+    return {
+        "P1": _row("P1", total > 3, f"offenders_total={total}"),
+        "P2": _row(
+            "P2",
+            dominant == "leading-underscore",
+            f"dominant shape={dominant} at {shape_counts.get(dominant, 0)}",
+        ),
+        "P3": _row("P3", r5 >= leading and r5 > 0,
+                   f"R5 residual={r5}, leading-underscore offenders={leading}"),
+        "P4": _row("P4", r2 < report["idents_total"],
+                   f"R2 renames={r2} of {report['idents_total']} idents"),
+        "P5": _row("P5", r4 == report["idents_total"],
+                   f"R4 renames={r4} of {report['idents_total']} idents"),
+    }
+
+
+def measurement_invalid(report: Dict[str, Any]) -> Optional[str]:
+    """Why this run cannot be believed, or None.
+
+    VALIDITY ONLY. A nonzero collision count is the number #263 asks for and
+    must NEVER fail the run -- finding collisions is this audit's entire
+    purpose. Do not widen this gate to make a run "pass".
+    """
+    if report["commits"] == 0:
+        return "Zero commits walked. Nothing was measured."
+    if report["triples_total"] == 0:
+        return (
+            "Zero inputs collected across "
+            f"{report['commits']} commits. A run that collected nothing "
+            "cannot report zero collisions as a finding."
+        )
+    failures = report["extraction_failures"]
+    if failures > report["commits"] * 0.01:
+        return (
+            f"_extract_commit raised on {failures} of {report['commits']} "
+            "commits (>1%). The input set is incomplete, so the count is a "
+            "bound rather than the exact number this audit exists to produce."
+        )
+    return None
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Count, exactly, how many _code_ident values on real history are "
+            "reachable from more than one (entity_type, file_path, name) input."
+        )
+    )
+    parser.add_argument("--repo-path", default=".")
+    parser.add_argument("--branch", default=None)
+    parser.add_argument("--jobs", type=int, default=None)
+    parser.add_argument("--json-out", "--output", dest="json_out", default=None)
+    args = parser.parse_args()
+
+    inputs, diagnostics = collect_inputs(args.repo_path, args.branch, jobs=args.jobs)
+    report = build_report(inputs, diagnostics, args.repo_path)
+
+    print(json.dumps(report, indent=2))
+    print()
+    print(f"repo:                   {report['repo_path']} @ {report['branch']}")
+    print(f"head:                   {report['head_commit']}")
+    print(f"commits:                {report['commits']}")
+    print(f"extraction failures:    {report['extraction_failures']}")
+    print(f"distinct inputs:        {report['triples_total']}")
+    print(f"distinct idents:        {report['idents_total']}")
+    print()
+    print("OFFENDERS (idents reachable from >1 distinct input)")
+    for entity_type in ENTITY_TYPES:
+        row = report["offenders"][entity_type]
+        print(f"  {entity_type:<12} {row['count']:>6} of {row['idents_total']}")
+    print(f"  {'TOTAL':<12} {report['offenders_total']:>6}")
+    print()
+    print("BY SHAPE (an offender may carry more than one label)")
+    for shape in SHAPES:
+        print(f"  {shape:<20} {report['offenders_by_shape'][shape]:>6}")
+    print()
+    print("CANDIDATE RULES")
+    print(f"  {'rule':<6} {'residual':>9} {'renames':>9}   description")
+    for rule_id in sorted(RULES):
+        row = report["candidates"][rule_id]
+        print(
+            f"  {rule_id:<6} {row['residual']:>9} {row['renames']:>9}   "
+            f"{row['description']}"
+        )
+    print()
+    print("PREDICTIONS (fixed before the run; a failure is a finding)")
+    for pid, _ in PREDICTIONS:
+        row = report["predictions"][pid]
+        print(f"  {pid}  {row['outcome']:<7} {row['evidence']}")
+
+    if report["candidates"]["R5"]["residual"] == 0 and (
+        report["offenders_by_shape"]["leading-underscore"] > 0
+    ):
+        print()
+        print(
+            "NOTE: R5 is the CONTROL and reported zero residual on a history\n"
+            "that HAS leading-underscore offenders. R5 slugs the name\n"
+            "independently, and strip('-') still eats the leading underscore,\n"
+            "so it cannot separate them. The scorer is wrong and every other\n"
+            "row in the candidate table is suspect. Do not act on this run."
+        )
+
+    reason = measurement_invalid(report)
+    if reason:
+        print()
+        print(f"INVALID MEASUREMENT. {reason}")
+        print("Do not adjust this gate to make a run pass.")
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.json_out}")
+    return 1 if reason else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+Also add `ENTITY_TYPES` to the test file's import block if not already present.
+
+- [ ] **Step 3b: Hoist every import to the top of both files**
+
+Tasks 1–5 each appended their own imports next to the code that needed them,
+so both files now carry `import` statements scattered through the body. Move
+them all into the single import block at the top of each file, keeping
+`mcp_server`'s import after the `sys.path` insert (it depends on it) and
+collapsing the duplicate `typing` imports into one line. This is a review
+finding waiting to happen — the #257 probe's test file took the same
+correction.
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -q
+```
+
+Expected: still green after the move.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v
+```
+
+Expected: 43 passed.
+
+- [ ] **Step 5: Prove the ablation**
+
+Temporarily make `measurement_invalid` also return a reason when
+`report["offenders_total"] > 0`. Re-run; expected:
+`test_finding_collisions_is_not_an_invalid_measurement` FAILS — that is the
+test standing between this audit and an exit gate that punishes it for finding
+what it was built to find. Revert.
+
+Then temporarily make `evaluate_predictions` return `"held"` unconditionally;
+expected: `test_a_prediction_can_actually_fail` FAILS. Revert both.
+
+- [ ] **Step 6: Run the full suite**
+
+```bash
+.venv/bin/python -m pytest tests/ -q
+```
+
+Expected: no new failures relative to the branch point. Record the count.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add evals/at_scale/probe_ident_collision_census.py tests/test_at_scale_ident_collision_census.py
+git commit -F - <<'EOF'
+Add the #263 audit's report, predictions, CLI and exit gate
+
+The exit gate is validity-only: zero commits, zero inputs, or >1%
+extraction failures. A nonzero collision count is the number #263 asks
+for and never fails the run.
+
+Predictions are fixed before any data exists and evaluated mechanically,
+so a failed one is recorded rather than smoothed over. The CLI prints a
+loud note when R5 -- the control -- comes back clean on a history that
+has leading-underscore offenders, since that means the scorer is broken.
+
+Refs #263
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK
+EOF
+```
+
+---
+
+### Task 6: Run the audit and record the measurement
+
+**Files:**
+- Create: `evals/at_scale/results/263-ident-collision-census.json`
+- Modify: `evals/at_scale/benchmark.md`
+
+**Interfaces:**
+- Consumes: `main()` from Task 5. Produces no new code surface.
+
+- [ ] **Step 1: Run the audit against this repository**
+
+```bash
+.venv/bin/python evals/at_scale/probe_ident_collision_census.py \
+  --repo-path . \
+  --json-out evals/at_scale/results/263-ident-collision-census.json
+```
+
+Expected: exit 0. If it exits 1, read the INVALID MEASUREMENT reason and address the cause — do not relax the gate.
+
+- [ ] **Step 2: Check the control before believing anything else**
+
+Confirm from the output that `R5` has a **nonzero** residual. If it is zero while `leading-underscore` is nonzero, the scorer is broken; stop and go back to Task 3.
+
+- [ ] **Step 3: Confirm the known collisions reproduce**
+
+```bash
+.venv/bin/python -c "
+import json
+r = json.load(open('evals/at_scale/results/263-ident-collision-census.json'))
+for ident in (
+    ':function/tests-test-mcp-server-py-commit',
+    ':function/tests-test-mcp-server-py-snapshot',
+    ':function/evals-at-scale-profile-forward-reconcile-attribution-py-main',
+):
+    print(ident, ident in r['offenders']['function']['idents'])
+"
+```
+
+Expected: all three `True`. These are the collisions #257 independently observed; an audit that misses them is not measuring the right thing, regardless of what its total says.
+
+- [ ] **Step 4: Record the result in `evals/at_scale/benchmark.md`**
+
+Add a subsection alongside the existing one-off probe entries, following how `probe_dep_preload_exposure.py` is described there. State: the headline offender count, the shape breakdown, the candidate table, **every prediction's outcome including the failed ones**, and the one-line conclusion on whether a fix needs a migration for existing graphs or only a forward change.
+
+Do not write the conclusion before reading the numbers.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add evals/at_scale/results/263-ident-collision-census.json evals/at_scale/benchmark.md
+git commit -F - <<'EOF'
+Record the #263 ident collision measurement
+
+<Replace this line with the actual headline numbers: offenders total and
+per type, the shape breakdown, and which candidate rules came back clean
+at what rename cost. Name every prediction that failed.>
+
+Refs #263
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK
+EOF
+```
+
+- [ ] **Step 6: Post the finding to #263**
+
+```bash
+gh issue comment 263 --body-file <(...)
+```
+
+Report the offender count, the shape breakdown, the candidate table, the failed predictions, and the migration-versus-forward-fix conclusion. Do not use any GitHub closing keyword — the audit does not settle the bug, it sizes it.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every spec section maps to a task: "Why the graph cannot answer this" → Task 4's module docstring and the source-derived collection; ":module/ namespace shared by three producers" → Task 1's `PRODUCERS` and Task 4's gitlink/import harvesting; "Stage 1" → Task 4; "Stage 2" → Tasks 1–2; "Stage 3" → Task 3; "Predictions" → Task 5; "Report fields" → Task 5's `build_report`; "Exit code" → Task 5's `measurement_invalid`; "Testing" (all six numbered requirements) → the tests in Tasks 1–4 (test 1 → Task 1, test 2 → Task 3, test 3 → Task 3, test 4 → Task 2, test 5 → Task 2 and Task 4, test 6 → Task 4's `TestCollectInputsEndToEnd`); "Deliverables" → Tasks 1–6, with `benchmark.md` in Task 6 and CLAUDE.md correctly untouched.
+
+**Placeholder scan.** One deliberate placeholder remains: Task 6 Step 5's commit body and Step 6's issue comment cannot be written before the numbers exist. Both are marked as such with explicit instructions on what to fill in. Every code step carries real code.
+
+**Type consistency.** `EntityInput` fields are `(entity_type, producer, file_path, name)` in Task 1 and used in that order in Tasks 2, 4 and 5. `group_by_ident` returns `Dict[str, List[EntityInput]]` in Task 1 and is consumed as such by `offenders`, `score_rule` and `build_report`. `RULES` values are `(description, ident_fn)` tuples in Task 3 and unpacked in that order in Task 5's CLI. `collect_inputs` returns `(inputs, diagnostics)` in Task 4 and is destructured that way in Task 5's `main`.

--- a/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
+++ b/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
@@ -370,6 +370,36 @@ class TestClassifyShapes:
         ]
         assert "cross-producer" in classify_shapes(members)
 
+    def test_private_pascal_case_beside_public_snake_case_is_leading_underscore(self):
+        """_Config/config and _Handler/handler are ordinary Python and they DO
+        collide (both -> :function/a-b-py-foo for _Foo/foo). An exact-case
+        _strip_private comparison drops them into "other", which is reserved
+        for UNPREDICTED families -- hiding a predicted one.
+
+        Counterfactual: with _strip_private compared exact-case, this pair
+        yields {"other"} and this test fails.
+        """
+        members = [_fn("a/b.py", "_Foo"), _fn("a/b.py", "foo")]
+        assert current_ident(members[0]) == current_ident(members[1])
+        assert "leading-underscore" in classify_shapes(members)
+
+    def test_a_producer_only_difference_is_not_a_case_collision(self):
+        """Two inputs whose raw values are byte-identical differ only in
+        producer -- exactly the cross-producer collision this audit exists to
+        find. Labelling them "case-only" asserts a case difference that is not
+        there.
+
+        Counterfactual: without the `a_raw != b_raw` guard, casefold equality
+        holds trivially and "case-only" is emitted.
+        """
+        members = [
+            EntityInput("module", "code", "vendor/x", None),
+            EntityInput("module", "gitlink", "vendor/x", None),
+        ]
+        shapes = classify_shapes(members)
+        assert "cross-producer" in shapes
+        assert "case-only" not in shapes
+
     def test_an_unclassifiable_pair_falls_through_to_other(self):
         """'other' is the interesting bucket -- it is where a collision nobody
         predicted shows up. It must be reachable, not vestigial.
@@ -422,15 +452,36 @@ def _strip_private(name: Optional[str]) -> str:
 
 
 def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
+    """Every collision family this pair belongs to.
+
+    The checks are INDEPENDENT, not an elif chain. A pair can belong to more
+    than one family and the caller returns a set, so making them exclusive
+    would silently drop the second label -- and, worse, would let the winner
+    depend on check order rather than on the data.
+
+    Each check also carries an inequality guard. Without one, "case-only"
+    fires on two inputs whose raw values are byte-identical (a pair differing
+    only in producer -- exactly the cross-producer collision this audit exists
+    to find), asserting a case difference that is not there.
+    """
     shapes: Set[str] = set()
     if a.producer != b.producer:
         shapes.add("cross-producer")
     a_raw, b_raw = raw_value(a), raw_value(b)
-    if a_raw.casefold() == b_raw.casefold():
+    if a_raw != b_raw and a_raw.casefold() == b_raw.casefold():
         shapes.add("case-only")
-    elif a.file_path == b.file_path and _strip_private(a.name) == _strip_private(b.name):
+    # casefold on BOTH sides, so a private PascalCase helper beside a public
+    # snake_case one (_Config/config, _Handler/handler -- ordinary Python) is
+    # still recognised as the underscore family. An exact-case comparison here
+    # drops those into "other", which is reserved for UNPREDICTED families and
+    # so would hide a predicted one.
+    if (
+        a.name != b.name
+        and a.file_path == b.file_path
+        and _strip_private(a.name).casefold() == _strip_private(b.name).casefold()
+    ):
         shapes.add("leading-underscore")
-    elif a.file_path != b.file_path or (a.name is None) != (b.name is None):
+    if a.file_path != b.file_path or (a.name is None) != (b.name is None):
         # The two inputs put the path/name boundary in different places, so
         # the ident cannot say where the path ended -- the collision family
         # _code_ident's docstring already anticipates.
@@ -455,9 +506,15 @@ def classify_shapes(members: Sequence[EntityInput]) -> Set[str]:
     return shapes
 ```
 
-Note the `elif` chain in `_pair_shapes`: `case-only` is checked before
-`leading-underscore` because `_Foo`/`foo` is genuinely both, and attributing it
-to case is the narrower claim.
+An earlier draft of this plan made these checks an `elif` chain, on the claim
+that `_Foo`/`foo` is "genuinely both case-only and leading-underscore" so the
+narrower label should win. **That premise is false and the chain is a defect.**
+Trace it: `a/b.py::_Foo`.casefold() is `a/b.py::_foo`, which does not equal
+`a/b.py::foo`, so `case-only` never fires on that pair at all; the extra
+underscore breaks the character correspondence `casefold` needs. Under
+exact-case `_strip_private`, `"Foo" != "foo"` kills `leading-underscore` too,
+and the pair lands in `"other"` despite genuinely colliding. Independent checks
+with casefolded `_strip_private` are what the code above does instead.
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
@@ -465,13 +522,17 @@ to case is the narrower claim.
 .venv/bin/python -m pytest tests/test_at_scale_ident_collision_census.py -v
 ```
 
-Expected: 14 passed.
+Expected: 16 passed.
 
 - [ ] **Step 5: Prove the ablation**
 
-Temporarily replace `classify_shapes`' body with `return {"leading-underscore"}`. Re-run.
+Three degradations, each reverted before the next.
 
-Expected: `test_case_only_pair_is_not_labelled_leading_underscore` and `test_an_unclassifiable_pair_falls_through_to_other` FAIL. Separately, temporarily replace `_strip_private` with `return (name or "").lstrip("_")` and confirm `test_private_public_field_on_one_class_is_leading_underscore` FAILS. Revert both.
+1. Replace `classify_shapes`' body with `return {"leading-underscore"}`. Expected FAIL: `test_case_only_pair_is_not_labelled_leading_underscore`, `test_an_unclassifiable_pair_falls_through_to_other`, `test_inputs_from_different_files_are_separator_vs_path`, `test_import_and_in_tree_module_are_cross_producer`, `test_a_producer_only_difference_is_not_a_case_collision`. (A constant label cannot satisfy any of the label-specific assertions — count them all rather than stopping at the first two.)
+2. Replace `_strip_private` with `return (name or "").lstrip("_")`. Expected FAIL: `test_private_public_field_on_one_class_is_leading_underscore` only.
+3. Drop the `a_raw != b_raw` guard from the `case-only` check, and separately drop `.casefold()` from the `_strip_private` comparison. Expected FAIL: `test_a_producer_only_difference_is_not_a_case_collision` for the first, `test_private_pascal_case_beside_public_snake_case_is_leading_underscore` for the second.
+
+Degradation 3 is the one that matters most: it is the pair of defects an earlier draft of this plan actively mandated.
 
 - [ ] **Step 6: Commit**
 

--- a/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
+++ b/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
@@ -1383,27 +1383,44 @@ def evaluate_predictions(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     total = report["offenders_total"]
     r5 = report["candidates"]["R5"]["residual"]
 
-    # P2. `max` returns the FIRST maximal element, and SHAPES[0] is
-    # "leading-underscore" -- so an all-zero corpus, or an exact tie, would
-    # hand P2 a "held" it did not earn. Both are ruled out explicitly:
-    # unevaluable when there are no offenders at all, and STRICT dominance
-    # otherwise, with the runner-up named in the evidence so a near-tie is
-    # visible without re-running anything.
+    # P2 is ruled by STRICT comparison against the runner-up, not by max().
+    # max() returns the first maximal element and SHAPES[0] is
+    # "leading-underscore", so it named leading-underscore the winner on a
+    # corpus where every count was 0 -- and a zero-offender run clears the
+    # validity gate, so that laundered "held" reached the committed artifact.
+    # The same first-wins bias read an exact tie as a win.
     rivals = sorted(
-        ((shape_counts.get(s, 0), s) for s in SHAPES if s != "other"),
+        (
+            (shape_counts.get(shape, 0), shape)
+            for shape in SHAPES
+            if shape not in ("other", "leading-underscore")
+        ),
         reverse=True,
     )
-    if not rivals or rivals[0][0] == 0:
-        p2 = _row("P2", False, "not evaluable: no offenders in this corpus")
-    else:
-        runner_up_count, runner_up = next(
-            ((c, s) for c, s in rivals if s != "leading-underscore"), (0, "none")
+    runner_up_count, runner_up = rivals[0]
+    if total == 0:
+        p2_held = False
+        p2_evidence = (
+            "not evaluable: no offenders in this corpus "
+            "(offenders_total=0, leading-underscore=0)"
         )
-        p2 = _row(
-            "P2",
-            leading > runner_up_count,
-            f"leading-underscore={leading}, runner-up {runner_up}="
-            f"{runner_up_count}",
+    elif leading == 0 and runner_up_count == 0:
+        # Offenders exist but every named shape is empty, i.e. they all landed
+        # in "other". Distinct from the case above and worth saying so:
+        # "other" is where an UNPREDICTED collision family surfaces, so this is
+        # a finding, not an empty run.
+        p2_held = False
+        p2_evidence = (
+            "not evaluable: no offender carries a named shape "
+            f"(offenders_total={total}, all in 'other')"
+        )
+    else:
+        # Strict: a tie is not a win. The runner-up is named and counted so a
+        # near-tie is visible without re-running anything.
+        p2_held = leading > runner_up_count
+        p2_evidence = (
+            f"leading-underscore={leading}, "
+            f"runner-up {runner_up}={runner_up_count}"
         )
 
     # P4 compares FRACTIONS, per entity type -- an ident-count total says
@@ -1529,15 +1546,20 @@ def main() -> int:
             f"{row['description']}"
         )
     print()
-    print("SELF-CHECKS (wiring assertions, NOT predictions)")
-    for sid, _ in SELF_CHECKS:
-        row = report["self_checks"][sid]
-        print(f"  {sid}  {row['outcome']:<7} {row['evidence']}")
-    print()
     print("PREDICTIONS (fixed before the run; a failure is a finding)")
     for pid, _ in PREDICTIONS:
         row = report["predictions"][pid]
         print(f"  {pid}  {row['outcome']:<7} {row['evidence']}")
+    print()
+    # Under its own heading, never inside the predictions block: these hold by
+    # construction, so counting them among the predictions would inflate the
+    # held tally with something that was never at risk.
+    print("SELF-CHECKS (hold by construction; a failure indicts the SCORER)")
+    for sid, _ in SELF_CHECKS:
+        row = report["self_checks"][sid]
+        print(f"  {sid}  {row['outcome']:<7} {row['evidence']}")
+        if row["outcome"] == "failed":
+            print(f"      {row['statement']}")
 
     if report["candidates"]["R5"]["residual"] == 0 and (
         report["offenders_by_shape"]["leading-underscore"] > 0

--- a/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
+++ b/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
@@ -475,8 +475,19 @@ def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
     # still recognised as the underscore family. An exact-case comparison here
     # drops those into "other", which is reserved for UNPREDICTED families and
     # so would hide a predicted one.
+    #
+    # The guard compares NAME casefold, not exact name, and requires that
+    # comparison to be UNEQUAL -- i.e. that the pair is not already
+    # explainable by case alone. Without it, a pair with no underscore at
+    # all (Foo/foo) also satisfies the stripped-casefold equality below,
+    # since stripping is a no-op when there is nothing to strip, and
+    # leading-underscore would fire on top of a plain case-only pair. That
+    # is the same false-positive shape as the case-only guard, just on the
+    # other check.
+    a_name_cf = (a.name or "").casefold()
+    b_name_cf = (b.name or "").casefold()
     if (
-        a.name != b.name
+        a_name_cf != b_name_cf
         and a.file_path == b.file_path
         and _strip_private(a.name).casefold() == _strip_private(b.name).casefold()
     ):

--- a/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
+++ b/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
@@ -356,12 +356,19 @@ class TestClassifyShapes:
         assert "case-only" in shapes
         assert "leading-underscore" not in shapes
 
-    def test_inputs_from_different_files_are_separator_vs_path(self):
-        """The path/name boundary fell differently on the two inputs -- the
-        case _code_ident's own docstring anticipates.
+    def test_a_name_that_is_a_trailing_path_segment_is_separator_vs_path(self):
+        """One input's NAME is a trailing whole path segment of the other's
+        file_path -- the case _code_ident's own docstring anticipates. These
+        two really collide, and "the paths differ" is NOT the test: a plain
+        paths-differ pair and mcp_server.py against a name of "server" are
+        both pinned as negatives.
         """
-        members = [_fn("a/b.py", "c"), _fn("a/b_py", "c")]
-        assert "separator-vs-path" in classify_shapes(members)
+        members = [
+            _fn("src/utils_py/handlers", "utils"),
+            _fn("src/utils.py", "handlers.utils"),
+        ]
+        assert current_ident(members[0]) == current_ident(members[1])
+        assert classify_shapes(members) == {"separator-vs-path"}
 
     def test_import_and_in_tree_module_are_cross_producer(self):
         members = [
@@ -451,6 +458,31 @@ def _strip_private(name: Optional[str]) -> str:
     return f"{head}{dot}{stripped}" if dot else stripped
 
 
+def _name_is_trailing_path_segment(named: EntityInput, other: EntityInput) -> bool:
+    """True if `named`'s name is a trailing WHOLE path segment of `other`'s
+    file_path, extension stripped -- the design spec's definition of
+    separator-vs-path verbatim.
+
+    WHOLE-SEGMENT, not raw string suffix: "mcp_server.py" does NOT end with the
+    segment "server". mcp_server._path_segments and
+    mcp_server._segments_end_with (mcp_server.py:4102-4117) already do exactly
+    this, so they are reused rather than re-implemented -- READING the audited
+    module is fine, only mutating it is forbidden. Casefolded on both sides for
+    the same reason the leading-underscore check is: the ident lowercases, so an
+    exact-case comparison would drop a genuine instance into "other".
+    """
+    if not named.name:
+        return False
+    segments = mcp_server._path_segments(other.file_path)
+    if not segments:
+        return False
+    segments = segments[:-1] + [Path(segments[-1]).stem]
+    return mcp_server._segments_end_with(
+        [seg.casefold() for seg in segments],
+        [seg.casefold() for seg in mcp_server._path_segments(named.name)],
+    )
+
+
 def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
     """Every collision family this pair belongs to.
 
@@ -492,10 +524,15 @@ def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
         and _strip_private(a.name).casefold() == _strip_private(b.name).casefold()
     ):
         shapes.add("leading-underscore")
-    if a.file_path != b.file_path or (a.name is None) != (b.name is None):
-        # The two inputs put the path/name boundary in different places, so
-        # the ident cannot say where the path ended -- the collision family
-        # _code_ident's docstring already anticipates.
+    # The spec's definition, narrowly: one input's NAME is a trailing whole
+    # path segment of the other's file_path, so the ident cannot say where the
+    # path ended and the name began -- the family _code_ident's docstring
+    # anticipates. This deliberately does NOT fire merely because the two
+    # file_paths differ: "the paths differ" describes most collisions on any
+    # history and says nothing about a path/name boundary. See
+    # _name_is_trailing_path_segment, which reuses mcp_server._path_segments
+    # and mcp_server._segments_end_with for the whole-segment comparison.
+    if _name_is_trailing_path_segment(a, b) or _name_is_trailing_path_segment(b, a):
         shapes.add("separator-vs-path")
     return shapes
 
@@ -505,9 +542,12 @@ def classify_shapes(members: Sequence[EntityInput]) -> Set[str]:
 
     An offender may carry more than one label (a cross-producer collision is
     usually also something else), so this returns a set rather than picking a
-    single winner. "other" is emitted only when nothing else applied: it is
-    where an unpredicted collision family would surface, and collapsing it
-    into any named label would hide exactly the finding worth having.
+    single winner. "other" is emitted when nothing BUT "cross-producer"
+    applied -- not when no label at all applied. "cross-producer" says which
+    call sites the two inputs came from, never what made their values collide,
+    so an offender carrying only that label is still unexplained and belongs in
+    the bucket where an unpredicted collision family surfaces. Collapsing
+    "other" into any named label would hide exactly the finding worth having.
     """
     shapes: Set[str] = set()
     for a, b in combinations(members, 2):

--- a/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
+++ b/docs/superpowers/plans/2026-08-11-ident-collision-audit.md
@@ -1282,13 +1282,30 @@ PREDICTIONS: Tuple[Tuple[str, str], ...] = (
     ("P1", "The true collision count exceeds the 3 #257's census found, "
            "because that census can only see collisions whose loser was "
            "closed and reopened."),
-    ("P2", "leading-underscore is the dominant named shape among all "
-           "offenders."),
+    ("P2", "leading-underscore STRICTLY outnumbers every other named shape "
+           "among all offenders."),
     ("P3", "R5, the control, reports a nonzero residual at least as large as "
            "the leading-underscore offender count."),
-    ("P4", "R2's rename count is proportionally lower on module idents than "
-           "on function idents, because a module input has no '::' separator."),
-    ("P5", "R4's rename count equals the total ident count."),
+    ("P4", "R2's rename cost falls on named entities, not on module idents: "
+           "a module input has no '::' separator to produce an adjacent "
+           "hyphen run, so R2 renames a strictly smaller FRACTION of module "
+           "idents than of function idents."),
+)
+
+# NOT a prediction -- a wiring assertion, kept out of PREDICTIONS so a reader
+# counting held/failed is not counting a tautology among them.
+#
+# R4 appends a hash suffix to EVERY ident by construction, so its rename count
+# must equal the total ident count; no run that clears the validity gate can
+# falsify that. Its value is diagnostic rather than predictive: if it ever
+# reports otherwise, score_rule's rename accounting is broken and every other
+# rule's rename number in the candidate table is suspect. This is the
+# rename-accounting analogue of R5's known-negative control, and it declares
+# itself as such for the same reason R5's description does.
+SELF_CHECKS: Tuple[Tuple[str, str], ...] = (
+    ("S1", "R4's rename count equals the total ident count. R4 appends a hash "
+           "suffix to every ident, so anything else means score_rule's rename "
+           "accounting is broken."),
 )
 
 
@@ -1347,6 +1364,7 @@ def build_report(
         ),
     }
     report["predictions"] = evaluate_predictions(report)
+    report["self_checks"] = evaluate_self_checks(report)
     return report
 
 
@@ -1363,28 +1381,80 @@ def evaluate_predictions(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
         }
 
     total = report["offenders_total"]
-    dominant = max(
-        (s for s in SHAPES if s != "other"),
-        key=lambda s: shape_counts.get(s, 0),
-        default="other",
-    )
     r5 = report["candidates"]["R5"]["residual"]
-    r4 = report["candidates"]["R4"]["renames"]
-    r2 = report["candidates"]["R2"]["renames"]
+
+    # P2. `max` returns the FIRST maximal element, and SHAPES[0] is
+    # "leading-underscore" -- so an all-zero corpus, or an exact tie, would
+    # hand P2 a "held" it did not earn. Both are ruled out explicitly:
+    # unevaluable when there are no offenders at all, and STRICT dominance
+    # otherwise, with the runner-up named in the evidence so a near-tie is
+    # visible without re-running anything.
+    rivals = sorted(
+        ((shape_counts.get(s, 0), s) for s in SHAPES if s != "other"),
+        reverse=True,
+    )
+    if not rivals or rivals[0][0] == 0:
+        p2 = _row("P2", False, "not evaluable: no offenders in this corpus")
+    else:
+        runner_up_count, runner_up = next(
+            ((c, s) for c, s in rivals if s != "leading-underscore"), (0, "none")
+        )
+        p2 = _row(
+            "P2",
+            leading > runner_up_count,
+            f"leading-underscore={leading}, runner-up {runner_up}="
+            f"{runner_up_count}",
+        )
+
+    # P4 compares FRACTIONS, per entity type -- an ident-count total says
+    # nothing about where the rename cost lands, which is the whole claim.
+    # A missing denominator is reported as unevaluable in prose BEFORE any
+    # number, so a reader never meets a bare 0/0.
+    r2_by_type = report["candidates"]["R2"]["renames_by_entity_type"]
+    mod = r2_by_type.get("module", {"renamed": 0, "total": 0})
+    fn = r2_by_type.get("function", {"renamed": 0, "total": 0})
+    if mod["total"] == 0 or fn["total"] == 0:
+        empty = "module" if mod["total"] == 0 else "function"
+        p4 = _row(
+            "P4", False,
+            f"not evaluable: no {empty} idents in this corpus "
+            f"(module {mod['renamed']}/{mod['total']}, "
+            f"function {fn['renamed']}/{fn['total']})",
+        )
+    else:
+        mod_frac = mod["renamed"] / mod["total"]
+        fn_frac = fn["renamed"] / fn["total"]
+        p4 = _row(
+            "P4", mod_frac < fn_frac,
+            f"R2 renames module {mod['renamed']}/{mod['total']}={mod_frac:.3f}, "
+            f"function {fn['renamed']}/{fn['total']}={fn_frac:.3f}",
+        )
 
     return {
         "P1": _row("P1", total > 3, f"offenders_total={total}"),
-        "P2": _row(
-            "P2",
-            dominant == "leading-underscore",
-            f"dominant shape={dominant} at {shape_counts.get(dominant, 0)}",
-        ),
+        "P2": p2,
         "P3": _row("P3", r5 >= leading and r5 > 0,
                    f"R5 residual={r5}, leading-underscore offenders={leading}"),
-        "P4": _row("P4", r2 < report["idents_total"],
-                   f"R2 renames={r2} of {report['idents_total']} idents"),
-        "P5": _row("P5", r4 == report["idents_total"],
-                   f"R4 renames={r4} of {report['idents_total']} idents"),
+        "P4": p4,
+    }
+
+
+def evaluate_self_checks(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """The wiring assertions, reported separately from PREDICTIONS.
+
+    Kept apart so a reader counting held/failed predictions is not counting a
+    tautology among them, and so a failure here reads as what it is: not a
+    surprising fact about this history, but a broken scorer.
+    """
+    statements = dict(SELF_CHECKS)
+    r4 = report["candidates"]["R4"]["renames"]
+    total_idents = report["idents_total"]
+    return {
+        "S1": {
+            "statement": statements["S1"],
+            "outcome": "held" if r4 == total_idents else "failed",
+            "evidence": f"R4 renames={r4} of {total_idents} idents",
+        },
     }
 
 
@@ -1458,6 +1528,11 @@ def main() -> int:
             f"  {rule_id:<6} {row['residual']:>9} {row['renames']:>9}   "
             f"{row['description']}"
         )
+    print()
+    print("SELF-CHECKS (wiring assertions, NOT predictions)")
+    for sid, _ in SELF_CHECKS:
+        row = report["self_checks"][sid]
+        print(f"  {sid}  {row['outcome']:<7} {row['evidence']}")
     print()
     print("PREDICTIONS (fixed before the run; a failure is a finding)")
     for pid, _ in PREDICTIONS:

--- a/docs/superpowers/specs/2026-08-11-ident-collision-audit-design.md
+++ b/docs/superpowers/specs/2026-08-11-ident-collision-audit-design.md
@@ -1,0 +1,334 @@
+# #263 — `_code_ident` collision audit: design
+
+Issue: project-minigraf/temporal_reasoning#263
+Date: 2026-08-11
+Status: design approved, not yet implemented
+
+## What this measures
+
+How many ident values produced by `_code_ident` (`mcp_server.py:4288`) over this
+repository's real history are reachable from **more than one distinct input**?
+
+`_canonical_ident` (`mcp_server.py:4090`) replaces every character outside
+`[a-z0-9-]` with a hyphen and then collapses runs of hyphens. `_code_ident`
+builds its input as `f"{file_path}::{name}"`, so the `::` separator and a
+leading underscore in `name` both become hyphens and the collapse merges them:
+
+```
+tests/test_mcp_server.py::_commit  ->  tests-test-mcp-server-py---commit  ->  tests-test-mcp-server-py-commit
+tests/test_mcp_server.py::commit   ->  tests-test-mcp-server-py--commit   ->  tests-test-mcp-server-py-commit
+```
+
+Two distinct code entities become one graph entity, and their lifecycles
+interleave on it. The audit answers one question and nothing else: **how many,
+and of what shape.** That number decides whether a fix needs a migration for
+existing graphs or only a forward change.
+
+This is the read-only-measurement-first precedent set by #244, #245 and #257.
+
+## Why the graph cannot answer this
+
+#263's body suggests the #257 census (`census_distinct_values` in
+`evals/at_scale/probe_description_preload_exposure.py`) already computes a lower
+bound for free, undercounting only because two colliding entities that share a
+description would not show up. **The undercount is structurally worse than
+that, and the audit must not be built on the graph.**
+
+When two entities collide, the second one to be parsed hits the `ident in
+entity_valid_from` branch in `_build_code_triples`. That branch appends a
+`:modified-in` triple and nothing else — it writes no `:entity-type`, no
+`:ident`, no `:description`, no `:file`, no `:introduced-by`. **The graph
+therefore holds no record of the second entity's `(file_path, name)` pair at
+all.** Widening the census key from `:description` to `(:file, :description)`
+does not help, because the pair is simply absent.
+
+The three collisions #257 found were visible only because those entities were
+closed and later reopened, which re-runs the introduction branch and rewrites
+`:description`. A collision whose loser never closes is invisible to any
+graph-side query, no matter how it is keyed.
+
+An exact count therefore has to be derived from the **inputs** — the
+`(entity_type, file_path, name)` triples parsed out of source — not from the
+facts that survived. Deriving from inputs makes the count exact rather than a
+bound.
+
+## The `:module/` namespace is shared by three producers
+
+Discovered while writing this spec; it widens the scope agreed in
+brainstorming and should be verified by the reader rather than taken on trust.
+
+`external-dependency` is **not** a separate ident namespace.
+`_preload_known_entities`' docstring states it (`mcp_server.py:7396`):
+"external-dependency entities share the module ident namespace and use the same
+`path` attribute as modules". Three call sites produce idents into that one
+`:module/` namespace:
+
+1. **In-tree modules** — `_code_ident("module", file_path)`
+   (`mcp_server.py:7044`).
+2. **Submodules / gitlinks** — `_code_ident("module", path)`
+   (`mcp_server.py:9556`), written with `:entity-type :type/external-dependency`
+   (`mcp_server.py:9563`).
+3. **Unresolved imports** — `_canonical_ident("module", import_name)`, the
+   fallback returns at `mcp_server.py:4250` and `4285`, written with
+   `:entity-type :type/external-dependency` (`mcp_server.py:9441`).
+
+Consequence for the audit: the module surface must be pooled into **one**
+bucket across all three producers, not audited three times in isolation. A
+cross-producer collision — an unresolved import slugging onto an in-tree
+module's ident, or two distinct import specifiers (`foo_bar`, `foo-bar`,
+`foo.bar`) landing on `:module/foo-bar` — is a real collision of the same kind,
+and only a pooled grouping can see it.
+
+## Scope decisions
+
+**In scope.** All five `_code_ident` entity types — `module`, `function`,
+`class`, `variable`, `field` — plus the unresolved-import producer that shares
+the `module` namespace. (#263's scope note lists `external-dependency` as a
+sixth type; it is not one, for the reason given in the section above.) These
+are all derived from parsed source, so a single extraction pass covers them.
+
+**Out of scope: `heuristic_extract`** (`mcp_server.py:6568`). It slugs
+natural-language phrases out of memory text. Collapsing there is plausibly
+*working as intended* — it dedups near-identical phrasings — and the values
+have no `(file_path, name)` structure to group by, so a collision count there
+would need separate interpretation before it meant anything. If it turns out to
+matter, it is its own issue.
+
+**Out of scope: any fix.** This audit changes no ident derivation, writes no
+facts, and opens no `MiniGrafDb` handle. The single-handle invariant is
+satisfied trivially rather than carefully.
+
+**Out of scope: migration sizing against a real graph.** The input-side count
+establishes whether existing graphs are corrupted at all. Measuring how much a
+given graph actually lost would need a completed at-scale ingestion and is
+deferred to whichever issue takes the fix.
+
+## Architecture
+
+Three stages, in one process, over one pass of history.
+
+```
+_git_commits(repo, None, branch)
+        |
+        v
+  [ProcessPoolExecutor]  _extract_commit(repo, hash, ignore_patterns)   <- Stage 1
+        |                         (read-only, stateless, no DB)
+        v
+  (entity_type, file_path, name) triples  +  unresolved import specifiers
+        |
+        +--> group by _code_ident        -> offenders, shapes             <- Stage 2
+        |
+        +--> group by each candidate rule -> residual, rename count       <- Stage 3
+        |
+        v
+  results/263-ident-collision-census.json
+```
+
+## Stage 1 — triple collection, through the real extractor
+
+The audit drives `_extract_commit(repo_path, commit_hash, ignore_patterns)`
+(`mcp_server.py:8455`) rather than re-implementing parsing. That function is
+already documented as read-only, stateless, DB-free, and safe across a process
+boundary — it is precisely what `_run_ingestion`'s worker pool runs. Driving it
+directly means the audit measures the code that actually produces idents in
+production, not a reimplementation that could drift from it.
+
+Commits come from `_git_commits(repo_path, None, branch)` (`mcp_server.py:4333`),
+ignore patterns from `_load_ignore_patterns(repo_path)` (`mcp_server.py:4721`),
+so the file set matches what ingestion would actually parse.
+
+For each commit, over each `(status, file_path, extracted, precomputed,
+old_path)` entry in `file_results` with status `A`/`M`/`R` (`D` entries carry
+`extracted is None` and are skipped):
+
+| source | triple |
+|---|---|
+| `file_path` | `("module", file_path, None)` |
+| `extracted["functions"]` | `("function", file_path, fn_name)` |
+| `extracted["classes"]` | `("class", file_path, cls_name)` |
+| `extracted["globals"]` | `("variable", file_path, gvar_name)` |
+| `extracted["fields"]` | `("field", file_path, f"{owning_class}.{field_name}")` |
+| `precomputed["resolved_imports"]`, rows with `is_resolved` false | import specifier, into the pooled `module` bucket |
+
+The `field` qualification and the category-to-`entity_type` mapping mirror
+`_precompute_file_triples` (`mcp_server.py:7089-7122`) exactly. Where this spec
+and that function disagree, that function is right and this spec is a bug.
+
+Walking `A`/`M`/`R` files across every commit reaches every version of every
+file that ever existed on the branch: each distinct blob at each path is
+introduced by exactly one such entry. No separate initial-tree pass is needed.
+
+Triples are accumulated into a set, so a name unchanged across 400 commits
+costs one entry, not 400.
+
+**Cost.** No DB, no ingestion, no fact writes. The hours the #245 and #257
+probes needed went to DB writes and #239's per-ident `:introduced-by` point
+queries, none of which this touches. Commits are dispatched to a
+`ProcessPoolExecutor` exactly as `_run_ingestion` does (`mcp_server.py:10572`).
+
+## Stage 2 — collision grouping and shape classification
+
+Group the collected triples by the ident the **current** rule produces:
+
+- code entities: `_code_ident(entity_type, file_path, name)`
+- pooled module bucket: `_code_ident("module", file_path)` for in-tree files and
+  gitlink paths, `_canonical_ident("module", import_name)` for unresolved
+  imports
+
+An **offender** is an ident whose input set has more than one member. Reported
+per entity type, with every offender's input set listed verbatim — a nonzero
+count escalates to fix design, and that work should start from the data rather
+than re-deriving it by hand.
+
+Each offender is classified by shape, from its input set:
+
+| shape | test |
+|---|---|
+| `leading-underscore` | two inputs identical but for a leading `_` on the name |
+| `case-only` | inputs equal under `casefold`, unequal otherwise |
+| `separator-vs-path` | the `name` of one input appears as a trailing path segment of another's `file_path` — the case `_code_ident`'s docstring already anticipates |
+| `cross-producer` | module-bucket only: inputs from two different producers |
+| `other` | anything else |
+
+Shapes are computed per offender over all pairs in its input set, so an offender
+may carry more than one shape label. `other` is the interesting bucket: it is
+where a collision nobody has predicted would show up.
+
+## Stage 3 — candidate rule scoring
+
+The triples are already in memory, so re-grouping them under a different
+derivation is nearly free. Five rules are scored on **two** numbers each:
+
+- **residual** — offenders remaining under that rule
+- **renames** — idents whose value differs from what the current rule produces
+
+Renames matter as much as residual: any change to derivation renames entities in
+every existing graph, and that cost is what decides forward-fix versus
+migration.
+
+| | rule | change to `_canonical_ident` | expectation |
+|---|---|---|---|
+| R1 | keep underscores | charset becomes `[^a-z0-9_-]` | fixes `_foo`/`foo`; renames nearly every ident, since paths like `test_mcp_server.py` carry underscores |
+| R2 | no hyphen collapse | drop `re.sub(r"-+", "-", slug)` | fixes it via separator arity (`py---commit` vs `py--commit`); renames every *named* entity but leaves most `module` idents alone |
+| R3 | R1 + R2 | both of the above | maximal information preservation |
+| R4 | hash suffix | append `-` + `sha256(value)` hex, first 8 | total distinctness including case; renames everything; costs ident readability |
+| R5 | independent part slugs | slug `file_path` and `name` separately, join with a fixed token | **control — expected to still collide** |
+
+**R5 is deliberately a rule expected to fail.** Slugging the name
+independently still runs `strip("-")` over it, so `_commit` and `commit` both
+reduce to `commit` and the collision survives the change. R5 exists so the
+scorer has a known-negative to be checked against: **if the scorer reports R5
+clean, the scorer is wrong**, and every other row it produced is suspect.
+
+Rules are implemented as standalone pure functions in the probe module, not by
+monkeypatching `mcp_server._canonical_ident`. The audit must not mutate the
+module it is measuring.
+
+## Predictions, fixed before any data exists
+
+Recorded now so the run cannot be rationalized afterwards.
+
+1. **The true collision count exceeds 3.** The #257 census found three, and it
+   can only see collisions whose loser was closed and reopened. Any collision
+   that never closed is invisible to it and visible here.
+2. **`leading-underscore` is the dominant shape** on the function surface.
+3. **R5 reports nonzero residual**, and its residual is at least the
+   `leading-underscore` offender count.
+4. **R2's rename count is far lower on `module` than on `function`.** Module
+   idents have no `::` separator, so they only change when their path already
+   contained adjacent non-alphanumerics.
+5. **R4's rename count equals the total ident count.** Every ident gains a
+   suffix.
+
+A prediction that fails is a finding about this design, not noise to be
+smoothed over. It goes in the recorded result.
+
+## Report fields
+
+Written to `evals/at_scale/results/263-ident-collision-census.json`:
+
+- `repo_path`, `branch`, `head_commit`, `commits` — provenance, with
+  `head_commit` taken from the walked commit list rather than a separate
+  `git rev-parse`, so it cannot disagree with what was measured
+- `triples_total`, `idents_total` — per entity type and pooled
+- `extraction_failures` — commits `_extract_commit` raised on, with hashes
+- `offenders` — per entity type: count, and the full ident → input-set map
+- `offenders_by_shape` — counts per shape label
+- `candidates` — per rule: `residual`, `renames`, and the rule's own
+  description string
+- `predictions` — each prediction above, with its outcome recorded as
+  `held` / `failed` and the number that decided it
+- `timestamp`
+
+## Exit code
+
+**Validity-only**, following the #257 probe's precedent. Nonzero exit means the
+*run* was invalid, never that collisions were found — finding them is the
+expected result of an audit whose entire purpose is to count them.
+
+Exit nonzero when: zero commits were walked; zero triples were collected; or
+`extraction_failures` exceeds 1% of commits walked.
+
+## Testing
+
+`tests/test_at_scale_ident_collision_census.py`, alongside the existing
+`test_at_scale_dep_preload_probe.py` and `test_at_scale_description_preload_probe.py`.
+
+Grouping, shape classification and rule scoring are pure functions over
+triples, so they are tested directly without walking a repository.
+
+**Ablation requirement.** Per the standing rule that a regression test must be
+shown to actually fail against the behaviour it claims to guard, every test
+below states the counterfactual it was checked against:
+
+1. **The three known real collisions as a fixture.** The `(file_path, name)`
+   pairs behind `:function/tests-test-mcp-server-py-commit`,
+   `…-snapshot` and
+   `:function/evals-at-scale-profile-forward-reconcile-attribution-py-main`
+   must group as offenders with shape `leading-underscore`.
+   *Counterfactual:* feeding only the public member of each pair yields zero
+   offenders.
+2. **R5 reports these same three as residual.** This is the scorer's
+   known-negative.
+   *Counterfactual:* a scorer that returns zero residual unconditionally passes
+   test 1 and fails this one.
+3. **R1, R2 and R3 each report them clean, and each reports a nonzero rename
+   count.** A rule that renames nothing cannot have changed derivation.
+4. **Shape classification separates its labels.** A case-only pair is not
+   labelled `leading-underscore`; a `separator-vs-path` pair is not labelled
+   `other`.
+   *Counterfactual:* a classifier returning a constant label fails.
+5. **Cross-producer pooling.** An unresolved import specifier and an in-tree
+   file path that slug to the same `:module/` ident are reported as one
+   offender with shape `cross-producer`.
+   *Counterfactual:* auditing the two producers into separate buckets reports
+   zero.
+6. **End-to-end through real extraction.** A purpose-built temp git repo with a
+   single Python file containing both `def _foo` and `def foo` is walked by the
+   real `_extract_commit`, and the collision reproduces. This is the test that
+   catches the audit mis-driving the extractor — every test above would still
+   pass if Stage 1 collected the wrong triples.
+
+## Deliverables
+
+- `evals/at_scale/probe_ident_collision_census.py` — the audit, with a CLI
+- `tests/test_at_scale_ident_collision_census.py` — the tests above
+- `evals/at_scale/results/263-ident-collision-census.json` — the recorded run
+- a note in `evals/at_scale/benchmark.md` placing this among the one-off
+  read-only probes, matching how `probe_dep_preload_exposure.py` is described
+- `CLAUDE.md` needs no change: `evals/at_scale/` is already described as
+  holding one-off read-only probes and their recorded measurements
+
+## What this explicitly does NOT do
+
+- **It does not fix anything.** No change to `_canonical_ident`, `_code_ident`,
+  or any caller.
+- **It does not propose a migration.** It produces the number that decides
+  whether one is needed.
+- **It does not measure an existing graph.** See the scope decision above.
+- **It does not audit `heuristic_extract`.**
+- **It does not claim its candidate scoring is a fix recommendation.** Residual
+  and rename counts are inputs to that decision, not the decision. A rule with
+  zero residual may still be unacceptable on rename cost, and choosing among
+  them is fact-model work with its own schema, idempotency, migration-coverage
+  and transact-path checks to clear.

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -829,3 +829,172 @@ into a close-oriented "prediction holds" framing.
    mechanism at all. The two arms it does close off are narrower: the shipped
    query agreed with the oracle on 12685 unambiguous comparisons, and no
    entity type other than `function` has an ident carrying two values.
+
+## Ident Collision Census — 263-ident-collision-census
+
+- Repo: `.` @ `master` (`14166d1`, full history, 674 commits)
+- Script: `evals/at_scale/probe_ident_collision_census.py`
+- Raw: `evals/at_scale/results/263-ident-collision-census.json`
+- Run: `.venv/bin/python evals/at_scale/probe_ident_collision_census.py
+  --repo-path . --json-out evals/at_scale/results/263-ident-collision-census.json`
+- Question: how many `_code_ident` values on real history are reachable from
+  more than one distinct `(entity_type, file_path, name)` input? #257's census
+  observed three such collisions from the graph side; #263 asks for the true
+  count and for what a fix would cost.
+
+**On the head commit.** `head_commit` is `14166d1`, mainline's tip — *not* the
+tip of the `audit-263-ident-collision-census` branch this probe was written on.
+That is deliberate, not a stale run: `collect_inputs` resolves an unspecified
+branch through `mcp_server._default_git_branch`, which returns `master` here, so
+the measurement counts the idents mainline history produces and excludes the
+probe being added. `branch` and `head_commit` are both recorded in the artifact
+and both printed by the CLI so a run is never ambiguous about what it read.
+
+**Why source-derived and not graph-derived.** A graph-side census structurally
+cannot answer this. When two entities collide, the loser takes
+`_build_code_triples`' already-known branch, which appends `:modified-in` and
+nothing else — no `:entity-type`, no `:ident`, no `:description`, no `:file`.
+The graph holds no record of the losing input's `(file_path, name)` pair at all.
+The three collisions #257 saw were visible only because those entities were
+closed and reopened, which re-runs the introduction branch. Any graph-side count
+is a bound; only the inputs give an exact one.
+
+| Metric | Value |
+|---|---|
+| Exit code | 0 (valid measurement) |
+| Commits walked | 674 |
+| Extraction failures | 0 |
+| Distinct inputs collected | 2789 |
+| Distinct idents | 2780 |
+| Ignore patterns applied | `3rdParty/`, `third_party/`, `vendor/`, `node_modules/`, `dist/`, `build/`, `*.min.js`, `*.map` |
+| **Offenders (idents reachable from >1 distinct input)** | **9 of 2780 (0.32%)** |
+| &nbsp;&nbsp;module | **1** of 133 |
+| &nbsp;&nbsp;function | **7** of 2058 |
+| &nbsp;&nbsp;class | **1** of 290 |
+| &nbsp;&nbsp;variable | 0 of 232 |
+| &nbsp;&nbsp;field | 0 of 67 |
+
+**By shape** (an offender may carry more than one label; `other` is emitted only
+when no named shape applied, so it is where an unpredicted family surfaces):
+
+| Shape | Count |
+|---|---|
+| leading-underscore | 7 |
+| case-only | 0 |
+| separator-vs-path | 1 |
+| cross-producer | 0 |
+| other | 1 |
+
+**The nine offenders in full:**
+
+| Ident | Colliding inputs | Shape |
+|---|---|---|
+| `:module/mcp-server` | import `mcp.server`, import `mcp_server` | separator-vs-path |
+| `:function/tests-test-mcp-server-py-commit` | `tests/test_mcp_server.py` `_commit` / `commit` | leading-underscore |
+| `:function/tests-test-mcp-server-py-snapshot` | `tests/test_mcp_server.py` `_snapshot` / `snapshot` | leading-underscore |
+| `:function/tests-test-mcp-server-py-boom` | `tests/test_mcp_server.py` `_boom` / `boom` | leading-underscore |
+| `:function/tests-test-mcp-server-py-parse` | `tests/test_mcp_server.py` `_parse` / `parse` | leading-underscore |
+| `:function/tests-test-mcp-server-py-results` | `tests/test_mcp_server.py` `_results` / `results` | leading-underscore |
+| `:function/evals-at-scale-profile-forward-reconcile-attribution-py-main` | `evals/at_scale/profile_forward_reconcile_attribution.py` `_main` / `main` | leading-underscore |
+| `:class/tests-test-mcp-server-py-fakedb` | `tests/test_mcp_server.py` `FakeDb` / `_FakeDb` | leading-underscore |
+| `:function/tests-test-mcp-server-py-init` | `tests/test_mcp_server.py` `__init__` / `_init` | **other** |
+
+**Candidate rules** — residual is offenders remaining under the rule; renames is
+baseline idents that move, i.e. the cost the change imposes on every existing
+graph:
+
+| Rule | Residual | Renames | % of 2780 | Description |
+|---|---|---|---|---|
+| R1 | **0** | 2710 | 97.5% | keep underscores: charset becomes `[^a-z0-9_-]` |
+| R2 | 1 | 2649 | 95.3% | no hyphen collapse: drop `re.sub(r'-+', '-', slug)` |
+| R3 | **0** | 2721 | 97.9% | R1 + R2 |
+| R4 | **0** | 2780 | 100.0% | hash suffix: current slug + `-` + `sha256(raw)[:8]` |
+| R5 | 9 | 2647 | 95.2% | CONTROL, expected to still collide |
+
+Rename cost by entity type, for the rules that reach zero residual:
+
+| Rule | module | function | class | variable | field |
+|---|---|---|---|---|---|
+| R1 | 74/133 | 2049/2058 | 289/290 | 231/232 | 67/67 |
+| R3 | 74/133 | 2058/2058 | 290/290 | 232/232 | 67/67 |
+| R4 | 133/133 | 2058/2058 | 290/290 | 232/232 | 67/67 |
+
+R2's split is recorded too, because P4 is ruled on it: module 2/133, function
+2058/2058, class 290/290, variable 232/232, field 67/67. R5's: module 0/133,
+function 2058/2058, class 290/290, variable 232/232, field 67/67.
+
+**Predictions** (fixed before any data existed; a failure is a finding about the
+design, not noise). All four held:
+
+| ID | Outcome | Evidence, verbatim |
+|---|---|---|
+| P1 — the true count exceeds the 3 #257's census found | **held** | `offenders_total=9` |
+| P2 — leading-underscore strictly outnumbers every other named shape | **held** | `leading-underscore=7, runner-up separator-vs-path=1` |
+| P3 — R5, the control, reports nonzero residual at least as large as the leading-underscore count | **held** | `R5 residual=9, leading-underscore offenders=7` |
+| P4 — R2's rename cost falls on named entities, not module idents | **held** | `R2 renames module 2/133 = 0.015, function 2058/2058 = 1.000` |
+
+Self-check (holds by construction; a failure would indict the scorer, not the
+design, which is why it is reported apart from the predictions):
+
+| ID | Outcome | Evidence, verbatim |
+|---|---|---|
+| S1 — R4 renames every ident, so its rename count must equal the ident total | **held** | `R4 renames=2780, idents_total=2780` |
+
+**The control behaved.** R5 came back with residual 9 — every offender survives
+it, because `_slug_current` strips leading hyphens, so `_commit` and `commit`
+both reduce to `commit` under independent slugging. The CLI's `NOTE: R5` warning
+did not fire. Had R5 reported clean while `leading-underscore` was nonzero, every
+other row in the candidate table would have been suspect.
+
+**Findings:**
+
+1. **The count is 9, three times what the graph could see.** #257's graph-side
+   census found 3; the input-side count is 9. All three of #257's are present
+   (`:function/tests-test-mcp-server-py-commit`,
+   `:function/tests-test-mcp-server-py-snapshot`,
+   `:function/evals-at-scale-profile-forward-reconcile-attribution-py-main`),
+   confirming the two measurements are of the same phenomenon and that the
+   graph-side number is the bound the design spec said it was. The six the graph
+   could not see are exactly the ones whose loser was never closed and reopened.
+
+2. **`other` was not empty, and what landed there is a real finding.**
+   `:function/tests-test-mcp-server-py-init` collides `__init__` with `_init`.
+   The shape classifier's `leading-underscore` test compares names after
+   `lstrip("_")` on the last dot-segment, so `__init__` → `init__` and `_init` →
+   `init` are unequal and the pair falls through to `other`. It is still an
+   underscore collision in substance — the trailing dunder underscores also slug
+   to hyphens and get stripped — but it is a *dunder-versus-private* variant the
+   predictions did not name. The classifier is not wrong; its
+   `leading-underscore` label is narrower than the underscore family actually
+   present on this history.
+
+3. **One collision is not an underscore problem at all, and it crosses the
+   internal/external boundary.** `:module/mcp-server` is reached from two
+   unresolved import specifiers: `mcp.server` (the external `mcp` package's
+   submodule) and `mcp_server` (this repository's own top-level module). `.` and
+   `_` both slug to `-`, so an external dependency and an in-tree module land on
+   one ident. This is the single offender R2 does not fix — dropping the hyphen
+   collapse changes nothing when there is no hyphen run to preserve — and it is
+   why R2's residual is 1 rather than 0. R1 fixes it (`mcp_server` keeps its
+   underscore); so do R3 and R4.
+
+4. **No cross-producer and no case-only collisions on this history.** Both
+   counts are 0. `cross-producer` being 0 does not mean the three producers
+   sharing the `:module/` namespace is safe — it means this repository has no
+   gitlinks at all (consistent with #257's `gitlink events: 0`), so the
+   code/gitlink arm of that risk was never exercised. Absence of opportunity,
+   not absence of risk.
+
+5. **Every zero-residual rule is a near-total rename.** The cheapest one, R1,
+   still moves 2710 of 2780 idents (97.5%); R3 moves 2721 (97.9%) and R4 moves
+   all 2780. There is no candidate here that fixes the 9 while leaving the other
+   2771 idents where they are. The per-type split shows why: R1 and R3 spare
+   only module idents (74/133 renamed) because a module's raw value is a bare
+   path with no `::` separator and often no underscore; every function, class,
+   variable and field ident carries a `::` that changes under any charset or
+   collapse change.
+
+**Conclusion: a fix needs a migration for existing graphs, not only a forward
+change** — the cheapest rule that eliminates all 9 collisions (R1) still renames
+97.5% of existing idents, so a forward-only change would orphan the history of
+nearly every code entity in every graph already written.

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -874,22 +874,35 @@ is a bound; only the inputs give an exact one.
 | &nbsp;&nbsp;variable | 0 of 232 |
 | &nbsp;&nbsp;field | 0 of 67 |
 
-**By shape** (an offender may carry more than one label; `other` is emitted only
-when no named shape applied, so it is where an unpredicted family surfaces):
+**The `module` row pools three producers.** `:module/` is one namespace shared by
+in-tree files (`_code_ident("module", path)`), gitlink/submodule paths, and the
+unresolved-import fallback `_canonical_ident("module", specifier)`, so the 133
+module idents are not 133 files. Split by producer over the same head: **57 from
+in-tree files, 76 from unresolved import specifiers, 0 from gitlinks** (this
+repository has no submodules — see finding 4). No module ident is reached from
+more than one producer, which is the same fact `cross-producer = 0` reports, so
+the two counts partition the 133 exactly. Sizing migration cost from `module 133`
+would over-count real file modules by more than 2×.
+
+**By shape** (an offender may carry more than one label; `other` is emitted when
+nothing *but* `cross-producer` applied — not when no label at all applied,
+because `cross-producer` names which call sites the inputs came from and never
+what made their values collide, so an offender carrying only that label is still
+unexplained and belongs where an unpredicted family surfaces):
 
 | Shape | Count |
 |---|---|
 | leading-underscore | 7 |
 | case-only | 0 |
-| separator-vs-path | 1 |
+| separator-vs-path | 0 |
 | cross-producer | 0 |
-| other | 1 |
+| other | 2 |
 
 **The nine offenders in full:**
 
 | Ident | Colliding inputs | Shape |
 |---|---|---|
-| `:module/mcp-server` | import `mcp.server`, import `mcp_server` | separator-vs-path |
+| `:module/mcp-server` | import `mcp.server`, import `mcp_server` | **other** |
 | `:function/tests-test-mcp-server-py-commit` | `tests/test_mcp_server.py` `_commit` / `commit` | leading-underscore |
 | `:function/tests-test-mcp-server-py-snapshot` | `tests/test_mcp_server.py` `_snapshot` / `snapshot` | leading-underscore |
 | `:function/tests-test-mcp-server-py-boom` | `tests/test_mcp_server.py` `_boom` / `boom` | leading-underscore |
@@ -928,10 +941,10 @@ design, not noise). All four held:
 
 | ID | Outcome | Evidence, verbatim |
 |---|---|---|
-| P1 — the true count exceeds the 3 #257's census found | **held** | `offenders_total=9` |
-| P2 — leading-underscore strictly outnumbers every other named shape | **held** | `leading-underscore=7, runner-up separator-vs-path=1` |
-| P3 — R5, the control, reports nonzero residual at least as large as the leading-underscore count | **held** | `R5 residual=9, leading-underscore offenders=7` |
-| P4 — R2's rename cost falls on named entities, not module idents | **held** | `R2 renames module 2/133 = 0.015, function 2058/2058 = 1.000` |
+| P1 — "The true collision count exceeds the 3 #257's census found, because that census can only see collisions whose loser was closed and reopened." | **held** | `offenders_total=9` |
+| P2 — "leading-underscore STRICTLY outnumbers every other named shape among all offenders." | **held** | `leading-underscore=7, runner-up separator-vs-path=0` |
+| P3 — "R5, the control, reports a nonzero residual at least as large as the leading-underscore offender count." | **held** | `R5 residual=9, leading-underscore offenders=7` |
+| P4 — "R2's rename cost falls on named entities, not on module idents: a module input has no `::` separator to produce an adjacent hyphen run, so R2 renames a strictly smaller FRACTION of module idents than of function idents." | **held** | `R2 renames module 2/133 = 0.015, function 2058/2058 = 1.000` |
 
 Self-check (holds by construction; a failure would indict the scorer, not the
 design, which is why it is reported apart from the predictions):
@@ -954,8 +967,13 @@ other row in the candidate table would have been suspect.
    `:function/tests-test-mcp-server-py-snapshot`,
    `:function/evals-at-scale-profile-forward-reconcile-attribution-py-main`),
    confirming the two measurements are of the same phenomenon and that the
-   graph-side number is the bound the design spec said it was. The six the graph
-   could not see are exactly the ones whose loser was never closed and reopened.
+   graph-side number is the bound the design spec said it was. The expected
+   reason the graph missed the other six is the mechanism above — their loser
+   was never closed and reopened, so the introduction branch never re-ran — but
+   this run did not measure that: it never opened a graph, so "six" is a
+   subtraction, not an observation. Nor is 9-vs-3 a controlled comparison: #257
+   measured at 656 commits and this run at 674, so the two counts are at
+   different heads and some of the gap could simply be history added since.
 
 2. **`other` was not empty, and what landed there is a real finding.**
    `:function/tests-test-mcp-server-py-init` collides `__init__` with `_init`.
@@ -976,23 +994,47 @@ other row in the candidate table would have been suspect.
    one ident. This is the single offender R2 does not fix — dropping the hyphen
    collapse changes nothing when there is no hyphen run to preserve — and it is
    why R2's residual is 1 rather than 0. R1 fixes it (`mcp_server` keeps its
-   underscore); so do R3 and R4.
+   underscore); so do R3 and R4. It is the **second** member of `other`, and the
+   shape table now says so: both of its inputs are unresolved import specifiers
+   with `name=None`, so there is no path/name boundary anywhere in the pair and
+   `separator-vs-path` — which asks whether one input's *name* is a trailing
+   whole path segment of the other's `file_path` — cannot apply to it.
 
-4. **No cross-producer and no case-only collisions on this history.** Both
-   counts are 0. `cross-producer` being 0 does not mean the three producers
-   sharing the `:module/` namespace is safe — it means this repository has no
-   gitlinks at all (consistent with #257's `gitlink events: 0`), so the
-   code/gitlink arm of that risk was never exercised. Absence of opportunity,
-   not absence of risk.
+4. **No cross-producer, no case-only and no separator-vs-path collisions on this
+   history.** All three counts are 0. `cross-producer` being 0 does not mean the
+   three producers sharing the `:module/` namespace is safe — it means this
+   repository has no gitlinks at all (consistent with #257's `gitlink events:
+   0`), so the code/gitlink arm of that risk was never exercised. Absence of
+   opportunity, not absence of risk. `separator-vs-path` at 0 is a *weaker*
+   result than it looks, for a structural reason: an ident carries its
+   entity_type, so every member of an offender group shares one, and the pairs
+   that most obviously satisfy the definition (a `module` at `src/auth/login.py`
+   against a `function` `login` in `src/auth.py`) span two types and therefore
+   can never be one group's members. The family is reachable within a single
+   type — `src/utils_py/handlers::utils` and `src/utils.py::handlers.utils` both
+   slug to `:function/src-utils-py-handlers-utils`, and the test suite pins that
+   pair — but it takes a path shape this repository does not contain. Read the 0
+   as "the `::` mitigation `_code_ident`'s docstring describes held on *this*
+   history", not as "the mitigation is airtight".
 
 5. **Every zero-residual rule is a near-total rename.** The cheapest one, R1,
    still moves 2710 of 2780 idents (97.5%); R3 moves 2721 (97.9%) and R4 moves
    all 2780. There is no candidate here that fixes the 9 while leaving the other
-   2771 idents where they are. The per-type split shows why: R1 and R3 spare
-   only module idents (74/133 renamed) because a module's raw value is a bare
-   path with no `::` separator and often no underscore; every function, class,
-   variable and field ident carries a `::` that changes under any charset or
-   collapse change.
+   2771 idents where they are. The per-type split shows why, and the two rules
+   spare different things:
+
+   - **R3** spares only module idents (74/133 renamed, 0 spared anywhere else).
+     It drops the collapse, and every named ident's raw value carries a `::`
+     whose adjacent hyphen run the collapse used to eat, so every function,
+     class, variable and field ident moves. A module's raw value is a bare path
+     with no `::`, so 59 of them are untouched.
+   - **R1** spares those same 59 module idents *and* 11 named ones (function
+     2049/2058, class 289/290, variable 231/232, field 67/67 → 9 + 1 + 1 + 0
+     spared). R1 changes only the charset, and `::` slugs to `-` under both the
+     current rule and R1, so a named ident whose path and name contain no
+     underscore at all is untouched — `install.py::main` is the shape.
+
+   The two together are 70 idents, exactly the 2780 − 2710 R1 does not rename.
 
 **Conclusion: a fix needs a migration for existing graphs, not only a forward
 change** — the cheapest rule that eliminates all 9 collisions (R1) still renames

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -1,0 +1,107 @@
+# evals/at_scale/probe_ident_collision_census.py
+"""#263 audit: how many _code_ident values on real history are reachable from
+more than one distinct (entity_type, file_path, name) input?
+
+_canonical_ident (mcp_server.py:4090) maps every character outside [a-z0-9-]
+to a hyphen and then collapses runs of hyphens. _code_ident builds its input as
+f"{file_path}::{name}", so the separator and a leading underscore in the name
+both become hyphens and the collapse merges them:
+
+    tests/test_mcp_server.py::_commit -> tests-test-mcp-server-py-commit
+    tests/test_mcp_server.py::commit  -> tests-test-mcp-server-py-commit
+
+WHY THIS AUDIT IS SOURCE-DERIVED AND NOT GRAPH-DERIVED. When two entities
+collide, the second one parsed takes _build_code_triples' `ident in
+entity_valid_from` branch, which appends a :modified-in triple and NOTHING
+else -- no :entity-type, no :ident, no :description, no :file. The graph
+therefore holds no record of the losing entity's (file_path, name) pair at
+all, and widening #257's census key from :description to (:file, :description)
+does not recover it. The three collisions #257 found were visible only because
+those entities were closed and reopened, which re-runs the introduction branch.
+Any graph-side count is a bound; only the inputs give an exact one.
+
+READ-ONLY BY CONSTRUCTION. This module opens no MiniGrafDb handle, writes no
+facts, and never mutates mcp_server. The candidate rules below are standalone
+pure functions, deliberately NOT monkeypatches of _canonical_ident -- an audit
+must not mutate the module it measures.
+
+See docs/superpowers/specs/2026-08-11-ident-collision-audit-design.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, NamedTuple, Optional
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import mcp_server  # noqa: E402
+
+
+# The five types _code_ident actually produces. external-dependency is NOT a
+# sixth: it shares the :module/ namespace (mcp_server.py:7396), which is why
+# the module bucket below is pooled across producers rather than split.
+ENTITY_TYPES = ("module", "function", "class", "variable", "field")
+
+# Which call site produced an input. Only ever used to label a collision as
+# cross-producer -- it is deliberately NOT part of the ident, because the
+# whole point is that these three feed one namespace.
+#   "code"    -- _code_ident over a parsed file (mcp_server.py:7044-7122)
+#   "gitlink" -- _code_ident("module", path) for a submodule (mcp_server.py:9556)
+#   "import"  -- _canonical_ident("module", specifier), the unresolved-import
+#                fallback (mcp_server.py:4250, 4285)
+PRODUCERS = ("code", "gitlink", "import")
+
+
+class EntityInput(NamedTuple):
+    """One (entity_type, file_path, name) triple that ever reached _code_ident.
+
+    For producer "import", file_path holds the raw import specifier and name is
+    None -- _canonical_ident("module", spec) is exactly _code_ident("module",
+    spec, None), so no separate ident path is needed.
+    """
+
+    entity_type: str
+    producer: str
+    file_path: str
+    name: Optional[str]
+
+
+def raw_value(inp: EntityInput) -> str:
+    """The string _code_ident slugs, reproducing mcp_server.py:4298-4301."""
+    if inp.name:
+        return f"{inp.file_path}::{inp.name}"
+    return inp.file_path
+
+
+def current_ident(inp: EntityInput) -> str:
+    """The ident production builds for this input, today."""
+    return mcp_server._code_ident(inp.entity_type, inp.file_path, inp.name)
+
+
+def group_by_ident(
+    inputs: Iterable[EntityInput],
+    ident_fn: Callable[[EntityInput], str],
+) -> Dict[str, List[EntityInput]]:
+    """Group DISTINCT inputs by the ident ident_fn assigns them.
+
+    Distinct is load-bearing: an unchanged name arrives once per commit that
+    touched its file, and counting occurrences would report every entity in
+    the repository as colliding with itself.
+    """
+    groups: Dict[str, Dict[EntityInput, None] ] = {}
+    for inp in inputs:
+        groups.setdefault(ident_fn(inp), {})[inp] = None
+    return {ident: list(members) for ident, members in groups.items()}
+
+
+def offenders(
+    groups: Dict[str, List[EntityInput]],
+) -> Dict[str, List[EntityInput]]:
+    """The groups reachable from more than one distinct input."""
+    return {
+        ident: members for ident, members in groups.items() if len(members) > 1
+    }

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -25,12 +25,34 @@ facts, and never mutates mcp_server. The candidate rules below are standalone
 pure functions, deliberately NOT monkeypatches of _canonical_ident -- an audit
 must not mutate the module it measures.
 
+WHAT THE CONTENT-FETCH `continue` DOES AND DOES NOT COST. _extract_commit
+silently drops an A/M file whose blob fetch raises (mcp_server.py:8641-8644).
+This is NOT an undercount of production's idents: production ingestion runs
+that same function and takes that same `continue`, so a file skipped there
+never produces an ident in production either. The census stays exact with
+respect to the idents production actually generates. The residual risk is
+narrower -- if a fetch fails TRANSIENTLY, two runs over the same head_commit
+can collect different input sets, so a recorded number is reproducible only to
+the extent that git object reads are. `extraction_failures` does not cover
+this: that counter only sees _extract_commit raising outright, and this branch
+swallows the error inside it.
+
+WHICH BRANCH GETS MEASURED. collect_inputs resolves an unspecified branch
+through mcp_server._default_git_branch, i.e. the repository's mainline, not
+whatever branch happens to be checked out. That is deliberate: the audit must
+count the idents mainline history produces, not ones introduced by the
+in-progress work that is adding this probe. `branch` and `head_commit` are
+both recorded and both printed, so a run is never ambiguous about what it read.
+
 See docs/superpowers/specs/2026-08-11-ident-collision-audit-design.md.
 """
 
 from __future__ import annotations
 
+import argparse
+import datetime
 import hashlib
+import json
 import multiprocessing
 import re
 import sys
@@ -404,6 +426,14 @@ def collect_inputs(
     Inputs are deduplicated here. A name unchanged across 400 commits costs one
     entry, not 400.
 
+    The resolved branch and the resolved ignore-pattern list are BOTH returned
+    as diagnostics because both are environment-dependent and both change which
+    idents get counted: _default_git_branch honours MINIGRAF_GIT_BRANCH, and
+    _load_ignore_patterns merges MINIGRAF_INGEST_IGNORE with any .temporalignore
+    in the working tree. Without them recorded, two runs on the same
+    head_commit can legitimately disagree with nothing in the artifact
+    explaining why.
+
     The pool uses an explicit "spawn" context for the same reason
     _run_ingestion does (mcp_server.py:10536-10546): workers are created lazily
     while other threads may already be alive in this process (this runs under
@@ -470,7 +500,261 @@ def collect_inputs(
     return ordered, {
         "head_commit": hashes[-1] if hashes else None,
         "branch": resolved_branch,
+        "ignore_patterns": list(ignore_patterns),
         "commits": len(hashes),
         "extraction_failures": len(failed),
         "failed_commits": failed,
     }
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: report, predictions, exit gate, CLI
+# ---------------------------------------------------------------------------
+
+
+# Fixed BEFORE any data exists, so the run cannot be rationalized afterwards.
+# A prediction that fails is a finding about the design, not noise to be
+# smoothed over: it is recorded in the result either way.
+#
+# Every statement below is worded to say exactly what evaluate_predictions
+# mechanically checks. A statement broader than its check would let a "held"
+# be read as evidence for something the audit never measured.
+PREDICTIONS: Tuple[Tuple[str, str], ...] = (
+    ("P1", "The true collision count exceeds the 3 #257's census found, "
+           "because that census can only see collisions whose loser was "
+           "closed and reopened."),
+    ("P2", "leading-underscore is the dominant named shape among all "
+           "offenders."),
+    ("P3", "R5, the control, reports a nonzero residual at least as large as "
+           "the leading-underscore offender count."),
+    ("P4", "R2 renames strictly fewer than all idents: it leaves plain module "
+           "idents untouched, because a module input has no '::' separator to "
+           "produce an adjacent hyphen run."),
+    ("P5", "R4's rename count equals the total ident count."),
+)
+
+
+def build_report(
+    inputs: Sequence[EntityInput],
+    diagnostics: Dict[str, Any],
+    repo_path: str,
+) -> Dict[str, Any]:
+    """Assemble the committed artifact from Stage 1's inputs.
+
+    Carries branch, head_commit AND ignore_patterns, because all three decide
+    which idents were counted and none of them is recoverable from the numbers
+    afterwards. head_commit is mainline's tip, not the working branch's, unless
+    a branch was passed explicitly -- see the module docstring.
+
+    The content-fetch caveat in the module docstring applies to every count
+    here: they are exact with respect to the idents production generates, and
+    reproducible only to the extent that git object reads are.
+    """
+    baseline = group_by_ident(inputs, current_ident)
+    all_offenders = offenders(baseline)
+
+    per_type: Dict[str, Dict[str, Any]] = {}
+    for entity_type in ENTITY_TYPES:
+        rows = {
+            ident: members
+            for ident, members in all_offenders.items()
+            if members[0].entity_type == entity_type
+        }
+        per_type[entity_type] = {
+            # A missing key and a zero are different claims; only the second
+            # says "measured, found none". Every type appears unconditionally.
+            "idents_total": sum(
+                1 for _ident, members in baseline.items()
+                if members[0].entity_type == entity_type
+            ),
+            "count": len(rows),
+            # Verbatim members, not just a count: a nonzero count escalates
+            # this to fix design, and that work starts from the data rather
+            # than re-deriving it by hand.
+            "idents": {
+                ident: [
+                    {"producer": m.producer, "file_path": m.file_path, "name": m.name}
+                    for m in members
+                ]
+                for ident, members in rows.items()
+            },
+        }
+
+    shape_counts: Dict[str, int] = {shape: 0 for shape in SHAPES}
+    for members in all_offenders.values():
+        for shape in classify_shapes(members):
+            shape_counts[shape] += 1
+
+    report: Dict[str, Any] = {
+        "repo_path": repo_path,
+        "branch": diagnostics["branch"],
+        "head_commit": diagnostics["head_commit"],
+        # Indexed, not .get()-with-default: a silent [] here would record "no
+        # patterns were applied" for a run whose patterns simply were not
+        # threaded, which is precisely the ambiguity this field exists to end.
+        "ignore_patterns": diagnostics["ignore_patterns"],
+        "commits": diagnostics["commits"],
+        "extraction_failures": diagnostics["extraction_failures"],
+        "failed_commits": diagnostics["failed_commits"],
+        "triples_total": len(inputs),
+        "idents_total": len(baseline),
+        "offenders": per_type,
+        "offenders_total": len(all_offenders),
+        "offenders_by_shape": shape_counts,
+        "candidates": score_all_rules(inputs, baseline),
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
+    }
+    report["predictions"] = evaluate_predictions(report)
+    return report
+
+
+def evaluate_predictions(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Score every declared prediction against the measured report.
+
+    Each outcome is derived from a number in the report. An evaluator that
+    returned "held" unconditionally would be worse than no predictions at all,
+    because it would launder a failed prediction as confirmation.
+    """
+    statements = dict(PREDICTIONS)
+    shape_counts = report["offenders_by_shape"]
+    leading = shape_counts.get("leading-underscore", 0)
+
+    def _row(pid: str, held: bool, evidence: str) -> Dict[str, Any]:
+        return {
+            "statement": statements[pid],
+            "outcome": "held" if held else "failed",
+            "evidence": evidence,
+        }
+
+    total = report["offenders_total"]
+    dominant = max(
+        (s for s in SHAPES if s != "other"),
+        key=lambda s: shape_counts.get(s, 0),
+        default="other",
+    )
+    r5 = report["candidates"]["R5"]["residual"]
+    r4 = report["candidates"]["R4"]["renames"]
+    r2 = report["candidates"]["R2"]["renames"]
+
+    return {
+        "P1": _row("P1", total > 3, f"offenders_total={total}"),
+        "P2": _row(
+            "P2",
+            dominant == "leading-underscore",
+            f"dominant shape={dominant} at {shape_counts.get(dominant, 0)}",
+        ),
+        "P3": _row("P3", r5 >= leading and r5 > 0,
+                   f"R5 residual={r5}, leading-underscore offenders={leading}"),
+        "P4": _row("P4", r2 < report["idents_total"],
+                   f"R2 renames={r2} of {report['idents_total']} idents"),
+        "P5": _row("P5", r4 == report["idents_total"],
+                   f"R4 renames={r4} of {report['idents_total']} idents"),
+    }
+
+
+def measurement_invalid(report: Dict[str, Any]) -> Optional[str]:
+    """Why this run cannot be believed, or None.
+
+    VALIDITY ONLY. A nonzero collision count is the number #263 asks for and
+    must NEVER fail the run -- finding collisions is this audit's entire
+    purpose. Do not widen this gate to make a run "pass".
+    """
+    if report["commits"] == 0:
+        return "Zero commits walked. Nothing was measured."
+    if report["triples_total"] == 0:
+        return (
+            "Zero inputs collected across "
+            f"{report['commits']} commits. A run that collected nothing "
+            "cannot report zero collisions as a finding."
+        )
+    failures = report["extraction_failures"]
+    if failures > report["commits"] * 0.01:
+        return (
+            f"_extract_commit raised on {failures} of {report['commits']} "
+            "commits (>1%). The input set is incomplete, so the count is a "
+            "bound rather than the exact number this audit exists to produce."
+        )
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Count, exactly, how many _code_ident values on real history are "
+            "reachable from more than one (entity_type, file_path, name) input."
+        )
+    )
+    parser.add_argument("--repo-path", default=".")
+    parser.add_argument("--branch", default=None)
+    parser.add_argument("--jobs", type=int, default=None)
+    parser.add_argument("--json-out", "--output", dest="json_out", default=None)
+    args = parser.parse_args()
+
+    inputs, diagnostics = collect_inputs(args.repo_path, args.branch, jobs=args.jobs)
+    report = build_report(inputs, diagnostics, args.repo_path)
+
+    print(json.dumps(report, indent=2))
+    print()
+    print(f"repo:                   {report['repo_path']} @ {report['branch']}")
+    # Printed next to the branch on purpose. With no --branch, this is
+    # mainline's tip rather than the checked-out branch's, which reads as a
+    # stale run unless both are visible together.
+    print(f"head:                   {report['head_commit']}")
+    print(f"ignore patterns:        {report['ignore_patterns'] or '(none)'}")
+    print(f"commits:                {report['commits']}")
+    print(f"extraction failures:    {report['extraction_failures']}")
+    print(f"distinct inputs:        {report['triples_total']}")
+    print(f"distinct idents:        {report['idents_total']}")
+    print()
+    print("OFFENDERS (idents reachable from >1 distinct input)")
+    for entity_type in ENTITY_TYPES:
+        row = report["offenders"][entity_type]
+        print(f"  {entity_type:<12} {row['count']:>6} of {row['idents_total']}")
+    print(f"  {'TOTAL':<12} {report['offenders_total']:>6}")
+    print()
+    print("BY SHAPE (an offender may carry more than one label)")
+    for shape in SHAPES:
+        print(f"  {shape:<20} {report['offenders_by_shape'][shape]:>6}")
+    print()
+    print("CANDIDATE RULES")
+    print(f"  {'rule':<6} {'residual':>9} {'renames':>9}   description")
+    for rule_id in sorted(RULES):
+        row = report["candidates"][rule_id]
+        print(
+            f"  {rule_id:<6} {row['residual']:>9} {row['renames']:>9}   "
+            f"{row['description']}"
+        )
+    print()
+    print("PREDICTIONS (fixed before the run; a failure is a finding)")
+    for pid, _ in PREDICTIONS:
+        row = report["predictions"][pid]
+        print(f"  {pid}  {row['outcome']:<7} {row['evidence']}")
+
+    if report["candidates"]["R5"]["residual"] == 0 and (
+        report["offenders_by_shape"]["leading-underscore"] > 0
+    ):
+        print()
+        print(
+            "NOTE: R5 is the CONTROL and reported zero residual on a history\n"
+            "that HAS leading-underscore offenders. R5 slugs the name\n"
+            "independently, and strip('-') still eats the leading underscore,\n"
+            "so it cannot separate them. The scorer is wrong and every other\n"
+            "row in the candidate table is suspect. Do not act on this run."
+        )
+
+    reason = measurement_invalid(report)
+    if reason:
+        print()
+        print(f"INVALID MEASUREMENT. {reason}")
+        print("Do not adjust this gate to make a run pass.")
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.json_out}")
+    return 1 if reason else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -30,10 +30,22 @@ See docs/superpowers/specs/2026-08-11-ident-collision-audit-design.md.
 
 from __future__ import annotations
 
+import hashlib
+import re
 import sys
 from itertools import combinations
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Set
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 _REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 if str(_REPO_ROOT) not in sys.path:
@@ -195,3 +207,119 @@ def classify_shapes(members: Sequence[EntityInput]) -> Set[str]:
     if not shapes - {"cross-producer"}:
         shapes.add("other")
     return shapes
+
+
+def _slug_current(value: str) -> str:
+    """_canonical_ident's slug, verbatim (mcp_server.py:4097-4098)."""
+    slug = re.sub(r"[^a-z0-9-]", "-", value.lower())
+    return re.sub(r"-+", "-", slug).strip("-")
+
+
+def _slug_keep_underscore(value: str) -> str:
+    """R1: '_' joins the allowed charset, so a private marker survives."""
+    slug = re.sub(r"[^a-z0-9_-]", "-", value.lower())
+    return re.sub(r"-+", "-", slug).strip("-")
+
+
+def _slug_no_collapse(value: str) -> str:
+    """R2: hyphen runs are preserved, so separator arity carries the marker
+    ('py---commit' against 'py--commit')."""
+    return re.sub(r"[^a-z0-9-]", "-", value.lower()).strip("-")
+
+
+def _slug_keep_underscore_no_collapse(value: str) -> str:
+    """R3: R1 and R2 together."""
+    return re.sub(r"[^a-z0-9_-]", "-", value.lower()).strip("-")
+
+
+def _ident_from_slug(slug_fn: Callable[[str], str]) -> Callable[[EntityInput], str]:
+    def ident(inp: EntityInput) -> str:
+        return f":{inp.entity_type}/{slug_fn(raw_value(inp))}"
+
+    return ident
+
+
+def _ident_hash_suffix(inp: EntityInput) -> str:
+    """R4: the current slug plus 8 hex of sha256 over the RAW value.
+
+    Hashing the raw value, before lowercasing, is what separates a case-only
+    collision as well -- the slug alone cannot.
+    """
+    value = raw_value(inp)
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
+    return f":{inp.entity_type}/{_slug_current(value)}-{digest}"
+
+
+def _ident_independent_parts(inp: EntityInput) -> str:
+    """R5, the CONTROL. Slugs file_path and name separately and joins them
+    with a fixed token.
+
+    This is expected to FAIL. _slug_current strips leading hyphens, so a name
+    of "_commit" reduces to "commit" exactly as "commit" does, and the pair
+    still collides. R5 exists so score_all_rules has a known-negative: if it
+    ever reports zero residual on a history with leading-underscore pairs, the
+    scorer is wrong and every other row it produced is suspect.
+    """
+    path_slug = _slug_current(inp.file_path)
+    if inp.name is None:
+        return f":{inp.entity_type}/{path_slug}"
+    return f":{inp.entity_type}/{path_slug}--{_slug_current(inp.name)}"
+
+
+RULES: Dict[str, Tuple[str, Callable[[EntityInput], str]]] = {
+    "R1": (
+        "keep underscores: charset becomes [^a-z0-9_-]",
+        _ident_from_slug(_slug_keep_underscore),
+    ),
+    "R2": (
+        "no hyphen collapse: drop re.sub(r'-+', '-', slug)",
+        _ident_from_slug(_slug_no_collapse),
+    ),
+    "R3": (
+        "R1 + R2: keep underscores and drop the collapse",
+        _ident_from_slug(_slug_keep_underscore_no_collapse),
+    ),
+    "R4": (
+        "hash suffix: current slug + '-' + sha256(raw value)[:8]",
+        _ident_hash_suffix,
+    ),
+    "R5": (
+        "CONTROL, expected to still collide: slug file_path and name "
+        "independently, join with '--'",
+        _ident_independent_parts,
+    ),
+}
+
+
+def score_rule(
+    inputs: Sequence[EntityInput],
+    ident_fn: Callable[[EntityInput], str],
+    baseline_groups: Dict[str, List[EntityInput]],
+) -> Dict[str, int]:
+    """Residual collisions and rename cost for one candidate rule.
+
+    renames counts BASELINE idents, not inputs: a baseline ident is renamed
+    when any input in its group maps somewhere other than that same ident.
+    Rename cost is not a footnote to residual -- every change to derivation
+    renames entities in every existing graph, and that cost is what decides
+    forward-fix against migration.
+    """
+    residual = len(offenders(group_by_ident(inputs, ident_fn)))
+    renames = sum(
+        1
+        for ident, members in baseline_groups.items()
+        if any(ident_fn(member) != ident for member in members)
+    )
+    return {"residual": residual, "renames": renames}
+
+
+def score_all_rules(
+    inputs: Sequence[EntityInput],
+    baseline_groups: Dict[str, List[EntityInput]],
+) -> Dict[str, Dict]:
+    scored = {}
+    for rule_id, (description, ident_fn) in RULES.items():
+        row = score_rule(inputs, ident_fn, baseline_groups)
+        row["description"] = description
+        scored[rule_id] = row
+    return scored

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -31,8 +31,9 @@ See docs/superpowers/specs/2026-08-11-ident-collision-audit-design.md.
 from __future__ import annotations
 
 import sys
+from itertools import combinations
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, NamedTuple, Optional
+from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Set
 
 _REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 if str(_REPO_ROOT) not in sys.path:
@@ -105,3 +106,60 @@ def offenders(
     return {
         ident: members for ident, members in groups.items() if len(members) > 1
     }
+
+
+SHAPES = (
+    "leading-underscore",
+    "case-only",
+    "separator-vs-path",
+    "cross-producer",
+    "other",
+)
+
+
+def _strip_private(name: Optional[str]) -> str:
+    """Drop leading underscores from the LAST dot-segment of a name.
+
+    Fields reach _code_ident qualified as "Cls.field" (mcp_server.py:7098), so
+    the private marker sits mid-string. A bare name.lstrip("_") would miss
+    "Cls._x" against "Cls.x" entirely.
+    """
+    if not name:
+        return ""
+    head, dot, last = name.rpartition(".")
+    stripped = last.lstrip("_")
+    return f"{head}{dot}{stripped}" if dot else stripped
+
+
+def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
+    shapes: Set[str] = set()
+    if a.producer != b.producer:
+        shapes.add("cross-producer")
+    a_raw, b_raw = raw_value(a), raw_value(b)
+    if a_raw.casefold() == b_raw.casefold():
+        shapes.add("case-only")
+    elif a.file_path == b.file_path and _strip_private(a.name) == _strip_private(b.name):
+        shapes.add("leading-underscore")
+    elif a.file_path != b.file_path or (a.name is None) != (b.name is None):
+        # The two inputs put the path/name boundary in different places, so
+        # the ident cannot say where the path ended -- the collision family
+        # _code_ident's docstring already anticipates.
+        shapes.add("separator-vs-path")
+    return shapes
+
+
+def classify_shapes(members: Sequence[EntityInput]) -> Set[str]:
+    """Label an offender by every collision family present among its inputs.
+
+    An offender may carry more than one label (a cross-producer collision is
+    usually also something else), so this returns a set rather than picking a
+    single winner. "other" is emitted only when nothing else applied: it is
+    where an unpredicted collision family would surface, and collapsing it
+    into any named label would hide exactly the finding worth having.
+    """
+    shapes: Set[str] = set()
+    for a, b in combinations(members, 2):
+        shapes |= _pair_shapes(a, b)
+    if not shapes - {"cross-producer"}:
+        shapes.add("other")
+    return shapes

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -130,7 +130,7 @@ def group_by_ident(
     touched its file, and counting occurrences would report every entity in
     the repository as colliding with itself.
     """
-    groups: Dict[str, Dict[EntityInput, None] ] = {}
+    groups: Dict[str, Dict[EntityInput, None]] = {}
     for inp in inputs:
         groups.setdefault(ident_fn(inp), {})[inp] = None
     return {ident: list(members) for ident, members in groups.items()}
@@ -166,6 +166,41 @@ def _strip_private(name: Optional[str]) -> str:
     head, dot, last = name.rpartition(".")
     stripped = last.lstrip("_")
     return f"{head}{dot}{stripped}" if dot else stripped
+
+
+def _name_is_trailing_path_segment(named: EntityInput, other: EntityInput) -> bool:
+    """True if `named`'s name is a trailing WHOLE path segment of `other`'s
+    file_path, extension stripped.
+
+    This is the design spec's definition of separator-vs-path verbatim (spec
+    line 189): "the `name` of one input appears as a trailing path segment of
+    another's `file_path`" -- the case _code_ident's own docstring anticipates,
+    where the ident cannot say whether the last component came from the path or
+    from the name.
+
+    WHOLE-SEGMENT, not raw string suffix. `mcp_server.py` does NOT end with the
+    segment `server`: the substring is there, but not as its own path
+    component, and calling that a path/name boundary would relabel ordinary
+    underscore collisions. The boundary logic is mcp_server._path_segments plus
+    mcp_server._segments_end_with (mcp_server.py:4102-4117), reused rather than
+    re-implemented for the third time -- reading the audited module is fine
+    here, only MUTATING it is forbidden.
+
+    Casefolded on both sides for the same reason the leading-underscore check
+    is: the ident lowercases, so `src/auth/Login.py` against a name of `login`
+    is a genuine instance of this family, and an exact-case comparison would
+    drop it into "other", which is reserved for UNPREDICTED families.
+    """
+    if not named.name:
+        return False
+    segments = mcp_server._path_segments(other.file_path)
+    if not segments:
+        return False
+    segments = segments[:-1] + [Path(segments[-1]).stem]
+    return mcp_server._segments_end_with(
+        [seg.casefold() for seg in segments],
+        [seg.casefold() for seg in mcp_server._path_segments(named.name)],
+    )
 
 
 def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
@@ -209,10 +244,14 @@ def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
         and _strip_private(a.name).casefold() == _strip_private(b.name).casefold()
     ):
         shapes.add("leading-underscore")
-    if a.file_path != b.file_path or (a.name is None) != (b.name is None):
-        # The two inputs put the path/name boundary in different places, so
-        # the ident cannot say where the path ended -- the collision family
-        # _code_ident's docstring already anticipates.
+    # The spec's definition, narrowly: one input's NAME is a trailing whole
+    # path segment of the other's file_path, so the ident cannot say where the
+    # path ended and the name began -- the family _code_ident's docstring
+    # anticipates. This deliberately does NOT fire merely because the two
+    # file_paths differ: "the paths differ" describes most collisions on any
+    # history and says nothing about a path/name boundary. See
+    # _name_is_trailing_path_segment.
+    if _name_is_trailing_path_segment(a, b) or _name_is_trailing_path_segment(b, a):
         shapes.add("separator-vs-path")
     return shapes
 
@@ -222,9 +261,12 @@ def classify_shapes(members: Sequence[EntityInput]) -> Set[str]:
 
     An offender may carry more than one label -- the per-pair checks are
     independent, not exclusive, so a cross-producer collision is usually also
-    something else. "other" is emitted only when nothing else applied: it is
-    where an unpredicted collision family would surface, and collapsing it
-    into any named label would hide exactly the finding worth having.
+    something else. "other" is emitted when nothing BUT "cross-producer"
+    applied -- not when no label at all applied. "cross-producer" says which
+    call sites the two inputs came from, never what made their values collide,
+    so an offender carrying only that label is still unexplained and belongs in
+    the bucket where an unpredicted collision family surfaces. Collapsing
+    "other" into any named label would hide exactly the finding worth having.
     """
     shapes: Set[str] = set()
     for a, b in combinations(members, 2):
@@ -459,9 +501,19 @@ def collect_inputs(
     runs, so this audit measures the code that actually produces idents in
     production rather than a reimplementation that could drift from it.
 
-    Walking A/M/R across every commit reaches every version of every file that
-    ever existed on the branch: each distinct blob at each path is introduced
-    by exactly one such entry, so no separate initial-tree pass is needed.
+    Every commit's file_results are consumed, filtered only on `extracted is
+    None` -- so A, M and R contribute, and so does any other status the raw
+    parse reports (T/typechange), which carries an extraction like any other
+    content change. That reaches every version of every file that ever existed
+    on the branch: each distinct blob at each path is introduced by exactly one
+    such entry, so no separate initial-tree pass is needed.
+
+    That coverage claim rests on mcp_server, not on this function.
+    _git_diff_tree_raw passes --root (mcp_server.py:4406), so the initial
+    commit reports its whole tree as adds instead of an empty diff, and merge
+    commits fall back to the --cc combined diff (_git_diff_tree_combined_raw,
+    mcp_server.py:4479) plus the one-parent-side supplement above it. A path a
+    merge resolved to a content no parent carried would otherwise be invisible.
 
     Inputs are deduplicated here. A name unchanged across 400 commits costs one
     entry, not 400.
@@ -691,6 +743,12 @@ def build_report(
         "commits": diagnostics["commits"],
         "extraction_failures": diagnostics["extraction_failures"],
         "failed_commits": diagnostics["failed_commits"],
+        # NAMED for the (entity_type, file_path, name) triple the question is
+        # framed on, but counted over DISTINCT EntityInputs, whose key is the
+        # 4-tuple including `producer`. The two coincide only while
+        # cross-producer is 0; on a history with gitlinks, one triple reached
+        # from two producers counts twice here, so read this as "distinct
+        # inputs", not "distinct triples".
         "triples_total": len(inputs),
         "idents_total": len(baseline),
         "offenders": per_type,

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -338,6 +338,46 @@ def score_rule(
     return {"residual": residual, "renames": renames}
 
 
+def renames_by_entity_type(
+    ident_fn: Callable[[EntityInput], str],
+    baseline_groups: Dict[str, List[EntityInput]],
+) -> Dict[str, Dict[str, int]]:
+    """Rename cost split by entity type, as {entity_type: {"renamed", "total"}}.
+
+    score_rule's single `renames` integer cannot answer the question that
+    decides between candidate rules: WHERE the rename cost lands. R2 drops
+    only the hyphen collapse, and a module input has no '::' separator to
+    produce an adjacent hyphen run, so it should spare module idents while
+    renaming nearly every named one. A whole-corpus total hides that shape
+    completely.
+
+    Keyed on the entity_type of a group's first member, matching how
+    build_report already partitions baseline groups per type.
+
+    The rename criterion is score_rule's, verbatim -- a baseline ident counts
+    as renamed when any input in its group maps somewhere other than that same
+    ident -- so these per-type counts SUM to score_rule's total. A test pins
+    that equality for every rule, because the two paths silently drifting is
+    how a per-type breakdown stops describing the total it sits beside.
+
+    Every declared entity type appears even at zero, for the same reason
+    build_report emits them all: a missing key and a zero are different claims.
+    An entity_type outside ENTITY_TYPES is still counted rather than dropped,
+    so the sum invariant holds unconditionally.
+    """
+    per_type: Dict[str, Dict[str, int]] = {
+        entity_type: {"renamed": 0, "total": 0} for entity_type in ENTITY_TYPES
+    }
+    for ident, members in baseline_groups.items():
+        row = per_type.setdefault(
+            members[0].entity_type, {"renamed": 0, "total": 0}
+        )
+        row["total"] += 1
+        if any(ident_fn(member) != ident for member in members):
+            row["renamed"] += 1
+    return per_type
+
+
 def score_all_rules(
     inputs: Sequence[EntityInput],
     baseline_groups: Dict[str, List[EntityInput]],
@@ -527,9 +567,10 @@ PREDICTIONS: Tuple[Tuple[str, str], ...] = (
            "offenders."),
     ("P3", "R5, the control, reports a nonzero residual at least as large as "
            "the leading-underscore offender count."),
-    ("P4", "R2 renames strictly fewer than all idents: it leaves plain module "
-           "idents untouched, because a module input has no '::' separator to "
-           "produce an adjacent hyphen run."),
+    ("P4", "R2's rename cost falls on named entities, not on module idents: "
+           "a module input has no '::' separator to produce an adjacent "
+           "hyphen run, so R2 renames a strictly smaller FRACTION of module "
+           "idents than of function idents."),
     ("P5", "R4's rename count equals the total ident count."),
 )
 
@@ -585,6 +626,12 @@ def build_report(
         for shape in classify_shapes(members):
             shape_counts[shape] += 1
 
+    candidates = score_all_rules(inputs, baseline)
+    for rule_id, (_description, ident_fn) in RULES.items():
+        candidates[rule_id]["renames_by_entity_type"] = renames_by_entity_type(
+            ident_fn, baseline
+        )
+
     report: Dict[str, Any] = {
         "repo_path": repo_path,
         "branch": diagnostics["branch"],
@@ -601,7 +648,11 @@ def build_report(
         "offenders": per_type,
         "offenders_total": len(all_offenders),
         "offenders_by_shape": shape_counts,
-        "candidates": score_all_rules(inputs, baseline),
+        # Composed here rather than inside score_all_rules: that function's
+        # {description, residual, renames} shape is Task 3's contract and a
+        # test pins it. The breakdown answers WHERE a rule's rename cost lands,
+        # which is what separates two rules that both reach zero residual.
+        "candidates": candidates,
         "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         ),
@@ -636,7 +687,41 @@ def evaluate_predictions(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     )
     r5 = report["candidates"]["R5"]["residual"]
     r4 = report["candidates"]["R4"]["renames"]
-    r2 = report["candidates"]["R2"]["renames"]
+
+    # P4 is a claim about the SHAPE of R2's rename cost, so it is ruled on
+    # fractions rather than on the whole-corpus total, which cannot distinguish
+    # "spares module idents" from "renames slightly fewer than everything".
+    r2_by_type = report["candidates"]["R2"]["renames_by_entity_type"]
+    module_row = r2_by_type["module"]
+    function_row = r2_by_type["function"]
+    empty_denominators = [
+        entity_type
+        for entity_type, row in (("module", module_row), ("function", function_row))
+        if row["total"] == 0
+    ]
+    if empty_denominators:
+        # Not evaluable on this corpus. Recorded as "failed" rather than as a
+        # third outcome value -- held/failed is pinned by a test -- but the
+        # evidence must say WHY, or a reader sees a bare 0/0 and reads a real
+        # ruling into a corpus that could not produce one.
+        p4_held = False
+        p4_evidence = (
+            "not evaluable: no "
+            + " or ".join(empty_denominators)
+            + " idents in this corpus (module "
+            f"{module_row['renamed']}/{module_row['total']}, function "
+            f"{function_row['renamed']}/{function_row['total']})"
+        )
+    else:
+        module_fraction = module_row["renamed"] / module_row["total"]
+        function_fraction = function_row["renamed"] / function_row["total"]
+        p4_held = module_fraction < function_fraction
+        p4_evidence = (
+            f"R2 renames module {module_row['renamed']}/{module_row['total']} "
+            f"= {module_fraction:.3f}, function "
+            f"{function_row['renamed']}/{function_row['total']} "
+            f"= {function_fraction:.3f}"
+        )
 
     return {
         "P1": _row("P1", total > 3, f"offenders_total={total}"),
@@ -647,8 +732,7 @@ def evaluate_predictions(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
         ),
         "P3": _row("P3", r5 >= leading and r5 > 0,
                    f"R5 residual={r5}, leading-underscore offenders={leading}"),
-        "P4": _row("P4", r2 < report["idents_total"],
-                   f"R2 renames={r2} of {report['idents_total']} idents"),
+        "P4": _row("P4", p4_held, p4_evidence),
         "P5": _row("P5", r4 == report["idents_total"],
                    f"R4 renames={r4} of {report['idents_total']} idents"),
     }
@@ -726,6 +810,23 @@ def main() -> int:
             f"  {rule_id:<6} {row['residual']:>9} {row['renames']:>9}   "
             f"{row['description']}"
         )
+    print()
+    # Only the zero-residual rules: they are the live contenders, and WHERE
+    # their rename cost lands is what separates them. One line per rule per
+    # type across all five rules would bury that under rows for rules already
+    # ruled out.
+    print("RENAME COST BY ENTITY TYPE (zero-residual rules only)")
+    contenders = [r for r in sorted(RULES) if report["candidates"][r]["residual"] == 0]
+    if not contenders:
+        print("  (none: no candidate rule reached zero residual)")
+    for rule_id in contenders:
+        breakdown = report["candidates"][rule_id]["renames_by_entity_type"]
+        cells = " ".join(
+            f"{entity_type}={breakdown[entity_type]['renamed']}"
+            f"/{breakdown[entity_type]['total']}"
+            for entity_type in ENTITY_TYPES
+        )
+        print(f"  {rule_id:<6} {cells}")
     print()
     print("PREDICTIONS (fixed before the run; a failure is a finding)")
     for pid, _ in PREDICTIONS:

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -132,15 +132,47 @@ def _strip_private(name: Optional[str]) -> str:
 
 
 def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
+    """Every collision family this pair belongs to.
+
+    The checks are INDEPENDENT, not an elif chain. A pair can belong to more
+    than one family and the caller returns a set, so making them exclusive
+    would silently drop the second label -- and, worse, would let the winner
+    depend on check order rather than on the data.
+
+    Each check also carries an inequality guard. Without one, "case-only"
+    fires on two inputs whose raw values are byte-identical (a pair differing
+    only in producer -- exactly the cross-producer collision this audit exists
+    to find), asserting a case difference that is not there.
+    """
     shapes: Set[str] = set()
     if a.producer != b.producer:
         shapes.add("cross-producer")
     a_raw, b_raw = raw_value(a), raw_value(b)
-    if a_raw.casefold() == b_raw.casefold():
+    if a_raw != b_raw and a_raw.casefold() == b_raw.casefold():
         shapes.add("case-only")
-    elif a.file_path == b.file_path and _strip_private(a.name) == _strip_private(b.name):
+    # casefold on BOTH sides, so a private PascalCase helper beside a public
+    # snake_case one (_Config/config, _Handler/handler -- ordinary Python) is
+    # still recognised as the underscore family. An exact-case comparison here
+    # drops those into "other", which is reserved for UNPREDICTED families and
+    # so would hide a predicted one.
+    #
+    # The guard compares NAME casefold, not exact name, and requires that
+    # comparison to be UNEQUAL -- i.e. that the pair is not already
+    # explainable by case alone. Without it, a pair with no underscore at
+    # all (Foo/foo) also satisfies the stripped-casefold equality below,
+    # since stripping is a no-op when there is nothing to strip, and
+    # leading-underscore would fire on top of a plain case-only pair. That
+    # is the same false-positive shape as Finding 1, just on the other
+    # check.
+    a_name_cf = (a.name or "").casefold()
+    b_name_cf = (b.name or "").casefold()
+    if (
+        a_name_cf != b_name_cf
+        and a.file_path == b.file_path
+        and _strip_private(a.name).casefold() == _strip_private(b.name).casefold()
+    ):
         shapes.add("leading-underscore")
-    elif a.file_path != b.file_path or (a.name is None) != (b.name is None):
+    if a.file_path != b.file_path or (a.name is None) != (b.name is None):
         # The two inputs put the path/name boundary in different places, so
         # the ident cannot say where the path ended -- the collision family
         # _code_ident's docstring already anticipates.
@@ -151,9 +183,9 @@ def _pair_shapes(a: EntityInput, b: EntityInput) -> Set[str]:
 def classify_shapes(members: Sequence[EntityInput]) -> Set[str]:
     """Label an offender by every collision family present among its inputs.
 
-    An offender may carry more than one label (a cross-producer collision is
-    usually also something else), so this returns a set rather than picking a
-    single winner. "other" is emitted only when nothing else applied: it is
+    An offender may carry more than one label -- the per-pair checks are
+    independent, not exclusive, so a cross-producer collision is usually also
+    something else. "other" is emitted only when nothing else applied: it is
     where an unpredicted collision family would surface, and collapsing it
     into any named label would hide exactly the finding worth having.
     """

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -571,8 +571,56 @@ PREDICTIONS: Tuple[Tuple[str, str], ...] = (
            "a module input has no '::' separator to produce an adjacent "
            "hyphen run, so R2 renames a strictly smaller FRACTION of module "
            "idents than of function idents."),
-    ("P5", "R4's rename count equals the total ident count."),
 )
+
+# NOT predictions. A prediction the data cannot contradict is a tautology, and
+# one sitting in the predictions block inflates the held count with something
+# that was never at risk. These are declared self-checks instead: statements
+# that MUST hold by construction, kept because a failure indicts the scorer
+# rather than the design. The model is RULES["R5"], whose description declares
+# it the known-negative control instead of pretending to be a candidate.
+#
+# P5 lived here as a prediction until review: R4 is _ident_hash_suffix, which
+# appends "-{digest}" to every ident unconditionally, so no run that clears the
+# validity gate can falsify it. The label P5 is retired and deliberately not
+# reused, so this artifact and the plan stay legible against each other.
+SELF_CHECKS: Tuple[Tuple[str, str], ...] = (
+    ("S1", "R4 appends a hash suffix to every ident by construction, so its "
+           "rename count must equal the total ident count. If it does not, "
+           "score_rule's rename accounting is broken and every other rule's "
+           "rename number in this table is suspect."),
+)
+
+
+def _outcome_row(statement: str, held: bool, evidence: str) -> Dict[str, Any]:
+    """One {statement, outcome, evidence} row, shared by predictions and
+    self-checks so nothing downstream needs a second shape."""
+    return {
+        "statement": statement,
+        "outcome": "held" if held else "failed",
+        "evidence": evidence,
+    }
+
+
+def evaluate_self_checks(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Score the by-construction invariants. A failure indicts the SCORER.
+
+    This is the rename-accounting analogue of the R5 control: R5 catches a
+    residual counter that reports a known-colliding rule as clean, and S1
+    catches a rename counter that has lost idents. Neither says anything about
+    the design under audit -- which is exactly why they are reported apart from
+    the predictions, where a held/failed tally is meant to be informative.
+    """
+    statements = dict(SELF_CHECKS)
+    r4_renames = report["candidates"]["R4"]["renames"]
+    idents_total = report["idents_total"]
+    return {
+        "S1": _outcome_row(
+            statements["S1"],
+            r4_renames == idents_total,
+            f"R4 renames={r4_renames}, idents_total={idents_total}",
+        ),
+    }
 
 
 def build_report(
@@ -658,6 +706,10 @@ def build_report(
         ),
     }
     report["predictions"] = evaluate_predictions(report)
+    # Reported apart from the predictions on purpose: a reader counting
+    # held/failed predictions must not be counting a by-construction invariant
+    # among them.
+    report["self_checks"] = evaluate_self_checks(report)
     return report
 
 
@@ -673,20 +725,52 @@ def evaluate_predictions(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     leading = shape_counts.get("leading-underscore", 0)
 
     def _row(pid: str, held: bool, evidence: str) -> Dict[str, Any]:
-        return {
-            "statement": statements[pid],
-            "outcome": "held" if held else "failed",
-            "evidence": evidence,
-        }
+        return _outcome_row(statements[pid], held, evidence)
 
     total = report["offenders_total"]
-    dominant = max(
-        (s for s in SHAPES if s != "other"),
-        key=lambda s: shape_counts.get(s, 0),
-        default="other",
-    )
     r5 = report["candidates"]["R5"]["residual"]
-    r4 = report["candidates"]["R4"]["renames"]
+
+    # P2 is ruled by STRICT comparison against the runner-up, not by max().
+    # max() returns the first maximal element and SHAPES[0] is
+    # "leading-underscore", so it named leading-underscore the winner on a
+    # corpus where every count was 0 -- and a zero-offender run clears the
+    # validity gate, so that laundered "held" reached the committed artifact.
+    # The same first-wins bias read an exact tie as a win. This is the defect
+    # P4 was corrected for, in a second place.
+    rivals = sorted(
+        (
+            (shape_counts.get(shape, 0), shape)
+            for shape in SHAPES
+            if shape not in ("other", "leading-underscore")
+        ),
+        reverse=True,
+    )
+    runner_up_count, runner_up = rivals[0]
+    if total == 0:
+        p2_held = False
+        p2_evidence = (
+            "not evaluable: no offenders in this corpus "
+            f"(offenders_total=0, leading-underscore=0)"
+        )
+    elif leading == 0 and runner_up_count == 0:
+        # Offenders exist but every named shape is empty, i.e. they all landed
+        # in "other". Distinct from the case above and worth saying so: "other"
+        # is where an UNPREDICTED collision family surfaces, so this is a
+        # finding, not an empty run.
+        p2_held = False
+        p2_evidence = (
+            "not evaluable: no offender carries a named shape "
+            f"(offenders_total={total}, all in 'other')"
+        )
+    else:
+        # Strict: a tie is not a win. The runner-up is named and counted so a
+        # near-tie is visible without re-running anything -- the old evidence
+        # string showed only the winner, which made a 3-vs-3 read as dominance.
+        p2_held = leading > runner_up_count
+        p2_evidence = (
+            f"leading-underscore={leading}, "
+            f"runner-up {runner_up}={runner_up_count}"
+        )
 
     # P4 is a claim about the SHAPE of R2's rename cost, so it is ruled on
     # fractions rather than on the whole-corpus total, which cannot distinguish
@@ -725,16 +809,10 @@ def evaluate_predictions(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
 
     return {
         "P1": _row("P1", total > 3, f"offenders_total={total}"),
-        "P2": _row(
-            "P2",
-            dominant == "leading-underscore",
-            f"dominant shape={dominant} at {shape_counts.get(dominant, 0)}",
-        ),
+        "P2": _row("P2", p2_held, p2_evidence),
         "P3": _row("P3", r5 >= leading and r5 > 0,
                    f"R5 residual={r5}, leading-underscore offenders={leading}"),
         "P4": _row("P4", p4_held, p4_evidence),
-        "P5": _row("P5", r4 == report["idents_total"],
-                   f"R4 renames={r4} of {report['idents_total']} idents"),
     }
 
 
@@ -832,6 +910,16 @@ def main() -> int:
     for pid, _ in PREDICTIONS:
         row = report["predictions"][pid]
         print(f"  {pid}  {row['outcome']:<7} {row['evidence']}")
+    print()
+    # Under its own heading, never inside the predictions block: these hold by
+    # construction, so counting them among the predictions would inflate the
+    # held tally with something that was never at risk.
+    print("SELF-CHECKS (hold by construction; a failure indicts the SCORER)")
+    for sid, _ in SELF_CHECKS:
+        row = report["self_checks"][sid]
+        print(f"  {sid}  {row['outcome']:<7} {row['evidence']}")
+        if row["outcome"] == "failed":
+            print(f"      {row['statement']}")
 
     if report["candidates"]["R5"]["residual"] == 0 and (
         report["offenders_by_shape"]["leading-underscore"] > 0

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -563,8 +563,8 @@ PREDICTIONS: Tuple[Tuple[str, str], ...] = (
     ("P1", "The true collision count exceeds the 3 #257's census found, "
            "because that census can only see collisions whose loser was "
            "closed and reopened."),
-    ("P2", "leading-underscore is the dominant named shape among all "
-           "offenders."),
+    ("P2", "leading-underscore STRICTLY outnumbers every other named shape "
+           "among all offenders."),
     ("P3", "R5, the control, reports a nonzero residual at least as large as "
            "the leading-underscore offender count."),
     ("P4", "R2's rename cost falls on named entities, not on module idents: "

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -431,13 +431,16 @@ def collect_inputs(
             ): commit_hash
             for commit_hash in hashes
         }
-        # as_completed, not futures.items(): both consume every submitted
-        # future, but submission order blocks on commit N while every result
-        # after it piles up unconsumed in memory. Harvesting is far cheaper
-        # than extraction, so draining in completion order keeps the backlog
-        # to what the pool has genuinely finished.
+        # as_completed drains in completion order, so a straggler at position 0
+        # does not hold the loop. That alone bounds NOTHING, though: a Future
+        # keeps its _result after result() returns, and this dict keeps a
+        # strong reference to every future for the whole `with` block, so peak
+        # memory would be identical to iterating futures.items(). The pop is
+        # what actually drops the reference and lets a consumed result be
+        # collected. Safe because as_completed snapshots its argument before
+        # the first loop body runs.
         for future in as_completed(futures):
-            commit_hash = futures[future]
+            commit_hash = futures.pop(future)
             try:
                 file_results, gitlink_changes, _gitmodules, _renamed = future.result()
             except Exception:
@@ -454,7 +457,17 @@ def collect_inputs(
     walk_order = {commit_hash: i for i, commit_hash in enumerate(hashes)}
     failed.sort(key=walk_order.__getitem__)
 
-    return list(seen), {
+    # `seen` was filled in result-consumption order, i.e. pool completion order,
+    # which varies run to run once jobs > 1. This audit's output is a COMMITTED
+    # artifact, so scheduling must not reach it: impose a total ordering on the
+    # inputs themselves. name is Optional, and sorting None against str raises,
+    # hence `or ""`.
+    ordered = sorted(
+        seen,
+        key=lambda inp: (inp.entity_type, inp.producer, inp.file_path, inp.name or ""),
+    )
+
+    return ordered, {
         "head_commit": hashes[-1] if hashes else None,
         "branch": resolved_branch,
         "commits": len(hashes),

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -31,11 +31,14 @@ See docs/superpowers/specs/2026-08-11-ident-collision-audit-design.md.
 from __future__ import annotations
 
 import hashlib
+import multiprocessing
 import re
 import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from itertools import combinations
 from pathlib import Path
 from typing import (
+    Any,
     Callable,
     Dict,
     Iterable,
@@ -323,3 +326,138 @@ def score_all_rules(
         row["description"] = description
         scored[rule_id] = row
     return scored
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: collect the inputs, through the real extractor
+# ---------------------------------------------------------------------------
+
+
+def inputs_from_commit_extraction(
+    file_results: Sequence[tuple],
+    gitlink_changes: Sequence[tuple],
+) -> List[EntityInput]:
+    """Harvest every _code_ident input one commit's extraction implies.
+
+    file_results entries are (status, file_path, extracted, precomputed,
+    old_path) per _extract_commit's contract (mcp_server.py:8475-8484). A "D"
+    entry carries extracted=None and precomputed=None and is skipped: the path
+    names an entity being CLOSED, not one being introduced, and its inputs were
+    already collected when it was introduced.
+
+    The category-to-entity_type mapping and the field qualification mirror
+    _precompute_file_triples (mcp_server.py:7044-7122). If that function and
+    this one ever disagree, that one is right.
+    """
+    collected: List[EntityInput] = []
+
+    for _status, file_path, extracted, precomputed, _old_path in file_results:
+        if extracted is None:
+            continue
+        collected.append(EntityInput("module", "code", file_path, None))
+        for fn_name in extracted.get("functions", []):
+            collected.append(EntityInput("function", "code", file_path, fn_name))
+        for cls_name in extracted.get("classes", []):
+            collected.append(EntityInput("class", "code", file_path, cls_name))
+        for gvar_name in extracted.get("globals", []):
+            collected.append(EntityInput("variable", "code", file_path, gvar_name))
+        for field_name, owning_class, _is_static in extracted.get("fields", []):
+            collected.append(
+                EntityInput("field", "code", file_path, f"{owning_class}.{field_name}")
+            )
+        # Only UNRESOLVED imports. A resolved one already points at the in-tree
+        # module ident the module producer above contributes, so counting it
+        # again would manufacture a cross-producer collision on every internal
+        # import in the repository.
+        for import_name, _dep_ident, is_resolved in (
+            (precomputed or {}).get("resolved_imports", [])
+        ):
+            if not is_resolved:
+                collected.append(EntityInput("module", "import", import_name, None))
+
+    # add/bump/remove all reach one `for kind, sha, path` loop that takes
+    # _code_ident("module", path) unconditionally (mcp_server.py:9555-9556),
+    # so every kind contributes.
+    for _kind, _sha, path in gitlink_changes:
+        collected.append(EntityInput("module", "gitlink", path, None))
+
+    return collected
+
+
+def collect_inputs(
+    repo_path: str,
+    branch: Optional[str] = None,
+    jobs: Optional[int] = None,
+) -> Tuple[List[EntityInput], Dict[str, Any]]:
+    """Walk the branch and collect every input that ever reached _code_ident.
+
+    Drives mcp_server._extract_commit rather than re-implementing parsing.
+    That function is documented read-only, stateless and DB-free
+    (mcp_server.py:8455) and is exactly what _run_ingestion's worker pool
+    runs, so this audit measures the code that actually produces idents in
+    production rather than a reimplementation that could drift from it.
+
+    Walking A/M/R across every commit reaches every version of every file that
+    ever existed on the branch: each distinct blob at each path is introduced
+    by exactly one such entry, so no separate initial-tree pass is needed.
+
+    Inputs are deduplicated here. A name unchanged across 400 commits costs one
+    entry, not 400.
+
+    The pool uses an explicit "spawn" context for the same reason
+    _run_ingestion does (mcp_server.py:10536-10546): workers are created lazily
+    while other threads may already be alive in this process (this runs under
+    pytest, and Task 5 puts a CLI on top of it), and forking with a thread
+    holding a lock deadlocks the child forever. It also makes the start method
+    independent of the platform default, which changed in 3.14.
+    """
+    resolved_branch = branch or mcp_server._default_git_branch(repo_path)
+    ignore_patterns = mcp_server._load_ignore_patterns(repo_path)
+    commits = mcp_server._git_commits(repo_path, None, resolved_branch)
+    # _git_commits walks --topo-order --reverse, so hashes[-1] is the branch
+    # tip. Taken from the walked list, not a separate rev-parse, so the
+    # reported head cannot disagree with what was actually measured.
+    hashes = [row[0] for row in commits]
+
+    seen: Dict[EntityInput, None] = {}
+    failed: List[str] = []
+
+    with ProcessPoolExecutor(
+        max_workers=jobs, mp_context=multiprocessing.get_context("spawn")
+    ) as executor:
+        futures = {
+            executor.submit(
+                mcp_server._extract_commit, repo_path, commit_hash, ignore_patterns
+            ): commit_hash
+            for commit_hash in hashes
+        }
+        # as_completed, not futures.items(): both consume every submitted
+        # future, but submission order blocks on commit N while every result
+        # after it piles up unconsumed in memory. Harvesting is far cheaper
+        # than extraction, so draining in completion order keeps the backlog
+        # to what the pool has genuinely finished.
+        for future in as_completed(futures):
+            commit_hash = futures[future]
+            try:
+                file_results, gitlink_changes, _gitmodules, _renamed = future.result()
+            except Exception:
+                # Per-commit failure must not abort the audit -- it is a
+                # measurement diagnostic, and the report's exit gate decides
+                # whether there were too many for the run to mean anything.
+                failed.append(commit_hash)
+                continue
+            for inp in inputs_from_commit_extraction(file_results, gitlink_changes):
+                seen[inp] = None
+
+    # Completion order is whatever the pool happened to finish first; sort back
+    # into walk order so a re-run's recorded diagnostic is byte-comparable.
+    walk_order = {commit_hash: i for i, commit_hash in enumerate(hashes)}
+    failed.sort(key=walk_order.__getitem__)
+
+    return list(seen), {
+        "head_commit": hashes[-1] if hashes else None,
+        "branch": resolved_branch,
+        "commits": len(hashes),
+        "extraction_failures": len(failed),
+        "failed_commits": failed,
+    }

--- a/evals/at_scale/results/263-ident-collision-census.json
+++ b/evals/at_scale/results/263-ident-collision-census.json
@@ -159,9 +159,9 @@
   "offenders_by_shape": {
     "leading-underscore": 7,
     "case-only": 0,
-    "separator-vs-path": 1,
+    "separator-vs-path": 0,
     "cross-producer": 0,
-    "other": 1
+    "other": 2
   },
   "candidates": {
     "R1": {
@@ -300,7 +300,7 @@
       }
     }
   },
-  "timestamp": "2026-08-14T01:46:18Z",
+  "timestamp": "2026-08-14T02:21:03Z",
   "predictions": {
     "P1": {
       "statement": "The true collision count exceeds the 3 #257's census found, because that census can only see collisions whose loser was closed and reopened.",
@@ -310,7 +310,7 @@
     "P2": {
       "statement": "leading-underscore STRICTLY outnumbers every other named shape among all offenders.",
       "outcome": "held",
-      "evidence": "leading-underscore=7, runner-up separator-vs-path=1"
+      "evidence": "leading-underscore=7, runner-up separator-vs-path=0"
     },
     "P3": {
       "statement": "R5, the control, reports a nonzero residual at least as large as the leading-underscore offender count.",

--- a/evals/at_scale/results/263-ident-collision-census.json
+++ b/evals/at_scale/results/263-ident-collision-census.json
@@ -1,0 +1,333 @@
+{
+  "repo_path": ".",
+  "branch": "master",
+  "head_commit": "14166d19c7126ad869500d6c864d1b541858f7d3",
+  "ignore_patterns": [
+    "3rdParty/",
+    "third_party/",
+    "vendor/",
+    "node_modules/",
+    "dist/",
+    "build/",
+    "*.min.js",
+    "*.map"
+  ],
+  "commits": 674,
+  "extraction_failures": 0,
+  "failed_commits": [],
+  "triples_total": 2789,
+  "idents_total": 2780,
+  "offenders": {
+    "module": {
+      "idents_total": 133,
+      "count": 1,
+      "idents": {
+        ":module/mcp-server": [
+          {
+            "producer": "import",
+            "file_path": "mcp.server",
+            "name": null
+          },
+          {
+            "producer": "import",
+            "file_path": "mcp_server",
+            "name": null
+          }
+        ]
+      }
+    },
+    "function": {
+      "idents_total": 2058,
+      "count": 7,
+      "idents": {
+        ":function/evals-at-scale-profile-forward-reconcile-attribution-py-main": [
+          {
+            "producer": "code",
+            "file_path": "evals/at_scale/profile_forward_reconcile_attribution.py",
+            "name": "_main"
+          },
+          {
+            "producer": "code",
+            "file_path": "evals/at_scale/profile_forward_reconcile_attribution.py",
+            "name": "main"
+          }
+        ],
+        ":function/tests-test-mcp-server-py-init": [
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "__init__"
+          },
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "_init"
+          }
+        ],
+        ":function/tests-test-mcp-server-py-boom": [
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "_boom"
+          },
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "boom"
+          }
+        ],
+        ":function/tests-test-mcp-server-py-commit": [
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "_commit"
+          },
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "commit"
+          }
+        ],
+        ":function/tests-test-mcp-server-py-parse": [
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "_parse"
+          },
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "parse"
+          }
+        ],
+        ":function/tests-test-mcp-server-py-results": [
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "_results"
+          },
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "results"
+          }
+        ],
+        ":function/tests-test-mcp-server-py-snapshot": [
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "_snapshot"
+          },
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "snapshot"
+          }
+        ]
+      }
+    },
+    "class": {
+      "idents_total": 290,
+      "count": 1,
+      "idents": {
+        ":class/tests-test-mcp-server-py-fakedb": [
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "FakeDb"
+          },
+          {
+            "producer": "code",
+            "file_path": "tests/test_mcp_server.py",
+            "name": "_FakeDb"
+          }
+        ]
+      }
+    },
+    "variable": {
+      "idents_total": 232,
+      "count": 0,
+      "idents": {}
+    },
+    "field": {
+      "idents_total": 67,
+      "count": 0,
+      "idents": {}
+    }
+  },
+  "offenders_total": 9,
+  "offenders_by_shape": {
+    "leading-underscore": 7,
+    "case-only": 0,
+    "separator-vs-path": 1,
+    "cross-producer": 0,
+    "other": 1
+  },
+  "candidates": {
+    "R1": {
+      "residual": 0,
+      "renames": 2710,
+      "description": "keep underscores: charset becomes [^a-z0-9_-]",
+      "renames_by_entity_type": {
+        "module": {
+          "renamed": 74,
+          "total": 133
+        },
+        "function": {
+          "renamed": 2049,
+          "total": 2058
+        },
+        "class": {
+          "renamed": 289,
+          "total": 290
+        },
+        "variable": {
+          "renamed": 231,
+          "total": 232
+        },
+        "field": {
+          "renamed": 67,
+          "total": 67
+        }
+      }
+    },
+    "R2": {
+      "residual": 1,
+      "renames": 2649,
+      "description": "no hyphen collapse: drop re.sub(r'-+', '-', slug)",
+      "renames_by_entity_type": {
+        "module": {
+          "renamed": 2,
+          "total": 133
+        },
+        "function": {
+          "renamed": 2058,
+          "total": 2058
+        },
+        "class": {
+          "renamed": 290,
+          "total": 290
+        },
+        "variable": {
+          "renamed": 232,
+          "total": 232
+        },
+        "field": {
+          "renamed": 67,
+          "total": 67
+        }
+      }
+    },
+    "R3": {
+      "residual": 0,
+      "renames": 2721,
+      "description": "R1 + R2: keep underscores and drop the collapse",
+      "renames_by_entity_type": {
+        "module": {
+          "renamed": 74,
+          "total": 133
+        },
+        "function": {
+          "renamed": 2058,
+          "total": 2058
+        },
+        "class": {
+          "renamed": 290,
+          "total": 290
+        },
+        "variable": {
+          "renamed": 232,
+          "total": 232
+        },
+        "field": {
+          "renamed": 67,
+          "total": 67
+        }
+      }
+    },
+    "R4": {
+      "residual": 0,
+      "renames": 2780,
+      "description": "hash suffix: current slug + '-' + sha256(raw value)[:8]",
+      "renames_by_entity_type": {
+        "module": {
+          "renamed": 133,
+          "total": 133
+        },
+        "function": {
+          "renamed": 2058,
+          "total": 2058
+        },
+        "class": {
+          "renamed": 290,
+          "total": 290
+        },
+        "variable": {
+          "renamed": 232,
+          "total": 232
+        },
+        "field": {
+          "renamed": 67,
+          "total": 67
+        }
+      }
+    },
+    "R5": {
+      "residual": 9,
+      "renames": 2647,
+      "description": "CONTROL, expected to still collide: slug file_path and name independently, join with '--'",
+      "renames_by_entity_type": {
+        "module": {
+          "renamed": 0,
+          "total": 133
+        },
+        "function": {
+          "renamed": 2058,
+          "total": 2058
+        },
+        "class": {
+          "renamed": 290,
+          "total": 290
+        },
+        "variable": {
+          "renamed": 232,
+          "total": 232
+        },
+        "field": {
+          "renamed": 67,
+          "total": 67
+        }
+      }
+    }
+  },
+  "timestamp": "2026-08-14T01:46:18Z",
+  "predictions": {
+    "P1": {
+      "statement": "The true collision count exceeds the 3 #257's census found, because that census can only see collisions whose loser was closed and reopened.",
+      "outcome": "held",
+      "evidence": "offenders_total=9"
+    },
+    "P2": {
+      "statement": "leading-underscore STRICTLY outnumbers every other named shape among all offenders.",
+      "outcome": "held",
+      "evidence": "leading-underscore=7, runner-up separator-vs-path=1"
+    },
+    "P3": {
+      "statement": "R5, the control, reports a nonzero residual at least as large as the leading-underscore offender count.",
+      "outcome": "held",
+      "evidence": "R5 residual=9, leading-underscore offenders=7"
+    },
+    "P4": {
+      "statement": "R2's rename cost falls on named entities, not on module idents: a module input has no '::' separator to produce an adjacent hyphen run, so R2 renames a strictly smaller FRACTION of module idents than of function idents.",
+      "outcome": "held",
+      "evidence": "R2 renames module 2/133 = 0.015, function 2058/2058 = 1.000"
+    }
+  },
+  "self_checks": {
+    "S1": {
+      "statement": "R4 appends a hash suffix to every ident by construction, so its rename count must equal the total ident count. If it does not, score_rule's rename accounting is broken and every other rule's rename number in this table is suspect.",
+      "outcome": "held",
+      "evidence": "R4 renames=2780, idents_total=2780"
+    }
+  }
+}

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -34,6 +34,7 @@ from evals.at_scale.probe_ident_collision_census import (
     measurement_invalid,
     offenders,
     raw_value,
+    renames_by_entity_type,
     score_all_rules,
     score_rule,
 )
@@ -257,6 +258,62 @@ class TestCandidateRules:
         _, ident_fn = RULES["R1"]
         assert ident_fn(module) != current_ident(module)
 
+    @pytest.mark.parametrize("rule_id", ["R1", "R2", "R3", "R4", "R5"])
+    def test_the_per_type_breakdown_sums_to_the_whole_corpus_total(self, rule_id):
+        """The breakdown sits beside score_rule's `renames` in the report, so
+        it must describe that same number. Two independent walks of the
+        baseline groups is exactly how a breakdown drifts from the total it
+        annotates -- silently, since neither is obviously wrong on its own.
+
+        Counterfactual: a renames_by_entity_type that counted INPUTS rather
+        than baseline idents reports 4 module + 6 function here against a
+        total of 8, and this fails for every rule.
+        """
+        inputs = _known_collision_inputs() + [
+            EntityInput("module", "code", "a/b_c.py", None),
+            EntityInput("module", "code", "d/e.py", None),
+            EntityInput("class", "code", "a/b_c.py", "Cls"),
+        ]
+        baseline = group_by_ident(inputs, current_ident)
+        _, ident_fn = RULES[rule_id]
+        breakdown = renames_by_entity_type(ident_fn, baseline)
+        assert sum(row["renamed"] for row in breakdown.values()) == score_rule(
+            inputs, ident_fn, baseline
+        )["renames"]
+        assert sum(row["total"] for row in breakdown.values()) == len(baseline)
+
+    def test_R2_spares_module_idents_while_renaming_function_idents(self):
+        """P4's mechanism, at the level the report measures it. A module input
+        has no '::' separator, so a path with no adjacent non-alphanumerics
+        produces no hyphen run for R2's dropped collapse to preserve.
+
+        Counterfactual: R1 changes the charset instead, so it renames the
+        underscore-bearing module ident too -- asserted below so this test
+        cannot pass against a breakdown that reports zero module renames for
+        every rule.
+        """
+        inputs = _known_collision_inputs() + [
+            EntityInput("module", "code", "a/b.py", None),
+            EntityInput("module", "code", "d/e.py", None),
+        ]
+        baseline = group_by_ident(inputs, current_ident)
+        r2 = renames_by_entity_type(RULES["R2"][1], baseline)
+        assert r2["module"] == {"renamed": 0, "total": 2}
+        assert r2["function"]["renamed"] == r2["function"]["total"] == 3
+
+        r4 = renames_by_entity_type(RULES["R4"][1], baseline)
+        assert r4["module"]["renamed"] == 2
+
+    def test_every_declared_entity_type_appears_even_at_zero(self):
+        """Same claim as the report's per-type offender table: a missing key
+        and a zero are different statements. P4's evaluator indexes "module"
+        directly and must not KeyError on a function-only corpus.
+        """
+        baseline = group_by_ident(_known_collision_inputs(), current_ident)
+        breakdown = renames_by_entity_type(RULES["R2"][1], baseline)
+        assert set(breakdown) == set(ENTITY_TYPES)
+        assert breakdown["module"] == {"renamed": 0, "total": 0}
+
     def test_score_all_rules_covers_every_declared_rule(self):
         inputs = _known_collision_inputs()
         baseline = group_by_ident(inputs, current_ident)
@@ -462,6 +519,20 @@ class TestBuildReport:
         report = _report_over(_known_collision_inputs())
         assert set(report["candidates"]) == set(RULES)
 
+    def test_each_candidate_row_carries_its_per_type_rename_breakdown(self):
+        """WHERE a rule's rename cost lands is what separates two rules that
+        both reach zero residual, and it is the data P4 is ruled on. Composed
+        in build_report, not in score_all_rules, whose
+        {description, residual, renames} shape is pinned elsewhere.
+        """
+        report = _report_over(_known_collision_inputs())
+        for rule_id in RULES:
+            breakdown = report["candidates"][rule_id]["renames_by_entity_type"]
+            assert set(breakdown) == set(ENTITY_TYPES)
+            assert sum(row["renamed"] for row in breakdown.values()) == (
+                report["candidates"][rule_id]["renames"]
+            )
+
     def test_what_shaped_the_file_set_is_recorded(self):
         """collect_inputs resolves the ignore patterns from
         MINIGRAF_INGEST_IGNORE plus any .temporalignore, so they decide which
@@ -539,6 +610,45 @@ class TestPredictions:
         """
         evaluated = evaluate_predictions(_report_over(_known_collision_inputs()))
         assert evaluated["P2"]["outcome"] == "held"
+
+    def test_P4_holds_when_R2_spares_module_idents(self):
+        """P4's claim is about the FRACTION renamed per type, not the corpus
+        total. A plain module path has no adjacent non-alphanumerics, so R2's
+        dropped collapse leaves it alone while every function ident -- whose
+        raw value always carries '::' -- moves.
+        """
+        report = _report_over(
+            _known_collision_inputs() + [EntityInput("module", "code", "a/b.py", None)]
+        )
+        row = evaluate_predictions(report)["P4"]
+        assert row["outcome"] == "held"
+        assert "module 0/1 = 0.000" in row["evidence"]
+        assert "function 3/3 = 1.000" in row["evidence"]
+
+    def test_P4_fails_when_module_idents_are_renamed_just_as_often(self):
+        """The counterfactual, and the proof P4 is falsifiable on a corpus
+        that CAN evaluate it: 'a//b.py' carries an adjacent separator run, so
+        R2 preserves it and the module fraction reaches function's 1.000.
+        A >= comparison, or one on totals rather than fractions, passes here.
+        """
+        report = _report_over(
+            _known_collision_inputs()
+            + [EntityInput("module", "code", "a//b.py", None)]
+        )
+        row = evaluate_predictions(report)["P4"]
+        assert row["outcome"] == "failed"
+        assert "module 1/1 = 1.000" in row["evidence"]
+
+    def test_P4_names_the_empty_denominator_rather_than_dividing_by_zero(self):
+        """A function-only corpus cannot rule on P4 at all. Recorded as
+        "failed" -- held/failed is pinned by test_every_declared_prediction_is
+        _evaluated -- but the evidence must say WHY, or a reader sees a bare
+        0/0 and reads a real ruling into a corpus that could not produce one.
+        """
+        row = evaluate_predictions(_report_over(_known_collision_inputs()))["P4"]
+        assert row["outcome"] == "failed"
+        assert "not evaluable: no module idents in this corpus" in row["evidence"]
+        assert "0/0" not in row["evidence"].split("(")[0]
 
 
 class TestCli:

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -138,6 +138,36 @@ class TestClassifyShapes:
         ]
         assert "cross-producer" in classify_shapes(members)
 
+    def test_private_pascal_case_beside_public_snake_case_is_leading_underscore(self):
+        """_Config/config and _Handler/handler are ordinary Python and they DO
+        collide (both -> :function/a-b-py-foo for _Foo/foo). An exact-case
+        _strip_private comparison drops them into "other", which is reserved
+        for UNPREDICTED families -- hiding a predicted one.
+
+        Counterfactual: with _strip_private compared exact-case, this pair
+        yields {"other"} and this test fails.
+        """
+        members = [_fn("a/b.py", "_Foo"), _fn("a/b.py", "foo")]
+        assert current_ident(members[0]) == current_ident(members[1])
+        assert "leading-underscore" in classify_shapes(members)
+
+    def test_a_producer_only_difference_is_not_a_case_collision(self):
+        """Two inputs whose raw values are byte-identical differ only in
+        producer -- exactly the cross-producer collision this audit exists to
+        find. Labelling them "case-only" asserts a case difference that is not
+        there.
+
+        Counterfactual: without the `a_raw != b_raw` guard, casefold equality
+        holds trivially and "case-only" is emitted.
+        """
+        members = [
+            EntityInput("module", "code", "vendor/x", None),
+            EntityInput("module", "gitlink", "vendor/x", None),
+        ]
+        shapes = classify_shapes(members)
+        assert "cross-producer" in shapes
+        assert "case-only" not in shapes
+
     def test_an_unclassifiable_pair_falls_through_to_other(self):
         """'other' is the interesting bucket -- it is where a collision nobody
         predicted shows up. It must be reachable, not vestigial.

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -12,18 +12,26 @@ nothing and does not belong here.
 """
 
 import subprocess
+import sys
 
 import pytest
 
+from evals.at_scale import probe_ident_collision_census
 from evals.at_scale.probe_ident_collision_census import (
+    ENTITY_TYPES,
+    PREDICTIONS,
     RULES,
     SHAPES,
     EntityInput,
+    build_report,
     classify_shapes,
     collect_inputs,
     current_ident,
+    evaluate_predictions,
     group_by_ident,
     inputs_from_commit_extraction,
+    main,
+    measurement_invalid,
     offenders,
     raw_value,
     score_all_rules,
@@ -376,6 +384,12 @@ class TestCollectInputsEndToEnd:
 
         assert diagnostics["commits"] == 1
         assert diagnostics["extraction_failures"] == 0
+        # The resolved ignore patterns decide which files were counted at all,
+        # so a recorded run that omits them cannot explain why a re-run on the
+        # same head_commit disagreed. Presence (not contents) is what is
+        # pinned: the list depends on the environment's MINIGRAF_INGEST_IGNORE
+        # and on any .temporalignore, which is exactly why it is recorded.
+        assert isinstance(diagnostics["ignore_patterns"], list)
         found = offenders(group_by_ident(inputs, current_ident))
         assert len(found) == 1
         names = {inp.name for inp in next(iter(found.values()))}
@@ -410,3 +424,178 @@ class TestCollectInputsEndToEnd:
             first,
             key=lambda inp: (inp.entity_type, inp.producer, inp.file_path, inp.name or ""),
         )
+
+
+def _report_over(inputs, **diag):
+    diagnostics = {
+        "head_commit": "abc123", "branch": "main", "commits": 10,
+        "extraction_failures": 0, "failed_commits": [],
+        "ignore_patterns": [],
+    }
+    diagnostics.update(diag)
+    return build_report(inputs, diagnostics, "/repo")
+
+
+class TestBuildReport:
+    def test_offenders_are_reported_verbatim_not_only_counted(self):
+        """A nonzero count escalates this to fix design, and that work should
+        start from the data rather than re-deriving it by hand. Counterfactual:
+        a report carrying only counts passes every other test in this class.
+        """
+        report = _report_over(_known_collision_inputs())
+        rows = report["offenders"]["function"]["idents"]
+        assert len(rows) == 3
+        members = rows[":function/tests-test-mcp-server-py-commit"]
+        assert sorted(m["name"] for m in members) == ["_commit", "commit"]
+        assert all(m["file_path"] == "tests/test_mcp_server.py" for m in members)
+        assert all(m["producer"] == "code" for m in members)
+
+    def test_every_entity_type_appears_even_at_zero(self):
+        """A missing key and a zero are different claims. Only the second one
+        says "measured, found none".
+        """
+        report = _report_over([_fn("a/b.py", "solo")])
+        assert set(report["offenders"]) == set(ENTITY_TYPES)
+        assert report["offenders"]["class"]["count"] == 0
+
+    def test_candidate_table_carries_every_rule(self):
+        report = _report_over(_known_collision_inputs())
+        assert set(report["candidates"]) == set(RULES)
+
+    def test_what_shaped_the_file_set_is_recorded(self):
+        """collect_inputs resolves the ignore patterns from
+        MINIGRAF_INGEST_IGNORE plus any .temporalignore, so they decide which
+        files were counted. Two runs on one head_commit can legitimately
+        disagree, and only this field explains why.
+
+        Counterfactual: a build_report that dropped the key still passes every
+        other test in this class, and its artifact silently loses the reason.
+        """
+        report = _report_over([_fn("a/b.py", "solo")], ignore_patterns=["vendor/*"])
+        assert report["ignore_patterns"] == ["vendor/*"]
+
+    def test_branch_and_head_commit_are_both_recorded(self):
+        """The audit resolves an unspecified branch through
+        _default_git_branch, so head_commit is mainline's tip and NOT the
+        working branch's. Recorded together, that reads as deliberate; with
+        either missing it reads as a stale run.
+        """
+        report = _report_over([_fn("a/b.py", "solo")])
+        assert report["branch"] == "main"
+        assert report["head_commit"] == "abc123"
+
+
+class TestExitGate:
+    def test_finding_collisions_is_not_an_invalid_measurement(self):
+        """The exit code reflects measurement VALIDITY, never the finding.
+        Collisions are the number #263 asks for and must never fail the run.
+        Do not adjust this gate to make a run pass.
+        """
+        report = _report_over(_known_collision_inputs())
+        assert report["offenders"]["function"]["count"] == 3
+        assert measurement_invalid(report) is None
+
+    def test_zero_commits_is_invalid(self):
+        assert measurement_invalid(_report_over([], commits=0)) is not None
+
+    def test_zero_triples_is_invalid(self):
+        """Distinguishes "measured, found none" from "measured nothing". A run
+        that collected no inputs cannot report zero collisions as a finding.
+        """
+        assert measurement_invalid(_report_over([])) is not None
+
+    def test_extraction_failures_above_one_percent_are_invalid(self):
+        inputs = _known_collision_inputs()
+        assert measurement_invalid(
+            _report_over(inputs, commits=100, extraction_failures=2)
+        ) is not None
+        assert measurement_invalid(
+            _report_over(inputs, commits=100, extraction_failures=1)
+        ) is None
+
+
+class TestPredictions:
+    def test_every_declared_prediction_is_evaluated(self):
+        report = _report_over(_known_collision_inputs())
+        evaluated = evaluate_predictions(report)
+        assert set(evaluated) == {pid for pid, _ in PREDICTIONS}
+        for row in evaluated.values():
+            assert row["outcome"] in ("held", "failed")
+
+    def test_a_prediction_can_actually_fail(self):
+        """Predictions exist to be falsifiable. An evaluator that returns
+        "held" unconditionally is worse than none, because it launders a
+        failed prediction as confirmation. Three offenders is exactly the
+        count P1 says the audit must EXCEED.
+        """
+        evaluated = evaluate_predictions(_report_over(_known_collision_inputs()))
+        assert evaluated["P1"]["outcome"] == "failed"
+
+    def test_a_prediction_can_actually_hold(self):
+        """The counterfactual for the test above: an evaluator hard-wired to
+        "failed" also makes a failed prediction meaningless, and would pass it.
+        The fixture is three same-file private/public pairs, so
+        leading-underscore is the only named shape present.
+        """
+        evaluated = evaluate_predictions(_report_over(_known_collision_inputs()))
+        assert evaluated["P2"]["outcome"] == "held"
+
+
+class TestCli:
+    def test_the_cli_prints_branch_head_and_exits_zero_on_a_valid_run(
+        self, monkeypatch, capsys
+    ):
+        """main's stdout is what a reader of the recorded run sees first. The
+        branch/head pair must be in it, because with no --branch the head is
+        mainline's tip rather than the checked-out branch's.
+
+        collect_inputs is stubbed rather than run: driving real history here
+        would take minutes and is Task 6's job. Everything downstream of it --
+        build_report, the gate, the exit code -- is the real code.
+        """
+        monkeypatch.setattr(
+            probe_ident_collision_census,
+            "collect_inputs",
+            lambda repo_path, branch=None, jobs=None: (
+                _known_collision_inputs(),
+                {
+                    "head_commit": "deadbee", "branch": "master", "commits": 7,
+                    "extraction_failures": 0, "failed_commits": [],
+                    "ignore_patterns": ["vendor/*"],
+                },
+            ),
+        )
+        monkeypatch.setattr(sys, "argv", ["probe", "--repo-path", "/repo"])
+
+        assert main() == 0
+
+        out = capsys.readouterr().out
+        assert "master" in out
+        assert "deadbee" in out
+        assert "vendor/*" in out
+        # The finding itself must not be reported as an error.
+        assert "INVALID MEASUREMENT" not in out
+
+    def test_the_cli_exits_nonzero_only_on_an_invalid_measurement(
+        self, monkeypatch, capsys
+    ):
+        """The counterfactual for the test above, and the pair that pins the
+        exit code to VALIDITY rather than to the finding: same offenders, but
+        nothing was walked.
+        """
+        monkeypatch.setattr(
+            probe_ident_collision_census,
+            "collect_inputs",
+            lambda repo_path, branch=None, jobs=None: (
+                [],
+                {
+                    "head_commit": None, "branch": "master", "commits": 0,
+                    "extraction_failures": 0, "failed_commits": [],
+                    "ignore_patterns": [],
+                },
+            ),
+        )
+        monkeypatch.setattr(sys, "argv", ["probe"])
+
+        assert main() == 1
+        assert "INVALID MEASUREMENT" in capsys.readouterr().out

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -337,6 +337,27 @@ class TestInputsFromCommitExtraction:
         assert paths == {"vendor/x", "vendor/y", "vendor/z"}
 
 
+def _make_repo(tmp_path, commits):
+    """Build a single-branch git repo, applying each {path: text} dict as one
+    commit. Shared by the collect_inputs tests, which need a REAL repo because
+    they drive the real _extract_commit rather than a stub.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for cmd in (
+        ["git", "init", "-q", "-b", "main"],
+        ["git", "config", "user.email", "t@example.com"],
+        ["git", "config", "user.name", "t"],
+    ):
+        subprocess.run(cmd, cwd=repo, check=True)
+    for i, files in enumerate(commits):
+        for name, text in files.items():
+            (repo / name).write_text(text)
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", f"c{i}"], cwd=repo, check=True)
+    return repo
+
+
 class TestCollectInputsEndToEnd:
     def test_a_private_public_pair_collides_through_real_extraction(self, tmp_path):
         """Drives the REAL _extract_commit over a purpose-built repo. Every
@@ -346,17 +367,10 @@ class TestCollectInputsEndToEnd:
 
         Counterfactual: with only `def helper` in the file, offenders is empty.
         """
-        repo = tmp_path / "repo"
-        repo.mkdir()
-        (repo / "mod.py").write_text("def _helper():\n    pass\n\ndef helper():\n    pass\n")
-        for cmd in (
-            ["git", "init", "-q", "-b", "main"],
-            ["git", "config", "user.email", "t@example.com"],
-            ["git", "config", "user.name", "t"],
-            ["git", "add", "-A"],
-            ["git", "commit", "-q", "-m", "init"],
-        ):
-            subprocess.run(cmd, cwd=repo, check=True)
+        repo = _make_repo(
+            tmp_path,
+            [{"mod.py": "def _helper():\n    pass\n\ndef helper():\n    pass\n"}],
+        )
 
         inputs, diagnostics = collect_inputs(str(repo), "main", jobs=1)
 
@@ -366,3 +380,33 @@ class TestCollectInputsEndToEnd:
         assert len(found) == 1
         names = {inp.name for inp in next(iter(found.values()))}
         assert names == {"_helper", "helper"}
+
+    def test_the_returned_inputs_do_not_depend_on_pool_scheduling(self, tmp_path):
+        """The audit's output is a COMMITTED artifact, so which worker finished
+        first must not reach it.
+
+        Counterfactual: returning `list(seen)` -- consumption order -- fails the
+        sorted-form assert even at jobs=1, because each file's module input is
+        collected before the functions parsed out of it while "function" sorts
+        before "module". With jobs > 1 it additionally varies between two
+        otherwise identical runs, which is what the equality assert pins.
+        """
+        repo = _make_repo(
+            tmp_path,
+            [
+                {"alpha.py": "import os\n\n\ndef a():\n    pass\n"},
+                {"beta.py": "class B:\n    def m(self):\n        pass\n"},
+            ],
+        )
+
+        first, _ = collect_inputs(str(repo), "main", jobs=2)
+        second, _ = collect_inputs(str(repo), "main", jobs=2)
+
+        # Guards the two asserts below against passing vacuously on an empty
+        # or single-element list.
+        assert len(first) > 4
+        assert first == second
+        assert first == sorted(
+            first,
+            key=lambda inp: (inp.entity_type, inp.producer, inp.file_path, inp.name or ""),
+        )

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -178,3 +178,83 @@ class TestClassifyShapes:
     def test_every_emitted_label_is_declared_in_SHAPES(self):
         members = [_fn("a/b.py", "_foo"), _fn("a/b.py", "foo")]
         assert classify_shapes(members) <= set(SHAPES)
+
+
+from evals.at_scale.probe_ident_collision_census import (  # noqa: E402
+    RULES,
+    score_all_rules,
+    score_rule,
+)
+
+
+def _known_collision_inputs():
+    inputs = []
+    for file_path, private, public in KNOWN_COLLISIONS:
+        inputs.append(_fn(file_path, private))
+        inputs.append(_fn(file_path, public))
+    return inputs
+
+
+class TestCandidateRules:
+    @pytest.mark.parametrize("rule_id", ["R1", "R2", "R3", "R4"])
+    def test_separating_rules_leave_no_residual(self, rule_id):
+        inputs = _known_collision_inputs()
+        _, ident_fn = RULES[rule_id]
+        assert offenders(group_by_ident(inputs, ident_fn)) == {}
+
+    def test_R5_still_collides_and_is_the_scorer_s_known_negative(self):
+        """R5 slugs path and name independently, so strip("-") still eats the
+        leading underscore and _commit/commit both reduce to "commit". R5 is
+        in the table precisely BECAUSE it does not work: a scorer that reports
+        R5 clean is broken, and every other row it produced is suspect.
+        """
+        inputs = _known_collision_inputs()
+        _, ident_fn = RULES["R5"]
+        assert len(offenders(group_by_ident(inputs, ident_fn))) == 3
+
+    @pytest.mark.parametrize("rule_id", ["R1", "R2", "R3", "R4"])
+    def test_every_separating_rule_renames_something(self, rule_id):
+        """A rule that renames nothing cannot have changed derivation, so a
+        zero residual from it would be arithmetic rather than a finding.
+        """
+        inputs = _known_collision_inputs()
+        baseline = group_by_ident(inputs, current_ident)
+        _, ident_fn = RULES[rule_id]
+        assert score_rule(inputs, ident_fn, baseline)["renames"] > 0
+
+    def test_R4_renames_every_ident(self):
+        """Every ident gains a hash suffix, so the rename count equals the
+        baseline ident count. Counterfactual: a renames metric that counted
+        only COLLIDING idents would report 3, not 3-of-3 plus the rest.
+        """
+        inputs = _known_collision_inputs() + [_fn("z/z.py", "solo")]
+        baseline = group_by_ident(inputs, current_ident)
+        _, ident_fn = RULES["R4"]
+        scored = score_rule(inputs, ident_fn, baseline)
+        assert scored["renames"] == len(baseline)
+        assert scored["residual"] == 0
+
+    def test_R2_leaves_a_plain_module_ident_unrenamed(self):
+        """R2 only drops the hyphen collapse. A module input has no '::'
+        separator, so a path with no adjacent non-alphanumerics is untouched.
+        This is what makes R2's rename cost differ by entity type.
+        """
+        module = EntityInput("module", "code", "a/b.py", None)
+        _, ident_fn = RULES["R2"]
+        assert ident_fn(module) == current_ident(module)
+
+    def test_R1_does_rename_that_same_module_ident(self):
+        """The counterfactual for the test above: R1 changes the charset, so
+        an underscore anywhere in the path moves the ident even with no name.
+        """
+        module = EntityInput("module", "code", "a/b_c.py", None)
+        _, ident_fn = RULES["R1"]
+        assert ident_fn(module) != current_ident(module)
+
+    def test_score_all_rules_covers_every_declared_rule(self):
+        inputs = _known_collision_inputs()
+        baseline = group_by_ident(inputs, current_ident)
+        scored = score_all_rules(inputs, baseline)
+        assert set(scored) == set(RULES)
+        for row in scored.values():
+            assert set(row) == {"description", "residual", "renames"}

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -21,6 +21,7 @@ from evals.at_scale.probe_ident_collision_census import (
     ENTITY_TYPES,
     PREDICTIONS,
     RULES,
+    SELF_CHECKS,
     SHAPES,
     EntityInput,
     build_report,
@@ -28,6 +29,7 @@ from evals.at_scale.probe_ident_collision_census import (
     collect_inputs,
     current_ident,
     evaluate_predictions,
+    evaluate_self_checks,
     group_by_ident,
     inputs_from_commit_extraction,
     main,
@@ -639,6 +641,68 @@ class TestPredictions:
         assert row["outcome"] == "failed"
         assert "module 1/1 = 1.000" in row["evidence"]
 
+    def test_P2_is_not_evaluable_on_a_zero_offender_corpus(self):
+        """P2's old evaluator used max() over SHAPES, which returns the FIRST
+        maximal element -- and SHAPES[0] is "leading-underscore". With every
+        count at 0 it named leading-underscore the winner and recorded "held".
+        A zero-offender run clears the validity gate, so that laundered "held"
+        reached the committed artifact.
+
+        Counterfactual: the max()-based evaluator returns "held" here.
+        """
+        report = _report_over([_fn("a/b.py", "solo"), _fn("a/b.py", "other")])
+        # The corpus is valid -- this is not a run that measured nothing.
+        assert report["offenders_total"] == 0
+        assert measurement_invalid(report) is None
+
+        row = evaluate_predictions(report)["P2"]
+        assert row["outcome"] == "failed"
+        assert row["evidence"].startswith("not evaluable: no offenders in this corpus")
+
+    def test_P2_does_not_treat_an_exact_tie_as_dominance(self):
+        """"Dominant" means strictly more than the runner-up. max()'s
+        first-wins bias read a tie as a win, and the old evidence string showed
+        only the winner, so the tie was invisible to a reader.
+
+        Counterfactual: with a >= comparison this records "held"; with the
+        runner-up omitted from the evidence, a reader cannot tell it was 1-1.
+        """
+        # One leading-underscore pair and one case-only pair: 1 each.
+        inputs = [
+            _fn("a/b.py", "_foo"), _fn("a/b.py", "foo"),
+            _fn("c/d.py", "Bar"), _fn("c/d.py", "bar"),
+        ]
+        report = _report_over(inputs)
+        assert report["offenders_by_shape"]["leading-underscore"] == 1
+        assert report["offenders_by_shape"]["case-only"] == 1
+
+        row = evaluate_predictions(report)["P2"]
+        assert row["outcome"] == "failed"
+        assert "leading-underscore=1" in row["evidence"]
+        assert "runner-up case-only=1" in row["evidence"]
+
+    def test_P2_holds_on_a_genuine_win_and_names_the_runner_up(self):
+        """The counterfactual for both tests above: an evaluator hard-wired to
+        "failed" for P2 passes them and fails this one.
+        """
+        inputs = _known_collision_inputs() + [
+            _fn("c/d.py", "Bar"), _fn("c/d.py", "bar"),
+        ]
+        report = _report_over(inputs)
+        row = evaluate_predictions(report)["P2"]
+        assert row["outcome"] == "held"
+        assert "leading-underscore=3" in row["evidence"]
+        assert "runner-up case-only=1" in row["evidence"]
+
+    def test_the_retired_P5_label_is_not_reused(self):
+        """P5 was an identity -- R4 appends a hash suffix unconditionally, so
+        no run clearing the gate could falsify it. It moved to self_checks.
+        Reusing the label for a different claim would make this artifact and
+        the plan disagree about what P5 ever meant.
+        """
+        assert "P5" not in dict(PREDICTIONS)
+        assert [pid for pid, _ in PREDICTIONS] == ["P1", "P2", "P3", "P4"]
+
     def test_P4_names_the_empty_denominator_rather_than_dividing_by_zero(self):
         """A function-only corpus cannot rule on P4 at all. Recorded as
         "failed" -- held/failed is pinned by test_every_declared_prediction_is
@@ -649,6 +713,52 @@ class TestPredictions:
         assert row["outcome"] == "failed"
         assert "not evaluable: no module idents in this corpus" in row["evidence"]
         assert "0/0" not in row["evidence"].split("(")[0]
+
+
+class TestSelfChecks:
+    def test_the_self_check_holds_on_a_correctly_scored_report(self):
+        """The corpus carries a NON-colliding ident on purpose. Every ident in
+        _known_collision_inputs() is an offender, so a rename counter degraded
+        to count only colliding idents would still agree with the total there
+        and S1 would not fire. The solo ident is what makes that bug visible --
+        the same counterfactual Task 3's test_R4_renames_every_ident uses.
+        """
+        report = _report_over(_known_collision_inputs() + [_fn("z/z.py", "solo")])
+        assert set(report["self_checks"]) == {sid for sid, _ in SELF_CHECKS}
+        assert report["idents_total"] == 4
+        assert report["offenders_total"] == 3
+        assert report["self_checks"]["S1"]["outcome"] == "held"
+
+    def test_the_self_check_reports_a_failure_when_rename_accounting_breaks(self):
+        """The whole point of keeping S1. R4 appends a hash suffix to every
+        ident by construction, so a rename count below the ident total means
+        score_rule LOST idents -- and then every other rule's rename number in
+        the table is suspect too.
+
+        The report is degraded directly rather than by ablating score_rule,
+        because a self-check that only fires when its own source is edited is
+        untestable in the suite that has to prove it fires at all.
+
+        Counterfactual: a self-check hard-wired to "held" -- exactly the shape
+        S1 replaced -- passes the test above and fails this one.
+        """
+        report = _report_over(_known_collision_inputs())
+        assert report["candidates"]["R4"]["renames"] == report["idents_total"]
+
+        report["candidates"]["R4"]["renames"] -= 1
+        row = evaluate_self_checks(report)["S1"]
+        assert row["outcome"] == "failed"
+        assert "R4 renames=2" in row["evidence"]
+        assert "idents_total=3" in row["evidence"]
+
+    def test_self_checks_are_reported_apart_from_predictions(self):
+        """A reader tallying held/failed predictions must not be counting a
+        by-construction invariant among them. S1 was P5 until review found no
+        run clearing the gate could falsify it.
+        """
+        report = _report_over(_known_collision_inputs())
+        assert set(report["predictions"]).isdisjoint(report["self_checks"])
+        assert "S1" not in report["predictions"]
 
 
 class TestCli:
@@ -685,6 +795,14 @@ class TestCli:
         assert "vendor/*" in out
         # The finding itself must not be reported as an error.
         assert "INVALID MEASUREMENT" not in out
+        # Self-checks under their own heading, after the predictions block, so
+        # a reader tallying held/failed predictions is not counting a
+        # by-construction invariant among them.
+        assert "SELF-CHECKS" in out
+        assert out.index("PREDICTIONS") < out.index("SELF-CHECKS")
+        predictions_block = out[out.index("PREDICTIONS"):out.index("SELF-CHECKS")]
+        assert "S1" not in predictions_block
+        assert "P5" not in out
 
     def test_the_cli_exits_nonzero_only_on_an_invalid_measurement(
         self, monkeypatch, capsys

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -14,15 +14,16 @@ nothing and does not belong here.
 import pytest
 
 from evals.at_scale.probe_ident_collision_census import (
+    RULES,
+    SHAPES,
     EntityInput,
+    classify_shapes,
     current_ident,
     group_by_ident,
     offenders,
     raw_value,
-)
-from evals.at_scale.probe_ident_collision_census import (  # noqa: E402
-    SHAPES,
-    classify_shapes,
+    score_all_rules,
+    score_rule,
 )
 
 
@@ -178,13 +179,6 @@ class TestClassifyShapes:
     def test_every_emitted_label_is_declared_in_SHAPES(self):
         members = [_fn("a/b.py", "_foo"), _fn("a/b.py", "foo")]
         assert classify_shapes(members) <= set(SHAPES)
-
-
-from evals.at_scale.probe_ident_collision_census import (  # noqa: E402
-    RULES,
-    score_all_rules,
-    score_rule,
-)
 
 
 def _known_collision_inputs():

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -11,6 +11,8 @@ against a degenerate stub as well as against the real implementation proves
 nothing and does not belong here.
 """
 
+import subprocess
+
 import pytest
 
 from evals.at_scale.probe_ident_collision_census import (
@@ -18,8 +20,10 @@ from evals.at_scale.probe_ident_collision_census import (
     SHAPES,
     EntityInput,
     classify_shapes,
+    collect_inputs,
     current_ident,
     group_by_ident,
+    inputs_from_commit_extraction,
     offenders,
     raw_value,
     score_all_rules,
@@ -252,3 +256,113 @@ class TestCandidateRules:
         assert set(scored) == set(RULES)
         for row in scored.values():
             assert set(row) == {"description", "residual", "renames"}
+
+
+class TestInputsFromCommitExtraction:
+    def test_deleted_files_carry_no_extraction_and_are_skipped(self):
+        """_extract_commit returns extracted=None and precomputed=None for a
+        "D" entry (contract at mcp_server.py:8477-8480, built at 8639).
+        Dereferencing either would raise; treating the path as a live module
+        input would invent an entity.
+        """
+        file_results = [("D", "a/gone.py", None, None, "")]
+        assert inputs_from_commit_extraction(file_results, []) == []
+
+    def test_a_parsed_file_yields_module_and_every_named_entity(self):
+        extracted = {
+            "functions": ["foo", "_foo"],
+            "classes": ["Cls"],
+            "globals": ["CONST"],
+            "fields": [("x", "Cls", False)],
+            "imports": [],
+            "calls": [],
+        }
+        precomputed = {"resolved_imports": []}
+        got = inputs_from_commit_extraction(
+            [("A", "a/b.py", extracted, precomputed, "")], []
+        )
+        assert EntityInput("module", "code", "a/b.py", None) in got
+        assert EntityInput("function", "code", "a/b.py", "_foo") in got
+        assert EntityInput("class", "code", "a/b.py", "Cls") in got
+        assert EntityInput("variable", "code", "a/b.py", "CONST") in got
+
+    def test_fields_are_qualified_with_their_owning_class(self):
+        """_precompute_file_triples builds the field name as
+        f"{owning_class}.{field_name}" (mcp_server.py:7098). An audit keying on
+        the bare field name would merge Cls.x and Other.x and overstate the
+        collision count.
+        """
+        extracted = {
+            "functions": [], "classes": ["Cls"], "globals": [],
+            "fields": [("x", "Cls", False)], "imports": [], "calls": [],
+        }
+        got = inputs_from_commit_extraction(
+            [("M", "a/b.py", extracted, {"resolved_imports": []}, "")], []
+        )
+        assert EntityInput("field", "code", "a/b.py", "Cls.x") in got
+        assert EntityInput("field", "code", "a/b.py", "x") not in got
+
+    def test_only_unresolved_imports_become_import_inputs(self):
+        """A resolved import already points at an in-tree module ident that the
+        module producer contributes. Counting it again would manufacture a
+        cross-producer collision on every internal import in the repository.
+        """
+        extracted = {
+            "functions": [], "classes": [], "globals": [],
+            "fields": [], "imports": [], "calls": [],
+        }
+        precomputed = {
+            "resolved_imports": [
+                ("a.b", ":module/a-b-py", True),
+                ("requests", ":module/requests", False),
+            ]
+        }
+        got = inputs_from_commit_extraction(
+            [("A", "z.py", extracted, precomputed, "")], []
+        )
+        assert EntityInput("module", "import", "requests", None) in got
+        assert EntityInput("module", "import", "a.b", None) not in got
+
+    def test_gitlink_paths_of_every_kind_become_module_inputs(self):
+        """_gitlink_changes emits add/bump/remove (mcp_server.py:4597); all
+        three fall into one `for kind, sha, path` loop that takes
+        _code_ident("module", path) unconditionally (mcp_server.py:9555-9556),
+        so all three name a submodule entity at that path.
+        """
+        got = inputs_from_commit_extraction(
+            [], [("add", "sha1", "vendor/x"), ("bump", "sha2", "vendor/y"),
+                 ("remove", "sha3", "vendor/z")]
+        )
+        paths = {inp.file_path for inp in got if inp.producer == "gitlink"}
+        assert paths == {"vendor/x", "vendor/y", "vendor/z"}
+
+
+class TestCollectInputsEndToEnd:
+    def test_a_private_public_pair_collides_through_real_extraction(self, tmp_path):
+        """Drives the REAL _extract_commit over a purpose-built repo. Every
+        other test in this file would still pass if Stage 1 collected the wrong
+        triples -- this is the one that catches the audit mis-driving the
+        extractor.
+
+        Counterfactual: with only `def helper` in the file, offenders is empty.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "mod.py").write_text("def _helper():\n    pass\n\ndef helper():\n    pass\n")
+        for cmd in (
+            ["git", "init", "-q", "-b", "main"],
+            ["git", "config", "user.email", "t@example.com"],
+            ["git", "config", "user.name", "t"],
+            ["git", "add", "-A"],
+            ["git", "commit", "-q", "-m", "init"],
+        ):
+            subprocess.run(cmd, cwd=repo, check=True)
+
+        inputs, diagnostics = collect_inputs(str(repo), "main", jobs=1)
+
+        assert diagnostics["commits"] == 1
+        assert diagnostics["extraction_failures"] == 0
+        found = offenders(group_by_ident(inputs, current_ident))
+        assert len(found) == 1
+        names = {inp.name for inp in next(iter(found.values()))}
+        assert names == {"_helper", "helper"}

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -20,6 +20,10 @@ from evals.at_scale.probe_ident_collision_census import (
     offenders,
     raw_value,
 )
+from evals.at_scale.probe_ident_collision_census import (  # noqa: E402
+    SHAPES,
+    classify_shapes,
+)
 
 
 # The three collisions #257's census actually found on this repository's
@@ -93,3 +97,54 @@ class TestGroupAndOffenders:
         """
         inputs = [_fn("a/b.py", "c")] * 400
         assert offenders(group_by_ident(inputs, current_ident)) == {}
+
+
+class TestClassifyShapes:
+    def test_private_public_pair_in_one_file_is_leading_underscore(self):
+        members = [_fn("a/b.py", "_foo"), _fn("a/b.py", "foo")]
+        assert "leading-underscore" in classify_shapes(members)
+
+    def test_private_public_field_on_one_class_is_leading_underscore(self):
+        """Fields arrive qualified as 'Cls.field', so the private marker sits
+        on the LAST dot-segment, not at the string's start. A classifier using
+        a bare lstrip('_') on the whole qualified name reports 'other' here.
+        """
+        members = [
+            EntityInput("field", "code", "a/b.py", "Cls._x"),
+            EntityInput("field", "code", "a/b.py", "Cls.x"),
+        ]
+        assert "leading-underscore" in classify_shapes(members)
+
+    def test_case_only_pair_is_not_labelled_leading_underscore(self):
+        """The labels must separate. A classifier returning a constant label
+        passes the two tests above and fails this one.
+        """
+        members = [_fn("a/b.py", "Foo"), _fn("a/b.py", "foo")]
+        shapes = classify_shapes(members)
+        assert "case-only" in shapes
+        assert "leading-underscore" not in shapes
+
+    def test_inputs_from_different_files_are_separator_vs_path(self):
+        """The path/name boundary fell differently on the two inputs -- the
+        case _code_ident's own docstring anticipates.
+        """
+        members = [_fn("a/b.py", "c"), _fn("a/b_py", "c")]
+        assert "separator-vs-path" in classify_shapes(members)
+
+    def test_import_and_in_tree_module_are_cross_producer(self):
+        members = [
+            EntityInput("module", "code", "a/b.py", None),
+            EntityInput("module", "import", "a.b.py", None),
+        ]
+        assert "cross-producer" in classify_shapes(members)
+
+    def test_an_unclassifiable_pair_falls_through_to_other(self):
+        """'other' is the interesting bucket -- it is where a collision nobody
+        predicted shows up. It must be reachable, not vestigial.
+        """
+        members = [_fn("a/b.py", "x-y"), _fn("a/b.py", "x.y")]
+        assert classify_shapes(members) == {"other"}
+
+    def test_every_emitted_label_is_declared_in_SHAPES(self):
+        members = [_fn("a/b.py", "_foo"), _fn("a/b.py", "foo")]
+        assert classify_shapes(members) <= set(SHAPES)

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -1,0 +1,95 @@
+# tests/test_at_scale_ident_collision_census.py
+"""Unit tests for the #263 _code_ident collision audit's analysis primitives.
+
+The audit's headline number cannot be asserted -- it is what the audit exists
+to discover. What CAN be asserted are the components that could silently
+produce a WRONG number: the ident grouping, the shape classifier, and the
+candidate-rule scorer.
+
+Every test names the counterfactual it was checked against. A test that passes
+against a degenerate stub as well as against the real implementation proves
+nothing and does not belong here.
+"""
+
+import pytest
+
+from evals.at_scale.probe_ident_collision_census import (
+    EntityInput,
+    current_ident,
+    group_by_ident,
+    offenders,
+    raw_value,
+)
+
+
+# The three collisions #257's census actually found on this repository's
+# history, as their (file_path, name) inputs. Used as a fixture throughout:
+# a run that does not reproduce these is not measuring the right thing.
+KNOWN_COLLISIONS = [
+    ("tests/test_mcp_server.py", "_commit", "commit"),
+    ("tests/test_mcp_server.py", "_snapshot", "snapshot"),
+    ("evals/at_scale/profile_forward_reconcile_attribution.py", "_main", "main"),
+]
+
+
+def _fn(file_path, name):
+    return EntityInput("function", "code", file_path, name)
+
+
+class TestRawValue:
+    def test_named_input_uses_the_double_colon_separator(self):
+        """raw_value must reproduce _code_ident's own input construction
+        (mcp_server.py:4298-4301) exactly -- the candidate rules in Task 3 all
+        re-slug this string, so a different separator here would score every
+        rule against a value production never actually builds.
+        """
+        assert raw_value(_fn("a/b.py", "c")) == "a/b.py::c"
+
+    def test_unnamed_input_is_the_bare_path(self):
+        assert raw_value(EntityInput("module", "code", "a/b.py", None)) == "a/b.py"
+
+
+class TestCurrentIdentCollapse:
+    def test_private_and_public_helper_collapse_onto_one_ident(self):
+        """This is #263's mechanism. Counterfactual: if _canonical_ident did
+        not collapse consecutive hyphens, these two would differ
+        ('...py---commit' vs '...py--commit') and this assert would fail.
+        """
+        private = current_ident(_fn("tests/test_mcp_server.py", "_commit"))
+        public = current_ident(_fn("tests/test_mcp_server.py", "commit"))
+        assert private == public == ":function/tests-test-mcp-server-py-commit"
+
+    def test_unrelated_names_in_one_file_stay_distinct(self):
+        """Guards against a stub current_ident that returns a constant, which
+        would pass the collapse test above and make every grouping test
+        vacuous.
+        """
+        assert current_ident(_fn("a/b.py", "alpha")) != current_ident(_fn("a/b.py", "beta"))
+
+
+class TestGroupAndOffenders:
+    def test_the_three_known_collisions_are_reported_as_offenders(self):
+        inputs = []
+        for file_path, private, public in KNOWN_COLLISIONS:
+            inputs.append(_fn(file_path, private))
+            inputs.append(_fn(file_path, public))
+        found = offenders(group_by_ident(inputs, current_ident))
+        assert len(found) == 3
+        for members in found.values():
+            assert len(members) == 2
+
+    def test_public_members_alone_yield_zero_offenders(self):
+        """The counterfactual for the test above. Feeding only the public half
+        of each pair must report nothing -- otherwise the offender count is
+        being produced by something other than the collision.
+        """
+        inputs = [_fn(file_path, public) for file_path, _, public in KNOWN_COLLISIONS]
+        assert offenders(group_by_ident(inputs, current_ident)) == {}
+
+    def test_the_same_input_twice_is_not_an_offender(self):
+        """A name unchanged across 400 commits arrives 400 times. Counting
+        occurrences instead of DISTINCT inputs would report the whole
+        repository as colliding.
+        """
+        inputs = [_fn("a/b.py", "c")] * 400
+        assert offenders(group_by_ident(inputs, current_ident)) == {}

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -16,6 +16,7 @@ import sys
 
 import pytest
 
+import mcp_server
 from evals.at_scale import probe_ident_collision_census
 from evals.at_scale.probe_ident_collision_census import (
     ENTITY_TYPES,
@@ -24,6 +25,7 @@ from evals.at_scale.probe_ident_collision_census import (
     SELF_CHECKS,
     SHAPES,
     EntityInput,
+    _slug_current,
     build_report,
     classify_shapes,
     collect_inputs,
@@ -140,12 +142,78 @@ class TestClassifyShapes:
         assert "case-only" in shapes
         assert "leading-underscore" not in shapes
 
-    def test_inputs_from_different_files_are_separator_vs_path(self):
-        """The path/name boundary fell differently on the two inputs -- the
-        case _code_ident's own docstring anticipates.
+    def test_a_name_that_is_a_trailing_path_segment_is_separator_vs_path(self):
+        """The spec's definition (design spec line 189): one input's NAME is a
+        trailing whole path segment of the other's file_path, so the ident
+        cannot say where the path ended and the name began -- the family
+        _code_ident's docstring anticipates.
+
+        These two REALLY collide, asserted below, and they are members one
+        offender group could actually hold: an ident carries its entity_type,
+        so every member of a group shares one, and a pair spanning two types
+        (the module src/auth/login.py against the function login in
+        src/auth.py) illustrates the family but can never be an offender.
+
+        Counterfactual: with the old `a.file_path != b.file_path` predicate the
+        label fired on any two inputs from different files, so it never
+        exercised this boundary at all; with a predicate that looks only at
+        file_path and never at `name`, this fails.
+        """
+        members = [
+            _fn("src/utils_py/handlers", "utils"),
+            _fn("src/utils.py", "handlers.utils"),
+        ]
+        assert current_ident(members[0]) == current_ident(members[1])
+        assert classify_shapes(members) == {"separator-vs-path"}
+
+    def test_a_plain_paths_differ_pair_is_not_separator_vs_path(self):
+        """The counterfactual for the test above, and the shape the old
+        predicate got wrong: a/b.py::c against a/b_py::c differ in file_path,
+        but 'c' is nowhere near either path's trailing segment, so nothing here
+        is about a path/name boundary.
+
+        Counterfactual: the old `a.file_path != b.file_path` predicate labels
+        this pair separator-vs-path and this assert fails.
         """
         members = [_fn("a/b.py", "c"), _fn("a/b_py", "c")]
-        assert "separator-vs-path" in classify_shapes(members)
+        assert "separator-vs-path" not in classify_shapes(members)
+
+    def test_an_underscore_inside_a_segment_is_not_a_trailing_segment(self):
+        """Whole-segment, not raw string suffix. 'mcp_server.py' contains
+        'server' but does not END WITH it as its own path component, so a
+        function named server elsewhere is not this family -- it is an
+        underscore/separator artifact, and calling it separator-vs-path would
+        relabel ordinary underscore collisions.
+
+        Counterfactual: a predicate using file_path.endswith(name) (or
+        endswith on the extension-stripped string) labels this pair
+        separator-vs-path.
+        """
+        members = [
+            EntityInput("module", "code", "mcp_server.py", None),
+            _fn("a/b.py", "server"),
+        ]
+        assert "separator-vs-path" not in classify_shapes(members)
+
+    def test_two_unresolved_import_specifiers_are_other_not_separator_vs_path(self):
+        """:module/mcp-server, verbatim from the recorded run: both inputs are
+        unresolved import specifiers with name=None, so there is no path/name
+        boundary anywhere in the pair. What collides them is that '.' and '_'
+        both slug to '-'. Under the old predicate this was labelled
+        separator-vs-path while the write-up's own finding explained it as the
+        slug charset -- the table and the prose disagreeing about one offender.
+
+        Counterfactual: the old predicate's dead `(a.name is None) != (b.name
+        is None)` clause never fires inside an ident group (entity type is
+        fixed, and module always has name=None), so the label came purely from
+        the paths differing, and this assert fails.
+        """
+        members = [
+            EntityInput("module", "import", "mcp.server", None),
+            EntityInput("module", "import", "mcp_server", None),
+        ]
+        assert current_ident(members[0]) == current_ident(members[1])
+        assert classify_shapes(members) == {"other"}
 
     def test_import_and_in_tree_module_are_cross_producer(self):
         members = [
@@ -194,6 +262,51 @@ class TestClassifyShapes:
     def test_every_emitted_label_is_declared_in_SHAPES(self):
         members = [_fn("a/b.py", "_foo"), _fn("a/b.py", "foo")]
         assert classify_shapes(members) <= set(SHAPES)
+
+
+class TestSlugParityWithProduction:
+    """_slug_current is a hand copy of _canonical_ident's slug, and R2 and R5
+    are built on it while the BASELINE is built on the real _code_ident. If the
+    two ever drift, every candidate rule is repriced against a slug production
+    does not use, silently -- the residual and rename columns would still look
+    like measurements.
+
+    Pinned by equality over adversarial values rather than by re-importing the
+    regex, because a copied regex that has drifted still compares equal to
+    itself. Counterfactual: change either side's charset or drop either
+    `re.sub` and these fail.
+    """
+
+    ADVERSARIAL = [
+        "",
+        "::",
+        "---",
+        "_leading",
+        "trailing_",
+        "__dunder__",
+        "mcp.server",
+        "mcp_server",
+        "tests/test_mcp_server.py::_commit",
+        "tests/test_mcp_server.py::commit",
+        "MixedCase/Path.PY::HelperName",
+        "a//b..c__d--e::f",
+        "a/b.py::Cls._x",
+        "9lives/2fast.py::_3d",
+        "evals/at_scale/probe.py::__init__",
+    ]
+
+    @pytest.mark.parametrize("value", ADVERSARIAL)
+    def test_the_hand_copied_slug_still_equals_canonical_ident(self, value):
+        assert f":x/{_slug_current(value)}" == mcp_server._canonical_ident("x", value)
+
+    def test_the_baseline_ident_is_the_hand_copy_over_the_same_raw_value(self):
+        """The other half of the parity: the baseline uses _code_ident, which
+        composes _canonical_ident over raw_value. Counterfactual: a raw_value
+        that built its input with a different separator passes the parametrized
+        test above and fails this one.
+        """
+        inp = _fn("tests/test_mcp_server.py", "_commit")
+        assert current_ident(inp) == f":function/{_slug_current(raw_value(inp))}"
 
 
 def _known_collision_inputs():


### PR DESCRIPTION
Read-only audit for #263, matching the measure-before-changing precedent of #244/#245/#257. **No production code changes** — `mcp_server.py` is untouched.

## What it measures

`_canonical_ident` (`mcp_server.py:4090`) maps every character outside `[a-z0-9-]` to a hyphen, then collapses hyphen runs. `_code_ident` builds its input as `f"{file_path}::{name}"`, so both the `::` separator and a leading underscore become hyphens and the collapse merges them — a private helper `_foo` and a public `foo` in one file land on one graph entity.

The audit walks real history through `mcp_server._extract_commit`, harvests every `(entity_type, file_path, name)` input that ever existed, groups them by the ident the current rule produces, classifies each collision by family, and scores five candidate replacement derivations.

## Why it is source-derived, not graph-derived

#263 suggested #257's census already gives a lower bound. The undercount is structurally worse than "it misses same-description pairs": when two entities collide, the loser takes `_build_code_triples`' already-known branch, which appends `:modified-in` and **nothing else** — no `:description`, no `:file`. The graph therefore holds no record of the losing input pair at all, and re-keying the census cannot recover it. Only the inputs give an exact count.

## The measurement

`master` @ `14166d1`, 674 commits, 0 extraction failures, 2789 distinct inputs, 2780 idents.

**9 offenders** (0.32%): module 1/133, function 7/2058, class 1/290, variable 0/232, field 0/67.
**Shapes:** leading-underscore 7, other 2, case-only 0, separator-vs-path 0, cross-producer 0.

| rule | residual | renames | module | function |
|---|---|---|---|---|
| R1 keep underscores | **0** | 2710 (97.5%) | 74/133 | 2049/2058 |
| R2 no hyphen collapse | 1 | 2649 (95.3%) | 2/133 | 2058/2058 |
| R3 R1+R2 | **0** | 2721 (97.9%) | 74/133 | 2058/2058 |
| R4 hash suffix | **0** | 2780 (100%) | 133/133 | 2058/2058 |
| R5 **control** | 9 | 2647 | — | — |

All four predictions held. R5 is a known-negative control that must keep colliding; it did. The S1 self-check on rename accounting held.

## What this says about a repair

**A migration for existing graphs is needed, not only a forward change.** The cheapest zero-residual rule still renames 97.5% of existing idents, so a forward-only change orphans the history of nearly every code entity in every graph already written.

## Three things beyond the issue as filed

1. **`other` is not empty.** `__init__` vs `_init` collides but is not `leading-underscore` under `_strip_private`'s `lstrip("_")`. The underscore family is wider than the label — left as-is deliberately, since a narrower label understates conservatively and folding it in would erase the signal that the taxonomy was incomplete.
2. **One collision has nothing to do with underscores.** `:module/mcp-server` is reached from the external `mcp.server` and this repo's own `mcp_server`: `.` and `_` both slug to `-`.
3. **`cross-producer: 0` is absence of opportunity.** This repo has no gitlinks, so that arm was never exercised.

## Reading the artifact

- `head_commit` is `14166d1` (mainline), **not** this branch's tip. Deliberate: the measurement must not include the probe being written.
- The `module` row pools three producers — 57 in-tree files, 76 unresolved import specifiers, 0 gitlinks. That split was computed by a separate `collect_inputs` pass and is **not** in the JSON.
- `separator-vs-path: 0` means the `::` mitigation held on *this* history, not that it is airtight.

## Deliverables

- `evals/at_scale/probe_ident_collision_census.py` — the audit and its CLI
- `tests/test_at_scale_ident_collision_census.py` — 87 tests
- `evals/at_scale/results/263-ident-collision-census.json` — the recorded run
- `evals/at_scale/benchmark.md` — the write-up
- design spec + implementation plan under `docs/superpowers/`

Full suite: 1316 passed, 1 xfailed. The audit opens no `MiniGrafDb` handle and writes no facts.

Refs #263 — this sizes the bug, it does not settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK
