### PR TITLE
R3 ident rule + graph format version (#263)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,22 @@ process that opens the graph. See #241.
 The fact index is bi-temporal: it includes historical (retracted/superseded) facts
 alongside current ones, labeled with their validity window.
 
+**Graph format version — there is no migration, by design.** `GRAPH_FORMAT_VERSION`
+(mcp_server.py) is stamped as `:ingestion/format-version` and ingestion refuses to
+run against any other version, including an absent stamp (which means the graph
+predates it). Bump it whenever a change makes stored facts unreadable by current
+code — today that means the ident rule in `_canonical_ident` (#263), since
+ingestion recomputes idents from `(type, path, name)` on every run rather than
+reading them back, so an old-rule graph read by new-rule code silently FORKS every
+entity instead of erroring.
+
+Do not propose a migration for this. The standing decision is that any graph built
+before #222 closes gets **rebuilt into a fresh graph path**, never migrated or
+re-ingested in place: several #222-arc fixes (#235, #251/#253, #238/#245, phase 2d)
+write facts that do not self-heal on a later ingest, so those graphs are condemned
+independently of any one bug. Re-running ingestion over an existing file repairs
+nothing. See `docs/superpowers/specs/2026-08-14-ident-rule-r3-and-format-version-design.md`.
+
 **Single-handle invariant.** At most one live `MiniGrafDb` handle may exist per
 process. Two handles on one file each cache their own `page_count` and corrupt
 each other — the flaky `Page N out of bounds (total pages: M)` (#251, #253,

--- a/SKILL.md
+++ b/SKILL.md
@@ -106,7 +106,9 @@ Before storing a new entity, always check for existing canonical idents and alia
 If a reference matches an existing ident or alias, reuse that exact ident.
 Only mint a new ident if the entity is genuinely new.
 
-Canonical ident form: lowercase, hyphens only — `:decision/redis` not `:decision/Redis_cache`.
+Canonical ident form: lowercase; `_` and `-` are both preserved, every other character becomes `-`; leading/trailing hyphens are stripped (underscores are not). So `Redis_cache` → `:decision/redis_cache`, and `pydantic.v2` → `:dependency/pydantic-v2`.
+
+Underscores are preserved deliberately (#263): folding `_` into `-` made `foo` and `_foo` the same entity. For the same reason hyphen runs are **not** collapsed, so `a  b` → `a--b`, not `a-b`.
 
 Allowed entity types: `:decision/`, `:preference/`, `:constraint/`, `:dependency/`, `:module/`, `:function/`, `:class/`, `:variable/`, `:field/` (code structure — auto-ingested); `:commit/`, `:tag/`, `:ingestion/` are system-only (written by `minigraf_ingest_git`), do not write to them directly
 Required attribute on all types: `:description`
@@ -299,6 +301,10 @@ Vendored/third-party/generated paths are skipped for AST extraction by default (
 
 Do not write to `:ingestion/watermark` or any `:ingestion/` entity directly.
 
+**Graph format version.** Ingestion stamps `:ingestion/format-version` on a new graph and refuses to run against a graph stamped at a different version — including a graph with no stamp at all, which means it predates the stamp. The check runs before any write, so a refused run leaves the graph untouched.
+
+There is **no migration**. Entity idents are recomputed from `(entity type, file path, name)` on every run rather than read back, so ingesting an old-rule graph with new-rule code would create a second, forked entity for everything already stored, silently and with no error. The supported recovery is to re-ingest into a **fresh graph path**: point `MINIGRAF_GRAPH_PATH` at a new file, or delete the existing graph along with its `.fts.sqlite3` index. Re-running ingestion over the existing file does not repair it.
+
 ### minigraf_ingest_status
 
 Poll the current git ingestion progress.
@@ -337,7 +343,9 @@ potentially stale watermark.
 
 `minigraf_ingest_git` writes the following entity types. All relationship attributes (`:parent`, `:introduced-by`, `:modified-in`, `:contains`, `:depends-on`, `:tagged-commit`, `:resolves-to`) are stored as keyword entity references — they bypass string-value schema validation by design and are directly traversable in queries.
 
-**Ident slugging:** non-alphanumeric characters in paths and names are replaced with hyphens and consecutive hyphens collapsed. Examples: `src/auth.py` → `:module/src-auth-py`; function `login` in `src/auth.py` → `:function/src-auth-py-login`.
+**Ident slugging:** characters outside `[a-z0-9_-]` in paths and names are replaced with hyphens; underscores are kept and hyphen runs are **not** collapsed. Examples: `src/auth.py` → `:module/src-auth-py`; function `login` in `src/auth.py` → `:function/src-auth-py--login` (the `::` join survives as `--`); `mcp_server.py` → `:module/mcp_server-py`.
+
+Both rules exist to keep distinct entities apart (#263): folding `_` into `-` made `foo` and `_foo` one entity, and collapsing hyphen runs let a path character stand in for the `::` join. Note this means idents minted before this change do not match idents minted after it — see `:ingestion/format-version` below.
 
 #### `:type/commit` — one per git commit
 Ident: `:commit/<first-12-chars-of-hash>`

--- a/docs/superpowers/specs/2026-08-14-ident-rule-r3-and-format-version-design.md
+++ b/docs/superpowers/specs/2026-08-14-ident-rule-r3-and-format-version-design.md
@@ -1,0 +1,225 @@
+# #263 — R3 ident rule + graph format version: design
+
+Fixes the ident collisions measured by the #263 audit (PR #264) by changing the
+slug rule, and replaces the migration that change would otherwise require with a
+graph-level format version and a loud refusal.
+
+## The decision this implements, and why there is no migration
+
+The audit found **9 of 2780 idents (0.32%) reachable from more than one
+`(entity_type, file_path, name)` input** over 674 commits. It also priced the
+repair: the cheapest zero-residual rule renames **97.5% of every ident in every
+existing graph**, so a fix needs a migration that rewrites every fact whose
+subject *or* object is an old ident, across bi-temporal history.
+
+That migration is **not being built.** The user's standing decision (2026-08-14)
+is that **any graph built before #222 closes must be fully rebuilt into a fresh
+graph path, never migrated or re-ingested in place** — there is no graph worth
+preserving and no other active user. That is a superset of this change: several
+#222-arc defects (#235's two-value `:introduced-by`, #251/#253's page-table
+corruption, #238/#245's misclassified `:depends-on`, phase 2d's data loss) write
+wrong facts and do **not** self-heal on a later ingest, so those graphs were
+already condemned independently of #263.
+
+Consequence: the rename cost is zero, and this is the cheapest moment this fix
+will ever have. It gets more expensive the moment a graph exists that someone
+would rather keep.
+
+## Rule: R3
+
+R3, verbatim from the audit's `_slug_keep_underscore_no_collapse`:
+
+```python
+re.sub(r"[^a-z0-9_-]", "-", value.lower()).strip("-")
+```
+
+Two changes from the current slug: `_` joins the allowed charset (so a private
+marker survives), and the consecutive-hyphen collapse is dropped (so separator
+arity carries information — `py--commit` against `py---commit`).
+
+Scored by the audit at **residual 0, renames 2721 of 2780**. Re-derived
+independently for this spec against the census artifact's own offender list: all
+9 pairs separate. That check is the acceptance corpus below, not a citation of
+the audit's score.
+
+**R4 (hash suffix) was rejected**, and the reason changed once the migration
+died. R4's appeal was total distinctness *by construction* when a migration was
+being paid for anyway. With nothing to preserve, the trade is judged on merits,
+and the merit that matters is that idents are the human- and agent-legible
+handle in query results: `:function/mcp_server-py--run_ingestion` reads,
+`:function/mcp-server-py-run-ingestion-a3f9` does not.
+
+**R3's zero is MEASURED over 674 commits of this repo, not proven by
+construction.** That is a real difference from R4 and is the price of the
+choice. It is why the census probe is retained as a gate (below) rather than
+retired as a one-off.
+
+### Verified: minigraf accepts these idents
+
+The one unknown that could have sunk R3. Confirmed empirically against
+minigraf 1.2.3 before this spec was written: `_` and hyphen-runs are accepted
+inside a keyword ident, round-trip on point queries, and
+`:function/mcp_server-py--_foo` / `--foo` and `--__init__` / `--_init` resolve
+to distinct entities.
+
+## The slug changes GLOBALLY, in `_canonical_ident`
+
+Not only in `_code_ident`. `_canonical_ident` (`mcp_server.py:4090`) is the
+single slug function; `_code_ident` (`4288`) delegates to it.
+
+The `:module/` namespace has three producers, and the one non-underscore
+collision does not go through `_code_ident` at all. Per the census artifact,
+`:module/mcp-server` is reached from **two unresolved import specifiers** —
+`mcp.server` and `mcp_server`, both `producer: "import"` — which reach the
+namespace via `_resolve_module_ident`'s bare `_canonical_ident` calls
+(`4250`/`4285`), because `.` and `_` both slug to `-`. Changing only
+`_code_ident` would leave this pair colliding untouched.
+
+(The audit write-up glossed this as "external dependency colliding with an
+in-tree module name". The census's own `producer` field says both sides are
+import specifiers; the failure mode is the same but the path is not
+`_code_ident`, which is exactly why the fix must live in `_canonical_ident`.)
+
+Going global also re-slugs the memory-entity idents minted at `6568`
+(`:decision/`, `:preference/`, `:constraint/`, …). Underscores are rare in
+natural-language-derived values so the practical effect is small, and with no
+graph worth preserving the cost is zero. One slug rule is also simpler to
+document and to reason about than two.
+
+## Graph format version — replacing the migration with detection
+
+The failure this closes is **silent split-brain**, and it is a direct
+consequence of how idents work: `_code_ident` is a **pure function** of
+`(entity_type, file_path, name)`, recomputed at every call site on every commit
+of every run. There is no stored ident table that ingestion consults. So an
+old-rule graph ingested by new-rule code does not error — it forks every
+entity. Membership checks key on the ident string, so each entity reads as brand
+new: `:introduced-by` re-set at the wrong commit, old facts never closed,
+`:contains` / `:modified-in` / `:depends-on` / `:class` split across two idents.
+
+### Shape
+
+A single `:ingestion/format-version` entity carrying `:version` (int).
+
+**`ingestion` is a REGISTERED `MINIGRAF_SCHEMA` type** (required
+`{:description}`; optional `{:hash, :alias, :last-run-at, :last-commit,
+:total-ingested}`). `minigraf_audit` iterates registered types and retracts any
+attribute outside a type's allowed set, querying the live graph directly — so a
+new attribute that is not added to that set is **silently destroyed by any audit
+run**. `:version` is therefore added to `ingestion`'s optional set, and
+`:description` is written because it is required.
+
+This is check 1 of the four schema/idempotency checks; all four apply:
+
+2. **Deterministic ident ≠ idempotent write.** The write must read the current
+   value first, no-op if unchanged, retract-then-reassert only if it genuinely
+   differs — the guard `_watermark_update` already establishes. A test must call
+   it twice and assert the raw fact count stays at one, and must prove
+   non-clobbering of an *advanced* value, not just non-duplication of an
+   unchanged one.
+3. **Absent stamp means version 0, NOT "fresh".** This is the trap that decides
+   whether the guard works at all. Every graph that exists today predates the
+   stamp, so "no stamp" must read as *old*, never as *new*. A guard that treats
+   absence as "fresh, adopt current version" silently stamps a corrupt graph as
+   good and produces exactly the split-brain it was built to prevent. The stamp
+   is written only when the graph is genuinely empty of ingestion state.
+4. **Internal `_transact`, not the public handler.** `ingestion` is registered
+   so `handle_minigraf_transact`'s `_validate_facts` would accept it, but the
+   established pattern for ingestion-internal metadata is the internal helpers
+   (`_transact`/`_retract`), as `_watermark_update`/`_frontier_persist_claim`
+   already do. Follow it.
+
+### Refusal, and why the check and the write are two functions
+
+On ingest, a stamp that does not match the current version **refuses before any
+write** — not partway through a run — naming the fix: rebuild into a fresh graph
+path. Refusing mid-run would leave a graph half-written under two rules, the
+failure this exists to prevent.
+
+This forced a split the spec did not originally anticipate, driven by two
+constraints that cannot both be met by one function:
+
+- `_graph_format_version_verify(db)` is **read-only** and runs at the very top
+  of `_load_ingestion_preload_state`, the earliest point in a run holding a db.
+- `_graph_format_version_stamp_if_new(db, ts, index_con)` is the run's **first
+  write**, on the write path with the run's `index_con`.
+
+The `index_con` is not incidental. A write without it falls through
+`_index_write`'s `index_con=None` path, which opens and commits a fact-index
+connection of its own — caught by
+`test_ingestion_commits_index_once_per_commit_not_per_triple`, which pins
+exactly one `open_writer` per run.
+
+The stamp must also be the first write rather than the last: a fresh graph that
+got its ingestion state written but not its stamp would, on the next run, be
+indistinguishable from a pre-#263 graph (state present, stamp absent) and be
+refused. `_graph_format_version_stamp_if_new` therefore also refuses to stamp a
+graph that already carries ingestion state, as a backstop to that ordering.
+
+## Regression gate: the 9 pairs, not the full probe
+
+Two different things, deliberately separated.
+
+- **CI gate (new unit test):** the 9 offender pairs from the census artifact,
+  pinned as data, asserted to produce distinct idents under the shipped
+  `_code_ident`/`_canonical_ident`. Cheap, deterministic, runs in the suite.
+  This is what catches a regression.
+- **`probe_ident_collision_census.py` is FROZEN at the pre-#263 rule.** This
+  reverses what this spec first said (that it would be retained as a live
+  re-measurement tool), and the reason is worth recording because it was not
+  obvious until the build: **its `PREDICTIONS` block was registered before any
+  data existed**, and P3/P4 are claims about R5 and R2 *as measured against the
+  old baseline*. Re-pointing its baseline at production would silently
+  re-evaluate pre-registered predictions against a different experiment while
+  still printing them as "held" — destroying the one property that makes a
+  pre-registered prediction worth anything.
+
+  So `current_ident` stops calling `mcp_server._code_ident` and composes the
+  frozen slug instead, and the parity test inverts: the copy must equal the
+  frozen historical rule and must **not** equal production. The probe now
+  reproduces the audit forever, and a census of *new* history under the shipped
+  rule needs its own probe — filed as a follow-up, not a mutation of this one.
+
+Per the #261 precedent this gate asserts a count, not a duration, and needs a
+positive control: the same 9 pairs must be shown to collide under the *old*
+slug, or the test cannot distinguish "R3 separates them" from "the corpus was
+wrong". The old slug is inlined in the test as the control.
+
+## Testing
+
+- The 9 offender pairs separate under the shipped ident functions; the same
+  corpus collides under the inlined pre-R3 slug (positive control).
+- R3 slug unit tests: underscore survives, hyphen runs preserved, leading and
+  trailing hyphens still stripped, underscores NOT stripped at the edges.
+- `_resolve_module_ident`'s external-import path and `_code_ident`'s in-tree
+  path no longer meet on `mcp.server` / `mcp_server`.
+- Format version: fresh graph gets stamped; absent stamp on a graph with
+  ingestion state reads as version 0 and refuses; matching version proceeds;
+  mismatched version refuses before any write; the write is idempotent across
+  two calls and does not clobber an advanced value.
+- `minigraf_audit` does not retract `:version` from the stamp entity.
+
+## Docs sync
+
+- **`SKILL.md:109`** currently states "Canonical ident form: lowercase, hyphens
+  only — `:decision/redis` not `:decision/Redis_cache`." That is wrong under R3
+  and must change: underscores are preserved, so `Redis_cache` slugs to
+  `redis_cache`. This line is agent-facing guidance for minting idents by hand,
+  so leaving it stale would actively teach the wrong convention.
+- The code-entity ident conventions (`SKILL.md:378`, `388`, `398`, `425`, `435`)
+  describe the `::`-join and namespace sharing, which are unchanged, but any
+  worked ident examples must be re-slugged.
+- `CLAUDE.md` needs the rebuild-not-migrate posture and the format version, so a
+  future session does not propose a migration.
+
+## What this explicitly does NOT do
+
+- **No migration, and no repair of any existing graph.** Rebuild into a fresh
+  path is the only supported recovery. This is the whole point, not an omission.
+- **#257 stays open.** Its remaining scope is downstream of this
+  (submodule `.gitmodules` renames become the sole remaining source of two
+  distinct `:description` values), but that arm is unmeasurable on this repo —
+  0 gitlink events — so this change makes #257 decidable, not decided.
+- **Does not claim collision-freedom by construction.** R3's zero is measured.
+  A contrived path/name combination could still collide; the gate and the probe
+  are how that stays visible.

--- a/evals/at_scale/probe_ident_collision_census.py
+++ b/evals/at_scale/probe_ident_collision_census.py
@@ -116,8 +116,23 @@ def raw_value(inp: EntityInput) -> str:
 
 
 def current_ident(inp: EntityInput) -> str:
-    """The ident production builds for this input, today."""
-    return mcp_server._code_ident(inp.entity_type, inp.file_path, inp.name)
+    """The ident the PRE-#263 rule built for this input.
+
+    FROZEN, and deliberately no longer `mcp_server._code_ident`. This whole
+    artifact is the audit that CHOSE the current rule: its PREDICTIONS block was
+    fixed before any data existed, and P3/P4 are statements about R5 and R2 as
+    measured against the old baseline. Re-baselining this onto whatever
+    production does today would silently re-evaluate those predictions against a
+    DIFFERENT experiment while still printing them as "held" -- destroying the
+    one property that makes a pre-registered prediction worth anything.
+
+    So this probe reproduces the historical measurement forever, and does NOT
+    track production. The forward guard against a regression in the shipped rule
+    is TestIdentCollisionRegression263 in tests/test_mcp_server.py; a census of
+    NEW history under the shipped rule needs its own probe (filed as a
+    follow-up), not a mutation of this one.
+    """
+    return f":{inp.entity_type}/{_slug_current(raw_value(inp))}"
 
 
 def group_by_ident(
@@ -277,7 +292,15 @@ def classify_shapes(members: Sequence[EntityInput]) -> Set[str]:
 
 
 def _slug_current(value: str) -> str:
-    """_canonical_ident's slug, verbatim (mcp_server.py:4097-4098)."""
+    """The PRE-#263 slug: '_' mapped to '-', then hyphen runs collapsed.
+
+    FROZEN. This was `_canonical_ident`'s slug verbatim when the audit ran;
+    production has since moved to R3 (#263). It is kept as a hand copy rather
+    than re-pointed at production for the reason in `current_ident`: this
+    artifact must keep reproducing the experiment its predictions were
+    registered against. The name is left as `_slug_current` so the recorded
+    report and this file stay legible against each other.
+    """
     slug = re.sub(r"[^a-z0-9-]", "-", value.lower())
     return re.sub(r"-+", "-", slug).strip("-")
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4090,12 +4090,37 @@ _MIN_ENTITY_LEN = 4
 def _canonical_ident(entity_type: str, value: str) -> str:
     """Slug-canonicalize a value into a Minigraf keyword ident.
 
-    Lowercases, replaces any character outside [a-z0-9-] with a hyphen,
-    collapses consecutive hyphens, strips leading/trailing hyphens.
-    Ported from _to_kw() in minigraf-examples LlamaIndex integration.
+    Lowercases, replaces any character outside [a-z0-9_-] with a hyphen,
+    strips leading/trailing hyphens. Originally ported from _to_kw() in
+    minigraf-examples' LlamaIndex integration.
+
+    #263 — TWO deliberate departures from that original rule, both load-bearing
+    for identity and neither safe to "simplify" away:
+
+    1. '_' is INSIDE the allowed charset, so a private marker survives. Mapping
+       it to '-' made `foo` and `_foo` (and `__init__` and `_init`) the same
+       entity.
+    2. Consecutive hyphens are NOT collapsed, so separator arity carries
+       information: `_code_ident`'s '::' join survives as '--' and stays
+       distinct from a single '-' that came from one character in the path.
+
+    Together these are rule R3 of the #263 audit, measured at ZERO residual
+    collisions over 674 commits of this repo (9 of 2780 idents collided under
+    the old rule). That zero is MEASURED, NOT PROVEN BY CONSTRUCTION — a
+    contrived path/name combination can still collide. R4 (a hash suffix) would
+    have been collision-free by construction and was rejected because idents are
+    the human- and agent-legible handle in query results. The guards are
+    TestIdentCollisionRegression263 (the 9 measured pairs, in the suite) and
+    evals/at_scale/probe_ident_collision_census.py (full-history re-measurement,
+    deliberately not in CI).
+
+    Changing this rule changes every ident the graph will ever mint, and
+    ingestion recomputes idents from scratch on every run rather than reading
+    them back — so an old-rule graph read by new-rule code forks every entity
+    silently. That is what :ingestion/format-version and its refusal exist to
+    catch; bump GRAPH_FORMAT_VERSION with any change here.
     """
-    slug = re.sub(r"[^a-z0-9-]", "-", value.lower())
-    slug = re.sub(r"-+", "-", slug).strip("-")
+    slug = re.sub(r"[^a-z0-9_-]", "-", value.lower()).strip("-")
     return f":{entity_type}/{slug}"
 
 
@@ -5257,6 +5282,124 @@ def _frontier_read_bounds(db: Any, ident: str) -> Optional[Tuple[str, str]]:
     return (results[0][0], results[0][1]) if results else None
 
 
+# Bumped whenever a change makes facts already in a graph unreadable by the
+# current code -- today that means the ident rule in _canonical_ident (#263),
+# since ingestion recomputes every ident from scratch rather than reading it
+# back, so an old-rule graph read by new-rule code silently FORKS every entity
+# instead of erroring. Version 1 is the R3 rule; a graph with no stamp at all
+# predates it. There is deliberately NO migration -- see
+# docs/superpowers/specs/2026-08-14-ident-rule-r3-and-format-version-design.md:
+# the supported recovery is a rebuild into a fresh graph path.
+GRAPH_FORMAT_VERSION = 1
+_FORMAT_VERSION_IDENT = ":ingestion/format-version"
+
+
+class GraphFormatVersionError(RuntimeError):
+    """Raised when a graph's format version does not match GRAPH_FORMAT_VERSION.
+
+    Deliberately a hard failure rather than a warning: continuing would write
+    new-rule idents alongside old-rule ones for the same entities, which
+    produces no error anywhere downstream and corrupts the graph silently.
+    """
+
+
+def _graph_format_version_read(db: Any) -> Optional[int]:
+    """Return the graph's stamped format version, or None if it has no stamp."""
+    raw = _db_execute(
+        db, f"(query [:find ?v :where [{_FORMAT_VERSION_IDENT} :version ?v]])"
+    )
+    results = json.loads(raw).get("results", [])
+    if not results:
+        return None
+    try:
+        return int(results[0][0])
+    except (TypeError, ValueError):
+        # A non-integer stamp is a corrupt stamp, and treating it as "absent"
+        # would let the graph be adopted at the current version. Report it as a
+        # version that can never match instead.
+        return -1
+
+
+def _graph_has_ingestion_state(db: Any) -> bool:
+    """True if this graph has been ingested into before.
+
+    This is what makes an ABSENT stamp mean "version 0", not "fresh" -- the
+    distinction the whole guard turns on. Every graph that exists today
+    predates the stamp, so treating absence as "new, adopt the current version"
+    would stamp a pre-#263 graph as good and produce exactly the silent fork
+    the stamp exists to prevent. Only a graph with no ingestion state at all
+    may be adopted.
+    """
+    return (
+        _watermark_query(db) is not None
+        or _frontier_read_bounds(db, _FRONTIER_LOW_IDENT) is not None
+        or _frontier_read_bounds(db, _FRONTIER_HIGH_IDENT) is not None
+    )
+
+
+def _graph_format_version_verify(db: Any) -> None:
+    """Refuse to ingest a graph written under a different ident rule.
+
+    READ-ONLY, and deliberately so: this runs at the very top of a run, before
+    anything has written, because a refusal partway through would leave a graph
+    half-written under two ident rules -- worse than either rule applied
+    consistently. The matching write lives in _graph_format_version_stamp_if_new.
+
+    Passes silently for a graph that is stamped at the current version, and for
+    a genuinely new graph (which the stamping half then adopts).
+    """
+    stamped = _graph_format_version_read(db)
+    if stamped == GRAPH_FORMAT_VERSION:
+        return
+    if stamped is None and not _graph_has_ingestion_state(db):
+        return  # genuinely new -- _graph_format_version_stamp_if_new adopts it
+    found = "no version stamp (pre-#263)" if stamped is None else f"version {stamped}"
+    raise GraphFormatVersionError(
+        f"This graph has {found}, but this build ingests at graph format "
+        f"version {GRAPH_FORMAT_VERSION}. The entity ident rule changed "
+        "(#263), and ingesting would silently create a second, forked "
+        "entity for everything already in the graph. There is no "
+        "migration: re-ingest into a FRESH graph path (set "
+        "MINIGRAF_GRAPH_PATH to a new file, or delete the existing graph "
+        "and its .fts.sqlite3 index first)."
+    )
+
+
+def _graph_format_version_stamp_if_new(
+    db: Any, run_ts_iso: str, index_con: Optional[Any] = None
+) -> None:
+    """Stamp a genuinely new graph at the current format version. No-op
+    otherwise.
+
+    Must be the FIRST write of a run. A fresh graph that got its ingestion state
+    written but not its stamp would, on the next run, look exactly like a
+    pre-#263 graph (state present, stamp absent) and be refused -- so this
+    cannot be deferred until after the walk.
+
+    Takes index_con so it joins the run's single fact-index session rather than
+    falling through _index_write's index_con=None path, which opens and commits
+    a connection of its own (pinned by
+    TestRunIngestionBatchedIndexWrites.test_ingestion_commits_index_once_per_commit_not_per_triple).
+
+    Writes via the internal _transact helper, never the public
+    handle_minigraf_transact handler, matching _watermark_update and
+    _frontier_persist_claim. Guarded read-first (#156: a deterministic ident
+    does NOT make a re-transact idempotent at the graph level), so calling this
+    on an already-stamped graph adds no facts.
+    """
+    if _graph_format_version_read(db) is not None or _graph_has_ingestion_state(db):
+        return
+    _transact(
+        db,
+        f"[[{_FORMAT_VERSION_IDENT} :entity-type :type/ingestion]"
+        f" [{_FORMAT_VERSION_IDENT} :ident \"{_FORMAT_VERSION_IDENT}\"]"
+        f' [{_FORMAT_VERSION_IDENT} :description "graph format version"]'
+        f" [{_FORMAT_VERSION_IDENT} :version {GRAPH_FORMAT_VERSION}]]",
+        run_ts_iso,
+        index_con=index_con,
+    )
+
+
 def _frontier_seed_from_watermark(
     db: Any, linearization: List[str], run_ts_iso: str, index_con: Optional[Any] = None
 ) -> None:
@@ -6119,7 +6262,14 @@ MINIGRAF_SCHEMA: Dict[str, Dict[str, Dict[str, type]]] = {
     },
     "ingestion": {
         "required": {":description": str},
-        "optional": {":hash": str, ":alias": str, ":last-run-at": str, ":last-commit": str, ":total-ingested": int},
+        # :version carries the graph format version (#263). It MUST stay listed
+        # here: minigraf_audit iterates every registered type and retracts any
+        # attribute outside its allowed set, querying the live graph directly,
+        # so dropping this line makes an audit run silently delete the very
+        # stamp that protects the graph from being read under the wrong ident
+        # rule.
+        "optional": {":hash": str, ":alias": str, ":last-run-at": str, ":last-commit": str,
+                     ":total-ingested": int, ":version": int},
     },
     "commit": {
         "required": {":description": str},
@@ -8260,6 +8410,14 @@ def _load_ingestion_preload_state(
     permuting hashes across positions.
     """
     db = _db if _db is not None else _open_db_at_with_extended_retry(_graph_path or _get_graph_path())
+    # FIRST thing after the handle exists, and deliberately here rather than
+    # anywhere later: this is the earliest point in a run that has a db, and
+    # everything below it (and every write in _frontier_load and the walks
+    # after it) would be written under the current ident rule. A refusal that
+    # fired later would leave a graph half-written under two rules. Read-only;
+    # the matching stamp write is _run_ingestion's first write. Raises
+    # GraphFormatVersionError, which _run_ingestion surfaces as a failed run.
+    _graph_format_version_verify(db)
     watermark = _watermark_query(db)
     if len(commit_metadata) != len(linearization):
         raise ValueError(
@@ -10517,6 +10675,12 @@ async def _run_ingestion(repo_path: str, branch: str) -> None:
             "%Y-%m-%dT%H:%M:%S.%f"
         )[:-3] + "Z"
         db = await _ensure_db_async()
+        # The run's FIRST write, ahead of _frontier_load's own migrations: a
+        # fresh graph that got ingestion state without its stamp would look
+        # exactly like a pre-#263 graph on the next run and be refused (#263).
+        await loop.run_in_executor(
+            write_executor, _graph_format_version_stamp_if_new, db, run_ts_iso, index_con,
+        )
         allocator = await loop.run_in_executor(
             write_executor, _frontier_load, db, linearization, run_ts_iso, index_con,
         )

--- a/tests/test_at_scale_ident_collision_census.py
+++ b/tests/test_at_scale_ident_collision_census.py
@@ -11,6 +11,7 @@ against a degenerate stub as well as against the real implementation proves
 nothing and does not belong here.
 """
 
+import re
 import subprocess
 import sys
 
@@ -264,17 +265,29 @@ class TestClassifyShapes:
         assert classify_shapes(members) <= set(SHAPES)
 
 
-class TestSlugParityWithProduction:
-    """_slug_current is a hand copy of _canonical_ident's slug, and R2 and R5
-    are built on it while the BASELINE is built on the real _code_ident. If the
-    two ever drift, every candidate rule is repriced against a slug production
-    does not use, silently -- the residual and rename columns would still look
-    like measurements.
+def _pre_263_slug(value):
+    """The slug rule as it stood when the #263 audit ran, inlined as the frozen
+    reference. Deliberately NOT imported from the probe -- a copy that has
+    drifted still compares equal to itself."""
+    slug = re.sub(r"[^a-z0-9-]", "-", value.lower())
+    return re.sub(r"-+", "-", slug).strip("-")
 
-    Pinned by equality over adversarial values rather than by re-importing the
-    regex, because a copied regex that has drifted still compares equal to
-    itself. Counterfactual: change either side's charset or drop either
-    `re.sub` and these fail.
+
+class TestSlugFrozenAtPre263:
+    """This probe is FROZEN at the pre-#263 rule and no longer tracks
+    production.
+
+    It used to assert parity with `_canonical_ident`, which was right while the
+    audit was choosing a rule: a drifted copy would have repriced every
+    candidate against a slug production did not use. Once #263 shipped R3 that
+    inverted. This artifact's PREDICTIONS were registered before any data
+    existed, and P3/P4 are claims about R5 and R2 as measured against the OLD
+    baseline -- re-pointing it at production would re-evaluate pre-registered
+    predictions against a different experiment while still printing "held".
+
+    So the assertion flips: the copy must equal the frozen historical rule, and
+    must NOT equal production, which has moved. Forward regression cover for the
+    shipped rule is TestIdentCollisionRegression263 in tests/test_mcp_server.py.
     """
 
     ADVERSARIAL = [
@@ -296,17 +309,35 @@ class TestSlugParityWithProduction:
     ]
 
     @pytest.mark.parametrize("value", ADVERSARIAL)
-    def test_the_hand_copied_slug_still_equals_canonical_ident(self, value):
-        assert f":x/{_slug_current(value)}" == mcp_server._canonical_ident("x", value)
+    def test_the_hand_copied_slug_still_equals_the_frozen_pre_263_rule(self, value):
+        assert _slug_current(value) == _pre_263_slug(value)
 
     def test_the_baseline_ident_is_the_hand_copy_over_the_same_raw_value(self):
-        """The other half of the parity: the baseline uses _code_ident, which
-        composes _canonical_ident over raw_value. Counterfactual: a raw_value
-        that built its input with a different separator passes the parametrized
-        test above and fails this one.
-        """
+        """The other half: the baseline must compose the FROZEN slug over
+        raw_value. Counterfactual: a raw_value that built its input with a
+        different separator passes the parametrized test above and fails this
+        one."""
         inp = _fn("tests/test_mcp_server.py", "_commit")
         assert current_ident(inp) == f":function/{_slug_current(raw_value(inp))}"
+
+    def test_the_frozen_rule_is_no_longer_productions_rule(self):
+        """The freeze is the point, so it is asserted rather than assumed. If
+        this ever passes by accident -- production reverting to the old slug --
+        #263 has been undone and the collision census is live again."""
+        collided = "tests/test_mcp_server.py::_commit"
+        assert f":function/{_slug_current(collided)}" != mcp_server._code_ident(
+            "function", "tests/test_mcp_server.py", "_commit"
+        )
+
+    def test_the_frozen_baseline_still_reproduces_a_known_audit_collision(self):
+        """What the freeze buys: the recorded measurement stays reproducible.
+        `_commit` and `commit` must still land on ONE ident here, exactly as
+        they did when the audit ran -- while production now separates them."""
+        import mcp_server as _m
+        a, b = _fn("tests/test_mcp_server.py", "_commit"), _fn("tests/test_mcp_server.py", "commit")
+        assert current_ident(a) == current_ident(b)
+        assert (_m._code_ident("function", a.file_path, a.name)
+                != _m._code_ident("function", b.file_path, b.name))
 
 
 def _known_collision_inputs():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,6 +18,7 @@ import asyncio
 import contextlib
 import datetime
 import json
+import re
 import sqlite3
 import sys
 import os
@@ -1531,6 +1532,135 @@ class TestIngestTagsGraphLevelIdempotency:
         assert json.loads(raw)["results"] == [["v1.1.0"]]
 
 
+TS = "2026-01-01T00:00:00.000Z"
+
+
+class TestGraphFormatVersion:
+    """#263: the ident rule changed, and ingestion recomputes every ident from
+    scratch rather than reading it back, so an old-rule graph ingested by
+    new-rule code forks every entity with no error anywhere. There is no
+    migration; the stamp exists to turn that silent fork into a refusal."""
+
+    def _stamp_count(self, db):
+        import mcp_server
+        raw = mcp_server._db_execute(
+            db, "(query [:find ?a ?v :where [:ingestion/format-version ?a ?v]])"
+        )
+        return json.loads(raw)["results"]
+
+    def test_fresh_graph_is_stamped_at_the_current_version(self, real_db):
+        import mcp_server
+        mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        assert mcp_server._graph_format_version_read(real_db) == mcp_server.GRAPH_FORMAT_VERSION
+
+    def test_stamped_graph_at_current_version_proceeds(self, real_db):
+        import mcp_server
+        mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)  # must not raise
+
+    def test_absent_stamp_on_an_ingested_graph_refuses(self, real_db):
+        """THE trap this guard turns on: every graph that exists today predates
+        the stamp, so an absent stamp must read as version 0 (old), never as
+        "fresh, adopt the current version". A guard that adopts here stamps a
+        pre-#263 graph as good and produces the exact fork it exists to stop."""
+        import mcp_server
+        mcp_server._watermark_update(real_db, "hash1", TS, "prior run")
+        with pytest.raises(mcp_server.GraphFormatVersionError) as exc:
+            mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        assert "no version stamp" in str(exc.value)
+        # And it must NOT have stamped the graph on its way out.
+        assert mcp_server._graph_format_version_read(real_db) is None
+
+    def test_mismatched_version_refuses(self, real_db, monkeypatch):
+        import mcp_server
+        mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        monkeypatch.setattr(mcp_server, "GRAPH_FORMAT_VERSION", mcp_server.GRAPH_FORMAT_VERSION + 1)
+        with pytest.raises(mcp_server.GraphFormatVersionError):
+            mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+
+    def test_refuses_before_writing_anything(self, real_db):
+        """A refusal partway through a run leaves a graph half-written under two
+        ident rules, which is worse than either rule applied consistently."""
+        import mcp_server
+        mcp_server._watermark_update(real_db, "hash1", TS, "prior run")
+        with execute_spy() as calls:
+            with pytest.raises(mcp_server.GraphFormatVersionError):
+                mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        assert not [c for c in calls if c.startswith("(transact") or c.startswith("(retract")]
+
+    def test_repeated_calls_do_not_duplicate_facts(self, real_db):
+        """#156: a deterministic ident does NOT make a re-transact idempotent at
+        the graph level -- re-asserting the same (entity, attribute, value)
+        under a new valid-from creates a second genuinely live fact."""
+        import mcp_server
+        for _ in range(3):
+            mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        rows = self._stamp_count(real_db)
+        assert len(rows) == 4, rows  # :entity-type, :ident, :description, :version -- one each
+
+    def test_does_not_clobber_an_advanced_version(self, real_db, monkeypatch):
+        """Proving non-duplication of an UNCHANGED value cannot distinguish a
+        correct guard from one that ignores its own check. A graph stamped
+        AHEAD of this build must be refused, never quietly rewritten backwards."""
+        import mcp_server
+        monkeypatch.setattr(mcp_server, "GRAPH_FORMAT_VERSION", mcp_server.GRAPH_FORMAT_VERSION + 5)
+        mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        future = mcp_server._graph_format_version_read(real_db)
+        monkeypatch.undo()
+        with pytest.raises(mcp_server.GraphFormatVersionError):
+            mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        assert mcp_server._graph_format_version_read(real_db) == future
+
+    def test_corrupt_non_integer_stamp_refuses_rather_than_reading_as_absent(self, real_db):
+        """A stamp that cannot be parsed must not fall through to the
+        absent-stamp branch, which on an empty graph would adopt it."""
+        import mcp_server
+        mcp_server._transact(
+            real_db,
+            '[[:ingestion/format-version :entity-type :type/ingestion]'
+            ' [:ingestion/format-version :ident ":ingestion/format-version"]'
+            ' [:ingestion/format-version :description "graph format version"]'
+            ' [:ingestion/format-version :version "not-a-number"]]',
+            TS,
+        )
+        assert mcp_server._graph_format_version_read(real_db) == -1
+        with pytest.raises(mcp_server.GraphFormatVersionError):
+            mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+
+    def test_stamping_refuses_a_graph_that_already_has_ingestion_state(self, real_db):
+        """What forces the stamp to be a run's FIRST write. If it could stamp a
+        graph that already carries ingestion state, then a pre-#263 graph would
+        be adopted as current on its next run — the exact silent fork the guard
+        exists to prevent. The ordering in _run_ingestion is what makes this
+        safe for a genuinely fresh graph; this is the backstop."""
+        import mcp_server
+        mcp_server._watermark_update(real_db, "hash1", TS, "prior run")
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        assert mcp_server._graph_format_version_read(real_db) is None
+
+    def test_audit_does_not_retract_the_version_stamp(self, real_db):
+        """minigraf_audit iterates every MINIGRAF_SCHEMA-registered type and
+        retracts attributes outside its allowed set. `ingestion` IS registered,
+        so :version must be in its optional set or an audit run silently
+        deletes the stamp that protects the graph."""
+        import mcp_server
+        mcp_server._graph_format_version_verify(real_db)
+        mcp_server._graph_format_version_stamp_if_new(real_db, TS)
+        mcp_server.handle_minigraf_audit()
+        assert mcp_server._graph_format_version_read(real_db) == mcp_server.GRAPH_FORMAT_VERSION
+
+
 class TestWatermarkUpdateGraphLevelIdempotency:
     """#187: same failure shape as #156 (TestIngestTagsGraphLevelIdempotency), but in
     _watermark_update -- called once per COMMIT rather than once per run. Only :hash
@@ -2416,21 +2546,39 @@ class TestCanonicalIdent:
         import mcp_server
         assert mcp_server._canonical_ident("preference", "use postgres") == ":preference/use-postgres"
 
-    def test_replaces_underscores(self):
+    def test_preserves_underscores(self):
+        """#263 (R3): '_' is inside the allowed charset. Mapping it to '-' is
+        what made `foo` and `_foo` one entity."""
         import mcp_server
-        assert mcp_server._canonical_ident("constraint", "must_be_stateless") == ":constraint/must-be-stateless"
+        assert mcp_server._canonical_ident("constraint", "must_be_stateless") == ":constraint/must_be_stateless"
 
     def test_replaces_dots(self):
         import mcp_server
         assert mcp_server._canonical_ident("dependency", "pydantic.v2") == ":dependency/pydantic-v2"
 
-    def test_collapses_consecutive_hyphens(self):
+    def test_preserves_hyphen_runs(self):
+        """#263 (R3): the collapse is gone, so separator arity is meaningful —
+        this is what keeps _code_ident's '::' join ('--') distinct from a single
+        path character that slugged to '-'."""
         import mcp_server
-        assert mcp_server._canonical_ident("decision", "use  Redis") == ":decision/use-redis"
+        assert mcp_server._canonical_ident("decision", "use  Redis") == ":decision/use--redis"
+
+    def test_underscore_and_dot_no_longer_share_a_slug(self):
+        """The #263 module-namespace offender in miniature: '.' still maps to
+        '-' but '_' does not, so `mcp.server` and `mcp_server` part ways."""
+        import mcp_server
+        assert mcp_server._canonical_ident("module", "mcp.server") == ":module/mcp-server"
+        assert mcp_server._canonical_ident("module", "mcp_server") == ":module/mcp_server"
 
     def test_strips_leading_trailing_hyphens(self):
         import mcp_server
         assert mcp_server._canonical_ident("decision", " redis ") == ":decision/redis"
+
+    def test_does_not_strip_leading_trailing_underscores(self):
+        """strip("-") must NOT become strip("-_"): a leading underscore is the
+        private marker #263 exists to preserve."""
+        import mcp_server
+        assert mcp_server._canonical_ident("function", "_private_") == ":function/_private_"
 
 
 class TestValidateFacts:
@@ -5903,22 +6051,112 @@ class TestCodeIdent:
 
     def test_function_ident_distinct_from_module(self):
         import mcp_server
-        # Same entity_type — separator must place tokens in a different order
+        # Same entity_type — separator must place tokens in a different order.
+        # Under #263's R3 the '::' join survives as '--' and the path's own '_'
+        # survives as '_', so these two are separated twice over rather than
+        # only by token order.
         fn_ident = mcp_server._code_ident("function", "src/auth.py", "login")
-        # "src/auth.py::login" → src-auth-py-login
-        # "src/auth_login.py"  → src-auth-login-py  (py comes last, not before login)
         file_ident = mcp_server._code_ident("function", "src/auth_login.py")
-        assert fn_ident == ":function/src-auth-py-login"
-        assert file_ident == ":function/src-auth-login-py"
+        assert fn_ident == ":function/src-auth-py--login"
+        assert file_ident == ":function/src-auth_login-py"
         assert fn_ident != file_ident
 
     def test_class_ident(self):
         import mcp_server
-        assert mcp_server._code_ident("class", "src/auth.py", "User") == ":class/src-auth-py-user"
+        assert mcp_server._code_ident("class", "src/auth.py", "User") == ":class/src-auth-py--user"
+
+    def test_private_and_public_names_are_distinct(self):
+        """#263's dominant shape (7 of 9 offenders): a leading underscore must
+        survive into the ident."""
+        import mcp_server
+        assert (mcp_server._code_ident("function", "a.py", "_commit")
+                != mcp_server._code_ident("function", "a.py", "commit"))
 
     def test_name_is_lowercased(self):
         import mcp_server
-        assert mcp_server._code_ident("function", "Foo.py", "MyFunc") == ":function/foo-py-myfunc"
+        assert mcp_server._code_ident("function", "Foo.py", "MyFunc") == ":function/foo-py--myfunc"
+
+
+# Every (entity_type, file_path, name) input pair that the #263 census found
+# reachable to ONE ident over 674 commits of this repo — 9 of 2780 idents
+# (0.32%), lifted verbatim from
+# evals/at_scale/results/263-ident-collision-census.json. Kept as DATA, not as
+# generated cases, so the corpus stays traceable to the measurement that
+# produced it.
+_263_COLLIDING_INPUTS = [
+    # (entity_type, [(file_path, name), (file_path, name)])
+    ("module", [("mcp.server", None), ("mcp_server", None)]),
+    ("function", [("evals/at_scale/profile_forward_reconcile_attribution.py", "_main"),
+                  ("evals/at_scale/profile_forward_reconcile_attribution.py", "main")]),
+    ("function", [("tests/test_mcp_server.py", "__init__"),
+                  ("tests/test_mcp_server.py", "_init")]),
+    ("function", [("tests/test_mcp_server.py", "_boom"), ("tests/test_mcp_server.py", "boom")]),
+    ("function", [("tests/test_mcp_server.py", "_commit"), ("tests/test_mcp_server.py", "commit")]),
+    ("function", [("tests/test_mcp_server.py", "_parse"), ("tests/test_mcp_server.py", "parse")]),
+    ("function", [("tests/test_mcp_server.py", "_results"), ("tests/test_mcp_server.py", "results")]),
+    ("function", [("tests/test_mcp_server.py", "_snapshot"), ("tests/test_mcp_server.py", "snapshot")]),
+    ("class", [("tests/test_mcp_server.py", "FakeDb"), ("tests/test_mcp_server.py", "_FakeDb")]),
+]
+
+
+def _pre_r3_slug(value):
+    """The slug rule as it stood before #263 — `_` outside the allowed charset
+    and consecutive hyphens collapsed. Inlined here as the POSITIVE CONTROL for
+    the corpus below, not imported, so it stays pinned even as the production
+    rule moves on."""
+    slug = re.sub(r"[^a-z0-9-]", "-", value.lower())
+    return re.sub(r"-+", "-", slug).strip("-")
+
+
+class TestIdentCollisionRegression263:
+    """#263: the R3 slug (`_` kept, hyphen-run collapse dropped) must keep every
+    input pair the census found colliding on a distinct ident.
+
+    Asserts a COUNT of distinct idents rather than any timing, per #261. The
+    corpus is a fixed 9 pairs, so it catches a regression in the rule but cannot
+    discover NEW collisions in new history — that stays the job of
+    evals/at_scale/probe_ident_collision_census.py, which is deliberately not
+    wired into CI (a 674-commit run is far too expensive for the suite)."""
+
+    def test_all_census_offenders_now_get_distinct_idents(self):
+        import mcp_server
+        still_colliding = []
+        for entity_type, inputs in _263_COLLIDING_INPUTS:
+            idents = {mcp_server._code_ident(entity_type, fp, name) for fp, name in inputs}
+            if len(idents) != len(inputs):
+                still_colliding.append((entity_type, inputs, sorted(idents)))
+        assert not still_colliding, (
+            f"{len(still_colliding)} of {len(_263_COLLIDING_INPUTS)} census "
+            f"offender pairs still collide: {still_colliding}"
+        )
+
+    def test_positive_control_corpus_collided_under_the_old_rule(self):
+        """Without this the test above cannot tell "R3 separates these" from
+        "the corpus was wrong and these never collided". Every pair must be
+        shown to collide under the pre-#263 slug."""
+        separated_anyway = []
+        for entity_type, inputs in _263_COLLIDING_INPUTS:
+            idents = set()
+            for fp, name in inputs:
+                value = f"{fp}::{name}" if name else fp
+                idents.add(f":{entity_type}/{_pre_r3_slug(value)}")
+            if len(idents) != 1:
+                separated_anyway.append((entity_type, inputs, sorted(idents)))
+        assert not separated_anyway, (
+            "these corpus pairs did NOT collide under the old rule, so they are "
+            f"not evidence of anything: {separated_anyway}"
+        )
+
+    def test_module_namespace_offender_crosses_the_bare_canonical_ident_path(self):
+        """The one non-underscore collision. Both `mcp.server` and `mcp_server`
+        reach `:module/` through _resolve_module_ident's bare _canonical_ident
+        call (mcp_server.py:4250/4285), not through _code_ident — which is why
+        the rule had to change in _canonical_ident itself. Fixing only
+        _code_ident would have left this pair colliding."""
+        import mcp_server
+        external = mcp_server._canonical_ident("module", "mcp.server")
+        in_tree = mcp_server._canonical_ident("module", "mcp_server")
+        assert external != in_tree, f"both still slug to {external}"
 
 
 @pytest.fixture
@@ -8710,6 +8948,12 @@ class TestIngestionWrites:
     def test_run_ingestion_writes_last_run_when_no_commits(self, real_db, tmp_path, monkeypatch):
         import mcp_server
 
+        # Stamp BEFORE the _watermark_query stub below: this test simulates a
+        # RESUMED run (watermark present, no commits left), and a graph with
+        # ingestion state but no format stamp is exactly what #263's guard
+        # refuses as pre-#263. Stamping first makes it a current-format graph;
+        # stamping after the stub would be refused by stamp_if_new itself.
+        mcp_server._graph_format_version_stamp_if_new(real_db, "2026-01-01T00:00:00.000Z")
         monkeypatch.setattr(mcp_server, "_watermark_query", lambda db: "abc123")
         monkeypatch.setattr(mcp_server, "_git_commits", lambda repo, watermark, branch: [])
         # #222 phase 2d: which commits get walked is now driven by
@@ -9429,21 +9673,28 @@ class TestPreloadKnownDeps:
         """
         import mcp_server
 
+        # The ident must be the one _code_ident builds for "mod_a.py" TODAY:
+        # _preload_known_deps keys ident_to_file by _code_ident("module", path)
+        # (mcp_server.py:8032), so a hand-written ident that no longer matches
+        # the rule silently drops every row and reads as the #133 bug returning.
+        # Under #263's R3 the path's '_' survives: ":module/mod_a-py".
+        src = mcp_server._code_ident("module", "mod_a.py")
+        assert src == ":module/mod_a-py"
         real_db.execute(
             '(transact {:valid-from "2020-01-01T00:00:00Z"} '
-            '[[:module/mod-a-py :entity-type :type/module] '
-            '[:module/mod-a-py :ident ":module/mod-a-py"]])'
+            f'[[{src} :entity-type :type/module] '
+            f'[{src} :ident "{src}"]])'
         )
         real_db.execute(
             '(transact {:valid-from "2024-01-01T00:00:00Z"} '
-            '[[:module/mod-a-py :depends-on :module/mod-b]])'
+            f'[[{src} :depends-on :module/mod-b]])'
         )
 
-        file_entities = {"mod_a.py": [":module/mod-a-py"]}
+        file_entities = {"mod_a.py": [src]}
         file_deps, dep_valid_from = mcp_server._preload_known_deps(real_db, file_entities)
 
         assert file_deps["mod_a.py"] == {":module/mod-b"}
-        assert dep_valid_from[(":module/mod-a-py", ":module/mod-b")] == "2024-01-01T00:00:00.000Z"
+        assert dep_valid_from[(src, ":module/mod-b")] == "2024-01-01T00:00:00.000Z"
 
     def test_query_includes_any_valid_time_and_forever_filter(self, real_db):
         """The query must ask for :any-valid-time (required for any per-fact


### PR DESCRIPTION
Closes #263.

## The decision this implements

The audit (PR #264) measured **9 of 2780 idents (0.32%)** reachable from more than one
`(entity_type, file_path, name)` input, and priced the repair: the cheapest
zero-residual rule renames **97.5% of every ident in every existing graph**.

That price is no longer paid. Any graph built before #222 closes gets **rebuilt into a
fresh path**, never migrated — several #222-arc defects (#235, #251/#253, #238/#245,
phase 2d) already write facts that do not self-heal on a later ingest, so those graphs
were condemned independently of this issue. With nothing to preserve the rename cost is
zero, and this is the cheapest moment the fix will ever have.

## Rule: R3

`re.sub(r"[^a-z0-9_-]", "-", value.lower()).strip("-")` — underscores join the allowed
charset, and the hyphen-run collapse is dropped so `_code_ident`'s `::` join survives as
`--`.

**R4 (hash suffix) was rejected once the migration died.** Its appeal was total
distinctness *while a migration was being paid for anyway*; with that gone the trade is
judged on merits, and idents are the human- and agent-legible handle in query results.
**R3's zero is MEASURED over 674 commits, not proven by construction** — that is the
real price of the choice, and why the measured corpus is pinned as a test.

**Verified against minigraf 1.2.3 before any code was written:** `_` and hyphen-runs are
accepted inside keyword idents and round-trip on point queries. That was the one unknown
that could have sunk R3.

## Two things the design got wrong until the build corrected them

**1. The fix had to go in `_canonical_ident` globally, not `_code_ident`.** The one
non-underscore offender is two *unresolved import specifiers* — `mcp.server` and
`mcp_server` — reaching `:module/` through `_resolve_module_ident`'s bare
`_canonical_ident` calls. A `_code_ident`-only change leaves it colliding untouched.
(The audit write-up glossed this as an external dep colliding with an in-tree module;
the census's own `producer` field says both sides are imports.)

**2. The guard had to be two functions.** `_graph_format_version_verify` is read-only and
runs at the top of the preload — the earliest point in a run holding a db — because a
refusal partway through leaves a graph half-written under two rules.
`_graph_format_version_stamp_if_new` is the run's **first** write, on the write path with
the run's `index_con`. Both constraints bite: without `index_con` the write falls through
`_index_write`'s `None` path and opens its own fact-index connection (caught by the
existing `open_writer`-count test); and stamping *last* would let a fresh graph acquire
ingestion state without a stamp, making it indistinguishable from a pre-#263 graph next
run — so `stamp_if_new` also refuses a graph that already has ingestion state.

## Why a version stamp instead of a migration

The failure mode is **silence**. Idents are recomputed from `(type, path, name)` on every
run rather than read back, so an old-rule graph read by new-rule code raises nothing — it
forks every entity, re-setting `:introduced-by` at the wrong commit, leaving old facts
unclosed, splitting `:contains`/`:modified-in`/`:depends-on`/`:class` across two idents.

All four schema/idempotency checks were applied:

| check | how |
|---|---|
| audit safety | `:version` added to `ingestion`'s `MINIGRAF_SCHEMA` optional set — without it `minigraf_audit` silently retracts the stamp |
| idempotent write | read-first guard (#156); three calls leave exactly 4 facts |
| absent ≠ fresh | **an absent stamp reads as version 0** — the trap the whole guard turns on, since every graph today predates it |
| transact path | internal `_transact`, not the public handler |

## The probe is frozen, not re-baselined

Shipping R3 moved the probe's baseline automatically (it called production
`_code_ident`) and its own parity test failed — correctly.

**Re-baselining it would have been wrong.** That artifact *is* the audit that chose R3,
and its `PREDICTIONS` block was registered before any data existed; P3 and P4 are claims
about R5 and R2 as measured against the **old** baseline. Re-pointing it at production
would re-evaluate pre-registered predictions against a different experiment while still
printing them as "held". So `current_ident` composes the frozen slug, and the parity test
inverts: the copy must equal the frozen rule and must **not** equal production.

Forward cover is `TestIdentCollisionRegression263`. A census of *new* history under the
shipped rule needs its own probe — worth filing as a follow-up.

## Tests

- The 9 census offender pairs pinned as data, **with a positive control** proving they
  collided under the old rule (otherwise the test cannot distinguish "R3 separates them"
  from "the corpus was wrong").
- R3 slug edges — underscores must survive `strip("-")`.
- Format version across fresh / absent / matching / mismatched / **advanced** / corrupt,
  plus audit survival and refuse-before-writing.
- Two existing tests carried stale hand-written idents; re-derived from `_code_ident`.

Full suite: **1334 passed, 1 xfailed** (baseline was 1316). `validate_evals.py` OK.

## Not in scope

`#257` stays open — its remaining scope is downstream of this, but the submodule arm is
unmeasurable on this repo (0 gitlink events), so this makes it decidable, not decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK