### PR TITLE
Assert matcher growth by operation count, not wall clock (#261)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,6 +13,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      # One interpreter failing says nothing about the other two, and cancelling
+      # them presents a single failure as three broken jobs — which cost real
+      # diagnosis time on PR #262. Let every interpreter report its own verdict.
+      fail-fast: false
       matrix:
         python-version:
           - "3.10"

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -132,3 +132,35 @@ subprocess via `subprocess.run` to prove the index is actually shared via
 the filesystem/OS page cache, not via any in-process Python state — mirrors
 the existing DB lock-retry cluster's "spawn a real subprocess to
 manufacture a real condition" pattern.
+
+## Performance guards count operations, never wall clock
+
+A performance regression test asserts on a **count that expresses the defect
+axis** — write calls, structures built, pairs evaluated — not on elapsed
+seconds. Counts are deterministic; elapsed seconds are a property of the
+machine and whatever else is running on it, so a wall-clock assertion fails
+on a shared or contended CI runner and gets attributed to whatever change
+happens to be in flight (#261, where a load-sensitive failure was twice read
+as a real defect on a green `master`).
+
+Worked examples:
+
+- `test_per_commit_writes_do_not_scale_with_entity_count` and
+  `test_per_commit_writes_stay_in_the_forward_walk_s_range` (#233) pin
+  per-commit write calls at a fixed commit count, not run time.
+- `test_matcher_per_pair_setup_does_not_scale_with_pool_size` (#261, replacing
+  a 12-second bound) counts the O(pool)-sized structures the rename matcher
+  builds and asserts the number is flat as the pool triples.
+
+Two things such a test needs:
+
+- **A positive control.** A flat or small count proves nothing unless the
+  larger input really did more work, so assert that too (the matcher test
+  requires the 3x pool to evaluate >4x the candidate pairs). Otherwise code
+  that silently stopped working passes.
+- **An ablation.** Reintroduce the defect in the production code, confirm the
+  test fails, and confirm it fails on the *assertion that names the defect* —
+  then revert. A guard that has never been seen red guarantees nothing.
+
+If a timing assertion genuinely cannot be avoided, its margin must be
+justified in a comment against measured numbers, not tuned until it passes.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5411,29 +5411,103 @@ class TestMatchRenamedEntities:
         assert removed["function"] == [("foo", old)]
         assert added["function"] == [("bar", new)]
 
-    def test_matcher_growth_is_bounded_not_cubic(self):
-        """P2 (second-pass) performance regression guard. The per-pair
-        O(all_names) dict rebuild (the cubic term) is gone; a 600x600 pool of
-        realistic small functions must complete well within a generous bound.
-        Pre-fix a 600x600 pool took ~32s (and grew ~cubically); post-fix it is
-        ~5s. The 12s bound is chosen to sit cleanly between the two — loose
-        enough to stay non-flaky on slower CI, tight enough that a regression
-        back to the cubic rebuild (which would blow past ~30s) fails here."""
+    def test_matcher_per_pair_setup_does_not_scale_with_pool_size(self, monkeypatch):
+        """P2 (second-pass) performance regression guard — the successor to the
+        wall-clock `test_matcher_growth_is_bounded_not_cubic` this replaces
+        (#261).
+
+        The defect was a per-candidate-pair O(all_names) rebuild:
+        `_match_renamed_entities` built a fresh `pair_tracked_names` dict for
+        every pair it evaluated, and `_match_candidate_pair` re-seeded an
+        O(all_names) reverse dict on every call. Layered on the inherent
+        O(removed x added) scan, that made total work cubic in pool size. The
+        fix builds both structures ONCE PER ROUND and passes them in read-only,
+        excluding the pair's own two names per-pair in O(1).
+
+        So the property is a COUNT, not a duration: over a whole matching run
+        the matcher builds at most one such structure PER ROUND, and that
+        number is FLAT in pool size no matter how many pairs get evaluated.
+        Both halves of the cubic term are pinned — the shared per-round
+        `tracked_names` (build count) and the precomputed `tracked_reserved`
+        (a None there means `_match_candidate_pair` rebuilds the multiset
+        internally, per call).
+
+        Counting rather than timing follows #233's precedent
+        (`test_per_commit_writes_do_not_scale_with_entity_count` pins the defect
+        axis — entity count at a fixed commit count — instead of a wall-clock
+        number). The old assertion here measured elapsed seconds and so failed
+        on an otherwise-green master purely under concurrent CPU load, twice
+        getting misread as a real defect; see #261.
+
+        The `calls` positive control is load-bearing: a flat build count is
+        evidence of anything only if the larger pool really did evaluate many
+        times more pairs. Without it, a matcher that silently stopped scanning
+        would sail through.
+        """
         import mcp_server
-        parser = mcp_server._get_parser("test.py")
-        n = 600
-        removed = {"function": [], "class": [], "variable": [], "field": []}
-        added = {"function": [], "class": [], "variable": [], "field": []}
-        for i in range(n):
-            src_o = f"def old_{i}(a, b):\n    total = a + b + {i}\n    return total * a\n"
-            src_n = f"def new_{i}(a, b):\n    total = a + b + {i}\n    return total * a\n"
-            removed["function"].append((f"old_{i}", parser.parse(src_o.encode()).root_node.children[0]))
-            added["function"].append((f"new_{i}", parser.parse(src_n.encode()).root_node.children[0]))
-        start = time.perf_counter()
-        matches = mcp_server._match_renamed_entities(removed, added)
-        elapsed = time.perf_counter() - start
-        assert len(matches) == n
-        assert elapsed < 12.0, f"600x600 matcher took {elapsed:.2f}s (expected ~5s; cubic regression?)"
+        real_pair = mcp_server._match_candidate_pair
+
+        def run(n):
+            """Match an n x n pool of realistic small functions. Returns
+            (distinct per-round structures the matcher built, candidate pairs
+            it evaluated)."""
+            parser = mcp_server._get_parser("test.py")
+            removed = {"function": [], "class": [], "variable": [], "field": []}
+            added = {"function": [], "class": [], "variable": [], "field": []}
+            for i in range(n):
+                src_o = f"def old_{i}(a, b):\n    total = a + b + {i}\n    return total * a\n"
+                src_n = f"def new_{i}(a, b):\n    total = a + b + {i}\n    return total * a\n"
+                removed["function"].append((f"old_{i}", parser.parse(src_o.encode()).root_node.children[0]))
+                added["function"].append((f"new_{i}", parser.parse(src_n.encode()).root_node.children[0]))
+            # Hold a reference to every structure seen: CPython recycles the
+            # id() of a freed temporary, so counting ids without pinning the
+            # objects would collapse a per-pair rebuild back to a handful of
+            # reused addresses and pass vacuously.
+            seen = []
+            calls = 0
+
+            def spy(old_node, new_node, tracked_names, tracked_reserved=None, **kwargs):
+                nonlocal calls
+                calls += 1
+                assert tracked_reserved is not None, (
+                    "_match_candidate_pair was called without a precomputed "
+                    "tracked_reserved, so it rebuilds the O(all_names) multiset "
+                    "on every call — half of the original cubic term is back"
+                )
+                seen.append((tracked_names, tracked_reserved))
+                return real_pair(
+                    old_node, new_node, tracked_names,
+                    tracked_reserved=tracked_reserved, **kwargs
+                )
+
+            with monkeypatch.context() as m:
+                m.setattr(mcp_server, "_match_candidate_pair", spy)
+                matches = mcp_server._match_renamed_entities(removed, added)
+            assert len(matches) == n, "every pair in the pool should still match"
+            return len({(id(t), id(r)) for t, r in seen}), calls
+
+        small_builds, small_calls = run(40)
+        large_builds, large_calls = run(120)
+
+        # Positive control: 3x the pool really did cost ~9x the pair
+        # evaluations (n(n+1)/2: 820 vs 7260), so the flat build count below is
+        # a fact about the matcher and not about a scan that never happened.
+        assert small_calls > 40, f"40x40 pool evaluated only {small_calls} pairs"
+        assert large_calls > 4 * small_calls, (
+            f"120x120 pool evaluated {large_calls} pairs vs {small_calls} for "
+            "40x40 — the two runs are not far enough apart to say anything"
+        )
+
+        assert small_builds <= mcp_server._MAX_MATCH_ROUNDS, (
+            f"40x40 pool built {small_builds} tracked-name structures for "
+            f"{small_calls} candidate pairs; the bound is one per round "
+            f"(<= {mcp_server._MAX_MATCH_ROUNDS}), not one per pair"
+        )
+        assert large_builds == small_builds, (
+            f"tracked-name structure builds grew {small_builds} -> "
+            f"{large_builds} when the pool tripled — per-pair setup is scaling "
+            "with pool size again (the cubic term)"
+        )
 
     def test_cross_file_short_body_not_matched_without_relationship(self):
         """#174: two unrelated entities (different file_groups keys) with a


### PR DESCRIPTION
Closes #261.

## What changed

`test_matcher_growth_is_bounded_not_cubic` asserted that a 600x600 rename-matcher
pool completed in under 12 seconds. That is a property of the machine as much as of
the code — it failed on an otherwise-green `master` purely under concurrent CPU load,
and the failure was twice attributed to whatever change was in flight before the load
sensitivity was isolated.

It is replaced by `test_matcher_per_pair_setup_does_not_scale_with_pool_size`, which
counts what the fix in 85c2a96 actually changed.

**The defect axis.** The cubic term was a per-candidate-pair O(all_names) rebuild: a
fresh `pair_tracked_names` dict per pair in `_match_renamed_entities`, plus a
re-seeded reverse dict per `_match_candidate_pair` call. The fix builds both once per
round and passes them in read-only, so the number of O(pool)-sized structures built
over a run is bounded by `_MAX_MATCH_ROUNDS` and **flat in pool size**, however many
pairs get evaluated. The test spies on `_match_candidate_pair` and asserts exactly
that at two pool sizes, pinning both halves — the shared per-round `tracked_names`
(build count) and the precomputed `tracked_reserved` (a `None` there restores the
internal per-call rebuild).

This follows #233's precedent of pinning the defect axis rather than a duration
(`test_per_commit_writes_do_not_scale_with_entity_count`).

**No production code changed.** `mcp_server.py` is untouched by this branch.

## Positive control

A flat count proves nothing about a run that never happened, so the test also requires
the 3x pool to evaluate more than 4x the candidate pairs (820 -> 7260 in practice).
Without that, a matcher which silently stopped scanning would sail through.

## Ablation — both halves proven separately

| ablation | result |
|---|---|
| reintroduce only the per-pair dict rebuild (`dict(tracked_names)` at the call site) | fails the build-count bound: `820 tracked-name structures for 820 candidate pairs; the bound is one per round (<= 10)` |
| restore the true pre-fix call shape (85c2a96 reverted: `pair_tracked_names` comprehension, no `tracked_reserved`) | fails the precomputed-multiset assertion |

Neither ablation shipped.

## Load behaviour

The new test carries no wall-clock assertion at all, so contention cannot change its
verdict. Confirmed green in a run artificially slowed 2x (16 busy loops on 8 cores;
the matcher class went 2.3s -> 4.8s wall clock and still passed). Runtime also drops
~5s -> ~0.1s, since the pool sizes needed for a count assertion are far smaller than
those needed for a timing one.

## Also in this branch

- **`fail-fast: false`** on the pytest matrix. Without it one interpreter's failure
  cancels the other two, presenting a single racing failure as three broken jobs —
  which cost real diagnosis time on PR #262. Called out in #261 as a live CI hazard of
  the same kind; drop this commit if you would rather it landed separately.
- **`docs/testing-conventions.md`** gains a section on performance guards: count the
  defect axis, never elapsed seconds, and pair the count with a positive control and
  an ablation. Both worked examples were already in the tree; the rule was only
  implicit, which is how a 12-second bound got written in the first place.

## Verification

- Full suite on this branch: **1316 passed, 1 xfailed** (`.venv/bin/python`, 175s) —
  identical to master's baseline.
- `TestMatchRenamedEntities`: 16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK