### PR TITLE
Close #257 as an accepted residual, and correct the two arms it was narrowed to

### DIFF
--- a/docs/superpowers/specs/2026-08-14-ident-rule-r3-and-format-version-design.md
+++ b/docs/superpowers/specs/2026-08-14-ident-rule-r3-and-format-version-design.md
@@ -220,6 +220,34 @@ wrong". The old slug is inlined in the test as the control.
   (submodule `.gitmodules` renames become the sole remaining source of two
   distinct `:description` values), but that arm is unmeasurable on this repo —
   0 gitlink events — so this change makes #257 decidable, not decided.
+
+  **REVISION 2026-08-14 — this bullet is wrong twice over, and #257 is now
+  CLOSED as an accepted residual.** Corrected against the shipped code when the
+  decision was actually taken:
+
+  1. **A submodule rename is not an arm at all.** `_gitlink_changes`
+     (`mcp_server.py:4622`) classifies purely from the gitlink tree entry's
+     old/new modes and never reads `.gitmodules`; `gitmodules_map` is only
+     fetched when a commit carries an `"add"` (`mcp_server.py:8914`); and the
+     `"bump"` branch writes `:pinned-commit` + `:modified-in` only
+     (`mcp_server.py:9745-9753`). A name-only `.gitmodules` edit therefore
+     produces no event and cannot rewrite `:description`. The real submodule arm
+     is narrower: **remove → re-add at the same path** with the name changed in
+     between. Still unmeasurable here (0 gitlink events).
+  2. **It was never the SOLE source.** Residual R3 slug collisions are a second
+     live arm, because the `:description` at these sites is the **pre-slug raw
+     value** (module → `file_path`, unresolved import → the raw specifier,
+     function/class/variable/field → the raw name). Ident → description is
+     injective only if the slug is, and R3's zero is measured over 674 commits,
+     not proven: `a/b.py` and `a-b.py` both reach `:module/a-b-py`. The #257
+     probe spec (`2026-08-11-description-preload-exposure-probe-design.md:53-57`)
+     named this arm correctly; the bullet above dropped it.
+
+  Both arms additionally require a **close-then-reintroduce**, since every
+  `entity_descriptions` write site is guarded by "ident not currently live".
+  That is what made accepting the residual defensible. The standing record is
+  `_preload_known_entities`' docstring plus the strict xfail in
+  `TestPreloadKnownEntitiesDescriptionValueIsDateBounded`.
 - **Does not claim collision-freedom by construction.** R3's zero is measured.
   A contrived path/name combination could still collide; the gate and the probe
   are how that stays visible.

--- a/evals/at_scale/benchmark.md
+++ b/evals/at_scale/benchmark.md
@@ -830,6 +830,30 @@ into a close-oriented "prediction holds" framing.
    query agreed with the oracle on 12685 unambiguous comparisons, and no
    entity type other than `function` has an ident carrying two values.
 
+**Resolution (2026-08-14): #257 CLOSED as an accepted residual, not fixed, and
+item 4 above is what closed it — it was never answered.** The interval-inversion
+fix is not built. Two corrections to how the arms were described, both verified
+against the shipped code:
+
+- **The submodule arm is remove → re-add at the same path, not a rename.**
+  `_gitlink_changes` classifies from the gitlink tree entry's modes and never
+  reads `.gitmodules`; `"bump"` writes `:pinned-commit` + `:modified-in` only.
+  A name-only `.gitmodules` edit produces no event and rewrites no
+  `:description`. Item 3's "independently variable from the ident-bearing path"
+  is right about the value and wrong about what triggers a second write.
+- **The three `function` collisions in item 4 were fixed by #263 (rule R3), but
+  the ARM is not closed.** These descriptions are pre-slug raw values, so
+  ident → description is injective only if the slug is, and R3's zero is
+  measured over 674 commits rather than proven: `a/b.py` and `a-b.py` both reach
+  `:module/a-b-py`. #267 is the missing census over history written under R3.
+
+Both arms additionally need a **close-then-reintroduce**, since every
+`entity_descriptions` write site is guarded by "ident not currently live". The
+standing record is `_preload_known_entities`' docstring and the strict xfail in
+`TestPreloadKnownEntitiesDescriptionValueIsDateBounded`, which fails the suite if
+anyone fixes the preload — so this measurement is not the only thing keeping the
+mechanism visible.
+
 ## Ident Collision Census — 263-ident-collision-census
 
 - Repo: `.` @ `master` (`14166d1`, full history, 674 commits)

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7506,7 +7506,42 @@ def _preload_known_entities(
     What survives is VALUES. entity_descriptions still carries whichever
     :description version was live at DATE T_hi(W), which can be a version
     written above W with an inverted author date. Membership is position-exact;
-    values are not. That is #257.
+    values are not. That is #257 -- CLOSED as an ACCEPTED residual, not fixed.
+    The xfail(strict=True) in tests/test_mcp_server.py's
+    TestPreloadKnownEntitiesDescriptionValueIsDateBounded pins that the shipped
+    query really does return the future value, so any fix trips the suite; do
+    not remove that marker to make it green.
+
+    Why accepting it is defensible, and what would make it fire. The defect
+    needs ONE ident carrying TWO distinct :description values in disjoint
+    windows. Every write site here is guarded by "ident not currently live"
+    (_build_code_triples' introduction branches; the unresolved-import stub at
+    the `dep_ident not in state.entity_valid_from` gate; the gitlink "add"
+    handler), so a second value requires a CLOSE-THEN-REINTRODUCE from a
+    different raw source value -- not merely a second writer. Two arms survive
+    #263:
+
+      1. A submodule REMOVED and re-ADDED at the same path with its .gitmodules
+         name changed in between. NOT a rename: _gitlink_changes classifies
+         purely from the gitlink tree entry's old/new modes and never reads
+         .gitmodules, gitmodules_map is only fetched when a commit carries an
+         "add", and the "bump" branch writes :pinned-commit and :modified-in
+         only. So a name-only .gitmodules edit produces no event at all and
+         cannot rewrite :description. Unmeasurable on this repository: every
+         full-history sweep so far (#245, #257, #263) found 0 gitlink events,
+         the same blind spot #245 recorded for :pinned-commit.
+      2. A residual _canonical_ident slug collision, because the :description
+         at these sites is the PRE-SLUG raw value -- module -> file_path,
+         unresolved import -> the raw specifier, function/class/variable/field
+         -> the raw name. So ident -> description is injective only if the slug
+         is, and R3's zero is MEASURED over 674 commits, not proven: `a/b.py`
+         and `a-b.py` both reach :module/a-b-py. This arm is why "the value is
+         a deterministic function of the ident" is true of the INPUTS and not
+         of the ident string.
+
+    Fixing it means position-filtering an INTERVAL per attribute, not
+    inverting one valid_to the way the close side does. Do not build that
+    without evidence the mechanism fires; there is none as of 2026-08-14.
 
     What the consequence is NOT: body-change detection. An earlier version of
     this paragraph claimed the forward walk diffs descriptions to decide

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10899,6 +10899,20 @@ class TestPreloadKnownEntitiesDescriptionValueIsDateBounded:
 
     It does. That is what the xfail below pins.
 
+    #257 WAS CLOSED 2026-08-14 as an ACCEPTED residual, and this class is the
+    reason closing it is safe: the mechanism stays pinned in the suite instead
+    of in an open issue. The strict marker is load-bearing in the CLOSED
+    direction too -- if someone fixes the preload, this test starts passing and
+    strict=True fails the suite, which is how a silent fix gets noticed. Do not
+    delete the marker to make a run green; delete it only together with the fix.
+    _preload_known_entities' docstring carries why acceptance is defensible: the
+    defect needs one ident with two distinct :description values in disjoint
+    windows, every write site is guarded by "ident not currently live", and the
+    two surviving arms (a submodule removed and re-added at the same path with a
+    changed .gitmodules name -- NOT a rename, which writes no :description at
+    all; and a residual R3 slug collision, since these descriptions are the
+    pre-slug raw values) are respectively unmeasurable here and measured zero.
+
     Same linearization as TestPreloadKnownEntitiesCloseSide, and the inversion
     is the same one: 0 = c0 @ 2026-04-01, 1 = c1 (WATERMARK) @ 2026-05-02,
     2 = c2 @ 2026-04-26. Position 2 sits above the watermark but carries the


### PR DESCRIPTION
Closes #257 as an **accepted residual, not a fix**. Documentation and docstrings only — `mcp_server.py` behaviour is untouched and the strict xfail stays exactly where it is.

## Why this closes rather than builds

The mechanism was already reachability-pinned (`TestPreloadKnownEntitiesDescriptionValueIsDateBounded`, `xfail(strict=True)`) and already measured on this repository's full history with a null result that the write-up itself calls uninformative rather than exculpatory. Nothing since has produced evidence it fires. What changed is that #263 shipped R3, which was the precondition #257 was waiting on — and re-deriving the remaining scope against the shipped code narrowed it further while correcting how it had been described.

## Two corrections to the record

The previous write-up (and the R3 spec's "what this does NOT do" bullet) said submodule `.gitmodules` renames become the sole remaining source of two distinct `:description` values. That is wrong twice over.

**1. A rename is not an arm at all.** `_gitlink_changes` (`mcp_server.py:4622`) classifies purely from the gitlink tree entry's old/new modes and never reads `.gitmodules`; `gitmodules_map` is fetched only when a commit carries an `"add"` (`mcp_server.py:8914`); the `"bump"` branch writes `:pinned-commit` + `:modified-in` and never touches `:description` (`mcp_server.py:9745-9753`). A name-only `.gitmodules` edit produces no gitlink event. The real submodule arm is **remove → re-add at the same path** with the name changed in between — still unmeasurable here (0 gitlink events on every full-history sweep so far).

**2. It was never the sole source.** Residual `_canonical_ident` slug collisions are a second live arm, because the `:description` at these sites is the **pre-slug raw value** — module → `file_path`, unresolved import → the raw specifier, function/class/variable/field → the raw name. Ident → description is injective only if the slug is, and R3's zero is measured over 674 commits rather than proven: `a/b.py` and `a-b.py` both reach `:module/a-b-py`. The #257 probe spec named this arm correctly; the R3 spec's bullet dropped it. #267 is the missing census over history written under R3.

**And both arms need more than a second writer.** Every `entity_descriptions` write site is guarded by "ident not currently live" — the `_build_code_triples` introduction branches, the unresolved-import stub's `dep_ident not in state.entity_valid_from` gate, the gitlink `"add"` handler. So two distinct values in disjoint windows require a **close-then-reintroduce** from a different raw source value. That precondition is what makes acceptance defensible.

## What keeps the mechanism visible after the close

- `_preload_known_entities`' docstring now carries both arms, the close-then-reintroduce precondition, and an explicit "do not build the interval-inversion fix without evidence".
- The test class docstring records why `strict=True` is load-bearing in the *closed* direction: if anyone fixes the preload, the xfail starts passing and the suite fails. Deleting the marker to green a run is called out as the wrong move.
- The R3 spec gains a **revision section** rather than a rewrite, following the reverse-walk spec's precedent — a spec records what was believed when written, and silently editing it erases that the belief was wrong.
- `benchmark.md`'s #257 entry gains a resolution note tying the close to its own item 4.

## Verification

- `.venv/bin/python -m pytest tests/test_mcp_server.py -k preload` → **55 passed, 1 xfailed**.
- `-k DescriptionValueIsDateBounded` → **2 passed, 1 xfailed** (the xfail is still xfailing, i.e. the defect is still pinned and unfixed).
- Closing-keyword scan over both commit messages, run with a positive control: no auto-close pairs. The only intended close is the `Closes #257` above. Refs #222 Refs #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK
