### PR TITLE
Set MINIGRAF_INDEX_PATH in .mcp.json alongside MINIGRAF_GRAPH_PATH

### DIFF
--- a/install.py
+++ b/install.py
@@ -386,7 +386,8 @@ def setup_mcp_json(target_dir: str) -> bool:
 
     - Creates the file if absent.
     - Merges into existing content if present (other servers are preserved).
-    - Always updates MINIGRAF_GRAPH_PATH to reflect the target project path.
+    - Always updates MINIGRAF_GRAPH_PATH and MINIGRAF_INDEX_PATH to reflect
+      the target project path.
     - Uses `uvx temporal-reasoning[git-ingestion]` so the published PyPI
       package is invoked directly — no local venv path baked in. `[git-ingestion]`
       is required so uvx's ephemeral venv actually has the tree-sitter
@@ -398,14 +399,16 @@ def setup_mcp_json(target_dir: str) -> bool:
       mainstream Python build this project targets, so unlike the rank-bm25
       cache it replaced, there is no missing-dependency fallback path to
       keep working (see issues #96, #117, #118).
-    - Only MINIGRAF_GRAPH_PATH is set here; ANTHROPIC_API_KEY and
-      MINIGRAF_EXTRACTION_STRATEGY belong in .claude/settings.local.json so
-      they are available to hook subprocesses as well as the MCP server.
+    - Only MINIGRAF_GRAPH_PATH and MINIGRAF_INDEX_PATH are set here;
+      ANTHROPIC_API_KEY and MINIGRAF_EXTRACTION_STRATEGY belong in
+      .claude/settings.local.json so they are available to hook subprocesses
+      as well as the MCP server.
     """
     import json
 
     mcp_json_path = os.path.join(target_dir, ".mcp.json")
     graph_path = os.path.join(target_dir, "memory.graph")
+    index_path = f"{graph_path}.fts.sqlite3"
 
     existing: dict = {}
     file_existed = os.path.exists(mcp_json_path)
@@ -422,6 +425,7 @@ def setup_mcp_json(target_dir: str) -> bool:
         "args": ["temporal-reasoning[git-ingestion]"],
         "env": {
             "MINIGRAF_GRAPH_PATH": graph_path,
+            "MINIGRAF_INDEX_PATH": index_path,
         },
     }
 
@@ -437,6 +441,7 @@ def setup_mcp_json(target_dir: str) -> bool:
     print(f"✓ {verb} {mcp_json_path}")
     print(f"    command = uvx temporal-reasoning[git-ingestion]")
     print(f"    MINIGRAF_GRAPH_PATH = {graph_path}")
+    print(f"    MINIGRAF_INDEX_PATH = {index_path}")
     return True
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -123,6 +123,13 @@ class TestSetupMcpJson:
         args = config["mcpServers"]["temporal-reasoning"]["args"]
         assert args == ["temporal-reasoning[git-ingestion]"]
 
+    def test_sets_index_path_alongside_graph_path(self, tmp_path):
+        install.setup_mcp_json(str(tmp_path))
+        with open(tmp_path / ".mcp.json") as f:
+            config = json.load(f)
+        env = config["mcpServers"]["temporal-reasoning"]["env"]
+        assert env["MINIGRAF_INDEX_PATH"] == f"{env['MINIGRAF_GRAPH_PATH']}.fts.sqlite3"
+
 
 class TestBuildPluginStub:
     def test_stub_mcp_json_uses_git_ingestion_extra(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What

`install.py`'s `setup_mcp_json` writes `MINIGRAF_GRAPH_PATH` into the generated `.mcp.json` but left the sidecar FTS5 index path implicit. This adds `MINIGRAF_INDEX_PATH` next to it, prints it in the install output, and updates the docstring.

## Behaviour

**This is a no-op at runtime.** The value written is `f"{graph_path}.fts.sqlite3"` — exactly what `fact_index.index_path_for()` already derives when the env var is unset (`fact_index.py:59-62`). The server resolves the same index file either way.

What it buys is explicitness: the index path is visible in `.mcp.json` and in install's console output rather than only inside `fact_index`. The cost is a second place that must stay correct — if the default derivation ever changes, `.mcp.json` files generated before that change would pin the old path explicitly. The new test guards that drift for freshly generated files.

## Test

`test_sets_index_path_alongside_graph_path` asserts the two env values stay in sync via the derivation rule rather than a hardcoded path.

`tests/test_install.py`: 39 passed.

## Note

`hooks/claude-code.json`, `hooks/opencode.json`, and `hooks/openclaw.json` still set only `MINIGRAF_GRAPH_PATH`. No behavioural gap — they fall back to the same derived default — but they are now inconsistent with `.mcp.json`. Left out of scope here.

Rebased onto master (was 267 commits behind); no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRGNkzJc5FdfpbzAh4ZZzK