### PR TITLE
Make rebuild_index's recovery loop identify the file it acts on

### DIFF
--- a/.github/workflows/fact-index-race.yml
+++ b/.github/workflows/fact-index-race.yml
@@ -1,0 +1,82 @@
+name: Fact index race stress
+
+# The #274 failure is probabilistic: rebuild_index's recovery loop only breaks
+# when several racing processes interleave a specific way, so a single run of
+# tests/test_fact_index.py proves very little. Measured on Python 3.10 before
+# the fix, the 8-racer test failed roughly 2 runs in 30 -- which is why CI
+# caught it on PR #273 while local runs (and the other interpreters in the
+# matrix) stayed green. Repeating the test many times converts that into a
+# signal a single PR run can actually rely on.
+#
+# 3.10 is not special to the bug -- the misclassified errors reproduce
+# identically on 3.12 and 3.14 -- it is simply the interpreter whose runner
+# timing surfaced the interleaving most often, so it is the cheapest place to
+# watch for a regression.
+#
+# Deliberately NOT part of the pytest.yml matrix: at ~60 repetitions this
+# takes minutes, and running it on every push to every file would tax CI for
+# a race that only fact_index.py's recovery loop can reintroduce.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: "How many times to repeat the concurrency tests"
+        required: false
+        default: "60"
+      python-version:
+        description: "Interpreter to stress"
+        required: false
+        default: "3.10"
+  pull_request:
+    paths:
+      - "fact_index.py"
+      - "tests/test_fact_index.py"
+      - ".github/workflows/fact-index-race.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  race:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ github.event.inputs.python-version || '3.10' }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,git-ingestion]"
+
+      - name: Report interpreter and SQLite build
+        # The failure modes here are SQLite's, not Python's, so the SQLite
+        # version is the number worth having in the log when triaging.
+        run: |
+          python -c "import sys, sqlite3; print('python', sys.version); print('sqlite', sqlite3.sqlite_version)"
+
+      - name: Repeat the concurrency tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          RUNS: ${{ github.event.inputs.runs || '60' }}
+        run: |
+          set -u
+          failures=0
+          for i in $(seq 1 "$RUNS"); do
+            if ! python -m pytest -q -p no:randomly \
+                tests/test_fact_index.py -k "concurrent or unlinked_mid_attempt or never_diagnosed or file_is_intact" \
+                > "run_${i}.log" 2>&1; then
+              failures=$((failures + 1))
+              echo "::error::iteration ${i} failed"
+              cat "run_${i}.log"
+            fi
+          done
+          echo "iterations=$RUNS failures=$failures"
+          # Any single failure is a real defect: these tests must hold every
+          # run, not most runs.
+          test "$failures" -eq 0

--- a/fact_index.py
+++ b/fact_index.py
@@ -482,6 +482,33 @@ def query_facts(
     return [[entity, attribute, value, valid_from, valid_to] for entity, attribute, value, valid_from, valid_to, _score in rows]
 
 
+def _file_identity(path: str) -> Optional[Tuple[int, int]]:
+    """(st_dev, st_ino) for the file at path, or None if nothing is there.
+
+    Identifies WHICH file a path currently names, so rebuild_index can tell
+    "the file I opened" from "whatever happens to sit at this path now" after
+    a racing recovery has swapped it. Any OSError (not just
+    FileNotFoundError) reads as "no identifiable file": an unreadable path is
+    equally not-the-file-we-opened for both callers below.
+    """
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    return (st.st_dev, st.st_ino)
+
+
+def _is_still_the_same_file(path: str, identity: Optional[Tuple[int, int]]) -> bool:
+    """True only when path POSITIVELY still names the file `identity` came
+    from. Unknown identity (None) and a vanished path both answer False:
+    callers use this to decide whether they may delete a file or must treat a
+    failure as fatal, and both of those need proof of sameness, not the
+    absence of proof of difference. An unlinked file and a file we could
+    never name are equally "not demonstrably ours".
+    """
+    return identity is not None and _file_identity(path) == identity
+
+
 def rebuild_index(
     path: str,
     facts: Sequence[Tuple[str, str, str, Optional[str], Optional[str]]],
@@ -513,7 +540,29 @@ def rebuild_index(
     attempts = 6
     base_delay = 0.02
     for attempt in range(attempts):
+        # Which file this attempt is about to work on (#274). Sampled BEFORE
+        # connect so a racer that swaps the path afterwards is detectable;
+        # when the path is empty, sqlite3.connect creates the file eagerly
+        # (before any statement runs), so re-sampling after it yields the
+        # identity of the file this connection actually holds. That second
+        # sample is the load-bearing one: the failure this guards against
+        # struck a process that found NO file at the path, had connect create
+        # one, and then lost it to a racer's unlink -- an interleaving that a
+        # before-connect sample alone cannot see, because there was no file
+        # to name at the time.
+        #
+        # Not airtight, and cannot be: a racer that swaps the path in the
+        # window between this stat and the connect leaves us holding an
+        # identity for a file we did not open. Closing that would need the
+        # inode of the connection's own descriptor, which sqlite3 does not
+        # expose. The window is orders of magnitude smaller than the one this
+        # replaces (a whole rebuild, vs. two adjacent syscalls), and both
+        # callers of the comparison fail safe -- they skip a delete, or take a
+        # bounded retry.
+        identity = _file_identity(path)
         con = sqlite3.connect(path, timeout=5.0, isolation_level=None)
+        if identity is None:
+            identity = _file_identity(path)
         try:
             con.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
             con.execute("PRAGMA journal_mode=WAL")
@@ -554,7 +603,30 @@ def rebuild_index(
             return
         except sqlite3.OperationalError as e:
             message = str(e).lower()
-            if "locked" not in message and "busy" not in message:
+            # Two kinds of transient. Lock/busy contention names itself in the
+            # message. The other kind (#274) does not: when a racing recovery
+            # unlinks or replaces the file mid-attempt, the statements still
+            # running against that now-orphaned inode fail with messages that
+            # describe the SYMPTOM, not the race -- observed as "disk I/O
+            # error", "attempt to write a readonly database" and "unable to
+            # open database file", and varying by which statement happened to
+            # touch the file first. Matching those strings would be wrong in
+            # both directions: they equally name genuinely fatal conditions
+            # (a full disk, a read-only mount), and the list is open-ended.
+            # So gate on evidence instead, and demand the evidence point at
+            # FATAL: re-raise only when the path positively still holds the
+            # same file we opened. Anything else -- a different file, or no
+            # file at all -- is the race. Note the asymmetry is deliberate:
+            # "no file at the path" cannot mean "we were never able to make
+            # one", because sqlite3.connect() runs OUTSIDE this try block, so
+            # an unwritable directory already raised there and never reaches
+            # this classifier. Reaching here with the path empty means the
+            # file existed and something unlinked it.
+            if (
+                "locked" not in message
+                and "busy" not in message
+                and _is_still_the_same_file(path, identity)
+            ):
                 raise
             if attempt == attempts - 1:
                 raise
@@ -574,16 +646,33 @@ def rebuild_index(
                 raise
             if attempt == attempts - 1:
                 raise
-            # TOCTOU: a concurrently-racing rebuild against the same
-            # corrupted file can already have removed it by the time this
-            # process gets here (unlike lock/busy contention, corruption is
-            # a static file property every racer detects at once, not a
-            # timing-dependent one) -- swallow the resulting FileNotFoundError
-            # rather than letting it propagate uncaught, since the file being
-            # gone is exactly the outcome this branch wants anyway.
-            try:
-                os.remove(path)
-            except FileNotFoundError:
-                pass
+            # Remove only the file we actually diagnosed (#274). This used to
+            # unlink by path unconditionally, which is a different and wider
+            # act: every racer detects this corruption at the same instant
+            # (it is a static property of the file, unlike timing-dependent
+            # lock contention), so by the time a straggler reaches here the
+            # winner has typically already removed the corrupt file and a NEW
+            # database sits in its place -- and the straggler would delete
+            # that replacement, a file it never inspected, purely for sharing
+            # the path. That is what broke the 8-racer test. Measured there,
+            # the deleted replacement was an EMPTY database that another
+            # racer's sqlite3.connect had just created (connect creates the
+            # file before any statement runs), and that racer's next
+            # statement then failed on the orphaned inode.
+            #
+            # A mismatch here means some other racer already did this branch's
+            # work, so skipping the removal IS the correct outcome, not a
+            # missed cleanup. The next attempt re-samples the identity and
+            # will remove the new file if that one is corrupt too.
+            #
+            # TOCTOU: the file can still vanish between this check and the
+            # unlink (another racer removing the very same file), so keep
+            # swallowing FileNotFoundError -- the file being gone is exactly
+            # what this branch wants anyway.
+            if _is_still_the_same_file(path, identity):
+                try:
+                    os.remove(path)
+                except FileNotFoundError:
+                    pass
         finally:
             con.close()

--- a/tests/test_fact_index.py
+++ b/tests/test_fact_index.py
@@ -1060,6 +1060,170 @@ def test_concurrent_rebuild_race_against_a_corrupted_file_is_safe(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# #274: the three tests below pin the two halves of rebuild_index's recovery
+# loop that the 8-racer test above only exercises probabilistically (it failed
+# roughly 2 runs in 30 on Python 3.10 before this fix, which is why CI caught
+# it on PR #273 and local runs did not). Each drives the SAME interleaving
+# deterministically by orchestrating WHEN a real racing unlink lands, using
+# real sqlite3 connections against real files throughout -- no faked
+# exceptions, in keeping with this module's real-sqlite3-only convention.
+# ---------------------------------------------------------------------------
+
+
+def _connect_hook(monkeypatch, target_path, side_effect):
+    """Run side_effect(real_connect) immediately after rebuild_index's FIRST
+    connect to target_path -- inside the window where the connection is open
+    but has not yet executed a statement, which is where a racing process's
+    unlink lands in the real failure.
+
+    side_effect is handed the UNPATCHED connect so a racer it simulates can
+    open databases of its own without counting as one of rebuild_index's
+    attempts. Returns the list of connected paths, so a test can prove how
+    many attempts the loop made.
+    """
+    real_connect = fact_index.sqlite3.connect
+    calls = []
+
+    def hooked(path_arg, *args, **kwargs):
+        con = real_connect(path_arg, *args, **kwargs)
+        calls.append(path_arg)
+        if path_arg == target_path and len(calls) == 1:
+            side_effect(real_connect)
+        return con
+
+    monkeypatch.setattr(fact_index.sqlite3, "connect", hooked)
+    return calls
+
+
+def test_rebuild_index_does_not_remove_a_file_it_never_diagnosed(tmp_path, monkeypatch):
+    """The corruption branch's os.remove must delete only the file this
+    process actually diagnosed as corrupt, not whatever happens to sit at the
+    path by the time it gets there. A racer that recovers first replaces the
+    corrupt file with a NEW database; a straggler still in its own corruption
+    branch would otherwise unlink that replacement -- a file it never
+    inspected -- purely because it shares the path.
+
+    Ablation: with the identity guard removed, this fails because the
+    replacement's inode is gone from the path afterwards."""
+    path = str(tmp_path / "t.fts.sqlite3")
+    corrupt_keepalive = str(tmp_path / "corrupt.keepalive")
+    with open(path, "wb") as f:
+        f.write(b"not a real sqlite file at all, just garbage bytes")
+    # A hard link keeps the corrupt inode ALIVE after the path stops pointing
+    # at it, so this process's open connection still reads real garbage and
+    # takes the corruption branch. Without it the inode would be unlinked and
+    # sqlite would raise a transient I/O error instead -- the other test's
+    # path, not this one's.
+    os.link(path, corrupt_keepalive)
+
+    replacement = str(tmp_path / "replacement.sqlite3")
+    replaced_inode = []
+
+    def racer_replaces_the_corrupt_file(real_connect):
+        # A different, valid database atomically takes the corrupt file's
+        # place -- exactly what the winning racer's rebuild leaves behind.
+        con = real_connect(replacement, isolation_level=None)
+        con.execute("CREATE TABLE marker (a)")
+        con.close()
+        os.replace(replacement, path)
+        # Recorded HERE, not after rebuild_index returns -- comparing the
+        # final inode against itself would assert nothing.
+        replaced_inode.append(os.stat(path).st_ino)
+
+    _connect_hook(monkeypatch, path, racer_replaces_the_corrupt_file)
+    fact_index.rebuild_index(
+        path, [(":decision/x", ":description", "survivor", None, None)]
+    )
+
+    # The replacement must still be the file at the path: same inode, never
+    # unlinked and re-created underneath us.
+    assert replaced_inode, "the racing replacement never ran"
+    assert os.stat(path).st_ino == replaced_inode[0]
+    con = fact_index.open_reader(path)
+    try:
+        rows = con.execute("SELECT entity FROM facts_fts").fetchall()
+    finally:
+        con.close()
+    assert rows == [(":decision/x",)]
+
+
+def test_rebuild_index_retries_when_its_file_is_unlinked_mid_attempt(tmp_path, monkeypatch):
+    """The exact #274 CI failure, driven deterministically. A racer's
+    corruption branch unlinks the brand-new empty database that THIS
+    process's connect just created; the next statement on that now-unlinked
+    inode raises OperationalError('disk I/O error') -- a message matching
+    neither 'locked'/'busy' nor the corruption substrings, so it used to
+    propagate and fail the run. It is transient: retrying recreates the file.
+
+    Note the victim here is a freshly-created EMPTY database, and the process
+    that loses it is one that found no file at the path at all -- so a guard
+    keyed on 'the file that was at this path when I started' cannot see the
+    substitution (there was no file to name). The guard must key on the file
+    the connection is actually using.
+
+    Ablation: without the fix this raises sqlite3.OperationalError."""
+    path = str(tmp_path / "t.fts.sqlite3")
+    assert not os.path.exists(path)
+
+    def racer_unlinks_our_new_file(_real_connect):
+        # connect() created the file eagerly; a racing corruption branch
+        # removes it by path before we execute anything against it.
+        os.remove(path)
+
+    calls = _connect_hook(monkeypatch, path, racer_unlinks_our_new_file)
+    fact_index.rebuild_index(
+        path, [(":decision/x", ":description", "recovered", None, None)]
+    )
+
+    assert len(calls) > 1, "expected the loop to retry after the unlink"
+    con = fact_index.open_reader(path)
+    try:
+        rows = con.execute("SELECT entity FROM facts_fts").fetchall()
+    finally:
+        con.close()
+    assert rows == [(":decision/x",)]
+
+
+def test_rebuild_index_still_raises_when_the_file_is_intact(tmp_path, monkeypatch):
+    """Negative control for the widened retry: an OperationalError whose file
+    is still exactly the file we opened is NOT transient, so it must
+    propagate on the first attempt rather than being absorbed by six
+    backoffs. A read-only database yields 'attempt to write a readonly
+    database' -- one of the very messages the retry gate now tolerates when
+    the file has been swapped -- so this proves the gate keys on file
+    identity and not on the message text."""
+    import pytest
+    if os.geteuid() == 0:
+        pytest.skip("root ignores the read-only permission bits this relies on")
+    path = str(tmp_path / "t.fts.sqlite3")
+    fact_index.rebuild_index(path, [(":decision/x", ":description", "intact", None, None)])
+    # Drop the WAL sidecars so the reopen below has to write the main file.
+    for suffix in ("-wal", "-shm"):
+        if os.path.exists(path + suffix):
+            os.remove(path + suffix)
+    os.chmod(path, 0o444)
+
+    real_connect = fact_index.sqlite3.connect
+    calls = []
+
+    def counting(path_arg, *args, **kwargs):
+        calls.append(path_arg)
+        return real_connect(path_arg, *args, **kwargs)
+
+    try:
+        monkeypatch.setattr(fact_index.sqlite3, "connect", counting)
+        with pytest.raises(sqlite3.OperationalError):
+            fact_index.rebuild_index(
+                path, [(":decision/y", ":description", "denied", None, None)]
+            )
+    finally:
+        # Restore write permission so pytest's tmp_path cleanup can remove it.
+        os.chmod(path, 0o644)
+
+    assert len(calls) == 1, f"a fatal error must not be retried, got {len(calls)} attempts"
+
+
+# ---------------------------------------------------------------------------
 # _tokenize / _MEMORY_PREFIXES -- ported (Task 13 coverage-gap fill) from the
 # deleted mcp_server.py TestBM25Tokenize, whose subject (mcp_server._tokenize
 # / mcp_server._MEMORY_PREFIXES) no longer exists: fact text is now indexed


### PR DESCRIPTION
## The defect

`rebuild_index`'s corruption branch called `os.remove(path)` unconditionally, deleting whatever sat at the path rather than the file it had diagnosed. Inode instrumentation of the 8-racer test showed a foreign file being unlinked in 11 of 25 trials.

The victim is a database another racer's `sqlite3.connect` had just created (connect creates the file before any statement runs). That racer's next statement then fails on the orphaned inode with `disk I/O error` — matching neither the lock/busy retry branch nor the corruption branch, so it propagated and failed the run.

## Correction to the mechanism described in #274

Two details in the issue's analysis turned out to be wrong, and they change the fix:

1. The deleted file is a freshly-created **empty** database, not a completed rebuild.
2. The racer that loses it is one that found **no file at the path at all** (`connected_ino=-1`).

Because of (2), the gate the issue proposed — "the file we opened is no longer the file at this path" — evaluates to *same* in exactly the failing case (both sides absent) and **would not have fixed the observed failure**. The identity must be re-sampled *after* connect, since a before-connect sample has no file to name.

A third unhandled message also turned up that the issue does not list: `unable to open database file`.

## The fix

Both halves of the loop key on the file's `(st_dev, st_ino)` sampled around connect, and both require positive proof of sameness:

- the corruption branch unlinks only the file it actually diagnosed, so a straggler no longer deletes a replacement it never inspected;
- an `OperationalError` is re-raised only when the path still holds the file we opened; a different file, or none, is the race and takes the existing bounded backoff.

Gating on identity rather than message text matters because the race surfaces as at least three messages (`disk I/O error`, `attempt to write a readonly database`, `unable to open database file`) depending on which statement touched the file first, and each also names a genuinely fatal condition. A full disk against an intact file still raises on the first attempt — pinned by a negative-control test.

## Verification (Python 3.10; 3.11/3.12/3.14 were already green)

| Configuration | Failures |
|---|---|
| Original, 8 racers | 2 / 30 |
| Original, 24-racer stress | 1 / 30 |
| Fixed, 8 racers | 0 / 1200 |
| Fixed, 24-racer stress (2880 processes) | 0 / 120 |

Full suite: 1464 passed, 1 xfailed on both 3.10 and 3.14.

The three new tests drive the interleavings deterministically using real sqlite3 connections and real unlinks (no faked exceptions, per the module's convention). Each was ablation-proven: removing its own guard fails exactly that test and no other.

**Caveat, stated rather than smoothed over:** 2 failures were observed in the first 120 runs *of the fixed code*, before instrumentation was added. Nothing reproduced in the 1200 runs since, and the two versions were diffed to confirm they are behaviorally identical (comments only), so the difference is not in the code — Fisher exact p ≈ 0.008 between the batches points at machine state. Reported as an unexplained observation rather than as proof the race is eliminated.

## Also added

`.github/workflows/fact-index-race.yml` repeats the concurrency tests 60× on 3.10 (manual dispatch + triggered on changes to `fact_index.py`). One run of a probabilistic race proves little; it is kept out of the `pytest.yml` matrix because it takes minutes.

Fixes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK